### PR TITLE
feat: tree-sitter parser with language detection

### DIFF
--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -1,1 +1,41 @@
-// Go tree-sitter node mappings
+use crate::languages::LanguageSupport;
+
+pub struct Go;
+
+impl LanguageSupport for Go {
+    fn name(&self) -> &str {
+        "go"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["go"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_go::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -13,3 +13,11 @@ pub trait LanguageSupport: Send + Sync {
     fn return_statement_node(&self) -> &str;
     fn operator_field(&self) -> &str;
 }
+
+/// Returns instances of all supported languages.
+pub fn all() -> Vec<Box<dyn LanguageSupport>> {
+    vec![
+        Box::new(go::Go),
+        Box::new(rust_lang::Rust),
+    ]
+}

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -1,1 +1,41 @@
-// Rust tree-sitter node mappings
+use crate::languages::LanguageSupport;
+
+pub struct Rust;
+
+impl LanguageSupport for Rust {
+    fn name(&self) -> &str {
+        "rust"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["rs"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_rust::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_expression"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_expression"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,1 +1,64 @@
-// tree-sitter language detection and AST parsing
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use crate::languages::{self, LanguageSupport};
+
+/// Parse a source file with tree-sitter, auto-detecting language from extension.
+pub fn parse_file(path: &Path, source: &[u8]) -> Result<(tree_sitter::Tree, Box<dyn LanguageSupport>)> {
+    let lang = detect_language(path)?;
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&lang.tree_sitter_language())?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| anyhow!("failed to parse {}", path.display()))?;
+    Ok((tree, lang))
+}
+
+/// Detect language from file extension.
+fn detect_language(path: &Path) -> Result<Box<dyn LanguageSupport>> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| anyhow!("no file extension: {}", path.display()))?;
+
+    for lang in languages::all() {
+        if lang.extensions().contains(&ext) {
+            return Ok(lang);
+        }
+    }
+
+    Err(anyhow!("unsupported language for extension: .{ext}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detect_go() {
+        let lang = detect_language(&PathBuf::from("main.go")).unwrap();
+        assert_eq!(lang.name(), "go");
+    }
+
+    #[test]
+    fn detect_rust() {
+        let lang = detect_language(&PathBuf::from("lib.rs")).unwrap();
+        assert_eq!(lang.name(), "rust");
+    }
+
+    #[test]
+    fn detect_unknown_extension() {
+        let result = detect_language(&PathBuf::from("script.py"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_go_source() {
+        let source = b"package main\n\nfunc main() {}\n";
+        let (tree, lang) = parse_file(Path::new("main.go"), source).unwrap();
+        assert_eq!(lang.name(), "go");
+        assert_eq!(tree.root_node().kind(), "source_file");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `parse_file()` in `src/parser.rs` with auto language detection from file extension
- Add Go and Rust `LanguageSupport` trait implementations with correct tree-sitter node names
- Add `languages::all()` registry function

## Test plan
- [x] `cargo build` passes
- [x] 4 unit tests pass (Go detection, Rust detection, unknown ext error, Go parse)

Closes #4