### PR TITLE
feat: implement all 14 mutation operators

### DIFF
--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,1 +1,151 @@
-// Binary operator mutations: < → <=, == → !=, && → ||
+use crate::MutationCandidate;
+use super::MutationOperator;
+
+const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
+
+pub fn find_operator_child(node: &tree_sitter::Node, source: &[u8], target: &str) -> Option<std::ops::Range<usize>> {
+    // Try field name "operator" first
+    if let Some(op_node) = node.child_by_field_name("operator") {
+        let text = &source[op_node.byte_range()];
+        if text == target.as_bytes() {
+            return Some(op_node.byte_range());
+        }
+    }
+    // Iterate unnamed children looking for the operator token
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if !child.is_named() {
+            let text = &source[child.byte_range()];
+            if text == target.as_bytes() {
+                return Some(child.byte_range());
+            }
+        }
+    }
+    None
+}
+
+fn is_binary_expr(node: &tree_sitter::Node) -> bool {
+    BINARY_EXPR_KINDS.contains(&node.kind())
+}
+
+macro_rules! binary_operator {
+    ($name:ident, $id:expr, $desc:expr, $from:expr, $to:expr) => {
+        pub struct $name;
+
+        impl MutationOperator for $name {
+            fn id(&self) -> &str { $id }
+            fn description(&self) -> &str { $desc }
+            fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+                if !is_binary_expr(node) {
+                    return vec![];
+                }
+                if let Some(range) = find_operator_child(node, source, $from) {
+                    vec![MutationCandidate {
+                        byte_range: range,
+                        replacement: $to.to_string(),
+                        operator_id: self.id().to_string(),
+                        description: self.description().to_string(),
+                    }]
+                } else {
+                    vec![]
+                }
+            }
+        }
+    };
+}
+
+binary_operator!(LtToLte, "lt_to_lte", "Replace < with <=", "<", "<=");
+binary_operator!(GtToGte, "gt_to_gte", "Replace > with >=", ">", ">=");
+binary_operator!(EqToNeq, "eq_to_neq", "Replace == with !=", "==", "!=");
+binary_operator!(AndToOr, "and_to_or", "Replace && with ||", "&&", "||");
+binary_operator!(OrToAnd, "or_to_and", "Replace || with &&", "||", "&&");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_go(src: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_go::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(src, None).unwrap()
+    }
+
+    fn find_binary_expr(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+        if is_binary_expr(&node) {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_binary_expr(child) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_lt_to_lte() {
+        let src = "package main\nfunc f() bool { return x < y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = LtToLte.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "<=");
+    }
+
+    #[test]
+    fn test_gt_to_gte() {
+        let src = "package main\nfunc f() bool { return x > y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = GtToGte.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, ">=");
+    }
+
+    #[test]
+    fn test_eq_to_neq() {
+        let src = "package main\nfunc f() bool { return x == y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = EqToNeq.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "!=");
+    }
+
+    #[test]
+    fn test_and_to_or() {
+        let src = "package main\nfunc f() bool { return x && y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = AndToOr.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "||");
+    }
+
+    #[test]
+    fn test_or_to_and() {
+        let src = "package main\nfunc f() bool { return x || y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = OrToAnd.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "&&");
+    }
+
+    #[test]
+    fn test_no_match() {
+        let src = "package main\nfunc f() bool { return x + y }";
+        let tree = parse_go(src);
+        let root = tree.root_node();
+        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let candidates = LtToLte.apply(&bin, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+}

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -1,1 +1,53 @@
-// Boundary mutations: + → -, - → +
+use crate::MutationCandidate;
+use super::MutationOperator;
+use super::binary::find_operator_child;
+
+const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
+
+fn is_binary_expr(node: &tree_sitter::Node) -> bool {
+    BINARY_EXPR_KINDS.contains(&node.kind())
+}
+
+pub struct PlusToMinus;
+
+impl MutationOperator for PlusToMinus {
+    fn id(&self) -> &str { "plus_to_minus" }
+    fn description(&self) -> &str { "Replace + with -" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+        if !is_binary_expr(node) {
+            return vec![];
+        }
+        if let Some(range) = find_operator_child(node, source, "+") {
+            vec![MutationCandidate {
+                byte_range: range,
+                replacement: "-".to_string(),
+                operator_id: self.id().to_string(),
+                description: self.description().to_string(),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}
+
+pub struct MinusToPlus;
+
+impl MutationOperator for MinusToPlus {
+    fn id(&self) -> &str { "minus_to_plus" }
+    fn description(&self) -> &str { "Replace - with +" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+        if !is_binary_expr(node) {
+            return vec![];
+        }
+        if let Some(range) = find_operator_child(node, source, "-") {
+            vec![MutationCandidate {
+                byte_range: range,
+                replacement: "+".to_string(),
+                operator_id: self.id().to_string(),
+                description: self.description().to_string(),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -1,1 +1,69 @@
-// Literal mutations: true → false, 0 → 1
+use crate::MutationCandidate;
+use super::MutationOperator;
+
+const TRUE_KINDS: &[&str] = &["true", "True", "TRUE"];
+const FALSE_KINDS: &[&str] = &["false", "False", "FALSE"];
+const INT_LITERAL_KINDS: &[&str] = &["integer_literal", "int_literal", "number", "number_literal"];
+
+pub struct TrueToFalse;
+
+impl MutationOperator for TrueToFalse {
+    fn id(&self) -> &str { "true_to_false" }
+    fn description(&self) -> &str { "Replace true with false" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+        if TRUE_KINDS.contains(&node.kind()) {
+            let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
+            if text == "true" || text == "True" || text == "TRUE" {
+                return vec![MutationCandidate {
+                    byte_range: node.byte_range(),
+                    replacement: "false".to_string(),
+                    operator_id: self.id().to_string(),
+                    description: self.description().to_string(),
+                }];
+            }
+        }
+        vec![]
+    }
+}
+
+pub struct FalseToTrue;
+
+impl MutationOperator for FalseToTrue {
+    fn id(&self) -> &str { "false_to_true" }
+    fn description(&self) -> &str { "Replace false with true" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+        if FALSE_KINDS.contains(&node.kind()) {
+            let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
+            if text == "false" || text == "False" || text == "FALSE" {
+                return vec![MutationCandidate {
+                    byte_range: node.byte_range(),
+                    replacement: "true".to_string(),
+                    operator_id: self.id().to_string(),
+                    description: self.description().to_string(),
+                }];
+            }
+        }
+        vec![]
+    }
+}
+
+pub struct ZeroToOne;
+
+impl MutationOperator for ZeroToOne {
+    fn id(&self) -> &str { "zero_to_one" }
+    fn description(&self) -> &str { "Replace 0 with 1" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+        if INT_LITERAL_KINDS.contains(&node.kind()) {
+            let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
+            if text == "0" {
+                return vec![MutationCandidate {
+                    byte_range: node.byte_range(),
+                    replacement: "1".to_string(),
+                    operator_id: self.id().to_string(),
+                    description: self.description().to_string(),
+                }];
+            }
+        }
+        vec![]
+    }
+}

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -9,3 +9,95 @@ pub trait MutationOperator: Send + Sync {
     fn description(&self) -> &str;
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate>;
 }
+
+const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
+const RETURN_KINDS: &[&str] = &["return_statement", "return_expression"];
+
+/// Negate a condition: remove `!` if present, otherwise wrap with `!(...)`
+pub struct NegateCondition;
+
+impl MutationOperator for NegateCondition {
+    fn id(&self) -> &str { "negate_condition" }
+    fn description(&self) -> &str { "Negate condition expression" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate> {
+        if !IF_STMT_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        let cond = node.child_by_field_name("condition");
+        if let Some(cond_node) = cond {
+            let text = std::str::from_utf8(&source[cond_node.byte_range()]).unwrap_or("");
+            let replacement = if text.starts_with('!') {
+                text[1..].trim_start_matches('(').trim_end_matches(')').to_string()
+            } else {
+                format!("!({})", text)
+            };
+            vec![crate::MutationCandidate {
+                byte_range: cond_node.byte_range(),
+                replacement,
+                operator_id: self.id().to_string(),
+                description: self.description().to_string(),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}
+
+/// Replace a return statement's value with a default
+pub struct ReturnEmpty;
+
+impl MutationOperator for ReturnEmpty {
+    fn id(&self) -> &str { "return_empty" }
+    fn description(&self) -> &str { "Replace return value with default" }
+    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate> {
+        if !RETURN_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        // Find the expression list or value child
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.named_children(&mut cursor).collect();
+        if children.is_empty() {
+            return vec![];
+        }
+        // The return value spans from first named child to end of last named child
+        let first = children.first().unwrap();
+        let last = children.last().unwrap();
+        let value_range = first.start_byte()..last.end_byte();
+        let text = std::str::from_utf8(&source[value_range.clone()]).unwrap_or("");
+
+        let replacement = if text.contains('"') || text.contains('\'') {
+            "\"\"".to_string()
+        } else if text == "true" || text == "false" {
+            "false".to_string()
+        } else {
+            "0".to_string()
+        };
+
+        vec![crate::MutationCandidate {
+            byte_range: value_range,
+            replacement,
+            operator_id: self.id().to_string(),
+            description: self.description().to_string(),
+        }]
+    }
+}
+
+/// Returns all 14 mutation operators
+pub fn all_operators() -> Vec<Box<dyn MutationOperator>> {
+    vec![
+        Box::new(binary::LtToLte),
+        Box::new(binary::GtToGte),
+        Box::new(binary::EqToNeq),
+        Box::new(binary::AndToOr),
+        Box::new(binary::OrToAnd),
+        Box::new(literal::TrueToFalse),
+        Box::new(literal::FalseToTrue),
+        Box::new(literal::ZeroToOne),
+        Box::new(boundary::PlusToMinus),
+        Box::new(boundary::MinusToPlus),
+        Box::new(removal::RemoveIfBody),
+        Box::new(removal::RemoveElse),
+        Box::new(NegateCondition),
+        Box::new(ReturnEmpty),
+    ]
+}

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -1,1 +1,69 @@
-// Statement removal: if body, else branch
+use crate::MutationCandidate;
+use super::MutationOperator;
+
+const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
+
+pub struct RemoveIfBody;
+
+impl MutationOperator for RemoveIfBody {
+    fn id(&self) -> &str { "remove_if_body" }
+    fn description(&self) -> &str { "Replace if body with empty block" }
+    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+        if !IF_STMT_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        // Look for "consequence" or "body" field
+        let body = node.child_by_field_name("consequence")
+            .or_else(|| node.child_by_field_name("body"));
+        if let Some(body_node) = body {
+            vec![MutationCandidate {
+                byte_range: body_node.byte_range(),
+                replacement: "{}".to_string(),
+                operator_id: self.id().to_string(),
+                description: self.description().to_string(),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}
+
+pub struct RemoveElse;
+
+impl MutationOperator for RemoveElse {
+    fn id(&self) -> &str { "remove_else" }
+    fn description(&self) -> &str { "Remove else clause" }
+    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+        if !IF_STMT_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        // Look for "alternative" or "else" field
+        let else_clause = node.child_by_field_name("alternative")
+            .or_else(|| node.child_by_field_name("else"));
+        if let Some(else_node) = else_clause {
+            // Find the "else" keyword before the clause to remove it too
+            // We remove from the else keyword (searching backwards) to end of else block
+            let mut cursor = node.walk();
+            let mut else_kw_start = else_node.start_byte();
+            for child in node.children(&mut cursor) {
+                if !child.is_named() {
+                    let text_range = child.byte_range();
+                    if text_range.end <= else_node.start_byte() {
+                        let kind = child.kind();
+                        if kind == "else" {
+                            else_kw_start = child.start_byte();
+                        }
+                    }
+                }
+            }
+            vec![MutationCandidate {
+                byte_range: else_kw_start..else_node.end_byte(),
+                replacement: String::new(),
+                operator_id: self.id().to_string(),
+                description: self.description().to_string(),
+            }]
+        } else {
+            vec![]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement 5 binary operators (LtToLte, GtToGte, EqToNeq, AndToOr, OrToAnd)
- Implement 3 literal operators (TrueToFalse, FalseToTrue, ZeroToOne)
- Implement 2 boundary operators (PlusToMinus, MinusToPlus)
- Implement 2 removal operators (RemoveIfBody, RemoveElse)
- Implement NegateCondition and ReturnEmpty in mod.rs
- Add `all_operators()` returning all 14 operators
- Unit tests for all 5 binary operators using tree-sitter-go

Closes #6