### PR TITLE
feat: Go and Rust language support with node mappings

### DIFF
--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -1,1 +1,32 @@
-// Go tree-sitter node mappings
+/// Go tree-sitter node mappings
+pub struct Go;
+
+impl crate::languages::LanguageSupport for Go {
+    fn name(&self) -> &str {
+        "go"
+    }
+    fn extensions(&self) -> &[&str] {
+        &["go"]
+    }
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_go::LANGUAGE.into()
+    }
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -13,3 +13,112 @@ pub trait LanguageSupport: Send + Sync {
     fn return_statement_node(&self) -> &str;
     fn operator_field(&self) -> &str;
 }
+
+/// Returns all supported languages.
+pub fn all() -> Vec<Box<dyn LanguageSupport>> {
+    vec![
+        Box::new(go::Go),
+        Box::new(rust_lang::Rust),
+    ]
+}
+
+/// Detects a language by file extension.
+pub fn detect(extension: &str) -> Option<Box<dyn LanguageSupport>> {
+    all().into_iter().find(|l| l.extensions().contains(&extension))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_go_parse_node_kinds() {
+        let lang = go::Go;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+
+        let code = r#"
+package main
+
+func add(a int, b int) int {
+    if a > b {
+        return a
+    }
+    return a + b
+}
+"#;
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        assert!(find_node_kind(&root, lang.if_statement_node()));
+        assert!(find_node_kind(&root, lang.binary_expression_node()));
+        assert!(find_node_kind(&root, lang.return_statement_node()));
+
+        // Verify operator field on binary_expression
+        let bin_expr = find_first_node_kind(&root, lang.binary_expression_node()).unwrap();
+        assert!(bin_expr.child_by_field_name(lang.operator_field()).is_some());
+    }
+
+    #[test]
+    fn test_rust_parse_node_kinds() {
+        let lang = rust_lang::Rust;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+
+        let code = r#"
+fn add(a: i32, b: i32) -> i32 {
+    if a > b {
+        return a;
+    }
+    a + b
+}
+"#;
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        assert!(find_node_kind(&root, lang.if_statement_node()));
+        assert!(find_node_kind(&root, lang.binary_expression_node()));
+        assert!(find_node_kind(&root, lang.return_statement_node()));
+
+        // Verify operator field on binary_expression
+        let bin_expr = find_first_node_kind(&root, lang.binary_expression_node()).unwrap();
+        assert!(bin_expr.child_by_field_name(lang.operator_field()).is_some());
+    }
+
+    #[test]
+    fn test_detect_by_extension() {
+        let go = detect("go").unwrap();
+        assert_eq!(go.name(), "go");
+
+        let rs = detect("rs").unwrap();
+        assert_eq!(rs.name(), "rust");
+
+        assert!(detect("py").is_none());
+    }
+
+    fn find_node_kind(node: &tree_sitter::Node, kind: &str) -> bool {
+        if node.kind() == kind {
+            return true;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if find_node_kind(&child, kind) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn find_first_node_kind<'a>(node: &tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == kind {
+            return Some(*node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_first_node_kind(&child, kind) {
+                return Some(found);
+            }
+        }
+        None
+    }
+}

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -1,1 +1,32 @@
-// Rust tree-sitter node mappings
+/// Rust tree-sitter node mappings
+pub struct Rust;
+
+impl crate::languages::LanguageSupport for Rust {
+    fn name(&self) -> &str {
+        "rust"
+    }
+    fn extensions(&self) -> &[&str] {
+        &["rs"]
+    }
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_rust::LANGUAGE.into()
+    }
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+    fn if_statement_node(&self) -> &str {
+        "if_expression"
+    }
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+    fn return_statement_node(&self) -> &str {
+        "return_expression"
+    }
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `LanguageSupport` trait for Go (`tree-sitter-go`) and Rust (`tree-sitter-rust`)
- Add `all()` and `detect(extension)` helpers to `src/languages/mod.rs`
- Tests verify parsed AST node kinds match the trait values for both languages

Closes #7