### PR TITLE
feat: terminal and JSON reporters

### DIFF
--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,1 +1,168 @@
-// JSON output for CI integration
+use crate::{MutationReport, MutationResult};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct JsonReport {
+    total: usize,
+    killed: usize,
+    survived: usize,
+    timeout: usize,
+    build_errors: usize,
+    duration_ms: u128,
+    mutations: Vec<JsonMutation>,
+}
+
+#[derive(Serialize)]
+struct JsonMutation {
+    file: String,
+    line: usize,
+    operator: String,
+    description: String,
+    result: String,
+}
+
+pub fn print_report(report: &MutationReport) {
+    let mutations: Vec<JsonMutation> = report
+        .results
+        .iter()
+        .map(|(m, r)| JsonMutation {
+            file: m.file.display().to_string(),
+            line: m.line,
+            operator: m.operator.clone(),
+            description: m.description.clone(),
+            result: match r {
+                MutationResult::Killed => "killed".to_string(),
+                MutationResult::Survived => "survived".to_string(),
+                MutationResult::Timeout => "timeout".to_string(),
+                MutationResult::BuildError => "build_error".to_string(),
+            },
+        })
+        .collect();
+
+    let json_report = JsonReport {
+        total: report.total,
+        killed: report.killed,
+        survived: report.survived,
+        timeout: report.timeout,
+        build_errors: report.build_errors,
+        duration_ms: report.duration.as_millis(),
+        mutations,
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json_report).expect("failed to serialize report")
+    );
+}
+
+/// Serialize report to a JSON string (for testing and programmatic use).
+pub fn to_json_string(report: &MutationReport) -> String {
+    let mutations: Vec<JsonMutation> = report
+        .results
+        .iter()
+        .map(|(m, r)| JsonMutation {
+            file: m.file.display().to_string(),
+            line: m.line,
+            operator: m.operator.clone(),
+            description: m.description.clone(),
+            result: match r {
+                MutationResult::Killed => "killed".to_string(),
+                MutationResult::Survived => "survived".to_string(),
+                MutationResult::Timeout => "timeout".to_string(),
+                MutationResult::BuildError => "build_error".to_string(),
+            },
+        })
+        .collect();
+
+    let json_report = JsonReport {
+        total: report.total,
+        killed: report.killed,
+        survived: report.survived,
+        timeout: report.timeout,
+        build_errors: report.build_errors,
+        duration_ms: report.duration.as_millis(),
+        mutations,
+    };
+
+    serde_json::to_string_pretty(&json_report).expect("failed to serialize report")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Mutation;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn sample_report() -> MutationReport {
+        MutationReport {
+            results: vec![
+                (
+                    Mutation {
+                        id: 1,
+                        file: PathBuf::from("src/auth.rs"),
+                        line: 47,
+                        column: 10,
+                        operator: "binary/lt_to_lte".to_string(),
+                        description: "changed < to <=".to_string(),
+                        original: "<".to_string(),
+                        replacement: "<=".to_string(),
+                        byte_range: 0..1,
+                    },
+                    MutationResult::Killed,
+                ),
+                (
+                    Mutation {
+                        id: 2,
+                        file: PathBuf::from("src/handler.rs"),
+                        line: 15,
+                        column: 5,
+                        operator: "binary/eq_to_neq".to_string(),
+                        description: "changed == to !=".to_string(),
+                        original: "==".to_string(),
+                        replacement: "!=".to_string(),
+                        byte_range: 0..2,
+                    },
+                    MutationResult::Survived,
+                ),
+            ],
+            duration: Duration::from_millis(1234),
+            total: 2,
+            killed: 1,
+            survived: 1,
+            timeout: 0,
+            build_errors: 0,
+        }
+    }
+
+    #[test]
+    fn json_output_is_valid_json() {
+        let report = sample_report();
+        let json_str = to_json_string(&report);
+        let value: serde_json::Value =
+            serde_json::from_str(&json_str).expect("output should be valid JSON");
+        assert!(value.is_object());
+    }
+
+    #[test]
+    fn json_output_has_correct_structure() {
+        let report = sample_report();
+        let json_str = to_json_string(&report);
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(value["total"], 2);
+        assert_eq!(value["killed"], 1);
+        assert_eq!(value["survived"], 1);
+        assert_eq!(value["timeout"], 0);
+        assert_eq!(value["build_errors"], 0);
+        assert_eq!(value["duration_ms"], 1234);
+
+        let mutations = value["mutations"].as_array().unwrap();
+        assert_eq!(mutations.len(), 2);
+        assert_eq!(mutations[0]["file"], "src/auth.rs");
+        assert_eq!(mutations[0]["line"], 47);
+        assert_eq!(mutations[0]["operator"], "binary/lt_to_lte");
+        assert_eq!(mutations[0]["result"], "killed");
+        assert_eq!(mutations[1]["result"], "survived");
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,2 +1,9 @@
 pub mod json;
 pub mod terminal;
+
+pub fn print_report(report: &crate::MutationReport, format: &str) {
+    match format {
+        "json" => json::print_report(report),
+        _ => terminal::print_report(report),
+    }
+}

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -1,1 +1,204 @@
-// Colored terminal output
+use crate::{MutationReport, MutationResult};
+#[allow(unused_imports)]
+use colored::Colorize;
+
+pub fn print_report(report: &MutationReport) {
+    println!();
+
+    for (mutation, result) in &report.results {
+        let file = mutation.file.display();
+        let line = mutation.line;
+        let operator = &mutation.operator;
+        let desc = &mutation.description;
+
+        match result {
+            MutationResult::Killed => {
+                println!(
+                    "  {} {}:{}  {} {}: {}",
+                    "✓ KILLED".green(),
+                    file,
+                    line,
+                    "—".dimmed(),
+                    operator.dimmed(),
+                    desc
+                );
+            }
+            MutationResult::Survived => {
+                println!(
+                    "  {} {}:{}  {} {}: {}",
+                    "✗ SURVIVED".red(),
+                    file,
+                    line,
+                    "—".dimmed(),
+                    operator.dimmed(),
+                    desc
+                );
+                println!(
+                    "              {}",
+                    "Your tests don't catch this mutation.".red()
+                );
+            }
+            MutationResult::Timeout => {
+                println!(
+                    "  {} {}:{}  {} {}: {}",
+                    "⏱ TIMEOUT".yellow(),
+                    file,
+                    line,
+                    "—".dimmed(),
+                    operator.dimmed(),
+                    desc
+                );
+            }
+            MutationResult::BuildError => {
+                println!(
+                    "  {} {}:{}  {} {}: {}",
+                    "⚠ BUILD ERROR".yellow(),
+                    file,
+                    line,
+                    "—".dimmed(),
+                    operator.dimmed(),
+                    desc
+                );
+            }
+        }
+        println!();
+    }
+
+    let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+    println!("{}", separator);
+    println!(
+        "Results: {}/{} mutations killed ({} survived)",
+        report.killed, report.total, report.survived
+    );
+    println!("Duration: {:.2}s", report.duration.as_secs_f64());
+    println!("{}", separator);
+}
+
+/// Format report as a plain-text string (no ANSI colors, for testing).
+pub fn format_report_plain(report: &MutationReport) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    for (mutation, result) in &report.results {
+        let file = mutation.file.display();
+        let line = mutation.line;
+        let operator = &mutation.operator;
+        let desc = &mutation.description;
+
+        match result {
+            MutationResult::Killed => {
+                writeln!(out, "  ✓ KILLED    {}:{} — {}: {}", file, line, operator, desc)
+                    .unwrap();
+            }
+            MutationResult::Survived => {
+                writeln!(
+                    out,
+                    "  ✗ SURVIVED  {}:{} — {}: {}",
+                    file, line, operator, desc
+                )
+                .unwrap();
+                writeln!(out, "              Your tests don't catch this mutation.").unwrap();
+            }
+            MutationResult::Timeout => {
+                writeln!(out, "  ⏱ TIMEOUT   {}:{} — {}: {}", file, line, operator, desc)
+                    .unwrap();
+            }
+            MutationResult::BuildError => {
+                writeln!(
+                    out,
+                    "  ⚠ BUILD ERROR {}:{} — {}: {}",
+                    file, line, operator, desc
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+    writeln!(out, "{}", separator).unwrap();
+    writeln!(
+        out,
+        "Results: {}/{} mutations killed ({} survived)",
+        report.killed, report.total, report.survived
+    )
+    .unwrap();
+    writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
+    writeln!(out, "{}", separator).unwrap();
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Mutation;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn sample_report() -> MutationReport {
+        MutationReport {
+            results: vec![
+                (
+                    Mutation {
+                        id: 1,
+                        file: PathBuf::from("src/auth.rs"),
+                        line: 47,
+                        column: 10,
+                        operator: "binary/lt_to_lte".to_string(),
+                        description: "changed < to <=".to_string(),
+                        original: "<".to_string(),
+                        replacement: "<=".to_string(),
+                        byte_range: 0..1,
+                    },
+                    MutationResult::Killed,
+                ),
+                (
+                    Mutation {
+                        id: 2,
+                        file: PathBuf::from("src/handler.rs"),
+                        line: 15,
+                        column: 5,
+                        operator: "binary/eq_to_neq".to_string(),
+                        description: "changed == to !=".to_string(),
+                        original: "==".to_string(),
+                        replacement: "!=".to_string(),
+                        byte_range: 0..2,
+                    },
+                    MutationResult::Survived,
+                ),
+            ],
+            duration: Duration::from_millis(1234),
+            total: 2,
+            killed: 1,
+            survived: 1,
+            timeout: 0,
+            build_errors: 0,
+        }
+    }
+
+    #[test]
+    fn terminal_output_contains_killed() {
+        let report = sample_report();
+        let output = format_report_plain(&report);
+        assert!(output.contains("✓ KILLED"));
+        assert!(output.contains("src/auth.rs:47"));
+        assert!(output.contains("binary/lt_to_lte"));
+    }
+
+    #[test]
+    fn terminal_output_contains_survived() {
+        let report = sample_report();
+        let output = format_report_plain(&report);
+        assert!(output.contains("✗ SURVIVED"));
+        assert!(output.contains("src/handler.rs:15"));
+        assert!(output.contains("Your tests don't catch this mutation."));
+    }
+
+    #[test]
+    fn terminal_output_contains_summary() {
+        let report = sample_report();
+        let output = format_report_plain(&report);
+        assert!(output.contains("Results: 1/2 mutations killed (1 survived)"));
+        assert!(output.contains("Duration: 1.23s"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement colored terminal reporter with per-mutation status lines and summary
- Implement JSON reporter with structured output for CI integration
- Add `print_report(report, format)` dispatcher in `report/mod.rs`
- 5 new tests covering JSON validity/structure and terminal output content

Closes #12