### PR TITLE
feat: integration tests with Go fixture

### DIFF
--- a/tests/fixtures/go/calc.go
+++ b/tests/fixtures/go/calc.go
@@ -1,0 +1,30 @@
+package calc
+
+// Add returns the sum of a and b.
+func Add(a, b int) int {
+	return a + b
+}
+
+// IsPositive returns true if n > 0.
+func IsPositive(n int) bool {
+	if n > 0 {
+		return true
+	}
+	return false
+}
+
+// Max returns the larger of a and b.
+func Max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Abs returns the absolute value of n.
+func Abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/tests/fixtures/go/calc_test.go
+++ b/tests/fixtures/go/calc_test.go
@@ -1,0 +1,27 @@
+package calc
+
+import "testing"
+
+// Deliberately weak tests — only tests happy path, misses edge cases
+
+func TestAdd(t *testing.T) {
+	if Add(2, 3) != 5 {
+		t.Error("expected 5")
+	}
+}
+
+func TestIsPositive(t *testing.T) {
+	if !IsPositive(1) {
+		t.Error("expected true for 1")
+	}
+	// Missing: test for 0 and negative numbers!
+}
+
+func TestMax(t *testing.T) {
+	if Max(3, 5) != 5 {
+		t.Error("expected 5")
+	}
+	// Missing: test for equal values, test for a > b!
+}
+
+// Missing: TestAbs entirely!

--- a/tests/fixtures/go/go.mod
+++ b/tests/fixtures/go/go.mod
@@ -1,0 +1,3 @@
+module example.com/calc
+
+go 1.21

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,0 +1,1 @@
+mod mutations;

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -1,0 +1,107 @@
+use std::path::PathBuf;
+use std::time::Duration;
+use togi::{ChangedFile, LineRange, MutationResult};
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/go")
+}
+
+#[test]
+fn generates_mutations_for_go_fixture() {
+    let root = fixture_path();
+
+    // Simulate the whole file being new — cover all lines
+    let changed = vec![ChangedFile {
+        path: PathBuf::from("calc.go"),
+        hunks: vec![LineRange { start: 1, end: 32 }],
+    }];
+
+    let mutations = togi::mutator::generate_mutations(&changed, &root, 200).unwrap();
+    assert!(
+        !mutations.is_empty(),
+        "expected mutations to be generated for calc.go"
+    );
+
+    let operators: Vec<&str> = mutations.iter().map(|m| m.operator.as_str()).collect();
+    println!("Generated {} mutations:", mutations.len());
+    for m in &mutations {
+        println!(
+            "  [{}] {}:{} — {}: '{}' → '{}'",
+            m.id, m.file.display(), m.line, m.operator, m.original, m.replacement
+        );
+    }
+
+    // Expect comparison operator mutations (>, <)
+    assert!(
+        operators.iter().any(|o| o.contains("gt") || o.contains("lt")),
+        "expected comparison operator mutations, got: {:?}",
+        operators
+    );
+
+    // Expect arithmetic mutations (+, -)
+    assert!(
+        operators.iter().any(|o| o.contains("add") || o.contains("sub") || o.contains("plus") || o.contains("minus") || o.contains("arith")),
+        "expected arithmetic mutations, got: {:?}",
+        operators
+    );
+
+    // Expect boolean literal mutations
+    assert!(
+        operators.iter().any(|o| o.contains("true") || o.contains("false") || o.contains("bool")),
+        "expected boolean literal mutations, got: {:?}",
+        operators
+    );
+}
+
+/// End-to-end test: generate mutations and run them against the Go test suite.
+/// Requires `go` to be installed. Run with: cargo test -- --ignored
+#[tokio::test]
+#[ignore]
+async fn end_to_end_go_fixture_some_mutations_survive() {
+    let root = fixture_path();
+
+    // Cover all lines of calc.go
+    let changed = vec![ChangedFile {
+        path: PathBuf::from("calc.go"),
+        hunks: vec![LineRange { start: 1, end: 32 }],
+    }];
+
+    let mutations = togi::mutator::generate_mutations(&changed, &root, 200).unwrap();
+    assert!(!mutations.is_empty());
+
+    let runner = togi::runner::TestRunner {
+        command: vec!["go".into(), "test".into(), "./...".into()],
+        timeout: Duration::from_secs(30),
+        parallelism: 1,
+        project_root: root,
+    };
+
+    let report = runner.run(mutations).await;
+
+    println!(
+        "Results: {} total, {} killed, {} survived, {} timeout, {} build errors",
+        report.total, report.killed, report.survived, report.timeout, report.build_errors
+    );
+    for (m, result) in &report.results {
+        println!(
+            "  [{}] {}:{} {}: '{}' → '{}' = {}",
+            m.id, m.file.display(), m.line, m.operator, m.original, m.replacement, result
+        );
+    }
+
+    // Some mutations should survive because the tests are deliberately weak
+    assert!(
+        report.survived > 0,
+        "expected some mutations to survive due to weak tests, but all were killed"
+    );
+
+    // Specifically: a mutation of > to >= in Max (line 18) should survive
+    // because the test only checks Max(3,5) — never the a > b case
+    let gt_to_gte_survived = report.results.iter().any(|(m, r)| {
+        m.operator.contains("gt_to_gte") && m.line == 18 && *r == MutationResult::Survived
+    });
+    assert!(
+        gt_to_gte_survived,
+        "expected > to >= mutation in Max (line 18) to survive"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds Go fixture (`tests/fixtures/go/`) with `calc.go` containing arithmetic/comparison functions and deliberately weak tests
- Adds integration test verifying mutation generation for the fixture (comparison, arithmetic, boolean operators)
- Adds end-to-end `#[ignore]` test that runs mutations against `go test` and asserts surviving mutants due to test gaps

## Test plan
- `cargo test` passes (non-ignored tests)
- `cargo test -- --ignored` runs the e2e test (requires `go` installed), confirms mutations survive

Closes #13