### PR TITLE
refactor: consolidate duplicate ChangedFile/LineRange types

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,20 +1,7 @@
 // Unified diff parsing → Vec<ChangedFile>
 
+use crate::{ChangedFile, LineRange};
 use std::path::PathBuf;
-
-/// A file that was changed in a diff, with the specific line ranges modified.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChangedFile {
-    pub path: PathBuf,
-    pub hunks: Vec<LineRange>,
-}
-
-/// An inclusive line range [start, end].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LineRange {
-    pub start: usize,
-    pub end: usize,
-}
 
 /// Parse unified diff output (from `git diff`) into a list of changed files
 /// with their modified line ranges. Only tracks added/modified lines.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub struct ChangedFile {
 }
 
 /// A range of changed lines (1-indexed, inclusive)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LineRange {
     pub start: usize,
     pub end: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,20 +72,11 @@ async fn run_check(
     }
 
     // 4. Parse diff into ChangedFiles
-    let diff_files = togi::diff::parse_diff(&diff_output);
-    if diff_files.is_empty() {
+    let changed_files = togi::diff::parse_diff(&diff_output);
+    if changed_files.is_empty() {
         println!("No added/modified lines found. Nothing to mutate.");
         return Ok(());
     }
-
-    // Convert diff::ChangedFile → lib ChangedFile
-    let changed_files: Vec<togi::ChangedFile> = diff_files
-        .into_iter()
-        .map(|f| togi::ChangedFile {
-            path: f.path,
-            hunks: f.hunks.into_iter().map(|h| togi::LineRange { start: h.start, end: h.end }).collect(),
-        })
-        .collect();
 
     // 5. Generate mutations
     let mutations = togi::mutator::generate_mutations(


### PR DESCRIPTION
## Summary
- Remove duplicate ChangedFile/LineRange from diff.rs, use lib.rs types
- Remove manual type conversion in main.rs
- Add PartialEq/Eq to LineRange for test assertions

Closes #28