### PR TITLE
feat: add --test-cmd CLI flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,10 @@ pub enum Commands {
         /// Show each mutation as it runs
         #[arg(long)]
         verbose: bool,
+
+        /// Override test command (e.g., 'go test ./...')
+        #[arg(long)]
+        test_cmd: Option<String>,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,9 @@ async fn main() {
             timeout,
             dry_run,
             verbose,
+            test_cmd,
         } => {
-            if let Err(e) = run_check(base, config, format, jobs, timeout, dry_run, verbose).await {
+            if let Err(e) = run_check(base, config, format, jobs, timeout, dry_run, verbose, test_cmd).await {
                 eprintln!("Error: {e}");
                 process::exit(2);
             }
@@ -45,6 +46,7 @@ async fn run_check(
     timeout: Option<u64>,
     dry_run: bool,
     verbose: bool,
+    test_cmd: Option<String>,
 ) -> anyhow::Result<()> {
     // 1. Load config
     let mut config = togi::config::Config::load(config_path.as_deref())?;
@@ -58,6 +60,9 @@ async fn run_check(
     }
     if let Some(t) = timeout {
         config.test.timeout = t;
+    }
+    if let Some(cmd) = test_cmd {
+        config.test.command = cmd.split_whitespace().map(String::from).collect();
     }
 
     // Find project root (git toplevel)


### PR DESCRIPTION
## Summary
- Adds `--test-cmd` flag to `togi check` for overriding the test command from CLI
- Splits the provided string by whitespace and uses it as `config.test.command`

Closes #36