### PR TITLE
docs: add CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# togi
+
+Fast, diff-targeted, language-agnostic mutation testing engine.
+
+## Architecture
+
+Single Rust binary. Pipeline: diff → parse → map → mutate → run → report.
+
+- `src/diff.rs` — parse unified diff into changed file/line ranges
+- `src/parser.rs` — tree-sitter language detection and AST parsing
+- `src/mapper.rs` — map changed lines to mutable AST nodes
+- `src/mutator.rs` — combine mapper + operators to generate mutations
+- `src/runner.rs` — parallel test execution with timeouts and file guards
+- `src/report/` — terminal and JSON output
+- `src/operators/` — mutation operators (binary, literal, boundary, removal)
+- `src/languages/` — per-language tree-sitter node mappings
+- `src/config.rs` — togi.toml parsing with auto-detection
+- `src/cli.rs` — clap CLI definitions
+
+## Conventions
+
+- Minimal diffs. One concern per commit.
+- All changes via PR, never direct to main.
+- `cargo test` must pass. `cargo clippy -- -D warnings` must pass.
+- `cargo fmt` enforced.
+
+## Adding a language
+
+1. Add the tree-sitter grammar crate to Cargo.toml
+2. Create `src/languages/{lang}.rs` implementing `LanguageSupport` trait (~50 lines)
+3. Add to `all()` in `src/languages/mod.rs`
+4. Add auto-detection in `src/config.rs` `detect_test_command()`
+5. Add a test parsing sample code to verify node kinds
+
+## Adding a mutation operator
+
+1. Implement `MutationOperator` trait in the appropriate file under `src/operators/`
+2. Add to `all_operators()` in `src/operators/mod.rs`
+3. The operator checks `node.kind()` and returns `MutationCandidate` with byte range and replacement
+
+## Test command
+
+```bash
+cargo test                    # unit + integration (skips ignored)
+cargo test -- --ignored       # run end-to-end tests (requires go)
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to togi
+
+## Getting started
+
+```bash
+git clone https://github.com/Darkroom4364/togi
+cd togi
+cargo build
+cargo test
+```
+
+## Adding a new language
+
+togi supports any language with a tree-sitter grammar. Adding one takes ~50 lines:
+
+1. Add the grammar crate to `Cargo.toml`:
+   ```toml
+   tree-sitter-java = "0.23"
+   ```
+
+2. Create `src/languages/java.rs`:
+   ```rust
+   pub struct Java;
+
+   impl crate::languages::LanguageSupport for Java {
+       fn name(&self) -> &str { "java" }
+       fn extensions(&self) -> &[&str] { &["java"] }
+       fn tree_sitter_language(&self) -> tree_sitter::Language {
+           tree_sitter_java::LANGUAGE.into()
+       }
+       // ... node mappings
+   }
+   ```
+
+3. Register in `src/languages/mod.rs`:
+   ```rust
+   pub mod java;
+   // and add Box::new(java::Java) to all()
+   ```
+
+4. Add test command detection in `src/config.rs`
+
+5. Verify node kinds by parsing sample code — don't guess!
+
+## Adding a mutation operator
+
+1. Implement `MutationOperator` in the appropriate file under `src/operators/`
+2. Register in `all_operators()` in `src/operators/mod.rs`
+3. Add unit tests using tree-sitter to parse sample code
+
+## Pull requests
+
+- One concern per PR
+- `cargo test` must pass
+- `cargo clippy -- -D warnings` must pass
+- `cargo fmt` must pass


### PR DESCRIPTION
## Summary

- Adds CLAUDE.md with architecture overview, conventions, and guides for adding languages/operators
- Adds CONTRIBUTING.md with getting started, language/operator contribution guides, and PR expectations

Closes #39