### PR TITLE
feat: add TypeScript language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-rust",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -718,6 +719,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ tempfile = "3"
 # Error handling
 anyhow = "1"
 thiserror = "2"
+tree-sitter-typescript = "0.23.2"

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -1,5 +1,6 @@
 pub mod go;
 pub mod rust_lang;
+pub mod typescript;
 
 /// Language-specific configuration for tree-sitter parsing and node identification
 pub trait LanguageSupport: Send + Sync {
@@ -19,5 +20,6 @@ pub fn all() -> Vec<Box<dyn LanguageSupport>> {
     vec![
         Box::new(go::Go),
         Box::new(rust_lang::Rust),
+        Box::new(typescript::TypeScript),
     ]
 }

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -1,0 +1,101 @@
+use crate::languages::LanguageSupport;
+
+pub struct TypeScript;
+
+impl LanguageSupport for TypeScript {
+    fn name(&self) -> &str {
+        "typescript"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ts", "tsx"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    #[test]
+    fn test_extensions() {
+        let ts = TypeScript;
+        assert!(ts.extensions().contains(&"ts"));
+        assert!(ts.extensions().contains(&"tsx"));
+    }
+
+    #[test]
+    fn test_parse_typescript_function() {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&TypeScript.tree_sitter_language())
+            .expect("Error loading TypeScript parser");
+
+        let code = r#"
+function add(a: number, b: number): number {
+    if (a > b) {
+        return a + b;
+    }
+    return true;
+}
+"#;
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+        assert!(!root.has_error());
+    }
+
+    #[test]
+    fn test_binary_expression_found() {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&TypeScript.tree_sitter_language())
+            .expect("Error loading TypeScript parser");
+
+        let code = "const x = a + b;";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        fn find_node<'a>(node: tree_sitter::Node<'a>, kind: &str) -> bool {
+            if node.kind() == kind {
+                return true;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if find_node(child, kind) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        assert!(find_node(root, TypeScript.binary_expression_node()));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `tree-sitter-typescript` dependency
- Implement `LanguageSupport` for TypeScript (`.ts`, `.tsx` extensions)
- Node mappings: binary_expression, if_statement, return_statement, true/false literals
- Unit tests for extension detection, parsing, and binary expression discovery

Closes #31