### PR TITLE
feat: add progress indicator during mutation runs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,11 @@ async fn main() {
             verbose,
             test_cmd,
         } => {
-            if let Err(e) = run_check(base, config, format, jobs, timeout, dry_run, verbose, test_cmd).await {
+            if let Err(e) = run_check(
+                base, config, format, jobs, timeout, dry_run, verbose, test_cmd,
+            )
+            .await
+            {
                 eprintln!("Error: {e}");
                 process::exit(2);
             }
@@ -75,7 +79,10 @@ async fn run_check(
     let diff_output = get_git_diff(&config.diff.base)?;
 
     if diff_output.is_empty() {
-        println!("No changes found in diff against `{}`. Nothing to mutate.", config.diff.base);
+        println!(
+            "No changes found in diff against `{}`. Nothing to mutate.",
+            config.diff.base
+        );
         return Ok(());
     }
 
@@ -100,7 +107,10 @@ async fn run_check(
 
     // 6. Handle dry-run
     if dry_run {
-        println!("Dry run — {} mutations would be generated:", mutations.len());
+        println!(
+            "Dry run — {} mutations would be generated:",
+            mutations.len()
+        );
         for m in &mutations {
             println!(
                 "  [{}] {}:{} — {}: {} → {}",
@@ -116,37 +126,17 @@ async fn run_check(
     }
 
     // 7. Run mutations
-    if verbose {
-        println!("Running {} mutations ({} jobs, {}s timeout)...", mutations.len(), config.test.jobs, config.test.timeout);
-    }
+    eprintln!("Running {} mutations...", mutations.len());
 
     let runner = togi::runner::TestRunner {
         command: config.test.command,
         timeout: Duration::from_secs(config.test.timeout),
         parallelism: config.test.jobs,
         project_root,
+        verbose,
     };
 
-    let total = mutations.len();
-    let report = if verbose {
-        // For verbose, print each mutation before running
-        // We still use the runner but print info first
-        for m in &mutations {
-            eprintln!(
-                "  [{}/{}] {}:{} — {}: {} → {}",
-                m.id + 1,
-                total,
-                m.file.display(),
-                m.line,
-                m.operator,
-                m.original,
-                m.replacement
-            );
-        }
-        runner.run(mutations).await
-    } else {
-        runner.run(mutations).await
-    };
+    let report = runner.run(mutations).await;
 
     // 8. Print report
     togi::report::print_report(&report, &format);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,6 +4,7 @@ use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
@@ -12,6 +13,7 @@ pub struct TestRunner {
     pub timeout: Duration,
     pub parallelism: usize,
     pub project_root: PathBuf,
+    pub verbose: bool,
 }
 
 struct FileGuard {
@@ -28,6 +30,9 @@ impl Drop for FileGuard {
 impl TestRunner {
     pub async fn run(&self, mutations: Vec<Mutation>) -> MutationReport {
         let start = Instant::now();
+        let total = mutations.len();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let verbose = self.verbose;
 
         // Group mutations by file to serialize mutations on the same file
         let mut by_file: HashMap<PathBuf, Vec<Mutation>> = HashMap::new();
@@ -43,6 +48,7 @@ impl TestRunner {
             let command = self.command.clone();
             let timeout = self.timeout;
             let project_root = self.project_root.clone();
+            let counter = counter.clone();
 
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
@@ -50,6 +56,24 @@ impl TestRunner {
                     let _permit = sem.acquire().await.unwrap();
                     let result =
                         run_single_mutation(&command, timeout, &project_root, &mutation).await;
+                    let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                    if verbose {
+                        let symbol = match result {
+                            MutationResult::Killed => "\u{2713} killed",
+                            MutationResult::Survived => "\u{2717} survived",
+                            MutationResult::Timeout => "⧖ timeout",
+                            MutationResult::BuildError => "⚠ build error",
+                        };
+                        eprintln!(
+                            "  [{}/{}] {}  {}:{} \u{2014} {}",
+                            n,
+                            total,
+                            symbol,
+                            mutation.file.display(),
+                            mutation.line,
+                            mutation.operator
+                        );
+                    }
                     results.push((mutation, result));
                 }
                 results
@@ -127,10 +151,8 @@ async fn run_single_mutation(
         return MutationResult::BuildError;
     }
 
-    // Run test command
-    let result = run_command(command, project_root, timeout).await;
-    // Guard will restore the file on drop
-    result
+    // Run test command; guard will restore the file on drop
+    run_command(command, project_root, timeout).await
 }
 
 async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration) -> MutationResult {

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -27,27 +27,40 @@ fn generates_mutations_for_go_fixture() {
     for m in &mutations {
         println!(
             "  [{}] {}:{} — {}: '{}' → '{}'",
-            m.id, m.file.display(), m.line, m.operator, m.original, m.replacement
+            m.id,
+            m.file.display(),
+            m.line,
+            m.operator,
+            m.original,
+            m.replacement
         );
     }
 
     // Expect comparison operator mutations (>, <)
     assert!(
-        operators.iter().any(|o| o.contains("gt") || o.contains("lt")),
+        operators
+            .iter()
+            .any(|o| o.contains("gt") || o.contains("lt")),
         "expected comparison operator mutations, got: {:?}",
         operators
     );
 
     // Expect arithmetic mutations (+, -)
     assert!(
-        operators.iter().any(|o| o.contains("add") || o.contains("sub") || o.contains("plus") || o.contains("minus") || o.contains("arith")),
+        operators.iter().any(|o| o.contains("add")
+            || o.contains("sub")
+            || o.contains("plus")
+            || o.contains("minus")
+            || o.contains("arith")),
         "expected arithmetic mutations, got: {:?}",
         operators
     );
 
     // Expect boolean literal mutations
     assert!(
-        operators.iter().any(|o| o.contains("true") || o.contains("false") || o.contains("bool")),
+        operators
+            .iter()
+            .any(|o| o.contains("true") || o.contains("false") || o.contains("bool")),
         "expected boolean literal mutations, got: {:?}",
         operators
     );
@@ -74,6 +87,7 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
         timeout: Duration::from_secs(30),
         parallelism: 1,
         project_root: root,
+        verbose: false,
     };
 
     let report = runner.run(mutations).await;
@@ -85,7 +99,13 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
     for (m, result) in &report.results {
         println!(
             "  [{}] {}:{} {}: '{}' → '{}' = {}",
-            m.id, m.file.display(), m.line, m.operator, m.original, m.replacement, result
+            m.id,
+            m.file.display(),
+            m.line,
+            m.operator,
+            m.original,
+            m.replacement,
+            result
         );
     }
 


### PR DESCRIPTION
## Summary
- Always prints `Running N mutations...` to stderr as minimal feedback
- In `--verbose` mode, prints per-mutation result lines (`[3/15] ✓ killed ...`) to stderr as each completes
- Uses atomic counter for correct numbering across parallel tasks
- stdout remains clean for JSON output

Closes #35