### PR TITLE
docs: add demo example showing surviving mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,51 @@ base = "origin/main"
 max_per_run = 20
 ```
 
+## Example: finding real test gaps
+
+The repo includes a Go fixture (`tests/fixtures/go/`) with deliberately weak tests.
+Running togi against it produces:
+
+```
+  ✓ KILLED  calc.go:5   — plus_to_minus: Replace + with -
+  ✓ KILLED  calc.go:10  — zero_to_one: Replace 0 with 1
+  ✓ KILLED  calc.go:11  — true_to_false: Replace true with false
+  ✗ SURVIVED  calc.go:13  — false_to_true: Replace false with true
+              Your tests don't catch this mutation.
+  ✗ SURVIVED  calc.go:18  — gt_to_gte: Replace > with >=
+              Your tests don't catch this mutation.
+  ✗ SURVIVED  calc.go:19  — return_empty: Replace return value with default
+              Your tests don't catch this mutation.
+  ✓ KILLED  calc.go:21  — return_empty: Replace return value with default
+  ✗ SURVIVED  calc.go:26  — zero_to_one: Replace 0 with 1
+              Your tests don't catch this mutation.
+  ✗ SURVIVED  calc.go:29  — return_empty: Replace return value with default
+              Your tests don't catch this mutation.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Results: 4/9 mutations killed (5 survived)
+Duration: 1.59s
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Each surviving mutation reveals a concrete test gap:
+
+- **`false_to_true` at line 13** — `TestIsPositive` never checks `IsPositive(0)` or negative inputs
+- **`gt_to_gte` at line 18** — `TestMax` only tests `Max(3,5)`, never the `a > b` path
+- **`return_empty` at line 19** — same: `Max` return value never verified for first-arg-wins
+- **`zero_to_one` at line 26** — `TestAbs` is entirely missing
+- **`return_empty` at line 29** — `Abs` return value never tested
+
+Run it yourself: `cargo test -- --ignored` (requires Go).
+
 ## Supported languages
 
 | Language | Extension | Status |
 |----------|-----------|--------|
 | Go | `.go` | Supported |
 | Rust | `.rs` | Supported |
-| Python | `.py` | Planned |
-| TypeScript | `.ts/.tsx` | Planned |
+| Python | `.py` | Supported |
+| TypeScript | `.ts/.tsx` | Supported |
 
 Adding a language is ~50 lines of tree-sitter node mappings.
 

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Demo: togi finding test gaps in a Go project with weak tests
+# Requires: go, cargo build (or cargo install togi)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$SCRIPT_DIR/.."
+TOGI="$ROOT/target/debug/togi"
+FIXTURE="$ROOT/tests/fixtures/go"
+
+if [[ ! -x "$TOGI" ]]; then
+  echo "Building togi..."
+  cargo build --manifest-path "$ROOT/Cargo.toml"
+fi
+
+echo "=== togi demo: finding test gaps ==="
+echo ""
+echo "The fixture has 4 Go functions with deliberately weak tests:"
+echo "  - TestAdd:        only tests Add(2,3)"
+echo "  - TestIsPositive: only tests IsPositive(1), misses 0 and negatives"
+echo "  - TestMax:        only tests Max(3,5), misses a>b case"
+echo "  - TestAbs:        MISSING entirely"
+echo ""
+
+# Work in a temp copy so we don't pollute the fixture
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cp -r "$FIXTURE"/* "$WORK/"
+cd "$WORK"
+
+# Set up git history: empty commit, then add all files
+git init -q
+git commit --allow-empty -q -m "empty"
+git add -A
+git commit -q -m "add calc module"
+
+echo "Running: togi check --base HEAD~1 --test-cmd 'go test ./...' --jobs 1"
+echo ""
+
+# GOWORK=off avoids Go complaining about workspace in temp dirs
+GOWORK=off "$TOGI" check --base HEAD~1 --test-cmd "go test ./..." --timeout 30 --jobs 1 || true


### PR DESCRIPTION
## Summary
- Adds "Example: finding real test gaps" section to README with real CLI output from the Go fixture (5/9 mutations survive)
- Adds `examples/demo.sh` script to reproduce the demo locally
- Updates supported languages table (Python/TypeScript now supported)

Closes #33