### PR TITLE
feat: release automation and GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: togi-linux-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            name: togi-macos-arm64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            name: togi-macos-x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.name }}.tar.gz togi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: '*.tar.gz'
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -167,6 +167,26 @@ togi applies 14 targeted mutation operators:
 | 1 | Some mutations survived — test gaps found |
 | 2 | Error (config, git, parse failure) |
 
+## CI Integration
+
+Add togi to your pull request workflow:
+
+```yaml
+# .github/workflows/togi.yml
+name: Mutation Testing
+on: [pull_request]
+jobs:
+  togi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Darkroom4364/togi@v1
+        with:
+          base: origin/main
+```
+
 ## License
 
 Apache-2.0

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,56 @@
+name: 'togi - Mutation Testing'
+description: 'Fast, diff-targeted mutation testing for your PRs'
+branding:
+  icon: 'shield'
+  color: 'orange'
+
+inputs:
+  base:
+    description: 'Base branch to diff against'
+    required: false
+    default: 'origin/main'
+  timeout:
+    description: 'Per-mutation timeout in seconds'
+    required: false
+    default: '30'
+  test-cmd:
+    description: 'Test command override'
+    required: false
+  format:
+    description: 'Output format (terminal or json)'
+    required: false
+    default: 'terminal'
+  version:
+    description: 'togi version to use'
+    required: false
+    default: 'latest'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install togi
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(curl -s https://api.github.com/repos/Darkroom4364/togi/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+        fi
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+          NAME="togi-${OS}-arm64"
+        else
+          NAME="togi-${OS}-x86_64"
+        fi
+        curl -sL "https://github.com/Darkroom4364/togi/releases/download/${VERSION}/${NAME}.tar.gz" | tar xz
+        chmod +x togi
+        sudo mv togi /usr/local/bin/
+
+    - name: Run togi
+      shell: bash
+      run: |
+        ARGS="check --base ${{ inputs.base }} --timeout ${{ inputs.timeout }} --format ${{ inputs.format }}"
+        if [ -n "${{ inputs.test-cmd }}" ]; then
+          ARGS="$ARGS --test-cmd '${{ inputs.test-cmd }}'"
+        fi
+        togi $ARGS


### PR DESCRIPTION
## Summary

- Add release workflow that builds Linux x86_64 and macOS (arm64/x86_64) binaries on tag push, creates GitHub Release with tarballs
- Add `action.yml` composite action so users can run togi in their PR workflows with `uses: Darkroom4364/togi@v1`
- Add CI Integration section to README with usage example

Closes #37
Closes #38