### PR TITLE
fix: handle edge cases in diff parsing, mutation, and test execution

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -74,6 +74,16 @@ pub fn parse_diff(input: &str) -> Vec<ChangedFile> {
         }
     }
 
+    // Warn if diff is very large
+    let total_changed: usize = files.iter().flat_map(|f| &f.hunks).map(|h| h.end - h.start + 1).sum();
+    if total_changed > 1000 {
+        eprintln!(
+            "warning: diff contains {} changed lines across {} files; mutations will be capped by max_per_run",
+            total_changed,
+            files.len()
+        );
+    }
+
     files
 }
 
@@ -161,6 +171,39 @@ index 1111111..2222222 100644
         let files = parse_diff(diff);
         // No added lines → no hunks → file not included
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn skips_binary_files() {
+        let diff = r#"diff --git a/image.png b/image.png
+Binary files a/image.png and b/image.png differ
+diff --git a/src/main.rs b/src/main.rs
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,3 +1,4 @@
+ fn main() {
++    println!("hi");
+ }
+"#;
+        let files = parse_diff(diff);
+        // Binary file has no `+++ b/...` line, so it is skipped
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
+    }
+
+    #[test]
+    fn deleted_file_produces_no_mutations() {
+        let diff = r#"diff --git a/removed.rs b/removed.rs
+--- a/removed.rs
++++ b/removed.rs
+@@ -1,4 +1,0 @@
+-fn old() {
+-    // deleted
+-    println!("gone");
+-}
+"#;
+        let files = parse_diff(diff);
+        assert!(files.is_empty(), "deleted-only file should produce no hunks");
     }
 
     #[test]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -117,6 +117,19 @@ mod tests {
     }
 
     #[test]
+    fn skips_nonexistent_files() {
+        let tmp = TempDir::new().unwrap();
+        // Reference a file that doesn't exist on disk
+        let changed = vec![ChangedFile {
+            path: PathBuf::from("ghost/missing.go"),
+            hunks: vec![LineRange { start: 1, end: 5 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        assert!(mutations.is_empty());
+    }
+
+    #[test]
     fn skips_unsupported_file_types() {
         let tmp = TempDir::new().unwrap();
         let rel = write_go_file(tmp.path(), "notes.txt", "hello world");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -261,6 +261,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn empty_replacement_splices_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+
+        // Replace "hello" with "" (empty), making the file shorter
+        let mutation = Mutation {
+            id: 1,
+            file: file.clone(),
+            line: 1,
+            column: 1,
+            operator: "removal".into(),
+            description: "remove text".into(),
+            original: "hello".into(),
+            replacement: "".into(),
+            byte_range: 0..5,
+        };
+
+        let result = run_single_mutation(
+            &["true".to_string()],
+            Duration::from_secs(5),
+            &dir.path().to_path_buf(),
+            &mutation,
+        )
+        .await;
+
+        assert_eq!(result, MutationResult::Survived);
+        // File should be restored to original
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn command_not_found_returns_build_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+
+        let mutation = make_test_mutation(&file);
+
+        let result = run_single_mutation(
+            &["nonexistent_binary_xyz_12345".to_string()],
+            Duration::from_secs(5),
+            &dir.path().to_path_buf(),
+            &mutation,
+        )
+        .await;
+
+        assert_eq!(result, MutationResult::BuildError);
+        // File should be restored
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+    }
+
+    #[tokio::test]
     async fn command_timeout_returns_timeout() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary
- Add warning log to stderr when diff exceeds 1000 changed lines
- Add unit tests for: binary files in diffs, deleted-only files, nonexistent files on disk, empty replacement splicing, and command-not-found returning BuildError
- All edge cases already handled gracefully in existing code; this adds verification tests

Closes #34