### PR TITLE
ci: dogfood togi on its own codebase in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,17 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Format
         run: cargo fmt -- --check
+
+  dogfood:
+    name: Dogfood (togi on togi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build togi
+        run: cargo build --release
+      - name: Run togi on last commit
+        run: ./target/release/togi check --base HEAD~1 --test-cmd "cargo test" --format terminal || true


### PR DESCRIPTION
## Summary
- Add dogfood job to CI that runs togi on its own last commit
- Informational (`|| true`) — reports mutations but doesn't block
- Validates the full pipeline works in CI

Dogfood results: 5/18 killed, 13 survived (mostly main.rs CLI glue with no unit tests)

Closes #40