### PR TITLE
test: add unit tests for boundary and removal operators

### DIFF
--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -51,3 +51,57 @@ impl MutationOperator for MinusToPlus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_go(src: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_go::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(src, None).unwrap()
+    }
+
+    fn find_first_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == kind {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_first_kind(child, kind) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_plus_to_minus() {
+        let src = "package main\nfunc f(a, b int) int { return a + b }";
+        let tree = parse_go(src);
+        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let candidates = PlusToMinus.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "-");
+    }
+
+    #[test]
+    fn test_minus_to_plus() {
+        let src = "package main\nfunc f(a, b int) int { return a - b }";
+        let tree = parse_go(src);
+        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let candidates = MinusToPlus.apply(&bin, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "+");
+    }
+
+    #[test]
+    fn test_no_match_on_comparison() {
+        let src = "package main\nfunc f(a, b int) bool { return a < b }";
+        let tree = parse_go(src);
+        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let candidates = PlusToMinus.apply(&bin, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+}

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -67,3 +67,70 @@ impl MutationOperator for RemoveElse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_go(src: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_go::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(src, None).unwrap()
+    }
+
+    fn find_first_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == kind {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_first_kind(child, kind) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_remove_if_body() {
+        let src = r#"package main
+func f(x int) { if x > 0 { println("yes") } }"#;
+        let tree = parse_go(src);
+        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let candidates = RemoveIfBody.apply(&if_node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "{}");
+    }
+
+    #[test]
+    fn test_remove_else() {
+        let src = "package main\nfunc f(x int) int { if x > 0 { return 1 } else { return 0 } }";
+        let tree = parse_go(src);
+        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let candidates = RemoveElse.apply(&if_node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "");
+        // The byte range should cover the else clause
+        let removed = &src[candidates[0].byte_range.clone()];
+        assert!(removed.contains("else"));
+    }
+
+    #[test]
+    fn test_remove_if_body_no_match_on_for() {
+        let src = "package main\nfunc f() { for i := 0; i < 10; i++ { println(i) } }";
+        let tree = parse_go(src);
+        let for_node = find_first_kind(tree.root_node(), "for_statement").unwrap();
+        let candidates = RemoveIfBody.apply(&for_node, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_remove_else_no_else_clause() {
+        let src = "package main\nfunc f(x int) { if x > 0 { println(x) } }";
+        let tree = parse_go(src);
+        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let candidates = RemoveElse.apply(&if_node, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add 3 unit tests for boundary operators (PlusToMinus, MinusToPlus, no-match on comparison)
- Add 4 unit tests for removal operators (RemoveIfBody, RemoveElse, no-match on for loop, no else clause)

## Test plan
- `cargo test -- boundary removal` passes all 7 tests