### PR TITLE
fix: resolve all clippy warnings and format issues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub test: TestConfig,
@@ -71,16 +71,6 @@ fn default_base() -> String {
 
 fn default_max_per_run() -> usize {
     20
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            test: TestConfig::default(),
-            diff: DiffConfig::default(),
-            mutations: MutationConfig::default(),
-        }
-    }
 }
 
 impl Default for TestConfig {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -17,23 +17,25 @@ pub fn parse_diff(input: &str) -> Vec<ChangedFile> {
     let mut range_end: usize = 0;
 
     for line in input.lines() {
-        if line.starts_with("+++ ") {
+        if let Some(path_str) = line.strip_prefix("+++ ") {
             // Flush previous hunk range
             flush_range(&mut current_hunks, &mut range_start, range_end);
             in_hunk = false;
 
             // Flush previous file
-            if let Some(path) = current_path.take() {
-                if !current_hunks.is_empty() {
-                    files.push(ChangedFile { path, hunks: current_hunks });
-                }
+            if let Some(path) = current_path.take()
+                && !current_hunks.is_empty()
+            {
+                files.push(ChangedFile {
+                    path,
+                    hunks: current_hunks,
+                });
             }
             current_hunks = Vec::new();
 
             // Extract path, stripping the `b/` prefix
-            let path_str = &line[4..];
-            let path = if path_str.starts_with("b/") {
-                PathBuf::from(&path_str[2..])
+            let path = if let Some(stripped) = path_str.strip_prefix("b/") {
+                PathBuf::from(stripped)
             } else {
                 PathBuf::from(path_str)
             };
@@ -68,14 +70,21 @@ pub fn parse_diff(input: &str) -> Vec<ChangedFile> {
 
     // Flush final state
     flush_range(&mut current_hunks, &mut range_start, range_end);
-    if let Some(path) = current_path.take() {
-        if !current_hunks.is_empty() {
-            files.push(ChangedFile { path, hunks: current_hunks });
-        }
+    if let Some(path) = current_path.take()
+        && !current_hunks.is_empty()
+    {
+        files.push(ChangedFile {
+            path,
+            hunks: current_hunks,
+        });
     }
 
     // Warn if diff is very large
-    let total_changed: usize = files.iter().flat_map(|f| &f.hunks).map(|h| h.end - h.start + 1).sum();
+    let total_changed: usize = files
+        .iter()
+        .flat_map(|f| &f.hunks)
+        .map(|h| h.end - h.start + 1)
+        .sum();
     if total_changed > 1000 {
         eprintln!(
             "warning: diff contains {} changed lines across {} files; mutations will be capped by max_per_run",
@@ -203,7 +212,10 @@ diff --git a/src/main.rs b/src/main.rs
 -}
 "#;
         let files = parse_diff(diff);
-        assert!(files.is_empty(), "deleted-only file should produce no hunks");
+        assert!(
+            files.is_empty(),
+            "deleted-only file should produce no hunks"
+        );
     }
 
     #[test]

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -80,7 +80,11 @@ mod tests {
             }
         }
         walk(&mut cursor, py.binary_expression_node(), &mut found);
-        assert!(found, "Expected to find '{}' node in Python AST", py.binary_expression_node());
+        assert!(
+            found,
+            "Expected to find '{}' node in Python AST",
+            py.binary_expression_node()
+        );
     }
 
     #[test]
@@ -111,7 +115,11 @@ mod tests {
             }
         }
         walk(&mut cursor, py.if_statement_node(), &mut found);
-        assert!(found, "Expected to find '{}' node in Python AST", py.if_statement_node());
+        assert!(
+            found,
+            "Expected to find '{}' node in Python AST",
+            py.if_statement_node()
+        );
     }
 
     #[test]
@@ -128,10 +136,20 @@ mod tests {
         let mut found_return = false;
         let mut found_binary = false;
         let mut cursor = root.walk();
-        fn walk(cursor: &mut tree_sitter::TreeCursor, ret: &str, bin: &str, fr: &mut bool, fb: &mut bool) {
+        fn walk(
+            cursor: &mut tree_sitter::TreeCursor,
+            ret: &str,
+            bin: &str,
+            fr: &mut bool,
+            fb: &mut bool,
+        ) {
             let kind = cursor.node().kind();
-            if kind == ret { *fr = true; }
-            if kind == bin { *fb = true; }
+            if kind == ret {
+                *fr = true;
+            }
+            if kind == bin {
+                *fb = true;
+            }
             if cursor.goto_first_child() {
                 loop {
                     walk(cursor, ret, bin, fr, fb);
@@ -142,7 +160,13 @@ mod tests {
                 cursor.goto_parent();
             }
         }
-        walk(&mut cursor, py.return_statement_node(), py.binary_expression_node(), &mut found_return, &mut found_binary);
+        walk(
+            &mut cursor,
+            py.return_statement_node(),
+            py.binary_expression_node(),
+            &mut found_return,
+            &mut found_binary,
+        );
         assert!(found_return, "Expected return_statement node");
         assert!(found_binary, "Expected binary_operator node");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ async fn main() {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_check(
     base: String,
     config_path: Option<PathBuf>,
@@ -105,7 +106,9 @@ async fn run_check(
     )?;
 
     if mutations.is_empty() {
-        println!("No mutations generated. This can happen if the changed files are in an unsupported language.\nSupported: Go (.go), Rust (.rs), Python (.py), TypeScript (.ts/.tsx)");
+        println!(
+            "No mutations generated. This can happen if the changed files are in an unsupported language.\nSupported: Go (.go), Rust (.rs), Python (.py), TypeScript (.ts/.tsx)"
+        );
         return Ok(());
     }
 

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -42,10 +42,8 @@ pub fn generate_mutations(
 
                     let line = node.start_position().row + 1;
                     let column = node.start_position().column + 1;
-                    let original = String::from_utf8_lossy(
-                        &source[candidate.byte_range.clone()],
-                    )
-                    .to_string();
+                    let original =
+                        String::from_utf8_lossy(&source[candidate.byte_range.clone()]).to_string();
 
                     mutations.push(Mutation {
                         id: next_id,
@@ -97,8 +95,16 @@ mod tests {
         assert!(!mutations.is_empty());
 
         let operators: Vec<&str> = mutations.iter().map(|m| m.operator.as_str()).collect();
-        assert!(operators.contains(&"lt_to_lte"), "expected lt_to_lte, got: {:?}", operators);
-        assert!(operators.contains(&"true_to_false"), "expected true_to_false, got: {:?}", operators);
+        assert!(
+            operators.contains(&"lt_to_lte"),
+            "expected lt_to_lte, got: {:?}",
+            operators
+        );
+        assert!(
+            operators.contains(&"true_to_false"),
+            "expected true_to_false, got: {:?}",
+            operators
+        );
     }
 
     #[test]

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,9 +1,13 @@
-use crate::MutationCandidate;
 use super::MutationOperator;
+use crate::MutationCandidate;
 
 const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
 
-pub fn find_operator_child(node: &tree_sitter::Node, source: &[u8], target: &str) -> Option<std::ops::Range<usize>> {
+pub fn find_operator_child(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    target: &str,
+) -> Option<std::ops::Range<usize>> {
     // Try field name "operator" first
     if let Some(op_node) = node.child_by_field_name("operator") {
         let text = &source[op_node.byte_range()];
@@ -33,8 +37,12 @@ macro_rules! binary_operator {
         pub struct $name;
 
         impl MutationOperator for $name {
-            fn id(&self) -> &str { $id }
-            fn description(&self) -> &str { $desc }
+            fn id(&self) -> &str {
+                $id
+            }
+            fn description(&self) -> &str {
+                $desc
+            }
             fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
                 if !is_binary_expr(node) {
                     return vec![];

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -1,6 +1,6 @@
-use crate::MutationCandidate;
 use super::MutationOperator;
 use super::binary::find_operator_child;
+use crate::MutationCandidate;
 
 const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
 
@@ -11,8 +11,12 @@ fn is_binary_expr(node: &tree_sitter::Node) -> bool {
 pub struct PlusToMinus;
 
 impl MutationOperator for PlusToMinus {
-    fn id(&self) -> &str { "plus_to_minus" }
-    fn description(&self) -> &str { "Replace + with -" }
+    fn id(&self) -> &str {
+        "plus_to_minus"
+    }
+    fn description(&self) -> &str {
+        "Replace + with -"
+    }
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
         if !is_binary_expr(node) {
             return vec![];
@@ -33,8 +37,12 @@ impl MutationOperator for PlusToMinus {
 pub struct MinusToPlus;
 
 impl MutationOperator for MinusToPlus {
-    fn id(&self) -> &str { "minus_to_plus" }
-    fn description(&self) -> &str { "Replace - with +" }
+    fn id(&self) -> &str {
+        "minus_to_plus"
+    }
+    fn description(&self) -> &str {
+        "Replace - with +"
+    }
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
         if !is_binary_expr(node) {
             return vec![];
@@ -63,7 +71,10 @@ mod tests {
         parser.parse(src, None).unwrap()
     }
 
-    fn find_first_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+    fn find_first_kind<'a>(
+        node: tree_sitter::Node<'a>,
+        kind: &str,
+    ) -> Option<tree_sitter::Node<'a>> {
         if node.kind() == kind {
             return Some(node);
         }

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -1,5 +1,5 @@
-use crate::MutationCandidate;
 use super::MutationOperator;
+use crate::MutationCandidate;
 
 const TRUE_KINDS: &[&str] = &["true", "True", "TRUE"];
 const FALSE_KINDS: &[&str] = &["false", "False", "FALSE"];
@@ -8,8 +8,12 @@ const INT_LITERAL_KINDS: &[&str] = &["integer_literal", "int_literal", "number",
 pub struct TrueToFalse;
 
 impl MutationOperator for TrueToFalse {
-    fn id(&self) -> &str { "true_to_false" }
-    fn description(&self) -> &str { "Replace true with false" }
+    fn id(&self) -> &str {
+        "true_to_false"
+    }
+    fn description(&self) -> &str {
+        "Replace true with false"
+    }
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
         if TRUE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
@@ -29,8 +33,12 @@ impl MutationOperator for TrueToFalse {
 pub struct FalseToTrue;
 
 impl MutationOperator for FalseToTrue {
-    fn id(&self) -> &str { "false_to_true" }
-    fn description(&self) -> &str { "Replace false with true" }
+    fn id(&self) -> &str {
+        "false_to_true"
+    }
+    fn description(&self) -> &str {
+        "Replace false with true"
+    }
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
         if FALSE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
@@ -50,8 +58,12 @@ impl MutationOperator for FalseToTrue {
 pub struct ZeroToOne;
 
 impl MutationOperator for ZeroToOne {
-    fn id(&self) -> &str { "zero_to_one" }
-    fn description(&self) -> &str { "Replace 0 with 1" }
+    fn id(&self) -> &str {
+        "zero_to_one"
+    }
+    fn description(&self) -> &str {
+        "Replace 0 with 1"
+    }
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
         if INT_LITERAL_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
@@ -122,8 +134,7 @@ mod tests {
     fn test_false_to_true() {
         let src = "package main\nfunc f() bool { return false }";
         let tree = parse_go(src);
-        let node =
-            find_node_by_kind(tree.root_node(), "false").expect("should find false node");
+        let node = find_node_by_kind(tree.root_node(), "false").expect("should find false node");
         let candidates = FalseToTrue.apply(&node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "true");
@@ -155,7 +166,12 @@ mod tests {
         let src = "package main\nvar trueValue = 1";
         let tree = parse_go(src);
         let mut candidates = vec![];
-        collect_all_candidates(tree.root_node(), src.as_bytes(), &TrueToFalse, &mut candidates);
+        collect_all_candidates(
+            tree.root_node(),
+            src.as_bytes(),
+            &TrueToFalse,
+            &mut candidates,
+        );
         assert!(candidates.is_empty());
     }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -30,8 +30,8 @@ impl MutationOperator for NegateCondition {
         let cond = node.child_by_field_name("condition");
         if let Some(cond_node) = cond {
             let text = std::str::from_utf8(&source[cond_node.byte_range()]).unwrap_or("");
-            let replacement = if text.starts_with('!') {
-                text[1..]
+            let replacement = if let Some(stripped) = text.strip_prefix('!') {
+                stripped
                     .trim_start_matches('(')
                     .trim_end_matches(')')
                     .to_string()

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -1,19 +1,24 @@
-use crate::MutationCandidate;
 use super::MutationOperator;
+use crate::MutationCandidate;
 
 const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
 
 pub struct RemoveIfBody;
 
 impl MutationOperator for RemoveIfBody {
-    fn id(&self) -> &str { "remove_if_body" }
-    fn description(&self) -> &str { "Replace if body with empty block" }
+    fn id(&self) -> &str {
+        "remove_if_body"
+    }
+    fn description(&self) -> &str {
+        "Replace if body with empty block"
+    }
     fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
         if !IF_STMT_KINDS.contains(&node.kind()) {
             return vec![];
         }
         // Look for "consequence" or "body" field
-        let body = node.child_by_field_name("consequence")
+        let body = node
+            .child_by_field_name("consequence")
             .or_else(|| node.child_by_field_name("body"));
         if let Some(body_node) = body {
             vec![MutationCandidate {
@@ -31,14 +36,19 @@ impl MutationOperator for RemoveIfBody {
 pub struct RemoveElse;
 
 impl MutationOperator for RemoveElse {
-    fn id(&self) -> &str { "remove_else" }
-    fn description(&self) -> &str { "Remove else clause" }
+    fn id(&self) -> &str {
+        "remove_else"
+    }
+    fn description(&self) -> &str {
+        "Remove else clause"
+    }
     fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
         if !IF_STMT_KINDS.contains(&node.kind()) {
             return vec![];
         }
         // Look for "alternative" or "else" field
-        let else_clause = node.child_by_field_name("alternative")
+        let else_clause = node
+            .child_by_field_name("alternative")
             .or_else(|| node.child_by_field_name("else"));
         if let Some(else_node) = else_clause {
             // Find the "else" keyword before the clause to remove it too
@@ -79,7 +89,10 @@ mod tests {
         parser.parse(src, None).unwrap()
     }
 
-    fn find_first_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+    fn find_first_kind<'a>(
+        node: tree_sitter::Node<'a>,
+        kind: &str,
+    ) -> Option<tree_sitter::Node<'a>> {
         if node.kind() == kind {
             return Some(node);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,11 +1,14 @@
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::languages::{self, LanguageSupport};
 
 /// Parse a source file with tree-sitter, auto-detecting language from extension.
-pub fn parse_file(path: &Path, source: &[u8]) -> Result<(tree_sitter::Tree, Box<dyn LanguageSupport>)> {
+pub fn parse_file(
+    path: &Path,
+    source: &[u8],
+) -> Result<(tree_sitter::Tree, Box<dyn LanguageSupport>)> {
     let lang = detect_language(path)?;
     let mut parser = tree_sitter::Parser::new();
     parser.set_language(&lang.tree_sitter_language())?;

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -87,8 +87,12 @@ pub fn format_report_plain(report: &MutationReport) -> String {
 
         match result {
             MutationResult::Killed => {
-                writeln!(out, "  ✓ KILLED    {}:{} — {}: {}", file, line, operator, desc)
-                    .unwrap();
+                writeln!(
+                    out,
+                    "  ✓ KILLED    {}:{} — {}: {}",
+                    file, line, operator, desc
+                )
+                .unwrap();
             }
             MutationResult::Survived => {
                 writeln!(
@@ -100,8 +104,12 @@ pub fn format_report_plain(report: &MutationReport) -> String {
                 writeln!(out, "              Your tests don't catch this mutation.").unwrap();
             }
             MutationResult::Timeout => {
-                writeln!(out, "  ⏱ TIMEOUT   {}:{} — {}: {}", file, line, operator, desc)
-                    .unwrap();
+                writeln!(
+                    out,
+                    "  ⏱ TIMEOUT   {}:{} — {}: {}",
+                    file, line, operator, desc
+                )
+                .unwrap();
             }
             MutationResult::BuildError => {
                 writeln!(


### PR DESCRIPTION
## Summary
- Fix clippy: derivable_impls, manual_strip, collapsible_if, too_many_arguments
- Run cargo fmt across all files
- CI should now pass cleanly