### PR TITLE
fix: centralize line indexing and move diff warning to mutator

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -79,20 +79,6 @@ pub fn parse_diff(input: &str) -> Vec<ChangedFile> {
         });
     }
 
-    // Warn if diff is very large
-    let total_changed: usize = files
-        .iter()
-        .flat_map(|f| &f.hunks)
-        .map(|h| h.end - h.start + 1)
-        .sum();
-    if total_changed > 1000 {
-        eprintln!(
-            "warning: diff contains {} changed lines across {} files; mutations will be capped by max_per_run",
-            total_changed,
-            files.len()
-        );
-    }
-
     files
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,16 @@ use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// Convert a 0-indexed tree-sitter row to a 1-indexed source line number.
+///
+/// Unified diffs and user-facing output use 1-indexed lines; tree-sitter uses
+/// 0-indexed rows. This function is the single conversion point between the two
+/// systems, preventing scattered `+ 1` arithmetic and off-by-one bugs.
+#[inline]
+pub fn ts_row_to_line(row: usize) -> usize {
+    row + 1
+}
+
 /// A file with changed line ranges from a diff
 #[derive(Debug, Clone)]
 pub struct ChangedFile {
@@ -20,7 +30,11 @@ pub struct ChangedFile {
     pub hunks: Vec<LineRange>,
 }
 
-/// A range of changed lines (1-indexed, inclusive)
+/// A range of changed lines (1-indexed, inclusive).
+///
+/// All line numbers in togi are 1-indexed to match unified diff format and
+/// user-facing output. Tree-sitter 0-indexed rows must be converted via
+/// [`ts_row_to_line`] before comparison with these ranges.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LineRange {
     pub start: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,13 @@ async fn run_check(
         config.mutations.max_per_run,
     )?;
 
+    if mutations.len() >= config.mutations.max_per_run {
+        eprintln!(
+            "warning: mutation count capped at max_per_run ({}). Increase in togi.toml or use --dry-run to preview.",
+            config.mutations.max_per_run
+        );
+    }
+
     if mutations.is_empty() {
         println!(
             "No mutations generated. This can happen if the changed files are in an unsupported language.\nSupported: Go (.go), Rust (.rs), Python (.py), TypeScript (.ts/.tsx)"

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,6 +1,6 @@
 // Map changed lines to AST nodes
 
-use crate::LineRange;
+use crate::{ts_row_to_line, LineRange};
 
 /// Node kinds that are relevant for mutation testing.
 const MUTABLE_NODE_KINDS: &[&str] = &[
@@ -39,9 +39,8 @@ fn collect_mutable_nodes<'a>(
 ) {
     let _ = source; // available for future use
 
-    // Convert 0-indexed rows to 1-indexed lines
-    let node_start = node.start_position().row + 1;
-    let node_end = node.end_position().row + 1;
+    let node_start = ts_row_to_line(node.start_position().row);
+    let node_end = ts_row_to_line(node.end_position().row);
 
     // Check if this node overlaps any changed line range
     if !overlaps(node_start, node_end, changed_lines) {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,6 +1,6 @@
 // Map changed lines to AST nodes
 
-use crate::{ts_row_to_line, LineRange};
+use crate::{LineRange, ts_row_to_line};
 
 /// Node kinds that are relevant for mutation testing.
 const MUTABLE_NODE_KINDS: &[&str] = &[

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -2,7 +2,7 @@
 
 use crate::mapper::find_mutable_nodes;
 use crate::operators::{self};
-use crate::{ChangedFile, Mutation};
+use crate::{ts_row_to_line, ChangedFile, Mutation};
 use anyhow::Result;
 use std::path::Path;
 
@@ -40,8 +40,8 @@ pub fn generate_mutations(
                         return Ok(mutations);
                     }
 
-                    let line = node.start_position().row + 1;
-                    let column = node.start_position().column + 1;
+                    let line = ts_row_to_line(node.start_position().row);
+                    let column = node.start_position().column + 1; // 1-indexed for display
                     let original =
                         String::from_utf8_lossy(&source[candidate.byte_range.clone()]).to_string();
 

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -2,7 +2,7 @@
 
 use crate::mapper::find_mutable_nodes;
 use crate::operators::{self};
-use crate::{ts_row_to_line, ChangedFile, Mutation};
+use crate::{ChangedFile, Mutation, ts_row_to_line};
 use anyhow::Result;
 use std::path::Path;
 


### PR DESCRIPTION
## Summary
- Add `ts_row_to_line()` helper to centralize tree-sitter 0-indexed → 1-indexed conversion, preventing scattered `+ 1` arithmetic and off-by-one bugs
- Remove misleading warning from diff parser that referenced `max_per_run` but had no access to it
- Surface an actionable warning in `main.rs` when mutations are actually capped, with guidance to adjust config or use `--dry-run`

Closes #73, closes #66

## Test plan
- [x] `cargo test` — all 68 unit tests pass
- [x] `cargo clippy -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy warnings for very large diffs.

* **New Features**
  * Added a warning when mutation generation hits the configured per-run cap, with suggestions to increase the limit or run a dry preview.

* **Refactor**
  * Standardized how source line numbers are computed and reported for more consistent mutation locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->