### PR TITLE
feat: add lockfile to prevent concurrent togi runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.swo
 .DS_Store
+.togi.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ tempfile = "3"
 # Error handling
 anyhow = "1"
 thiserror = "2"
+
+# Platform
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 tree-sitter-typescript = "0.23.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tree-sitter = "0.26"
 tree-sitter-go = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"
+tree-sitter-typescript = "0.23.2"
 
 # Diff parsing
 diffy = "0.4"
@@ -43,7 +44,6 @@ thiserror = "2"
 # Platform
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-tree-sitter-typescript = "0.23.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod config;
 pub mod diff;
 pub mod languages;
+pub mod lock;
 pub mod mapper;
 pub mod mutator;
 pub mod operators;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,7 +1,8 @@
 //! File-based lock to prevent concurrent togi runs on the same repo.
 
 use anyhow::{Context, Result, bail};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const LOCK_FILE: &str = ".togi.lock";
@@ -23,26 +24,40 @@ pub fn acquire(project_root: &Path) -> Result<LockGuard> {
     let path = project_root.join(LOCK_FILE);
     let pid = std::process::id();
 
-    if path.exists() {
-        let contents = fs::read_to_string(&path).unwrap_or_default();
-        if let Ok(existing_pid) = contents.trim().parse::<u32>()
-            && process_alive(existing_pid)
-        {
-            bail!(
-                "another togi process (PID {}) is already running in this directory.\n\
-                 If this is stale, remove {} manually.",
-                existing_pid,
-                path.display()
-            );
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => {
+            file.write_all(pid.to_string().as_bytes())
+                .with_context(|| format!("failed to write lock file: {}", path.display()))?;
+            Ok(LockGuard { path })
         }
-        // Stale lock — previous process died without cleanup
-        fs::remove_file(&path).ok();
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Lock file exists — check if the holder is still alive
+            let contents = fs::read_to_string(&path).unwrap_or_default();
+            if let Ok(existing_pid) = contents.trim().parse::<u32>()
+                && process_alive(existing_pid)
+            {
+                bail!(
+                    "another togi process (PID {}) is already running in this directory.\n\
+                     If this is stale, remove {} manually.",
+                    existing_pid,
+                    path.display()
+                );
+            }
+            // Stale lock — remove and retry once
+            fs::remove_file(&path).ok();
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .with_context(|| format!("failed to create lock file: {}", path.display()))?;
+            file.write_all(pid.to_string().as_bytes())
+                .with_context(|| format!("failed to write lock file: {}", path.display()))?;
+            Ok(LockGuard { path })
+        }
+        Err(e) => {
+            Err(e).with_context(|| format!("failed to create lock file: {}", path.display()))
+        }
     }
-
-    fs::write(&path, pid.to_string())
-        .with_context(|| format!("failed to create lock file: {}", path.display()))?;
-
-    Ok(LockGuard { path })
 }
 
 fn process_alive(pid: u32) -> bool {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,6 +1,6 @@
 //! File-based lock to prevent concurrent togi runs on the same repo.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,103 @@
+//! File-based lock to prevent concurrent togi runs on the same repo.
+
+use anyhow::{bail, Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const LOCK_FILE: &str = ".togi.lock";
+
+/// RAII lock guard. Removes the lock file on drop.
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Acquire a lock for the given project root directory.
+/// Returns an error if another togi process is already running.
+pub fn acquire(project_root: &Path) -> Result<LockGuard> {
+    let path = project_root.join(LOCK_FILE);
+    let pid = std::process::id();
+
+    if path.exists() {
+        let contents = fs::read_to_string(&path).unwrap_or_default();
+        if let Ok(existing_pid) = contents.trim().parse::<u32>()
+            && process_alive(existing_pid)
+        {
+            bail!(
+                "another togi process (PID {}) is already running in this directory.\n\
+                 If this is stale, remove {} manually.",
+                existing_pid,
+                path.display()
+            );
+        }
+        // Stale lock — previous process died without cleanup
+        fs::remove_file(&path).ok();
+    }
+
+    fs::write(&path, pid.to_string())
+        .with_context(|| format!("failed to create lock file: {}", path.display()))?;
+
+    Ok(LockGuard { path })
+}
+
+fn process_alive(pid: u32) -> bool {
+    // PID 0 and overflow values are not valid process IDs
+    if pid == 0 || pid > i32::MAX as u32 {
+        return false;
+    }
+    // On Unix, signal 0 checks if process exists without sending a signal
+    #[cfg(unix)]
+    {
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn acquire_and_release() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join(LOCK_FILE);
+
+        {
+            let _guard = acquire(dir.path()).unwrap();
+            assert!(lock_path.exists());
+        }
+        // Lock removed after drop
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn rejects_concurrent_lock() {
+        let dir = TempDir::new().unwrap();
+
+        let _guard = acquire(dir.path()).unwrap();
+        let result = acquire(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cleans_stale_lock() {
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join(LOCK_FILE);
+
+        // Write a lock with a PID that (almost certainly) doesn't exist
+        fs::write(&lock_path, "4294967295").unwrap();
+
+        let _guard = acquire(dir.path()).unwrap();
+        assert!(lock_path.exists());
+    }
+}

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -54,9 +54,7 @@ pub fn acquire(project_root: &Path) -> Result<LockGuard> {
                 .with_context(|| format!("failed to write lock file: {}", path.display()))?;
             Ok(LockGuard { path })
         }
-        Err(e) => {
-            Err(e).with_context(|| format!("failed to create lock file: {}", path.display()))
-        }
+        Err(e) => Err(e).with_context(|| format!("failed to create lock file: {}", path.display())),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,9 @@ async fn run_check(
     // Find project root (git toplevel)
     let project_root = get_project_root()?;
 
+    // Acquire lock to prevent concurrent runs
+    let _lock = togi::lock::acquire(&project_root)?;
+
     // Auto-detect test command if not explicitly configured
     config.resolve_test_command(&project_root);
 


### PR DESCRIPTION
## Summary
- Adds `.togi.lock` with PID-based locking to prevent concurrent togi runs from corrupting source files
- Stale locks (dead process) are automatically cleaned up
- Lock is released via RAII `Drop` implementation
- Clear error message directs user to manual cleanup if needed

Closes #67

## Test plan
- [x] `cargo test` — 71 tests pass (3 new lock tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Stale lock detection handles edge cases (overflow PIDs, dead processes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added locking mechanism to manage concurrent application runs within a repository.

* **Chores**
  * Updated project dependencies and configuration to support platform-specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->