### PR TITLE
feat: add --show-output flag for survived mutation diagnostics

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,10 @@ pub enum Commands {
         #[arg(long)]
         verbose: bool,
 
+        /// Show test output for survived mutations
+        #[arg(long)]
+        show_output: bool,
+
         /// Override test command (e.g., 'go test ./...')
         #[arg(long)]
         test_cmd: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,11 @@ async fn main() {
             timeout,
             dry_run,
             verbose,
+            show_output,
             test_cmd,
         } => {
             if let Err(e) = run_check(
-                base, config, format, jobs, timeout, dry_run, verbose, test_cmd,
+                base, config, format, jobs, timeout, dry_run, verbose, show_output, test_cmd,
             )
             .await
             {
@@ -55,6 +56,7 @@ async fn run_check(
     timeout: Option<u64>,
     dry_run: bool,
     verbose: bool,
+    show_output: bool,
     test_cmd: Option<String>,
 ) -> anyhow::Result<()> {
     // 1. Load config
@@ -141,6 +143,7 @@ async fn run_check(
         parallelism: config.test.jobs,
         project_root,
         verbose,
+        show_output,
     };
 
     let report = runner.run(mutations).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,15 @@ async fn main() {
             test_cmd,
         } => {
             if let Err(e) = run_check(
-                base, config, format, jobs, timeout, dry_run, verbose, show_output, test_cmd,
+                base,
+                config,
+                format,
+                jobs,
+                timeout,
+                dry_run,
+                verbose,
+                show_output,
+                test_cmd,
             )
             .await
             {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -56,8 +56,14 @@ impl TestRunner {
                 let mut results = Vec::new();
                 for mutation in file_mutations {
                     let _permit = sem.acquire().await.unwrap();
-                    let outcome =
-                        run_single_mutation(&command, timeout, &project_root, &mutation, show_output).await;
+                    let outcome = run_single_mutation(
+                        &command,
+                        timeout,
+                        &project_root,
+                        &mutation,
+                        show_output,
+                    )
+                    .await;
                     let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
                     if verbose {
                         let symbol = match outcome.result {
@@ -153,7 +159,12 @@ async fn run_single_mutation(
     // Read original content
     let original = match std::fs::read(&file_path) {
         Ok(content) => content,
-        Err(_) => return MutationOutcome { result: MutationResult::BuildError, test_output: None },
+        Err(_) => {
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
     };
 
     // Set up file guard for guaranteed restoration
@@ -166,21 +177,35 @@ async fn run_single_mutation(
     let mut mutated = original.clone();
     let range = mutation.byte_range.clone();
     if range.end > mutated.len() {
-        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
+        return MutationOutcome {
+            result: MutationResult::BuildError,
+            test_output: None,
+        };
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
     if std::fs::write(&file_path, &mutated).is_err() {
-        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
+        return MutationOutcome {
+            result: MutationResult::BuildError,
+            test_output: None,
+        };
     }
 
     // Run test command; guard will restore the file on drop
     run_command(command, project_root, timeout, capture_output).await
 }
 
-async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration, capture_output: bool) -> MutationOutcome {
+async fn run_command(
+    command: &[String],
+    cwd: &PathBuf,
+    timeout_dur: Duration,
+    capture_output: bool,
+) -> MutationOutcome {
     if command.is_empty() {
-        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
+        return MutationOutcome {
+            result: MutationResult::BuildError,
+            test_output: None,
+        };
     }
 
     let mut cmd = tokio::process::Command::new(&command[0]);
@@ -196,7 +221,12 @@ async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration, c
 
     let child = match cmd.spawn() {
         Ok(c) => c,
-        Err(_) => return MutationOutcome { result: MutationResult::BuildError, test_output: None },
+        Err(_) => {
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
     };
 
     match tokio::time::timeout(timeout_dur, child.wait_with_output()).await {
@@ -219,10 +249,19 @@ async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration, c
             } else {
                 None
             };
-            MutationOutcome { result, test_output }
+            MutationOutcome {
+                result,
+                test_output,
+            }
         }
-        Ok(Err(_)) => MutationOutcome { result: MutationResult::BuildError, test_output: None },
-        Err(_) => MutationOutcome { result: MutationResult::Timeout, test_output: None },
+        Ok(Err(_)) => MutationOutcome {
+            result: MutationResult::BuildError,
+            test_output: None,
+        },
+        Err(_) => MutationOutcome {
+            result: MutationResult::Timeout,
+            test_output: None,
+        },
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,6 +14,7 @@ pub struct TestRunner {
     pub parallelism: usize,
     pub project_root: PathBuf,
     pub verbose: bool,
+    pub show_output: bool,
 }
 
 struct FileGuard {
@@ -49,16 +50,17 @@ impl TestRunner {
             let timeout = self.timeout;
             let project_root = self.project_root.clone();
             let counter = counter.clone();
+            let show_output = self.show_output;
 
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
                 for mutation in file_mutations {
                     let _permit = sem.acquire().await.unwrap();
-                    let result =
-                        run_single_mutation(&command, timeout, &project_root, &mutation).await;
+                    let outcome =
+                        run_single_mutation(&command, timeout, &project_root, &mutation, show_output).await;
                     let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
                     if verbose {
-                        let symbol = match result {
+                        let symbol = match outcome.result {
                             MutationResult::Killed => "\u{2713} killed",
                             MutationResult::Survived => "\u{2717} survived",
                             MutationResult::Timeout => "⧖ timeout",
@@ -74,7 +76,22 @@ impl TestRunner {
                             mutation.operator
                         );
                     }
-                    results.push((mutation, result));
+                    if show_output
+                        && outcome.result == MutationResult::Survived
+                        && let Some(output) = &outcome.test_output
+                    {
+                        eprintln!(
+                            "  ┌─ test output for {}:{} ({})",
+                            mutation.file.display(),
+                            mutation.line,
+                            mutation.operator
+                        );
+                        for line in output.lines() {
+                            eprintln!("  │ {}", line);
+                        }
+                        eprintln!("  └─");
+                    }
+                    results.push((mutation, outcome.result));
                 }
                 results
             });
@@ -119,18 +136,24 @@ impl TestRunner {
     }
 }
 
+struct MutationOutcome {
+    result: MutationResult,
+    test_output: Option<String>,
+}
+
 async fn run_single_mutation(
     command: &[String],
     timeout: Duration,
     project_root: &PathBuf,
     mutation: &Mutation,
-) -> MutationResult {
+    capture_output: bool,
+) -> MutationOutcome {
     let file_path = project_root.join(&mutation.file);
 
     // Read original content
     let original = match std::fs::read(&file_path) {
         Ok(content) => content,
-        Err(_) => return MutationResult::BuildError,
+        Err(_) => return MutationOutcome { result: MutationResult::BuildError, test_output: None },
     };
 
     // Set up file guard for guaranteed restoration
@@ -143,43 +166,63 @@ async fn run_single_mutation(
     let mut mutated = original.clone();
     let range = mutation.byte_range.clone();
     if range.end > mutated.len() {
-        return MutationResult::BuildError;
+        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
     if std::fs::write(&file_path, &mutated).is_err() {
-        return MutationResult::BuildError;
+        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
     }
 
     // Run test command; guard will restore the file on drop
-    run_command(command, project_root, timeout).await
+    run_command(command, project_root, timeout, capture_output).await
 }
 
-async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration) -> MutationResult {
+async fn run_command(command: &[String], cwd: &PathBuf, timeout_dur: Duration, capture_output: bool) -> MutationOutcome {
     if command.is_empty() {
-        return MutationResult::BuildError;
+        return MutationOutcome { result: MutationResult::BuildError, test_output: None };
     }
 
     let mut cmd = tokio::process::Command::new(&command[0]);
     cmd.args(&command[1..]).current_dir(cwd);
-    cmd.stdout(std::process::Stdio::null());
-    cmd.stderr(std::process::Stdio::null());
+
+    if capture_output {
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+    } else {
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+    }
 
     let child = match cmd.spawn() {
         Ok(c) => c,
-        Err(_) => return MutationResult::BuildError,
+        Err(_) => return MutationOutcome { result: MutationResult::BuildError, test_output: None },
     };
 
     match tokio::time::timeout(timeout_dur, child.wait_with_output()).await {
         Ok(Ok(output)) => {
-            if output.status.success() {
+            let result = if output.status.success() {
                 MutationResult::Survived
             } else {
                 MutationResult::Killed
-            }
+            };
+            let test_output = if capture_output {
+                let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if !stderr.is_empty() {
+                    if !combined.is_empty() {
+                        combined.push('\n');
+                    }
+                    combined.push_str(&stderr);
+                }
+                Some(combined)
+            } else {
+                None
+            };
+            MutationOutcome { result, test_output }
         }
-        Ok(Err(_)) => MutationResult::BuildError,
-        Err(_) => MutationResult::Timeout,
+        Ok(Err(_)) => MutationOutcome { result: MutationResult::BuildError, test_output: None },
+        Err(_) => MutationOutcome { result: MutationResult::Timeout, test_output: None },
     }
 }
 
@@ -228,15 +271,16 @@ mod tests {
 
         let mutation = make_test_mutation(&file);
 
-        let result = run_single_mutation(
+        let outcome = run_single_mutation(
             &["true".to_string()],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
+            false,
         )
         .await;
 
-        assert_eq!(result, MutationResult::Survived);
+        assert_eq!(outcome.result, MutationResult::Survived);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
@@ -248,15 +292,16 @@ mod tests {
 
         let mutation = make_test_mutation(&file);
 
-        let result = run_single_mutation(
+        let outcome = run_single_mutation(
             &["false".to_string()],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
+            false,
         )
         .await;
 
-        assert_eq!(result, MutationResult::Killed);
+        assert_eq!(outcome.result, MutationResult::Killed);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
@@ -279,15 +324,16 @@ mod tests {
             byte_range: 0..5,
         };
 
-        let result = run_single_mutation(
+        let outcome = run_single_mutation(
             &["true".to_string()],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
+            false,
         )
         .await;
 
-        assert_eq!(result, MutationResult::Survived);
+        assert_eq!(outcome.result, MutationResult::Survived);
         // File should be restored to original
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
@@ -300,15 +346,16 @@ mod tests {
 
         let mutation = make_test_mutation(&file);
 
-        let result = run_single_mutation(
+        let outcome = run_single_mutation(
             &["nonexistent_binary_xyz_12345".to_string()],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
+            false,
         )
         .await;
 
-        assert_eq!(result, MutationResult::BuildError);
+        assert_eq!(outcome.result, MutationResult::BuildError);
         // File should be restored
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
@@ -321,15 +368,16 @@ mod tests {
 
         let mutation = make_test_mutation(&file);
 
-        let result = run_single_mutation(
+        let outcome = run_single_mutation(
             &["sleep".to_string(), "10".to_string()],
             Duration::from_millis(100),
             &dir.path().to_path_buf(),
             &mutation,
+            false,
         )
         .await;
 
-        assert_eq!(result, MutationResult::Timeout);
+        assert_eq!(outcome.result, MutationResult::Timeout);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 }

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -88,6 +88,7 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
         parallelism: 1,
         project_root: root,
         verbose: false,
+        show_output: false,
     };
 
     let report = runner.run(mutations).await;


### PR DESCRIPTION
## Summary
- Add `--show-output` CLI flag that captures and displays test stdout/stderr for survived mutations
- Output is formatted with box-drawing characters for readability
- When not set, test output is still sent to /dev/null for performance

Closes #69

## Test plan
- [x] `cargo test` — all 68 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Manually verified output formatting with a surviving mutation