### PR TITLE
test: add CLI integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,10 +68,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bytes"
@@ -151,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "diffy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +224,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -308,12 +355,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -356,6 +418,36 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -576,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,9 +698,11 @@ name = "togi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "colored",
  "diffy",
+ "predicates",
  "serde",
  "serde_json",
  "tempfile",
@@ -762,6 +862,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ tempfile = "3"
 anyhow = "1"
 thiserror = "2"
 tree-sitter-typescript = "0.23.2"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -130,9 +130,12 @@ fn check_format_json_outputs_valid_json() {
     let output = togi()
         .args([
             "check",
-            "--base", "HEAD",
-            "--format", "json",
-            "--test-cmd", "false",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "false",
         ])
         .current_dir(dir.path())
         .output()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,162 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn togi() -> Command {
+    Command::cargo_bin("togi").unwrap()
+}
+
+/// Set up a minimal git repo with a Go file and a diff to test against.
+fn setup_git_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path();
+
+    // Init git repo
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+
+    // Create initial commit with a Go file
+    let go_file = path.join("main.go");
+    fs::write(
+        &go_file,
+        "package main\n\nfunc add(a, b int) int {\n\treturn a + b\n}\n",
+    )
+    .unwrap();
+    fs::write(path.join("go.mod"), "module example.com/test\n\ngo 1.21\n").unwrap();
+
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+
+    // Make a change (add a comparison)
+    fs::write(
+        &go_file,
+        "package main\n\nfunc add(a, b int) int {\n\tif a > b {\n\t\treturn a\n\t}\n\treturn a + b\n}\n",
+    )
+    .unwrap();
+
+    dir
+}
+
+#[test]
+fn init_creates_config() {
+    let dir = TempDir::new().unwrap();
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created togi.toml"));
+
+    assert!(dir.path().join("togi.toml").exists());
+}
+
+#[test]
+fn init_fails_if_config_exists() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("togi.toml"), "").unwrap();
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn check_no_diff_exits_zero() {
+    let dir = setup_git_repo();
+
+    // Commit the working change so there's no unstaged diff against HEAD
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "second"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Diff HEAD against HEAD = no changes
+    togi()
+        .args(["check", "--base", "HEAD"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No changes found"));
+}
+
+#[test]
+fn check_dry_run_lists_mutations() {
+    let dir = setup_git_repo();
+
+    togi()
+        .args(["check", "--base", "HEAD", "--dry-run", "--test-cmd", "true"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mutations would be generated"));
+}
+
+#[test]
+fn check_format_json_outputs_valid_json() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base", "HEAD",
+            "--format", "json",
+            "--test-cmd", "false",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Exit code 1 = survived mutations exist
+    assert!(output.status.code() == Some(1) || output.status.code() == Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON output: {e}\nstdout: {stdout}"));
+    assert!(value.get("total").is_some());
+    assert!(value.get("mutations").is_some());
+}
+
+#[test]
+fn check_invalid_config_exits_two() {
+    let dir = setup_git_repo();
+    fs::write(dir.path().join("togi.toml"), "invalid {{{{ toml").unwrap();
+
+    togi()
+        .args(["check", "--base", "HEAD"])
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Error"));
+}


### PR DESCRIPTION
## Summary
- Add 6 CLI integration tests using `assert_cmd` and `predicates`
- Covers: `togi init`, `togi check` with dry-run, JSON output, no-diff, and invalid config
- Verifies exit codes (0, 1, 2), stdout content, and JSON validity

Closes #70

## Test plan
- [x] `cargo test --test cli` — all 6 tests pass
- [x] `cargo clippy --tests -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New integration test suite validates CLI command execution across initialization, configuration validation, dry-run operations, JSON output generation, and error handling with appropriate exit codes.

* **Chores**
  * Expanded development dependencies for testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->