### PR TITLE
feat: add progress indicator for mutation test runs

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -29,11 +29,13 @@ impl Drop for FileGuard {
 }
 
 impl TestRunner {
+    #[allow(clippy::manual_is_multiple_of)]
     pub async fn run(&self, mutations: Vec<Mutation>) -> MutationReport {
         let start = Instant::now();
         let total = mutations.len();
         let counter = Arc::new(AtomicUsize::new(0));
         let verbose = self.verbose;
+        let is_tty = std::io::stderr().is_terminal();
 
         // Group mutations by file to serialize mutations on the same file
         let mut by_file: HashMap<PathBuf, Vec<Mutation>> = HashMap::new();
@@ -75,11 +77,10 @@ impl TestRunner {
                             mutation.operator
                         );
                     } else {
-                        let is_tty = std::io::stderr().is_terminal();
                         if is_tty {
                             eprint!("\r  [{}/{}] testing mutations...", n, total);
                             let _ = std::io::stderr().flush();
-                        } else if n == total || (total >= 4 && n.is_multiple_of(total / 4)) {
+                        } else if n == total || (total >= 4 && n % (total / 4) == 0) {
                             eprintln!("  [{}/{}] testing mutations...", n, total);
                         }
                     }
@@ -98,7 +99,7 @@ impl TestRunner {
         }
 
         // Clear progress line on TTY
-        if !verbose && std::io::stderr().is_terminal() {
+        if !verbose && is_tty {
             eprint!("\r                                        \r");
             let _ = std::io::stderr().flush();
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,6 +2,7 @@
 
 use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::HashMap;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -73,6 +74,14 @@ impl TestRunner {
                             mutation.line,
                             mutation.operator
                         );
+                    } else {
+                        let is_tty = std::io::stderr().is_terminal();
+                        if is_tty {
+                            eprint!("\r  [{}/{}] testing mutations...", n, total);
+                            let _ = std::io::stderr().flush();
+                        } else if n == total || (total >= 4 && n.is_multiple_of(total / 4)) {
+                            eprintln!("  [{}/{}] testing mutations...", n, total);
+                        }
                     }
                     results.push((mutation, result));
                 }
@@ -86,6 +95,12 @@ impl TestRunner {
             if let Ok(results) = handle.await {
                 all_results.extend(results);
             }
+        }
+
+        // Clear progress line on TTY
+        if !verbose && std::io::stderr().is_terminal() {
+            eprint!("\r                                        \r");
+            let _ = std::io::stderr().flush();
         }
 
         let duration = start.elapsed();


### PR DESCRIPTION
## Summary
- Show `[n/total] testing mutations...` progress in non-verbose mode
- On TTY: single overwritten line using `\r`
- On non-TTY (CI): periodic progress at 25% intervals
- Cleared after completion before report output

Closes #72

## Test plan
- [x] `cargo test` — all 68 tests pass
- [x] `cargo clippy -- -D warnings` — clean