### PR TITLE
fix: improve return_empty operator with node-kind-based replacement

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -80,15 +80,18 @@ impl MutationOperator for ReturnEmpty {
         let first_kind = first.kind();
         let replacement = match first_kind {
             // String literals
-            "interpreted_string_literal" | "raw_string_literal" | "string"
-            | "string_literal" | "template_string" => "\"\"".to_string(),
+            "interpreted_string_literal"
+            | "raw_string_literal"
+            | "string"
+            | "string_literal"
+            | "template_string" => "\"\"".to_string(),
             // Boolean literals
             "true" | "false" | "boolean" => "false".to_string(),
             // Null/nil/None
             "null" | "nil" | "none" | "None" => text.to_string(), // already a zero-value, skip
             // Numeric literals
-            "integer_literal" | "int_literal" | "float_literal" | "number"
-            | "integer" | "float" => "0".to_string(),
+            "integer_literal" | "int_literal" | "float_literal" | "number" | "integer"
+            | "float" => "0".to_string(),
             // Fallback: use text-based heuristic
             _ => {
                 if text == "nil" || text == "null" || text == "None" {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -71,17 +71,36 @@ impl MutationOperator for ReturnEmpty {
             return vec![];
         }
         // The return value spans from first named child to end of last named child
-        let first = children.first().unwrap();
-        let last = children.last().unwrap();
+        let first = &children[0];
+        let last = &children[children.len() - 1];
         let value_range = first.start_byte()..last.end_byte();
         let text = std::str::from_utf8(&source[value_range.clone()]).unwrap_or("");
 
-        let replacement = if text.contains('"') || text.contains('\'') {
-            "\"\"".to_string()
-        } else if text == "true" || text == "false" {
-            "false".to_string()
-        } else {
-            "0".to_string()
+        // Use tree-sitter node kind of the first child for more accurate replacement
+        let first_kind = first.kind();
+        let replacement = match first_kind {
+            // String literals
+            "interpreted_string_literal" | "raw_string_literal" | "string"
+            | "string_literal" | "template_string" => "\"\"".to_string(),
+            // Boolean literals
+            "true" | "false" | "boolean" => "false".to_string(),
+            // Null/nil/None
+            "null" | "nil" | "none" | "None" => text.to_string(), // already a zero-value, skip
+            // Numeric literals
+            "integer_literal" | "int_literal" | "float_literal" | "number"
+            | "integer" | "float" => "0".to_string(),
+            // Fallback: use text-based heuristic
+            _ => {
+                if text == "nil" || text == "null" || text == "None" {
+                    return vec![]; // Already a zero-value, mutation not useful
+                } else if text == "true" || text == "false" {
+                    "false".to_string()
+                } else if text.starts_with('"') || text.starts_with('\'') || text.starts_with('`') {
+                    "\"\"".to_string()
+                } else {
+                    "0".to_string()
+                }
+            }
         };
 
         vec![crate::MutationCandidate {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -88,7 +88,7 @@ impl MutationOperator for ReturnEmpty {
             // Boolean literals
             "true" | "false" | "boolean" => "false".to_string(),
             // Null/nil/None
-            "null" | "nil" | "none" | "None" => text.to_string(), // already a zero-value, skip
+            "null" | "nil" | "none" | "None" => return vec![], // already a zero-value, skip
             // Numeric literals
             "integer_literal" | "int_literal" | "float_literal" | "number" | "integer"
             | "float" => "0".to_string(),


### PR DESCRIPTION
## Summary
- Use tree-sitter node kinds instead of naive text matching to determine replacement values
- Correctly handles: string literals, booleans, numerics, null/nil/None
- Skips mutations on already-zero-value returns (nil, null, None) to reduce noise
- Falls back to text heuristic for unrecognized node kinds, now also handling backtick strings

Closes #64

## Test plan
- [x] `cargo test` — all 68 tests pass
- [x] `cargo clippy -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved accuracy of code transformation handling for empty return statements by using semantic node type detection instead of text-based matching, with better handling of different value types (strings, booleans, numbers, and null values).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->