### PR TITLE
feat: add language support for Java, C, C++, Ruby, and C#

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,8 +647,13 @@ dependencies = [
  "tokio",
  "toml",
  "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
  "tree-sitter-go",
+ "tree-sitter-java",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
 ]
@@ -735,10 +740,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -755,6 +800,16 @@ name = "tree-sitter-python"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ tree-sitter-go = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23.2"
+tree-sitter-java = "0.23"
+tree-sitter-c = "0.23"
+tree-sitter-cpp = "0.23"
+tree-sitter-ruby = "0.23"
+tree-sitter-c-sharp = "0.23"
 
 # Diff parsing
 diffy = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,8 +71,7 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     if project_root.join("pom.xml").exists() {
         detected.push(("pom.xml", vec!["mvn".into(), "test".into()]));
     }
-    if project_root.join("build.gradle").exists()
-        || project_root.join("build.gradle.kts").exists()
+    if project_root.join("build.gradle").exists() || project_root.join("build.gradle.kts").exists()
     {
         detected.push(("build.gradle", vec!["./gradlew".into(), "test".into()]));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,18 @@ fn default_test_command() -> Vec<String> {
 }
 
 /// Auto-detect the test command based on project files in the given root.
+fn has_file_with_ext(dir: &Path, ext: &str) -> bool {
+    dir.read_dir()
+        .map(|entries| {
+            entries.filter_map(Result::ok).any(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case(ext))
+            })
+        })
+        .unwrap_or(false)
+}
+
 pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     let mut detected: Vec<(&str, Vec<String>)> = Vec::new();
 
@@ -62,7 +74,7 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     if project_root.join("build.gradle").exists()
         || project_root.join("build.gradle.kts").exists()
     {
-        detected.push(("build.gradle", vec!["gradle".into(), "test".into()]));
+        detected.push(("build.gradle", vec!["./gradlew".into(), "test".into()]));
     }
     if project_root.join("Gemfile").exists() {
         detected.push((
@@ -72,6 +84,9 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     }
     if project_root.join("CMakeLists.txt").exists() {
         detected.push(("CMakeLists.txt", vec!["ctest".into()]));
+    }
+    if has_file_with_ext(project_root, "sln") || has_file_with_ext(project_root, "csproj") {
+        detected.push((".sln/.csproj", vec!["dotnet".into(), "test".into()]));
     }
 
     if detected.len() > 1 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,23 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     if project_root.join("package.json").exists() {
         detected.push(("package.json", vec!["npm".into(), "test".into()]));
     }
+    if project_root.join("pom.xml").exists() {
+        detected.push(("pom.xml", vec!["mvn".into(), "test".into()]));
+    }
+    if project_root.join("build.gradle").exists()
+        || project_root.join("build.gradle.kts").exists()
+    {
+        detected.push(("build.gradle", vec!["gradle".into(), "test".into()]));
+    }
+    if project_root.join("Gemfile").exists() {
+        detected.push((
+            "Gemfile",
+            vec!["bundle".into(), "exec".into(), "rspec".into()],
+        ));
+    }
+    if project_root.join("CMakeLists.txt").exists() {
+        detected.push(("CMakeLists.txt", vec!["ctest".into()]));
+    }
 
     if detected.len() > 1 {
         let names: Vec<&str> = detected.iter().map(|(name, _)| *name).collect();

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -1,0 +1,57 @@
+use crate::languages::LanguageSupport;
+
+pub struct C;
+
+impl LanguageSupport for C {
+    fn name(&self) -> &str {
+        "c"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["c", "h"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_c::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_c_binary_expression() {
+        let lang = C;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "int f() { return a > b; }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("binary_expression"));
+    }
+}

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -1,0 +1,57 @@
+use crate::languages::LanguageSupport;
+
+pub struct Cpp;
+
+impl LanguageSupport for Cpp {
+    fn name(&self) -> &str {
+        "cpp"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["cpp", "cc", "cxx", "hpp", "hxx"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_cpp::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cpp_binary_expression() {
+        let lang = Cpp;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "bool f() { return a > b; }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("binary_expression"));
+    }
+}

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -1,0 +1,57 @@
+use crate::languages::LanguageSupport;
+
+pub struct CSharp;
+
+impl LanguageSupport for CSharp {
+    fn name(&self) -> &str {
+        "c_sharp"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["cs"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_c_sharp::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_csharp_binary_expression() {
+        let lang = CSharp;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "class T { bool F() { return a > b; } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("binary_expression"));
+    }
+}

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -1,0 +1,57 @@
+use crate::languages::LanguageSupport;
+
+pub struct Java;
+
+impl LanguageSupport for Java {
+    fn name(&self) -> &str {
+        "java"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["java"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_java::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary_expression"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if_statement"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return_statement"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_java_binary_expression() {
+        let lang = Java;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "class T { boolean f() { return a > b; } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("binary_expression"));
+    }
+}

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -1,5 +1,10 @@
+pub mod c;
+pub mod cpp;
+pub mod csharp;
 pub mod go;
+pub mod java;
 pub mod python;
+pub mod ruby;
 pub mod rust_lang;
 pub mod typescript;
 
@@ -19,8 +24,13 @@ pub trait LanguageSupport: Send + Sync {
 /// Returns instances of all supported languages.
 pub fn all() -> Vec<Box<dyn LanguageSupport>> {
     vec![
+        Box::new(c::C),
+        Box::new(cpp::Cpp),
+        Box::new(csharp::CSharp),
         Box::new(go::Go),
+        Box::new(java::Java),
         Box::new(python::Python),
+        Box::new(ruby::Ruby),
         Box::new(rust_lang::Rust),
         Box::new(typescript::TypeScript),
     ]

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -1,0 +1,57 @@
+use crate::languages::LanguageSupport;
+
+pub struct Ruby;
+
+impl LanguageSupport for Ruby {
+    fn name(&self) -> &str {
+        "ruby"
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["rb"]
+    }
+
+    fn tree_sitter_language(&self) -> tree_sitter::Language {
+        tree_sitter_ruby::LANGUAGE.into()
+    }
+
+    fn binary_expression_node(&self) -> &str {
+        "binary"
+    }
+
+    fn if_statement_node(&self) -> &str {
+        "if"
+    }
+
+    fn boolean_true_literals(&self) -> &[&str] {
+        &["true"]
+    }
+
+    fn boolean_false_literals(&self) -> &[&str] {
+        &["false"]
+    }
+
+    fn return_statement_node(&self) -> &str {
+        "return"
+    }
+
+    fn operator_field(&self) -> &str {
+        "operator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ruby_binary_expression() {
+        let lang = Ruby;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "def f\n  a > b\nend\n";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("binary"));
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn detect_unknown_extension() {
-        let result = detect_language(&PathBuf::from("script.rb"));
+        let result = detect_language(&PathBuf::from("script.lua"));
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary
- Add 5 new languages: Java, C, C++, Ruby, C#
- Each has a `LanguageSupport` implementation with correct tree-sitter node kinds
- Auto-detection added for Maven (`pom.xml`), Gradle (`build.gradle`), Ruby (`Gemfile`), CMake (`CMakeLists.txt`)
- Supported languages now: Go, Rust, Python, TypeScript, Java, C, C++, Ruby, C#

Closes #71

## Test plan
- [x] `cargo test` — 73 tests pass (5 new parsing tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Each language parses sample code and finds expected node kinds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class language support for Java, C, C++, Ruby, and C#.
  * Improved detection of project test commands for Maven, Gradle, Bundler/RSpec (Ruby), CMake/CTest, and .NET.

* **Tests**
  * Added/updated unit tests to validate parsing and detection for the newly supported languages and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->