### PR TITLE
docs: replace "language-agnostic" with "multi-language"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # togi
 
-Fast, diff-targeted, language-agnostic mutation testing engine.
+Fast, diff-targeted, multi-language mutation testing engine.
 
 ## Architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "togi"
 version = "0.1.0"
 edition = "2024"
-description = "Fast, diff-targeted, language-agnostic mutation testing"
+description = "Fast, diff-targeted, multi-language mutation testing"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Darkroom4364/togi"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 togi (鍛 — Japanese for "sharpening"), hone your tests by finding the mutations they miss.
 
-Fast, diff-targeted mutation testing. Language-agnostic. No LLM. Runs on every PR in seconds.
+Fast, diff-targeted mutation testing. Multi-language. No LLM. Runs on every PR in seconds.
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- Update README, Cargo.toml description, and CLAUDE.md
- "language-agnostic" → "multi-language" since togi requires per-language tree-sitter node mappings (~50 lines each)

## Context
togi is extensible to any language with a tree-sitter grammar, but not truly agnostic — each language needs an adapter mapping node kinds.