### PR TITLE
feat: add --all flag to mutate entire codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Fast, diff-targeted, multi-language mutation testing engine.
 
 Single Rust binary. Pipeline: diff → parse → map → mutate → run → report.
 
-- `src/diff.rs` — parse unified diff into changed file/line ranges
+- `src/diff.rs` — parse unified diff into changed file/line ranges; `--all` mode file collection
 - `src/parser.rs` — tree-sitter language detection and AST parsing
 - `src/mapper.rs` — map changed lines to mutable AST nodes
 - `src/mutator.rs` — combine mapper + operators to generate mutations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +279,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +317,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -648,6 +702,7 @@ dependencies = [
  "clap",
  "colored",
  "diffy",
+ "ignore",
  "libc",
  "predicates",
  "serde",
@@ -666,7 +721,6 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +648,7 @@ dependencies = [
  "clap",
  "colored",
  "diffy",
+ "libc",
  "predicates",
  "serde",
  "serde_json",
@@ -656,6 +666,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "walkdir",
 ]
 
 [[package]]
@@ -863,6 +874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +939,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1"
 
 # Filesystem
 tempfile = "3"
-walkdir = "2"
+ignore = "0.4"
 
 # Error handling
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1"
 
 # Filesystem
 tempfile = "3"
+walkdir = "2"
 
 # Error handling
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ togi check --dry-run
 # JSON output for CI
 togi check --format json
 
+# Mutate all supported files (not just the diff)
+togi check --all
+
 # Adjust parallelism and timeout
 togi check --jobs 8 --timeout 60
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,10 @@ pub struct Cli {
 pub enum Commands {
     /// Run mutation testing on the current diff
     Check {
+        /// Mutate all supported files instead of just the diff
+        #[arg(long, conflicts_with = "base")]
+        all: bool,
+
         /// Base branch to diff against
         #[arg(long, default_value = "origin/main")]
         base: String,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -37,13 +37,12 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
             continue;
         }
 
-        let line_count = std::io::BufRead::lines(std::io::BufReader::new(
-            match std::fs::File::open(path) {
+        let line_count =
+            std::io::BufRead::lines(std::io::BufReader::new(match std::fs::File::open(path) {
                 Ok(f) => f,
                 Err(_) => continue,
-            },
-        ))
-        .count();
+            }))
+            .count();
         if line_count == 0 {
             continue;
         }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,7 +4,7 @@ use crate::{ChangedFile, LineRange};
 use std::path::{Path, PathBuf};
 
 /// Build ChangedFile entries for every supported file in the project tree.
-/// Each file gets a single hunk covering all lines.
+/// Respects `.gitignore` rules. Skips test files.
 pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<ChangedFile>> {
     use crate::languages;
 
@@ -16,28 +16,13 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 
     let mut files = Vec::new();
 
-    for entry in walkdir::WalkDir::new(project_root)
-        .into_iter()
-        .filter_entry(|e| {
-            let name = e.file_name().to_string_lossy();
-            if e.file_type().is_dir() {
-                return !name.starts_with('.')
-                    && !matches!(
-                        name.as_ref(),
-                        "target"
-                            | "node_modules"
-                            | "vendor"
-                            | "build"
-                            | "dist"
-                            | "__pycache__"
-                            | "venv"
-                    );
-            }
-            true
-        })
+    for entry in ignore::WalkBuilder::new(project_root)
+        .hidden(true)
+        .git_ignore(true)
+        .build()
     {
         let entry = entry?;
-        if !entry.file_type().is_file() {
+        if !entry.file_type().map_or(false, |ft| ft.is_file()) {
             continue;
         }
         let path = entry.path();
@@ -46,6 +31,9 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
             None => continue,
         };
         if !supported_extensions.contains(&ext) {
+            continue;
+        }
+        if is_test_file(path) {
             continue;
         }
 
@@ -75,6 +63,30 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
     }
 
     Ok(files)
+}
+
+/// Returns true for files that look like test files across supported languages.
+fn is_test_file(path: &Path) -> bool {
+    let name = match path.file_stem().and_then(|s| s.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    // Go: *_test.go
+    // Python: test_*.py / *_test.py
+    // Ruby: *_test.rb / test_*.rb / *_spec.rb
+    // Java/C#: *Test.java / *Tests.java / *Test.cs
+    // JS/TS: *.test.ts / *.spec.ts (stem after first dot)
+    if name.ends_with("_test") || name.starts_with("test_") || name.ends_with("_spec") {
+        return true;
+    }
+    if name.ends_with("Test") || name.ends_with("Tests") || name.ends_with("Spec") {
+        return true;
+    }
+    // *.test.ts, *.spec.ts — file_stem gives "foo.test"
+    if name.ends_with(".test") || name.ends_with(".spec") {
+        return true;
+    }
+    false
 }
 
 /// Parse unified diff output (from `git diff`) into a list of changed files
@@ -293,9 +305,12 @@ diff --git a/src/main.rs b/src/main.rs
     }
 
     #[test]
-    fn collect_all_finds_supported_files_and_skips_excluded_dirs() {
+    fn collect_all_finds_supported_files_and_respects_gitignore() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
+
+        // Init a git repo so .gitignore is respected
+        std::fs::create_dir(root.join(".git")).unwrap();
 
         // Supported file
         let src = root.join("src");
@@ -310,20 +325,33 @@ diff --git a/src/main.rs b/src/main.rs
         std::fs::create_dir_all(&hidden).unwrap();
         std::fs::write(hidden.join("secret.rs"), "fn x() {}\n").unwrap();
 
-        // node_modules (should be skipped)
-        let nm = root.join("node_modules");
-        std::fs::create_dir_all(&nm).unwrap();
-        std::fs::write(nm.join("dep.js"), "var x = 1;\n").unwrap();
+        // Gitignored dir
+        std::fs::write(root.join(".gitignore"), "generated/\n").unwrap();
+        let generated = root.join("generated");
+        std::fs::create_dir_all(&generated).unwrap();
+        std::fs::write(generated.join("out.rs"), "fn gen() {}\n").unwrap();
 
-        // build dir (should be skipped)
-        let build = root.join("build");
-        std::fs::create_dir_all(&build).unwrap();
-        std::fs::write(build.join("out.go"), "package main\n").unwrap();
+        // Test file (should be skipped)
+        std::fs::write(src.join("main_test.go"), "package main\n").unwrap();
 
         let files = collect_all_supported_files(root).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
         assert_eq!(files[0].hunks.len(), 1);
         assert_eq!(files[0].hunks[0], LineRange { start: 1, end: 1 });
+    }
+
+    #[test]
+    fn is_test_file_detects_common_patterns() {
+        assert!(is_test_file(Path::new("foo_test.go")));
+        assert!(is_test_file(Path::new("test_utils.py")));
+        assert!(is_test_file(Path::new("UserTest.java")));
+        assert!(is_test_file(Path::new("UserTests.cs")));
+        assert!(is_test_file(Path::new("app.test.ts")));
+        assert!(is_test_file(Path::new("app.spec.tsx")));
+        assert!(is_test_file(Path::new("widget_spec.rb")));
+        assert!(!is_test_file(Path::new("main.rs")));
+        assert!(!is_test_file(Path::new("utils.py")));
+        assert!(!is_test_file(Path::new("contest.go")));
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -22,7 +22,7 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         .build()
     {
         let entry = entry?;
-        if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
             continue;
         }
         let path = entry.path();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -20,12 +20,18 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         .into_iter()
         .filter_entry(|e| {
             let name = e.file_name().to_string_lossy();
-            // Skip hidden dirs, target/, node_modules/, vendor/
             if e.file_type().is_dir() {
                 return !name.starts_with('.')
-                    && name != "target"
-                    && name != "node_modules"
-                    && name != "vendor";
+                    && !matches!(
+                        name.as_ref(),
+                        "target"
+                            | "node_modules"
+                            | "vendor"
+                            | "build"
+                            | "dist"
+                            | "__pycache__"
+                            | "venv"
+                    );
             }
             true
         })
@@ -43,9 +49,13 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
             continue;
         }
 
-        let line_count = std::fs::read_to_string(path)
-            .map(|s| s.lines().count())
-            .unwrap_or(0);
+        let line_count = std::io::BufRead::lines(std::io::BufReader::new(
+            match std::fs::File::open(path) {
+                Ok(f) => f,
+                Err(_) => continue,
+            },
+        ))
+        .count();
         if line_count == 0 {
             continue;
         }
@@ -280,5 +290,40 @@ diff --git a/src/main.rs b/src/main.rs
 "#;
         let files = parse_diff(diff);
         assert_eq!(files[0].path, PathBuf::from("path/to/file.rs"));
+    }
+
+    #[test]
+    fn collect_all_finds_supported_files_and_skips_excluded_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Supported file
+        let src = root.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.rs"), "fn main() {}\n").unwrap();
+
+        // Unsupported extension
+        std::fs::write(root.join("readme.txt"), "hi\n").unwrap();
+
+        // Hidden dir (should be skipped)
+        let hidden = root.join(".hidden");
+        std::fs::create_dir_all(&hidden).unwrap();
+        std::fs::write(hidden.join("secret.rs"), "fn x() {}\n").unwrap();
+
+        // node_modules (should be skipped)
+        let nm = root.join("node_modules");
+        std::fs::create_dir_all(&nm).unwrap();
+        std::fs::write(nm.join("dep.js"), "var x = 1;\n").unwrap();
+
+        // build dir (should be skipped)
+        let build = root.join("build");
+        std::fs::create_dir_all(&build).unwrap();
+        std::fs::write(build.join("out.go"), "package main\n").unwrap();
+
+        let files = collect_all_supported_files(root).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
+        assert_eq!(files[0].hunks.len(), 1);
+        assert_eq!(files[0].hunks[0], LineRange { start: 1, end: 1 });
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -75,7 +75,8 @@ fn is_test_file(path: &Path) -> bool {
         let s = component.as_os_str().to_str().unwrap_or("");
         if matches!(
             s,
-            "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs"
+            "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs" | "testdata"
+                | "fixtures"
         ) {
             return true;
         }
@@ -375,5 +376,7 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(is_test_file(Path::new("tests/helper.rs")));
         assert!(is_test_file(Path::new("__tests__/utils.ts")));
         assert!(is_test_file(Path::new("src/test/java/Foo.java")));
+        assert!(is_test_file(Path::new("testdata/input.go")));
+        assert!(is_test_file(Path::new("fixtures/setup.py")));
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,7 +1,71 @@
 // Unified diff parsing → Vec<ChangedFile>
 
 use crate::{ChangedFile, LineRange};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Build ChangedFile entries for every supported file in the project tree.
+/// Each file gets a single hunk covering all lines.
+pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<ChangedFile>> {
+    use crate::languages;
+
+    let langs = languages::all();
+    let supported_extensions: Vec<&str> = langs
+        .iter()
+        .flat_map(|lang| lang.extensions().to_vec())
+        .collect();
+
+    let mut files = Vec::new();
+
+    for entry in walkdir::WalkDir::new(project_root)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            // Skip hidden dirs, target/, node_modules/, vendor/
+            if e.file_type().is_dir() {
+                return !name.starts_with('.')
+                    && name != "target"
+                    && name != "node_modules"
+                    && name != "vendor";
+            }
+            true
+        })
+    {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let ext = match path.extension().and_then(|e| e.to_str()) {
+            Some(e) => e,
+            None => continue,
+        };
+        if !supported_extensions.contains(&ext) {
+            continue;
+        }
+
+        let line_count = std::fs::read_to_string(path)
+            .map(|s| s.lines().count())
+            .unwrap_or(0);
+        if line_count == 0 {
+            continue;
+        }
+
+        let rel_path = path
+            .strip_prefix(project_root)
+            .unwrap_or(path)
+            .to_path_buf();
+
+        files.push(ChangedFile {
+            path: rel_path,
+            hunks: vec![LineRange {
+                start: 1,
+                end: line_count,
+            }],
+        });
+    }
+
+    Ok(files)
+}
 
 /// Parse unified diff output (from `git diff`) into a list of changed files
 /// with their modified line ranges. Only tracks added/modified lines.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -75,7 +75,13 @@ fn is_test_file(path: &Path) -> bool {
         let s = component.as_os_str().to_str().unwrap_or("");
         if matches!(
             s,
-            "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs" | "testdata"
+            "tests"
+                | "test"
+                | "__tests__"
+                | "__test__"
+                | "spec"
+                | "specs"
+                | "testdata"
                 | "fixtures"
         ) {
             return true;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -16,15 +16,16 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 
     let mut files = Vec::new();
 
-    for entry in ignore::WalkBuilder::new(project_root)
+    let mut entries: Vec<_> = ignore::WalkBuilder::new(project_root)
         .hidden(true)
         .git_ignore(true)
         .build()
-    {
-        let entry = entry?;
-        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-            continue;
-        }
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
+        .collect();
+    entries.sort_by(|a, b| a.path().cmp(b.path()));
+
+    for entry in &entries {
         let path = entry.path();
         let ext = match path.extension().and_then(|e| e.to_str()) {
             Some(e) => e,
@@ -40,7 +41,10 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         let line_count =
             std::io::BufRead::lines(std::io::BufReader::new(match std::fs::File::open(path) {
                 Ok(f) => f,
-                Err(_) => continue,
+                Err(e) => {
+                    eprintln!("warning: could not read {}: {e}", path.display());
+                    continue;
+                }
             }))
             .count();
         if line_count == 0 {
@@ -66,6 +70,16 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 
 /// Returns true for files that look like test files across supported languages.
 fn is_test_file(path: &Path) -> bool {
+    // Check if any ancestor directory is a known test directory
+    for component in path.components() {
+        let s = component.as_os_str().to_str().unwrap_or("");
+        if matches!(
+            s,
+            "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs"
+        ) {
+            return true;
+        }
+    }
     let name = match path.file_stem().and_then(|s| s.to_str()) {
         Some(n) => n,
         None => return false,
@@ -333,6 +347,11 @@ diff --git a/src/main.rs b/src/main.rs
         // Test file (should be skipped)
         std::fs::write(src.join("main_test.go"), "package main\n").unwrap();
 
+        // File inside tests/ directory (should be skipped)
+        let tests_dir = root.join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+        std::fs::write(tests_dir.join("helper.rs"), "fn help() {}\n").unwrap();
+
         let files = collect_all_supported_files(root).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
@@ -352,5 +371,9 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(!is_test_file(Path::new("main.rs")));
         assert!(!is_test_file(Path::new("utils.py")));
         assert!(!is_test_file(Path::new("contest.go")));
+        // Directory-based detection
+        assert!(is_test_file(Path::new("tests/helper.rs")));
+        assert!(is_test_file(Path::new("__tests__/utils.ts")));
+        assert!(is_test_file(Path::new("src/test/java/Foo.java")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ async fn main() {
 
     match cli.command {
         togi::cli::Commands::Check {
+            all,
             base,
             config,
             format,
@@ -20,6 +21,7 @@ async fn main() {
             test_cmd,
         } => {
             if let Err(e) = run_check(
+                all,
                 base,
                 config,
                 format,
@@ -57,6 +59,7 @@ async fn main() {
 
 #[allow(clippy::too_many_arguments)]
 async fn run_check(
+    all: bool,
     base: String,
     config_path: Option<PathBuf>,
     format: String,
@@ -93,23 +96,31 @@ async fn run_check(
     // Auto-detect test command if not explicitly configured
     config.resolve_test_command(&project_root);
 
-    // 3. Run git diff
-    let diff_output = get_git_diff(&config.diff.base)?;
-
-    if diff_output.is_empty() {
-        println!(
-            "No changes found in diff against `{}`. Nothing to mutate.",
-            config.diff.base
-        );
-        return Ok(());
-    }
-
-    // 4. Parse diff into ChangedFiles
-    let changed_files = togi::diff::parse_diff(&diff_output);
-    if changed_files.is_empty() {
-        println!("No added/modified lines found. Nothing to mutate.");
-        return Ok(());
-    }
+    // 3. Build list of files to mutate
+    let changed_files = if all {
+        let files = togi::diff::collect_all_supported_files(&project_root)?;
+        if files.is_empty() {
+            println!("No supported source files found. Nothing to mutate.");
+            return Ok(());
+        }
+        eprintln!("Scanning all {} supported files...", files.len());
+        files
+    } else {
+        let diff_output = get_git_diff(&config.diff.base)?;
+        if diff_output.is_empty() {
+            println!(
+                "No changes found in diff against `{}`. Nothing to mutate.",
+                config.diff.base
+            );
+            return Ok(());
+        }
+        let files = togi::diff::parse_diff(&diff_output);
+        if files.is_empty() {
+            println!("No added/modified lines found. Nothing to mutate.");
+            return Ok(());
+        }
+        files
+    };
 
     // 5. Generate mutations
     let mutations = togi::mutator::generate_mutations(

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn run_check(
             println!("No supported source files found. Nothing to mutate.");
             return Ok(());
         }
-        eprintln!("Scanning all {} supported files...", files.len());
+        println!("Scanning all {} supported files...", files.len());
         files
     } else {
         let diff_output = get_git_diff(&config.diff.base)?;


### PR DESCRIPTION
## Summary
- Adds `--all` flag to `togi check` that skips the diff step and walks the project tree for all supported source files
- Conflicts with `--base` via clap (`conflicts_with`)
- Skips hidden dirs, `target/`, `node_modules/`, `vendor/`
- `max_per_run` cap still applies to bound mutation count

Closes #86

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `togi check --all --dry-run` finds 33 files, generates mutations
- [x] `togi check --all --base HEAD` correctly errors on conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --all option to Check to scan all supported source files project-wide, skipping test-like and empty files.

* **Chores**
  * Added an ignore-pattern handling dependency so directory traversal respects .gitignore and hidden entries.

* **Tests**
  * Added tests for full-project file collection, extension filtering, ignore/.gitignore behavior, and test-file detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->