### PR TITLE
fix: warn on walk errors, use relative paths for test-file check

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -20,7 +20,13 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         .hidden(true)
         .git_ignore(true)
         .build()
-        .filter_map(|e| e.ok())
+        .filter_map(|e| match e {
+            Ok(entry) => Some(entry),
+            Err(err) => {
+                eprintln!("warning: skipping path during walk: {err}");
+                None
+            }
+        })
         .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
         .collect();
     entries.sort_by(|a, b| a.path().cmp(b.path()));
@@ -34,7 +40,11 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         if !supported_extensions.contains(&ext) {
             continue;
         }
-        if is_test_file(path) {
+        let rel_path = path
+            .strip_prefix(project_root)
+            .unwrap_or(path)
+            .to_path_buf();
+        if is_test_file(&rel_path) {
             continue;
         }
 
@@ -50,11 +60,6 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         if line_count == 0 {
             continue;
         }
-
-        let rel_path = path
-            .strip_prefix(project_root)
-            .unwrap_or(path)
-            .to_path_buf();
 
         files.push(ChangedFile {
             path: rel_path,


### PR DESCRIPTION
## Summary
- Replace silent `filter_map(|e| e.ok())` with warning on traversal errors
- Run `is_test_file` on repo-relative path to avoid false positives when the repo lives under dirs like `/tmp/tests/`

Supersedes #92.

## Test plan
- [x] `cargo test` passes
- [ ] Run `togi --all` in a repo nested under a `tests/` or `fixtures/` parent dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for file collection operations—warnings are now displayed when files cannot be accessed instead of being silently skipped.

* **Refactor**
  * Optimized test file filtering logic for improved performance during file collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->