### PR TITLE
fix: narrow is_test_file bare 'test' match to src/test only

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -20,7 +20,13 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         .hidden(true)
         .git_ignore(true)
         .build()
-        .filter_map(|e| e.ok())
+        .filter_map(|e| match e {
+            Ok(entry) => Some(entry),
+            Err(err) => {
+                eprintln!("warning: skipping path during walk: {err}");
+                None
+            }
+        })
         .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
         .collect();
     entries.sort_by(|a, b| a.path().cmp(b.path()));
@@ -34,7 +40,11 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         if !supported_extensions.contains(&ext) {
             continue;
         }
-        if is_test_file(path) {
+        let rel_path = path
+            .strip_prefix(project_root)
+            .unwrap_or(path)
+            .to_path_buf();
+        if is_test_file(&rel_path) {
             continue;
         }
 
@@ -50,11 +60,6 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
         if line_count == 0 {
             continue;
         }
-
-        let rel_path = path
-            .strip_prefix(project_root)
-            .unwrap_or(path)
-            .to_path_buf();
 
         files.push(ChangedFile {
             path: rel_path,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -81,7 +81,6 @@ fn is_test_file(path: &Path) -> bool {
         if matches!(
             s,
             "tests"
-                | "test"
                 | "__tests__"
                 | "__test__"
                 | "spec"
@@ -91,6 +90,11 @@ fn is_test_file(path: &Path) -> bool {
         ) {
             return true;
         }
+    }
+    // Java/Kotlin/Gradle: src/test/... — match "test" only when preceded by "src"
+    let comps: Vec<_> = path.components().collect();
+    if comps.windows(2).any(|w| w[0].as_os_str() == "src" && w[1].as_os_str() == "test") {
+        return true;
     }
     let name = match path.file_stem().and_then(|s| s.to_str()) {
         Some(n) => n,
@@ -387,6 +391,9 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(is_test_file(Path::new("tests/helper.rs")));
         assert!(is_test_file(Path::new("__tests__/utils.ts")));
         assert!(is_test_file(Path::new("src/test/java/Foo.java")));
+        assert!(is_test_file(Path::new("module/src/test/kotlin/Bar.kt")));
+        assert!(!is_test_file(Path::new("test/integration/main.go")));
+        assert!(!is_test_file(Path::new("cmd/test/server.go")));
         assert!(is_test_file(Path::new("testdata/input.go")));
         assert!(is_test_file(Path::new("fixtures/setup.py")));
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -80,20 +80,17 @@ fn is_test_file(path: &Path) -> bool {
         let s = component.as_os_str().to_str().unwrap_or("");
         if matches!(
             s,
-            "tests"
-                | "__tests__"
-                | "__test__"
-                | "spec"
-                | "specs"
-                | "testdata"
-                | "fixtures"
+            "tests" | "__tests__" | "__test__" | "spec" | "specs" | "testdata" | "fixtures"
         ) {
             return true;
         }
     }
     // Java/Kotlin/Gradle: src/test/... — match "test" only when preceded by "src"
     let comps: Vec<_> = path.components().collect();
-    if comps.windows(2).any(|w| w[0].as_os_str() == "src" && w[1].as_os_str() == "test") {
+    if comps
+        .windows(2)
+        .any(|w| w[0].as_os_str() == "src" && w[1].as_os_str() == "test")
+    {
         return true;
     }
     let name = match path.file_stem().and_then(|s| s.to_str()) {


### PR DESCRIPTION
## Summary
- Removed bare `"test"` from directory-name match list in `is_test_file`
- Added targeted `src/test/...` check using component windowing
- Prevents false exclusions like `test/integration/main.go` in `--all` mode

Closes #89

## Test plan
- [x] Existing `is_test_file` tests pass
- [x] New positive case: `module/src/test/kotlin/Bar.kt`
- [x] New negative cases: `test/integration/main.go`, `cmd/test/server.go`
- [x] clippy clean