### PR TITLE
feat: filter build-error mutations before running tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,10 @@ pub enum Commands {
         /// Override test command (e.g., 'go test ./...')
         #[arg(long)]
         test_cmd: Option<String>,
+
+        /// Override build check command (e.g., 'cargo check')
+        #[arg(long)]
+        build_cmd: Option<String>,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
 pub struct TestConfig {
     #[serde(default = "default_test_command")]
     pub command: Vec<String>,
+    #[serde(default = "default_test_command")]
+    pub build_command: Vec<String>,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
     #[serde(default = "default_jobs")]
@@ -109,6 +111,29 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     }
 }
 
+pub fn detect_build_command(project_root: &Path) -> Vec<String> {
+    if project_root.join("Cargo.toml").exists() {
+        return vec!["cargo".into(), "check".into()];
+    }
+    if project_root.join("go.mod").exists() {
+        return vec!["go".into(), "build".into(), "./...".into()];
+    }
+    if project_root.join("tsconfig.json").exists() {
+        return vec!["npx".into(), "tsc".into(), "--noEmit".into()];
+    }
+    if project_root.join("pom.xml").exists() {
+        return vec!["mvn".into(), "compile".into(), "-q".into()];
+    }
+    if project_root.join("build.gradle").exists() || project_root.join("build.gradle.kts").exists()
+    {
+        return vec!["./gradlew".into(), "compileJava".into()];
+    }
+    if has_file_with_ext(project_root, "sln") || has_file_with_ext(project_root, "csproj") {
+        return vec!["dotnet".into(), "build".into(), "--no-restore".into()];
+    }
+    vec![]
+}
+
 fn default_timeout() -> u64 {
     30
 }
@@ -131,6 +156,7 @@ impl Default for TestConfig {
     fn default() -> Self {
         Self {
             command: default_test_command(),
+            build_command: default_test_command(),
             timeout: default_timeout(),
             jobs: default_jobs(),
         }
@@ -180,12 +206,20 @@ impl Config {
         }
     }
 
+    /// If no build command was explicitly set in togi.toml, auto-detect from project files.
+    pub fn resolve_build_command(&mut self, project_root: &Path) {
+        if self.test.build_command.is_empty() {
+            self.test.build_command = detect_build_command(project_root);
+        }
+    }
+
     /// Write a template togi.toml to the given path.
     pub fn write_template(path: &Path) -> anyhow::Result<()> {
         let template = r#"# togi.toml — mutation testing configuration
 
 [test]
 command = ["cargo", "test"]
+# build_command = ["cargo", "check"]  # auto-detected; compile check before running tests
 timeout = 30
 # jobs = 4  # defaults to number of CPUs
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
 pub struct TestConfig {
     #[serde(default = "default_test_command")]
     pub command: Vec<String>,
-    #[serde(default = "default_test_command")]
+    #[serde(default)]
     pub build_command: Vec<String>,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
@@ -156,7 +156,7 @@ impl Default for TestConfig {
     fn default() -> Self {
         Self {
             command: default_test_command(),
-            build_command: default_test_command(),
+            build_command: vec![],
             timeout: default_timeout(),
             jobs: default_jobs(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ async fn main() {
             verbose,
             show_output,
             test_cmd,
+            build_cmd,
         } => {
             if let Err(e) = run_check(
                 all,
@@ -31,6 +32,7 @@ async fn main() {
                 verbose,
                 show_output,
                 test_cmd,
+                build_cmd,
             )
             .await
             {
@@ -69,6 +71,7 @@ async fn run_check(
     verbose: bool,
     show_output: bool,
     test_cmd: Option<String>,
+    build_cmd: Option<String>,
 ) -> anyhow::Result<()> {
     // 1. Load config
     let mut config = togi::config::Config::load(config_path.as_deref())?;
@@ -86,6 +89,9 @@ async fn run_check(
     if let Some(cmd) = test_cmd {
         config.test.command = cmd.split_whitespace().map(String::from).collect();
     }
+    if let Some(cmd) = build_cmd {
+        config.test.build_command = cmd.split_whitespace().map(String::from).collect();
+    }
 
     // Find project root (git toplevel)
     let project_root = get_project_root()?;
@@ -95,6 +101,7 @@ async fn run_check(
 
     // Auto-detect test command if not explicitly configured
     config.resolve_test_command(&project_root);
+    config.resolve_build_command(&project_root);
 
     // 3. Build list of files to mutate
     let changed_files = if all {
@@ -122,12 +129,14 @@ async fn run_check(
         files
     };
 
-    // 5. Generate mutations
-    let mutations = togi::mutator::generate_mutations(
-        &changed_files,
-        &project_root,
-        config.mutations.max_per_run,
-    )?;
+    // 5. Generate mutations (over-generate when build check active to compensate for filtered mutations)
+    let generation_limit = if config.test.build_command.is_empty() {
+        config.mutations.max_per_run
+    } else {
+        config.mutations.max_per_run * 2
+    };
+    let mutations =
+        togi::mutator::generate_mutations(&changed_files, &project_root, generation_limit)?;
 
     if mutations.len() >= config.mutations.max_per_run {
         eprintln!(
@@ -168,11 +177,13 @@ async fn run_check(
 
     let runner = togi::runner::TestRunner {
         command: config.test.command,
+        build_command: config.test.build_command,
         timeout: Duration::from_secs(config.test.timeout),
         parallelism: config.test.jobs,
         project_root,
         verbose,
         show_output,
+        max_tested: Some(config.mutations.max_per_run),
     };
 
     let report = runner.run(mutations).await;

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 struct JsonReport {
     total: usize,
+    tested: usize,
     killed: usize,
     survived: usize,
     timeout: usize,
@@ -49,6 +50,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
 
     let json_report = JsonReport {
         total: report.total,
+        tested: report.total - report.build_errors,
         killed: report.killed,
         survived: report.survived,
         timeout: report.timeout,

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -66,10 +66,17 @@ pub fn print_report(report: &MutationReport) {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     println!("{}", separator);
+    let tested = report.total - report.build_errors;
     println!(
         "Results: {}/{} mutations killed ({} survived)",
-        report.killed, report.total, report.survived
+        report.killed, tested, report.survived
     );
+    if report.build_errors > 0 {
+        println!(
+            "Build errors: {} (filtered, not counted in score)",
+            report.build_errors
+        );
+    }
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
 }
@@ -124,12 +131,21 @@ pub fn format_report_plain(report: &MutationReport) -> String {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     writeln!(out, "{}", separator).unwrap();
+    let tested = report.total - report.build_errors;
     writeln!(
         out,
         "Results: {}/{} mutations killed ({} survived)",
-        report.killed, report.total, report.survived
+        report.killed, tested, report.survived
     )
     .unwrap();
+    if report.build_errors > 0 {
+        writeln!(
+            out,
+            "Build errors: {} (filtered, not counted in score)",
+            report.build_errors
+        )
+        .unwrap();
+    }
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{}", separator).unwrap();
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,11 +11,13 @@ use tokio::sync::Semaphore;
 
 pub struct TestRunner {
     pub command: Vec<String>,
+    pub build_command: Vec<String>,
     pub timeout: Duration,
     pub parallelism: usize,
     pub project_root: PathBuf,
     pub verbose: bool,
     pub show_output: bool,
+    pub max_tested: Option<usize>,
 }
 
 struct FileGuard {
@@ -37,6 +39,7 @@ impl TestRunner {
         let start = Instant::now();
         let total = mutations.len();
         let counter = Arc::new(AtomicUsize::new(0));
+        let tested_counter = Arc::new(AtomicUsize::new(0));
         let verbose = self.verbose;
         let is_tty = std::io::stderr().is_terminal();
 
@@ -54,22 +57,35 @@ impl TestRunner {
             let command = self.command.clone();
             let timeout = self.timeout;
             let project_root = self.project_root.clone();
+            let build_command = self.build_command.clone();
             let counter = counter.clone();
+            let tested_counter = tested_counter.clone();
+            let max_tested = self.max_tested;
             let show_output = self.show_output;
 
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
                 for mutation in file_mutations {
+                    // Stop if enough mutations have been tested
+                    if let Some(max) = max_tested
+                        && tested_counter.load(Ordering::Relaxed) >= max
+                    {
+                        break;
+                    }
                     // Semaphore is never closed, so acquire cannot fail
                     let _permit = sem.acquire().await.unwrap();
                     let outcome = run_single_mutation(
                         &command,
+                        &build_command,
                         timeout,
                         &project_root,
                         &mutation,
                         show_output,
                     )
                     .await;
+                    if outcome.result != MutationResult::BuildError {
+                        tested_counter.fetch_add(1, Ordering::Relaxed);
+                    }
                     let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
                     if verbose {
                         let symbol = match outcome.result {
@@ -168,6 +184,7 @@ struct MutationOutcome {
 
 async fn run_single_mutation(
     command: &[String],
+    build_command: &[String],
     timeout: Duration,
     project_root: &PathBuf,
     mutation: &Mutation,
@@ -208,6 +225,17 @@ async fn run_single_mutation(
             result: MutationResult::BuildError,
             test_output: None,
         };
+    }
+
+    // Build check: skip expensive test if mutation doesn't compile
+    if !build_command.is_empty() {
+        let build_outcome = run_command(build_command, project_root, timeout, false).await;
+        if build_outcome.result != MutationResult::Survived {
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
     }
 
     // Run test command; guard will restore the file on drop
@@ -331,6 +359,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
@@ -352,6 +381,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["false".to_string()],
+            &[],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
@@ -384,6 +414,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
@@ -406,6 +437,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["nonexistent_binary_xyz_12345".to_string()],
+            &[],
             Duration::from_secs(5),
             &dir.path().to_path_buf(),
             &mutation,
@@ -428,6 +460,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["sleep".to_string(), "10".to_string()],
+            &[],
             Duration::from_millis(100),
             &dir.path().to_path_buf(),
             &mutation,

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -88,6 +88,8 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
         parallelism: 1,
         project_root: root,
         verbose: false,
+        build_command: vec![],
+        max_tested: None,
         show_output: false,
     };
 


### PR DESCRIPTION
## Summary
- Adds a build check step (`cargo check`, `go build`, etc.) that runs before the expensive test suite, skipping mutations that don't compile
- Build errors don't count toward `max_per_run` — generates 2x mutations to compensate for filtered ones
- Report score excludes build errors from the denominator for accurate signal
- New `--build-cmd` CLI flag and `build_command` config option with auto-detection

## Test plan
- [x] `cargo test` — 85 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual test with a project that produces build-error mutations

Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--build-cmd` CLI flag to override the build check command
  * Automatic build command detection for projects using Cargo, Go, TypeScript, Maven, Gradle, or .NET
  * Build command execution and error tracking during mutation testing

* **Improvements**
  * Build errors are now excluded from mutation score calculation
  * Added `tested` field to JSON reports and terminal output to distinguish tested mutations from build errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->