### PR TITLE
feat: add baseline mode for regression detection

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,139 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+const BASELINE_FILE: &str = ".togi-baseline";
+
+/// Per-file mutation score snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileScore {
+    pub killed: usize,
+    pub total: usize,
+}
+
+/// Baseline snapshot of mutation scores.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Baseline {
+    pub files: HashMap<String, FileScore>,
+    pub killed: usize,
+    pub total: usize,
+}
+
+/// Persist a baseline snapshot to `.togi-baseline`.
+pub fn save_baseline(baseline: &Baseline) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(baseline)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    std::fs::write(BASELINE_FILE, json)
+}
+
+/// Load a previously saved baseline, returning `None` if the file doesn't exist.
+pub fn load_baseline() -> Option<Baseline> {
+    let path = Path::new(BASELINE_FILE);
+    if !path.exists() {
+        return None;
+    }
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Returns `true` if the current overall score is a regression compared to the baseline.
+///
+/// A regression means the current kill ratio is strictly lower than the baseline kill ratio.
+/// If either run has zero total mutations, no regression is reported.
+pub fn check_regression(current: &Baseline, baseline: &Baseline) -> bool {
+    if current.total == 0 || baseline.total == 0 {
+        return false;
+    }
+    let current_ratio = current.killed as f64 / current.total as f64;
+    let baseline_ratio = baseline.killed as f64 / baseline.total as f64;
+    current_ratio < baseline_ratio
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_baseline(killed: usize, total: usize) -> Baseline {
+        Baseline {
+            files: HashMap::new(),
+            killed,
+            total,
+        }
+    }
+
+    #[test]
+    fn no_regression_when_score_improves() {
+        let baseline = make_baseline(5, 10);
+        let current = make_baseline(7, 10);
+        assert!(!check_regression(&current, &baseline));
+    }
+
+    #[test]
+    fn no_regression_when_score_same() {
+        let baseline = make_baseline(5, 10);
+        let current = make_baseline(5, 10);
+        assert!(!check_regression(&current, &baseline));
+    }
+
+    #[test]
+    fn regression_when_score_drops() {
+        let baseline = make_baseline(5, 10);
+        let current = make_baseline(3, 10);
+        assert!(check_regression(&current, &baseline));
+    }
+
+    #[test]
+    fn no_regression_when_baseline_empty() {
+        let baseline = make_baseline(0, 0);
+        let current = make_baseline(3, 10);
+        assert!(!check_regression(&current, &baseline));
+    }
+
+    #[test]
+    fn no_regression_when_current_empty() {
+        let baseline = make_baseline(5, 10);
+        let current = make_baseline(0, 0);
+        assert!(!check_regression(&current, &baseline));
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let mut files = HashMap::new();
+        files.insert(
+            "src/main.rs".to_string(),
+            FileScore {
+                killed: 3,
+                total: 5,
+            },
+        );
+        let baseline = Baseline {
+            files,
+            killed: 3,
+            total: 5,
+        };
+
+        save_baseline(&baseline).unwrap();
+        let loaded = load_baseline().unwrap();
+
+        assert_eq!(loaded.killed, 3);
+        assert_eq!(loaded.total, 5);
+        assert_eq!(loaded.files["src/main.rs"].killed, 3);
+
+        std::env::set_current_dir(prev).unwrap();
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        assert!(load_baseline().is_none());
+
+        std::env::set_current_dir(prev).unwrap();
+    }
+}

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -19,21 +19,26 @@ pub struct Baseline {
     pub total: usize,
 }
 
-/// Persist a baseline snapshot to `.togi-baseline`.
-pub fn save_baseline(baseline: &Baseline) -> std::io::Result<()> {
-    let json = serde_json::to_string_pretty(baseline)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    std::fs::write(BASELINE_FILE, json)
+/// Persist a baseline snapshot to `.togi-baseline` inside `dir`.
+pub fn save_baseline(baseline: &Baseline, dir: &Path) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(baseline).map_err(std::io::Error::other)?;
+    std::fs::write(dir.join(BASELINE_FILE), json)
 }
 
-/// Load a previously saved baseline, returning `None` if the file doesn't exist.
-pub fn load_baseline() -> Option<Baseline> {
-    let path = Path::new(BASELINE_FILE);
+/// Load a previously saved baseline from `dir`, returning `None` if the file doesn't exist.
+pub fn load_baseline(dir: &Path) -> Option<Baseline> {
+    let path = dir.join(BASELINE_FILE);
     if !path.exists() {
         return None;
     }
-    let data = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&data).ok()
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str(&data) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            eprintln!("warning: failed to parse {}: {}", path.display(), e);
+            None
+        }
+    }
 }
 
 /// Returns `true` if the current overall score is a regression compared to the baseline.
@@ -99,8 +104,6 @@ mod tests {
     #[test]
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let prev = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
 
         let mut files = HashMap::new();
         files.insert(
@@ -116,24 +119,17 @@ mod tests {
             total: 5,
         };
 
-        save_baseline(&baseline).unwrap();
-        let loaded = load_baseline().unwrap();
+        save_baseline(&baseline, dir.path()).unwrap();
+        let loaded = load_baseline(dir.path()).unwrap();
 
         assert_eq!(loaded.killed, 3);
         assert_eq!(loaded.total, 5);
         assert_eq!(loaded.files["src/main.rs"].killed, 3);
-
-        std::env::set_current_dir(prev).unwrap();
     }
 
     #[test]
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let prev = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        assert!(load_baseline().is_none());
-
-        std::env::set_current_dir(prev).unwrap();
+        assert!(load_baseline(dir.path()).is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod baseline;
 pub mod cli;
 pub mod config;
 pub mod diff;


### PR DESCRIPTION
## Summary
- Adds `src/baseline.rs` with `Baseline` / `FileScore` types and JSON persistence to `.togi-baseline`
- Exports `save_baseline()`, `load_baseline()`, `check_regression()` public API
- Includes 7 unit tests covering regression logic, roundtrip serialization, and edge cases

## Integration note
Requires `pub mod baseline;` added to `src/lib.rs` to compile as part of the crate.

Closes TOG-10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Baseline mutation-score tracking: Save mutation-score snapshots to establish quality baselines. Automatically compare future test runs against these baselines to detect performance regressions and maintain code quality standards across development cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->