### PR TITLE
feat: add collect_changed_since for --since flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +713,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "siphasher",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ ignore = "0.4"
 anyhow = "1"
 thiserror = "2"
 
+# Hashing
+siphasher = "1"
+
 # Platform
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -56,8 +56,8 @@ impl CacheKey {
 /// Look up a previously cached result.
 ///
 /// Returns `None` on cache miss or any I/O / deserialization error.
-pub fn lookup(key: &CacheKey) -> Option<CachedResult> {
-    let path = entry_path(key);
+pub fn lookup(project_root: &Path, key: &CacheKey) -> Option<CachedResult> {
+    let path = entry_path(project_root, key);
     let data = fs::read_to_string(path).ok()?;
     serde_json::from_str(&data).ok()
 }
@@ -66,8 +66,8 @@ pub fn lookup(key: &CacheKey) -> Option<CachedResult> {
 ///
 /// Creates the cache directory if it doesn't exist. Silently ignores
 /// write errors so cache failures never break the main pipeline.
-pub fn store(key: &CacheKey, result: CachedResult) {
-    let path = entry_path(key);
+pub fn store(project_root: &Path, key: &CacheKey, result: CachedResult) {
+    let path = entry_path(project_root, key);
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
     }
@@ -75,21 +75,21 @@ pub fn store(key: &CacheKey, result: CachedResult) {
 }
 
 /// Delete all cached results.
-pub fn clear() {
-    let dir = cache_dir();
+pub fn clear(project_root: &Path) {
+    let dir = cache_dir(project_root);
     if dir.exists() {
         let _ = fs::remove_dir_all(&dir);
     }
 }
 
-/// Return the cache directory path (relative to cwd).
-fn cache_dir() -> PathBuf {
-    PathBuf::from(CACHE_DIR)
+/// Return the cache directory path under the given project root.
+fn cache_dir(project_root: &Path) -> PathBuf {
+    project_root.join(CACHE_DIR)
 }
 
 /// Return the file path for a given cache key.
-fn entry_path(key: &CacheKey) -> PathBuf {
-    cache_dir().join(key.digest())
+fn entry_path(project_root: &Path, key: &CacheKey) -> PathBuf {
+    cache_dir(project_root).join(key.digest())
 }
 
 fn hash_bytes(data: &[u8]) -> u64 {
@@ -107,75 +107,59 @@ fn hash_str(s: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-
-    /// Run a test body inside a temporary directory so cache files don't
-    /// pollute the repo.
-    fn in_temp_dir(f: impl FnOnce()) {
-        let tmp = tempfile::tempdir().expect("create tempdir");
-        let prev = env::current_dir().expect("cwd");
-        env::set_current_dir(tmp.path()).expect("chdir");
-        f();
-        env::set_current_dir(prev).expect("restore cwd");
-    }
 
     #[test]
     fn store_and_lookup() {
-        in_temp_dir(|| {
-            let key = CacheKey::new(b"fn main() {}", "replace + with -", "cargo test");
-            store(&key, CachedResult::Killed);
-            assert_eq!(lookup(&key), Some(CachedResult::Killed));
-        });
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let key = CacheKey::new(b"fn main() {}", "replace + with -", "cargo test");
+        store(tmp.path(), &key, CachedResult::Killed);
+        assert_eq!(lookup(tmp.path(), &key), Some(CachedResult::Killed));
     }
 
     #[test]
     fn lookup_miss_returns_none() {
-        in_temp_dir(|| {
-            let key = CacheKey::new(b"code", "desc", "cmd");
-            assert_eq!(lookup(&key), None);
-        });
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let key = CacheKey::new(b"code", "desc", "cmd");
+        assert_eq!(lookup(tmp.path(), &key), None);
     }
 
     #[test]
     fn different_content_different_key() {
-        in_temp_dir(|| {
-            let k1 = CacheKey::new(b"v1", "desc", "cmd");
-            let k2 = CacheKey::new(b"v2", "desc", "cmd");
-            store(&k1, CachedResult::Survived);
-            store(&k2, CachedResult::Killed);
-            assert_eq!(lookup(&k1), Some(CachedResult::Survived));
-            assert_eq!(lookup(&k2), Some(CachedResult::Killed));
-        });
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let k1 = CacheKey::new(b"v1", "desc", "cmd");
+        let k2 = CacheKey::new(b"v2", "desc", "cmd");
+        store(tmp.path(), &k1, CachedResult::Survived);
+        store(tmp.path(), &k2, CachedResult::Killed);
+        assert_eq!(lookup(tmp.path(), &k1), Some(CachedResult::Survived));
+        assert_eq!(lookup(tmp.path(), &k2), Some(CachedResult::Killed));
     }
 
     #[test]
     fn clear_removes_cache() {
-        in_temp_dir(|| {
-            let key = CacheKey::new(b"code", "desc", "cmd");
-            store(&key, CachedResult::Timeout);
-            assert!(cache_dir().exists());
-            clear();
-            assert!(!cache_dir().exists());
-            assert_eq!(lookup(&key), None);
-        });
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let key = CacheKey::new(b"code", "desc", "cmd");
+        store(tmp.path(), &key, CachedResult::Timeout);
+        assert!(cache_dir(tmp.path()).exists());
+        clear(tmp.path());
+        assert!(!cache_dir(tmp.path()).exists());
+        assert_eq!(lookup(tmp.path(), &key), None);
     }
 
     #[test]
     fn all_result_variants_roundtrip() {
-        in_temp_dir(|| {
-            for (i, result) in [
-                CachedResult::Killed,
-                CachedResult::Survived,
-                CachedResult::Timeout,
-                CachedResult::BuildError,
-            ]
-            .iter()
-            .enumerate()
-            {
-                let key = CacheKey::new(format!("file{i}").as_bytes(), "desc", "cmd");
-                store(&key, *result);
-                assert_eq!(lookup(&key), Some(*result));
-            }
-        });
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        for (i, result) in [
+            CachedResult::Killed,
+            CachedResult::Survived,
+            CachedResult::Timeout,
+            CachedResult::BuildError,
+        ]
+        .iter()
+        .enumerate()
+        {
+            let key = CacheKey::new(format!("file{i}").as_bytes(), "desc", "cmd");
+            store(tmp.path(), &key, *result);
+            assert_eq!(lookup(tmp.path(), &key), Some(*result));
+        }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,181 @@
+//! Incremental mutation cache.
+//!
+//! Caches mutation test results keyed on (file content hash, mutation
+//! description, test command hash) so unchanged mutations can be skipped
+//! on subsequent runs. Results are stored as JSON files in `.togi-cache/`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Directory where cache entries are stored.
+const CACHE_DIR: &str = ".togi-cache";
+
+/// A cached mutation test result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CachedResult {
+    Killed,
+    Survived,
+    Timeout,
+    BuildError,
+}
+
+/// Components that form a unique cache key.
+pub struct CacheKey {
+    /// Hash of the source file content.
+    pub file_content_hash: u64,
+    /// The mutation description string (operator + what changed).
+    pub mutation_description: String,
+    /// Hash of the test command string.
+    pub test_command_hash: u64,
+}
+
+impl CacheKey {
+    /// Build a cache key from raw inputs.
+    pub fn new(file_content: &[u8], mutation_description: &str, test_command: &str) -> Self {
+        Self {
+            file_content_hash: hash_bytes(file_content),
+            mutation_description: mutation_description.to_string(),
+            test_command_hash: hash_str(test_command),
+        }
+    }
+
+    /// Compute the hex digest used as the cache filename.
+    fn digest(&self) -> String {
+        let mut h = DefaultHasher::new();
+        self.file_content_hash.hash(&mut h);
+        self.mutation_description.hash(&mut h);
+        self.test_command_hash.hash(&mut h);
+        format!("{:016x}", h.finish())
+    }
+}
+
+/// Look up a previously cached result.
+///
+/// Returns `None` on cache miss or any I/O / deserialization error.
+pub fn lookup(key: &CacheKey) -> Option<CachedResult> {
+    let path = entry_path(key);
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Store a mutation result in the cache.
+///
+/// Creates the cache directory if it doesn't exist. Silently ignores
+/// write errors so cache failures never break the main pipeline.
+pub fn store(key: &CacheKey, result: CachedResult) {
+    let path = entry_path(key);
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, serde_json::to_string(&result).unwrap_or_default());
+}
+
+/// Delete all cached results.
+pub fn clear() {
+    let dir = cache_dir();
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+/// Return the cache directory path (relative to cwd).
+fn cache_dir() -> PathBuf {
+    PathBuf::from(CACHE_DIR)
+}
+
+/// Return the file path for a given cache key.
+fn entry_path(key: &CacheKey) -> PathBuf {
+    cache_dir().join(key.digest())
+}
+
+fn hash_bytes(data: &[u8]) -> u64 {
+    let mut h = DefaultHasher::new();
+    data.hash(&mut h);
+    h.finish()
+}
+
+fn hash_str(s: &str) -> u64 {
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    /// Run a test body inside a temporary directory so cache files don't
+    /// pollute the repo.
+    fn in_temp_dir(f: impl FnOnce()) {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let prev = env::current_dir().expect("cwd");
+        env::set_current_dir(tmp.path()).expect("chdir");
+        f();
+        env::set_current_dir(prev).expect("restore cwd");
+    }
+
+    #[test]
+    fn store_and_lookup() {
+        in_temp_dir(|| {
+            let key = CacheKey::new(b"fn main() {}", "replace + with -", "cargo test");
+            store(&key, CachedResult::Killed);
+            assert_eq!(lookup(&key), Some(CachedResult::Killed));
+        });
+    }
+
+    #[test]
+    fn lookup_miss_returns_none() {
+        in_temp_dir(|| {
+            let key = CacheKey::new(b"code", "desc", "cmd");
+            assert_eq!(lookup(&key), None);
+        });
+    }
+
+    #[test]
+    fn different_content_different_key() {
+        in_temp_dir(|| {
+            let k1 = CacheKey::new(b"v1", "desc", "cmd");
+            let k2 = CacheKey::new(b"v2", "desc", "cmd");
+            store(&k1, CachedResult::Survived);
+            store(&k2, CachedResult::Killed);
+            assert_eq!(lookup(&k1), Some(CachedResult::Survived));
+            assert_eq!(lookup(&k2), Some(CachedResult::Killed));
+        });
+    }
+
+    #[test]
+    fn clear_removes_cache() {
+        in_temp_dir(|| {
+            let key = CacheKey::new(b"code", "desc", "cmd");
+            store(&key, CachedResult::Timeout);
+            assert!(cache_dir().exists());
+            clear();
+            assert!(!cache_dir().exists());
+            assert_eq!(lookup(&key), None);
+        });
+    }
+
+    #[test]
+    fn all_result_variants_roundtrip() {
+        in_temp_dir(|| {
+            for (i, result) in [
+                CachedResult::Killed,
+                CachedResult::Survived,
+                CachedResult::Timeout,
+                CachedResult::BuildError,
+            ]
+            .iter()
+            .enumerate()
+            {
+                let key = CacheKey::new(format!("file{i}").as_bytes(), "desc", "cmd");
+                store(&key, *result);
+                assert_eq!(lookup(&key), Some(*result));
+            }
+        });
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,10 +4,11 @@
 //! description, test command hash) so unchanged mutations can be skipped
 //! on subsequent runs. Results are stored as JSON files in `.togi-cache/`.
 
-use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+
+use siphasher::sip::SipHasher;
 
 use serde::{Deserialize, Serialize};
 
@@ -45,7 +46,7 @@ impl CacheKey {
 
     /// Compute the hex digest used as the cache filename.
     fn digest(&self) -> String {
-        let mut h = DefaultHasher::new();
+        let mut h = SipHasher::new();
         self.file_content_hash.hash(&mut h);
         self.mutation_description.hash(&mut h);
         self.test_command_hash.hash(&mut h);
@@ -93,13 +94,13 @@ fn entry_path(project_root: &Path, key: &CacheKey) -> PathBuf {
 }
 
 fn hash_bytes(data: &[u8]) -> u64 {
-    let mut h = DefaultHasher::new();
+    let mut h = SipHasher::new();
     data.hash(&mut h);
     h.finish()
 }
 
 fn hash_str(s: &str) -> u64 {
-    let mut h = DefaultHasher::new();
+    let mut h = SipHasher::new();
     s.hash(&mut h);
     h.finish()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Deserialize)]
@@ -11,6 +12,11 @@ pub struct Config {
     pub mutations: MutationConfig,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanguageTestConfig {
+    pub command: Vec<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct TestConfig {
     #[serde(default = "default_test_command")]
@@ -19,6 +25,8 @@ pub struct TestConfig {
     pub timeout: u64,
     #[serde(default = "default_jobs")]
     pub jobs: usize,
+    #[serde(flatten, default)]
+    pub languages: HashMap<String, LanguageTestConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -133,6 +141,7 @@ impl Default for TestConfig {
             command: default_test_command(),
             timeout: default_timeout(),
             jobs: default_jobs(),
+            languages: HashMap::new(),
         }
     }
 }
@@ -171,6 +180,14 @@ impl Config {
             }
             None => Ok(Config::default()),
         }
+    }
+
+    /// Look up a per-language test command from `[test.<language>]` sections.
+    pub fn test_command_for_language(&self, language: &str) -> Option<&[String]> {
+        self.test
+            .languages
+            .get(language)
+            .map(|c| c.command.as_slice())
     }
 
     /// If no test command was explicitly set in togi.toml, auto-detect from project files.
@@ -368,5 +385,37 @@ timeout = 120
     #[test]
     fn default_timeout_is_30() {
         assert_eq!(default_timeout(), 30);
+    }
+
+    #[test]
+    fn parse_per_language_test_commands() {
+        let toml_str = r#"
+[test]
+command = ["make", "test"]
+
+[test.rust]
+command = ["cargo", "test"]
+
+[test.python]
+command = ["pytest", "-x"]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.test.command, vec!["make", "test"]);
+        assert_eq!(
+            config.test_command_for_language("rust"),
+            Some(vec!["cargo".to_string(), "test".to_string()].as_slice())
+        );
+        assert_eq!(
+            config.test_command_for_language("python"),
+            Some(vec!["pytest".to_string(), "-x".to_string()].as_slice())
+        );
+        assert_eq!(config.test_command_for_language("go"), None);
+    }
+
+    #[test]
+    fn no_language_overrides_by_default() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.test.languages.is_empty());
+        assert_eq!(config.test_command_for_language("rust"), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Deserialize)]
@@ -12,11 +11,6 @@ pub struct Config {
     pub mutations: MutationConfig,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct LanguageTestConfig {
-    pub command: Vec<String>,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct TestConfig {
     #[serde(default = "default_test_command")]
@@ -25,8 +19,6 @@ pub struct TestConfig {
     pub timeout: u64,
     #[serde(default = "default_jobs")]
     pub jobs: usize,
-    #[serde(flatten, default)]
-    pub languages: HashMap<String, LanguageTestConfig>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,7 +133,6 @@ impl Default for TestConfig {
             command: default_test_command(),
             timeout: default_timeout(),
             jobs: default_jobs(),
-            languages: HashMap::new(),
         }
     }
 }
@@ -180,14 +171,6 @@ impl Config {
             }
             None => Ok(Config::default()),
         }
-    }
-
-    /// Look up a per-language test command from `[test.<language>]` sections.
-    pub fn test_command_for_language(&self, language: &str) -> Option<&[String]> {
-        self.test
-            .languages
-            .get(language)
-            .map(|c| c.command.as_slice())
     }
 
     /// If no test command was explicitly set in togi.toml, auto-detect from project files.
@@ -385,37 +368,5 @@ timeout = 120
     #[test]
     fn default_timeout_is_30() {
         assert_eq!(default_timeout(), 30);
-    }
-
-    #[test]
-    fn parse_per_language_test_commands() {
-        let toml_str = r#"
-[test]
-command = ["make", "test"]
-
-[test.rust]
-command = ["cargo", "test"]
-
-[test.python]
-command = ["pytest", "-x"]
-"#;
-        let config: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.test.command, vec!["make", "test"]);
-        assert_eq!(
-            config.test_command_for_language("rust"),
-            Some(vec!["cargo".to_string(), "test".to_string()].as_slice())
-        );
-        assert_eq!(
-            config.test_command_for_language("python"),
-            Some(vec!["pytest".to_string(), "-x".to_string()].as_slice())
-        );
-        assert_eq!(config.test_command_for_language("go"), None);
-    }
-
-    #[test]
-    fn no_language_overrides_by_default() {
-        let config: Config = toml::from_str("").unwrap();
-        assert!(config.test.languages.is_empty());
-        assert_eq!(config.test_command_for_language("rust"), None);
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -84,7 +84,7 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result<Vec<ChangedFile>> {
     // Try as a commit ref first (SHA, branch, tag).
     let output = Command::new("git")
-        .args(["diff", &format!("{since}...HEAD")])
+        .args(["diff", &format!("{since}..HEAD")])
         .current_dir(project_root)
         .output()?;
 
@@ -104,21 +104,33 @@ pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result
         }
         let base = String::from_utf8(rev_output.stdout)?.trim().to_string();
         if base.is_empty() {
-            // No commit before that date — diff the entire history.
+            // No commit before that date — diff the entire history
+            // against the empty tree.
+            let empty_tree = Command::new("git")
+                .args(["hash-object", "-t", "tree", "/dev/null"])
+                .current_dir(project_root)
+                .output()?;
+            if !empty_tree.status.success() {
+                anyhow::bail!(
+                    "git hash-object failed: {}",
+                    String::from_utf8_lossy(&empty_tree.stderr)
+                );
+            }
+            let tree_sha = String::from_utf8(empty_tree.stdout)?.trim().to_string();
             let out = Command::new("git")
-                .args(["diff", "--root", "HEAD"])
+                .args(["diff", &format!("{tree_sha}..HEAD")])
                 .current_dir(project_root)
                 .output()?;
             if !out.status.success() {
                 anyhow::bail!(
-                    "git diff --root failed: {}",
+                    "git diff (empty tree) failed: {}",
                     String::from_utf8_lossy(&out.stderr)
                 );
             }
             String::from_utf8(out.stdout)?
         } else {
             let out = Command::new("git")
-                .args(["diff", &format!("{base}...HEAD")])
+                .args(["diff", &format!("{base}..HEAD")])
                 .current_dir(project_root)
                 .output()?;
             if !out.status.success() {
@@ -583,6 +595,44 @@ diff --git a/src/main.rs b/src/main.rs
 
         // Use a date between the two commits — should pick up the second commit.
         let files = collect_changed_since(root, "2024-03-01").unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("main.rs"));
+        assert!(!files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn collect_changed_since_root_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let run = |args: &[&str], date: &str| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_DATE", date)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+
+        run(&["init"], "2024-06-01T00:00:00Z");
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        run(&["add", "."], "2024-06-01T00:00:00Z");
+        run(&["commit", "-m", "initial"], "2024-06-01T00:00:00Z");
+
+        // Date before any commit — triggers git diff --root HEAD fallback.
+        let files = collect_changed_since(root, "2024-01-01").unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("main.rs"));
         assert!(!files[0].hunks.is_empty());

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -105,18 +105,8 @@ pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result
         let base = String::from_utf8(rev_output.stdout)?.trim().to_string();
         if base.is_empty() {
             // No commit before that date — diff the entire history
-            // against the empty tree.
-            let empty_tree = Command::new("git")
-                .args(["hash-object", "-t", "tree", "/dev/null"])
-                .current_dir(project_root)
-                .output()?;
-            if !empty_tree.status.success() {
-                anyhow::bail!(
-                    "git hash-object failed: {}",
-                    String::from_utf8_lossy(&empty_tree.stderr)
-                );
-            }
-            let tree_sha = String::from_utf8(empty_tree.stdout)?.trim().to_string();
+            // against the well-known empty tree SHA.
+            let tree_sha = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
             let out = Command::new("git")
                 .args(["diff", &format!("{tree_sha}..HEAD")])
                 .current_dir(project_root)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -73,6 +73,43 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
     Ok(files)
 }
 
+/// Collect changed files and line ranges since a given git ref or date.
+///
+/// `since` can be a commit SHA, branch name, tag, or a date string that
+/// `git log --since` understands (e.g. "2024-01-01", "3 days ago").
+///
+/// Returns the same `Vec<ChangedFile>` format as `parse_diff`, filtering
+/// out test files and files with no added lines.
+pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result<Vec<ChangedFile>> {
+    use std::process::Command;
+
+    // Try as a commit ref first (SHA, branch, tag).
+    let output = Command::new("git")
+        .args(["diff", &format!("{since}...HEAD")])
+        .current_dir(project_root)
+        .output()?;
+
+    let diff_output = if output.status.success() {
+        String::from_utf8(output.stdout)?
+    } else {
+        // Fall back to date-based: git log --since=<date> -p
+        let output = Command::new("git")
+            .args(["log", &format!("--since={since}"), "-p", "--reverse"])
+            .current_dir(project_root)
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git log --since failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        String::from_utf8(output.stdout)?
+    };
+
+    let all = parse_diff(&diff_output);
+    Ok(all.into_iter().filter(|f| !is_test_file(&f.path)).collect())
+}
+
 /// Returns true for files that look like test files across supported languages.
 fn is_test_file(path: &Path) -> bool {
     // Check if any ancestor directory is a known test directory
@@ -393,5 +430,83 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(!is_test_file(Path::new("cmd/test/server.go")));
         assert!(is_test_file(Path::new("testdata/input.go")));
         assert!(is_test_file(Path::new("fixtures/setup.py")));
+    }
+
+    #[test]
+    fn collect_changed_since_ref() {
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .unwrap()
+        };
+
+        run(&["init"]);
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "initial"]);
+
+        let out = run(&["rev-parse", "HEAD"]);
+        let base = String::from_utf8(out.stdout).unwrap().trim().to_string();
+
+        std::fs::write(
+            root.join("main.rs"),
+            "fn main() {\n    println!(\"hi\");\n}\n",
+        )
+        .unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "add print"]);
+
+        let files = collect_changed_since(root, &base).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("main.rs"));
+        assert!(!files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn collect_changed_since_filters_test_files() {
+        use std::process::Command;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .unwrap()
+        };
+
+        run(&["init"]);
+        std::fs::write(root.join("lib.rs"), "pub fn x() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "initial"]);
+
+        let out = run(&["rev-parse", "HEAD"]);
+        let base = String::from_utf8(out.stdout).unwrap().trim().to_string();
+
+        std::fs::write(root.join("lib.rs"), "pub fn x() { 1 }\n").unwrap();
+        std::fs::write(root.join("lib_test.rs"), "fn test() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "add changes"]);
+
+        let files = collect_changed_since(root, &base).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("lib.rs"));
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -621,7 +621,7 @@ diff --git a/src/main.rs b/src/main.rs
         run(&["add", "."], "2024-06-01T00:00:00Z");
         run(&["commit", "-m", "initial"], "2024-06-01T00:00:00Z");
 
-        // Date before any commit — triggers git diff --root HEAD fallback.
+        // Date before any commit — triggers empty-tree SHA fallback.
         let files = collect_changed_since(root, "2024-01-01").unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("main.rs"));

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,6 +2,7 @@
 
 use crate::{ChangedFile, LineRange};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Build ChangedFile entries for every supported file in the project tree.
 /// Respects `.gitignore` rules. Skips test files.
@@ -81,8 +82,6 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 /// Returns the same `Vec<ChangedFile>` format as `parse_diff`, filtering
 /// out test files and files with no added lines.
 pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result<Vec<ChangedFile>> {
-    use std::process::Command;
-
     // Try as a commit ref first (SHA, branch, tag).
     let output = Command::new("git")
         .args(["diff", &format!("{since}...HEAD")])
@@ -92,18 +91,41 @@ pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result
     let diff_output = if output.status.success() {
         String::from_utf8(output.stdout)?
     } else {
-        // Fall back to date-based: git log --since=<date> -p
-        let output = Command::new("git")
-            .args(["log", &format!("--since={since}"), "-p", "--reverse"])
+        // Fall back to date-based: resolve to a baseline commit, then diff.
+        let rev_output = Command::new("git")
+            .args(["rev-list", "-1", &format!("--before={since}"), "HEAD"])
             .current_dir(project_root)
             .output()?;
-        if !output.status.success() {
+        if !rev_output.status.success() {
             anyhow::bail!(
-                "git log --since failed: {}",
-                String::from_utf8_lossy(&output.stderr)
+                "git rev-list --before failed: {}",
+                String::from_utf8_lossy(&rev_output.stderr)
             );
         }
-        String::from_utf8(output.stdout)?
+        let base = String::from_utf8(rev_output.stdout)?.trim().to_string();
+        if base.is_empty() {
+            // No commit before that date — diff the entire history.
+            let out = Command::new("git")
+                .args(["diff", "--root", "HEAD"])
+                .current_dir(project_root)
+                .output()?;
+            if !out.status.success() {
+                anyhow::bail!(
+                    "git diff --root failed: {}",
+                    String::from_utf8_lossy(&out.stderr)
+                );
+            }
+            String::from_utf8(out.stdout)?
+        } else {
+            let out = Command::new("git")
+                .args(["diff", &format!("{base}...HEAD")])
+                .current_dir(project_root)
+                .output()?;
+            if !out.status.success() {
+                anyhow::bail!("git diff failed: {}", String::from_utf8_lossy(&out.stderr));
+            }
+            String::from_utf8(out.stdout)?
+        }
     };
 
     let all = parse_diff(&diff_output);
@@ -434,13 +456,11 @@ diff --git a/src/main.rs b/src/main.rs
 
     #[test]
     fn collect_changed_since_ref() {
-        use std::process::Command;
-
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
 
         let run = |args: &[&str]| {
-            Command::new("git")
+            let out = Command::new("git")
                 .args(args)
                 .current_dir(root)
                 .env("GIT_AUTHOR_NAME", "test")
@@ -448,7 +468,14 @@ diff --git a/src/main.rs b/src/main.rs
                 .env("GIT_COMMITTER_NAME", "test")
                 .env("GIT_COMMITTER_EMAIL", "t@t")
                 .output()
-                .unwrap()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
         };
 
         run(&["init"]);
@@ -475,13 +502,11 @@ diff --git a/src/main.rs b/src/main.rs
 
     #[test]
     fn collect_changed_since_filters_test_files() {
-        use std::process::Command;
-
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
 
         let run = |args: &[&str]| {
-            Command::new("git")
+            let out = Command::new("git")
                 .args(args)
                 .current_dir(root)
                 .env("GIT_AUTHOR_NAME", "test")
@@ -489,7 +514,14 @@ diff --git a/src/main.rs b/src/main.rs
                 .env("GIT_COMMITTER_NAME", "test")
                 .env("GIT_COMMITTER_EMAIL", "t@t")
                 .output()
-                .unwrap()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
         };
 
         run(&["init"]);
@@ -508,5 +540,51 @@ diff --git a/src/main.rs b/src/main.rs
         let files = collect_changed_since(root, &base).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("lib.rs"));
+    }
+
+    #[test]
+    fn collect_changed_since_date_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let run = |args: &[&str], date: &str| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_DATE", date)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+
+        run(&["init"], "2024-01-01T00:00:00Z");
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        run(&["add", "."], "2024-01-01T00:00:00Z");
+        run(&["commit", "-m", "initial"], "2024-01-01T00:00:00Z");
+
+        std::fs::write(
+            root.join("main.rs"),
+            "fn main() {\n    println!(\"hi\");\n}\n",
+        )
+        .unwrap();
+        run(&["add", "."], "2024-06-15T00:00:00Z");
+        run(&["commit", "-m", "add print"], "2024-06-15T00:00:00Z");
+
+        // Use a date between the two commits — should pick up the second commit.
+        let files = collect_changed_since(root, "2024-03-01").unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, PathBuf::from("main.rs"));
+        assert!(!files[0].hunks.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod cli;
 pub mod config;
 pub mod diff;


### PR DESCRIPTION
## Summary
- Adds `pub fn collect_changed_since(project_root, since)` to `src/diff.rs`
- Accepts a commit SHA/ref or date string, returns `Vec<ChangedFile>` with changed line ranges
- Tries `git diff <ref>...HEAD` first, falls back to `git log --since` for date strings
- Filters out test files from results
- Two new tests covering ref-based lookup and test-file filtering

Resolves TOG-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve and analyze code changes since a given commit/date while excluding test files.
  * Add an incremental, on-disk mutation-result cache with lookup/store/clear operations and stable keys.

* **Tests**
  * Unit tests validating change-collection scenarios (refs, date fallbacks, test-file filtering).
  * Unit tests covering cache behavior (store/lookup, miss handling, key uniqueness, clear, and JSON round-trip).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->