### PR TITLE
perf: use bytecount for line counting in collect_all

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ serde_json = "1"
 tempfile = "3"
 ignore = "0.4"
 
+# Byte counting
+bytecount = "0.6"
+
 # Error handling
 anyhow = "1"
 thiserror = "2"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -48,15 +48,21 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
             continue;
         }
 
-        let line_count =
-            std::io::BufRead::lines(std::io::BufReader::new(match std::fs::File::open(path) {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("warning: could not read {}: {e}", path.display());
-                    continue;
-                }
-            }))
-            .count();
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("warning: could not read {}: {e}", path.display());
+                continue;
+            }
+        };
+        let newlines = bytecount::count(&bytes, b'\n');
+        let line_count = if bytes.is_empty() {
+            0
+        } else if bytes.last() == Some(&b'\n') {
+            newlines
+        } else {
+            newlines + 1
+        };
         if line_count == 0 {
             continue;
         }


### PR DESCRIPTION
## Summary

- Replace `BufRead::lines().count()` with `bytecount::count(&bytes, b'\n')` in `collect_all_supported_files`
- Avoids per-line `String` allocation and UTF-8 decoding — just counts `\n` bytes (SIMD-accelerated)
- Correctly handles files with/without trailing newline

Fixes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file line counting during diff processing for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->