### PR TITLE
fix: use git init in collect_all test

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -341,8 +341,12 @@ diff --git a/src/main.rs b/src/main.rs
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
 
-        // Init a git repo so .gitignore is respected
-        std::fs::create_dir(root.join(".git")).unwrap();
+        // Init a real git repo so the ignore crate respects .gitignore
+        std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root)
+            .status()
+            .expect("git init failed");
 
         // Supported file
         let src = root.join("src");


### PR DESCRIPTION
## Summary
- Replace empty `.git/` dir with `git init -q` in `collect_all_finds_supported_files_and_respects_gitignore` test
- The `ignore` crate needs a real git repo to respect `.gitignore` on all platforms
- Fixes #90

## Test plan
- [x] Target test passes
- [x] Full `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup updated to initialize real Git repositories instead of creating placeholder directories.
  * Ensures `.gitignore`-related behavior is validated against an actual repository, improving test accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->