### PR TITLE
fix: replace fragile string-matching error classification

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,11 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+/// Error type for configuration loading failures.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct ConfigError(pub String);
+
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -230,9 +235,11 @@ impl Config {
 
         match config_path {
             Some(p) => {
-                let content = std::fs::read_to_string(&p)?;
-                let config: Config = toml::from_str(&content)
-                    .map_err(|e| anyhow::anyhow!("Invalid togi.toml at {}: {e}", p.display()))?;
+                let content = std::fs::read_to_string(&p)
+                    .map_err(|e| ConfigError(format!("Could not read {}: {e}", p.display())))?;
+                let config: Config = toml::from_str(&content).map_err(|e| {
+                    ConfigError(format!("Invalid togi.toml at {}: {e}", p.display()))
+                })?;
                 Ok(config)
             }
             None => Ok(Config::default()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,7 @@ async fn main() {
             .await
             {
                 eprintln!("Error: {e}");
-                let msg = e.to_string();
-                if msg.contains("toml") || msg.contains("config") || msg.contains("togi.toml") {
+                if e.downcast_ref::<togi::config::ConfigError>().is_some() {
                     eprintln!("Hint: run 'togi check --help' for usage information.");
                 }
                 process::exit(2);


### PR DESCRIPTION
## Summary
- Add `ConfigError` type in `config.rs` for config load/parse failures
- Replace string matching in `main.rs` with `downcast_ref::<ConfigError>()`

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration error handling has been improved to provide more specific and informative error messages when configuration files fail to load or contain invalid syntax.
  * Error reporting and user guidance for configuration-related issues has been enhanced to provide clearer context for troubleshooting problems during application startup and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->