### PR TITLE
fix: log actual errors instead of silent BuildError mapping

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -204,7 +204,8 @@ async fn run_single_mutation(
     // Read original content
     let original = match std::fs::read(&file_path) {
         Ok(content) => content,
-        Err(_) => {
+        Err(e) => {
+            eprintln!("warning: could not read {}: {e}", file_path.display());
             return MutationOutcome {
                 result: MutationResult::BuildError,
                 test_output: None,
@@ -229,7 +230,8 @@ async fn run_single_mutation(
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
-    if std::fs::write(&file_path, &mutated).is_err() {
+    if let Err(e) = std::fs::write(&file_path, &mutated) {
+        eprintln!("warning: could not write {}: {e}", file_path.display());
         return MutationOutcome {
             result: MutationResult::BuildError,
             test_output: None,
@@ -277,7 +279,8 @@ async fn run_command(
 
     let child = match cmd.spawn() {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) => {
+            eprintln!("warning: could not spawn command {:?}: {e}", &command[0]);
             return MutationOutcome {
                 result: MutationResult::BuildError,
                 test_output: None,


### PR DESCRIPTION
## Summary
- Log file read/write and command spawn errors via `eprintln!` before returning `BuildError`
- No enum or report format changes

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics when file operations or commands fail, now displaying affected file paths and command details for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->