### PR TITLE
chore: add .claude/ and togi.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.swo
 .DS_Store
 .togi.lock
+.claude/
+togi.toml


### PR DESCRIPTION
Closes #147

Adds `.claude/` and `togi.toml` to `.gitignore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional files from the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->