### PR TITLE
refactor: extract shared tree-walking test helpers

### DIFF
--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -43,6 +43,7 @@ impl LanguageSupport for Python {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
 
     #[test]
     fn test_python_extension_detection() {
@@ -61,25 +62,9 @@ mod tests {
         let tree = parser.parse(code, None).unwrap();
         let root = tree.root_node();
 
-        // Walk tree to find binary_operator node
         let mut found = false;
         let mut cursor = root.walk();
-        fn walk(cursor: &mut tree_sitter::TreeCursor, target: &str, found: &mut bool) {
-            if cursor.node().kind() == target {
-                *found = true;
-                return;
-            }
-            if cursor.goto_first_child() {
-                loop {
-                    walk(cursor, target, found);
-                    if *found || !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-                cursor.goto_parent();
-            }
-        }
-        walk(&mut cursor, py.binary_expression_node(), &mut found);
+        walk_for_kind(&mut cursor, py.binary_expression_node(), &mut found);
         assert!(
             found,
             "Expected to find '{}' node in Python AST",
@@ -99,22 +84,7 @@ mod tests {
 
         let mut found = false;
         let mut cursor = root.walk();
-        fn walk(cursor: &mut tree_sitter::TreeCursor, target: &str, found: &mut bool) {
-            if cursor.node().kind() == target {
-                *found = true;
-                return;
-            }
-            if cursor.goto_first_child() {
-                loop {
-                    walk(cursor, target, found);
-                    if *found || !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-                cursor.goto_parent();
-            }
-        }
-        walk(&mut cursor, py.if_statement_node(), &mut found);
+        walk_for_kind(&mut cursor, py.if_statement_node(), &mut found);
         assert!(
             found,
             "Expected to find '{}' node in Python AST",
@@ -132,35 +102,10 @@ mod tests {
         let tree = parser.parse(code, None).unwrap();
         let root = tree.root_node();
 
-        // Verify we can find return_statement and binary_operator
         let mut found_return = false;
         let mut found_binary = false;
         let mut cursor = root.walk();
-        fn walk(
-            cursor: &mut tree_sitter::TreeCursor,
-            ret: &str,
-            bin: &str,
-            fr: &mut bool,
-            fb: &mut bool,
-        ) {
-            let kind = cursor.node().kind();
-            if kind == ret {
-                *fr = true;
-            }
-            if kind == bin {
-                *fb = true;
-            }
-            if cursor.goto_first_child() {
-                loop {
-                    walk(cursor, ret, bin, fr, fb);
-                    if (*fr && *fb) || !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-                cursor.goto_parent();
-            }
-        }
-        walk(
+        walk_for_two_kinds(
             &mut cursor,
             py.return_statement_node(),
             py.binary_expression_node(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub mod parser;
 pub mod report;
 pub mod runner;
 
+#[cfg(test)]
+pub mod test_helpers;
+
 use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -82,7 +82,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x < y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "<=");
@@ -93,7 +94,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x > y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = GtToGte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, ">=");
@@ -104,7 +106,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x == y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = EqToNeq.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "!=");
@@ -115,7 +118,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x && y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = AndToOr.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "||");
@@ -126,7 +130,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x || y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = OrToAnd.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "&&");
@@ -137,7 +142,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x + y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression")
+            .expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -75,32 +75,14 @@ binary_operator!(ModToMul, "mod_to_mul", "Replace % with *", "%", "*");
 mod tests {
     use super::*;
 
-    fn parse_go(src: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(src, None).unwrap()
-    }
-
-    fn find_binary_expr(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
-        if is_binary_expr(&node) {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_binary_expr(child) {
-                return Some(found);
-            }
-        }
-        None
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     #[test]
     fn test_lt_to_lte() {
         let src = "package main\nfunc f() bool { return x < y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "<=");
@@ -111,7 +93,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return x > y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = GtToGte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, ">=");
@@ -122,7 +104,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return x == y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = EqToNeq.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "!=");
@@ -133,7 +115,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return x && y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = AndToOr.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "||");
@@ -144,7 +126,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return x || y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = OrToAnd.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "&&");
@@ -155,7 +137,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return x + y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_binary_expr(root).expect("should find binary_expression");
+        let bin = find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -82,8 +82,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x < y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "<=");
@@ -94,8 +94,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x > y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = GtToGte.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, ">=");
@@ -106,8 +106,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x == y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = EqToNeq.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "!=");
@@ -118,8 +118,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x && y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = AndToOr.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "||");
@@ -130,8 +130,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x || y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = OrToAnd.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "&&");
@@ -142,8 +142,8 @@ mod tests {
         let src = "package main\nfunc f() bool { return x + y }";
         let tree = parse_go(src);
         let root = tree.root_node();
-        let bin = find_node_by_kind(root, "binary_expression")
-            .expect("should find binary_expression");
+        let bin =
+            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
         let candidates = LtToLte.apply(&bin, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -64,34 +64,13 @@ impl MutationOperator for MinusToPlus {
 mod tests {
     use super::*;
 
-    fn parse_go(src: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(src, None).unwrap()
-    }
-
-    fn find_first_kind<'a>(
-        node: tree_sitter::Node<'a>,
-        kind: &str,
-    ) -> Option<tree_sitter::Node<'a>> {
-        if node.kind() == kind {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_first_kind(child, kind) {
-                return Some(found);
-            }
-        }
-        None
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     #[test]
     fn test_plus_to_minus() {
         let src = "package main\nfunc f(a, b int) int { return a + b }";
         let tree = parse_go(src);
-        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
         let candidates = PlusToMinus.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "-");
@@ -101,7 +80,7 @@ mod tests {
     fn test_minus_to_plus() {
         let src = "package main\nfunc f(a, b int) int { return a - b }";
         let tree = parse_go(src);
-        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
         let candidates = MinusToPlus.apply(&bin, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "+");
@@ -111,7 +90,7 @@ mod tests {
     fn test_no_match_on_comparison() {
         let src = "package main\nfunc f(a, b int) bool { return a < b }";
         let tree = parse_go(src);
-        let bin = find_first_kind(tree.root_node(), "binary_expression").unwrap();
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
         let candidates = PlusToMinus.apply(&bin, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -179,28 +179,7 @@ impl MutationOperator for DecrementNumeric {
 mod tests {
     use super::*;
 
-    fn parse_go(src: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(src, None).unwrap()
-    }
-
-    fn find_node_by_kind<'a>(
-        node: tree_sitter::Node<'a>,
-        kind: &str,
-    ) -> Option<tree_sitter::Node<'a>> {
-        if node.kind() == kind {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_node_by_kind(child, kind) {
-                return Some(found);
-            }
-        }
-        None
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     fn collect_all_candidates(
         node: tree_sitter::Node,

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -149,29 +149,7 @@ pub fn all_operators() -> Vec<Box<dyn MutationOperator>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn find_node_by_kind<'a>(
-        node: tree_sitter::Node<'a>,
-        kind: &str,
-    ) -> Option<tree_sitter::Node<'a>> {
-        if node.kind() == kind {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if let Some(found) = find_node_by_kind(child, kind) {
-                return Some(found);
-            }
-        }
-        None
-    }
-
-    fn parse_go(source: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(source, None).unwrap()
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     #[test]
     fn test_negate_simple_condition() {

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -150,35 +150,14 @@ impl MutationOperator for RemoveAssignment {
 mod tests {
     use super::*;
 
-    fn parse_go(src: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(src, None).unwrap()
-    }
-
-    fn find_first_kind<'a>(
-        node: tree_sitter::Node<'a>,
-        kind: &str,
-    ) -> Option<tree_sitter::Node<'a>> {
-        if node.kind() == kind {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_first_kind(child, kind) {
-                return Some(found);
-            }
-        }
-        None
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     #[test]
     fn test_remove_if_body() {
         let src = r#"package main
 func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
-        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
         let candidates = RemoveIfBody.apply(&if_node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "{}");
@@ -188,7 +167,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
     fn test_remove_else() {
         let src = "package main\nfunc f(x int) int { if x > 0 { return 1 } else { return 0 } }";
         let tree = parse_go(src);
-        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
         let candidates = RemoveElse.apply(&if_node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
@@ -201,7 +180,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
     fn test_remove_if_body_no_match_on_for() {
         let src = "package main\nfunc f() { for i := 0; i < 10; i++ { println(i) } }";
         let tree = parse_go(src);
-        let for_node = find_first_kind(tree.root_node(), "for_statement").unwrap();
+        let for_node = find_node_by_kind(tree.root_node(), "for_statement").unwrap();
         let candidates = RemoveIfBody.apply(&for_node, src.as_bytes());
         assert!(candidates.is_empty());
     }
@@ -210,7 +189,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
     fn test_remove_else_no_else_clause() {
         let src = "package main\nfunc f(x int) { if x > 0 { println(x) } }";
         let tree = parse_go(src);
-        let if_node = find_first_kind(tree.root_node(), "if_statement").unwrap();
+        let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
         let candidates = RemoveElse.apply(&if_node, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/operators/unary.rs
+++ b/src/operators/unary.rs
@@ -62,34 +62,13 @@ impl MutationOperator for RemoveUnaryNeg {
 mod tests {
     use super::*;
 
-    fn parse_go(src: &str) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        let lang = tree_sitter_go::LANGUAGE;
-        parser.set_language(&lang.into()).unwrap();
-        parser.parse(src, None).unwrap()
-    }
-
-    fn find_first_kind<'a>(
-        node: tree_sitter::Node<'a>,
-        kind: &str,
-    ) -> Option<tree_sitter::Node<'a>> {
-        if node.kind() == kind {
-            return Some(node);
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if let Some(found) = find_first_kind(child, kind) {
-                return Some(found);
-            }
-        }
-        None
-    }
+    use crate::test_helpers::{find_node_by_kind, parse_go};
 
     #[test]
     fn test_remove_unary_not() {
         let src = "package main\nfunc f(x bool) bool { return !x }";
         let tree = parse_go(src);
-        let node = find_first_kind(tree.root_node(), "unary_expression").unwrap();
+        let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
         let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "x");
@@ -99,7 +78,7 @@ mod tests {
     fn test_remove_unary_neg() {
         let src = "package main\nfunc f(x int) int { return -x }";
         let tree = parse_go(src);
-        let node = find_first_kind(tree.root_node(), "unary_expression").unwrap();
+        let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
         let candidates = RemoveUnaryNeg.apply(&node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "x");
@@ -112,7 +91,7 @@ mod tests {
         let lang = tree_sitter_python::LANGUAGE;
         parser.set_language(&lang.into()).unwrap();
         let tree = parser.parse(src, None).unwrap();
-        let node = find_first_kind(tree.root_node(), "not_operator").unwrap();
+        let node = find_node_by_kind(tree.root_node(), "not_operator").unwrap();
         let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "y");
@@ -122,7 +101,7 @@ mod tests {
     fn test_unary_not_no_match_on_neg() {
         let src = "package main\nfunc f(x int) int { return -x }";
         let tree = parse_go(src);
-        let node = find_first_kind(tree.root_node(), "unary_expression").unwrap();
+        let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
         let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
         assert!(candidates.is_empty());
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,71 @@
+/// Shared test utilities for tree-sitter parsing and node lookup.
+/// Used across operator and language tests to avoid duplication.
+
+/// Parse Go source code into a tree-sitter tree.
+pub fn parse_go(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_go::LANGUAGE;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
+/// Recursively find the first node matching `kind` in the tree.
+/// Visits all children (named and anonymous).
+pub fn find_node_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_node_by_kind(child, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Walk a tree cursor looking for a node of the given kind, setting `found` to true.
+pub fn walk_for_kind(cursor: &mut tree_sitter::TreeCursor, target: &str, found: &mut bool) {
+    if cursor.node().kind() == target {
+        *found = true;
+        return;
+    }
+    if cursor.goto_first_child() {
+        loop {
+            walk_for_kind(cursor, target, found);
+            if *found || !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}
+
+/// Walk a tree cursor looking for two node kinds simultaneously.
+pub fn walk_for_two_kinds(
+    cursor: &mut tree_sitter::TreeCursor,
+    kind_a: &str,
+    kind_b: &str,
+    found_a: &mut bool,
+    found_b: &mut bool,
+) {
+    let kind = cursor.node().kind();
+    if kind == kind_a {
+        *found_a = true;
+    }
+    if kind == kind_b {
+        *found_b = true;
+    }
+    if cursor.goto_first_child() {
+        loop {
+            walk_for_two_kinds(cursor, kind_a, kind_b, found_a, found_b);
+            if (*found_a && *found_b) || !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}


### PR DESCRIPTION
Closes #139

- New `src/test_helpers.rs` with `parse_go`, `find_node_by_kind`, `walk_for_kind`, `walk_for_two_kinds`
- Removed duplicate helpers from 6 operator files and `languages/python.rs`
- Net -105 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated and simplified test helpers into a shared test utilities module.
  * Replaced duplicated in-file test traversal logic with the shared utilities across multiple test suites.
  * Tests preserved existing behavior and assertions; test selection and outcomes remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->