### PR TITLE
refactor: unify error handling on anyhow, drop thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ shell-words = "1"
 
 # Error handling
 anyhow = "1"
-thiserror = "2"
 
 # Hashing
 siphasher = "1"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -20,9 +20,10 @@ pub struct Baseline {
 }
 
 /// Persist a baseline snapshot to `.togi-baseline` inside `dir`.
-pub fn save_baseline(baseline: &Baseline, dir: &Path) -> std::io::Result<()> {
-    let json = serde_json::to_string_pretty(baseline).map_err(std::io::Error::other)?;
-    std::fs::write(dir.join(BASELINE_FILE), json)
+pub fn save_baseline(baseline: &Baseline, dir: &Path) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(baseline)?;
+    std::fs::write(dir.join(BASELINE_FILE), json)?;
+    Ok(())
 }
 
 /// Load a previously saved baseline from `dir`, returning `None` if the file doesn't exist.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,7 @@
+use anyhow::Context;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-
-/// Error type for configuration loading failures.
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-pub struct ConfigError(pub String);
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
@@ -236,10 +232,9 @@ impl Config {
         match config_path {
             Some(p) => {
                 let content = std::fs::read_to_string(&p)
-                    .map_err(|e| ConfigError(format!("Could not read {}: {e}", p.display())))?;
-                let config: Config = toml::from_str(&content).map_err(|e| {
-                    ConfigError(format!("Invalid togi.toml at {}: {e}", p.display()))
-                })?;
+                    .with_context(|| format!("could not read {}", p.display()))?;
+                let config: Config = toml::from_str(&content)
+                    .with_context(|| format!("invalid togi.toml at {}", p.display()))?;
                 Ok(config)
             }
             None => Ok(Config::default()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,7 @@ async fn main() {
                 build_cmd,
             };
             if let Err(e) = run_check(cfg).await {
-                eprintln!("Error: {e}");
-                if e.downcast_ref::<togi::config::ConfigError>().is_some() {
-                    eprintln!("Hint: run 'togi check --help' for usage information.");
-                }
+                eprintln!("Error: {e:#}");
                 process::exit(2);
             }
         }


### PR DESCRIPTION
Closes #143

- Switch `baseline::save_baseline` from `std::io::Result` to `anyhow::Result`
- Replace `ConfigError` with `anyhow::Context` in `config::load`
- Remove `thiserror` dependency
- Use `{e:#}` in main for full error chain display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified error handling mechanisms throughout the application, resulting in more consistent and informative error messages to aid users in troubleshooting issues.
  * Streamlined error propagation and reporting for improved diagnostic clarity.

* **Chores**
  * Removed an external dependency from the project, reducing overall installation footprint and maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->