### PR TITLE
test: expand unit test coverage across modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,26 +692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "togi"
 version = "0.1.0"
 dependencies = [
@@ -729,7 +709,6 @@ dependencies = [
  "shell-words",
  "siphasher",
  "tempfile",
- "thiserror",
  "tokio",
  "toml",
  "tree-sitter",

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -45,6 +45,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_c_extension_detection() {
+        let lang = C;
+        assert_eq!(lang.name(), "c");
+        assert!(lang.extensions().contains(&"c"));
+        assert!(lang.extensions().contains(&"h"));
+        assert!(!lang.extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_c_parse_if_statement() {
+        let lang = C;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "void f() { if (x < 10) { return; } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("if_statement"));
+    }
+
+    #[test]
     fn parses_c_binary_expression() {
         let lang = C;
         let mut parser = tree_sitter::Parser::new();

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -45,6 +45,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_cpp_extension_detection() {
+        let lang = Cpp;
+        assert_eq!(lang.name(), "cpp");
+        assert!(lang.extensions().contains(&"cpp"));
+        assert!(lang.extensions().contains(&"hpp"));
+        assert!(!lang.extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_cpp_parse_if_statement() {
+        let lang = Cpp;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "void f() { if (x < 10) { return; } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("if_statement"));
+    }
+
+    #[test]
     fn parses_cpp_binary_expression() {
         let lang = Cpp;
         let mut parser = tree_sitter::Parser::new();

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -45,6 +45,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_csharp_extension_detection() {
+        let lang = CSharp;
+        assert_eq!(lang.name(), "c_sharp");
+        assert!(lang.extensions().contains(&"cs"));
+        assert!(!lang.extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_csharp_parse_if_statement() {
+        let lang = CSharp;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "class T { void F() { if (x < 10) { return; } } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("if_statement"));
+    }
+
+    #[test]
     fn parses_csharp_binary_expression() {
         let lang = CSharp;
         let mut parser = tree_sitter::Parser::new();

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -39,3 +39,80 @@ impl LanguageSupport for Go {
         "operator"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
+
+    #[test]
+    fn test_go_extension_detection() {
+        let go = Go;
+        assert_eq!(go.extensions(), &["go"]);
+        assert_eq!(go.name(), "go");
+    }
+
+    #[test]
+    fn test_go_parse_binary_expression() {
+        let go = Go;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&go.tree_sitter_language()).unwrap();
+
+        let code = "package main\nfunc f() int { return a + b }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found = false;
+        let mut cursor = root.walk();
+        walk_for_kind(&mut cursor, go.binary_expression_node(), &mut found);
+        assert!(
+            found,
+            "Expected to find '{}' node in Go AST",
+            go.binary_expression_node()
+        );
+    }
+
+    #[test]
+    fn test_go_parse_if_statement() {
+        let go = Go;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&go.tree_sitter_language()).unwrap();
+
+        let code = "package main\nfunc f() { if x < 10 { return } }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found = false;
+        let mut cursor = root.walk();
+        walk_for_kind(&mut cursor, go.if_statement_node(), &mut found);
+        assert!(
+            found,
+            "Expected to find '{}' node in Go AST",
+            go.if_statement_node()
+        );
+    }
+
+    #[test]
+    fn test_go_parse_function_with_return() {
+        let go = Go;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&go.tree_sitter_language()).unwrap();
+
+        let code = "package main\nfunc add(a, b int) int { return a + b }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found_return = false;
+        let mut found_binary = false;
+        let mut cursor = root.walk();
+        walk_for_two_kinds(
+            &mut cursor,
+            go.return_statement_node(),
+            go.binary_expression_node(),
+            &mut found_return,
+            &mut found_binary,
+        );
+        assert!(found_return, "Expected return_statement node");
+        assert!(found_binary, "Expected binary_expression node");
+    }
+}

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -45,6 +45,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_java_extension_detection() {
+        let lang = Java;
+        assert_eq!(lang.name(), "java");
+        assert!(lang.extensions().contains(&"java"));
+        assert!(!lang.extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_java_parse_if_statement() {
+        let lang = Java;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "class T { void f() { if (x < 10) { return; } } }";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("if_statement"));
+    }
+
+    #[test]
     fn parses_java_binary_expression() {
         let lang = Java;
         let mut parser = tree_sitter::Parser::new();

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -45,6 +45,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_ruby_extension_detection() {
+        let lang = Ruby;
+        assert_eq!(lang.name(), "ruby");
+        assert!(lang.extensions().contains(&"rb"));
+        assert!(!lang.extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_ruby_parse_if_statement() {
+        let lang = Ruby;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang.tree_sitter_language()).unwrap();
+        let code = "if x < 10\n  puts x\nend\n";
+        let tree = parser.parse(code, None).unwrap();
+        let src = tree.root_node().to_sexp();
+        assert!(src.contains("if"));
+    }
+
+    #[test]
     fn parses_ruby_binary_expression() {
         let lang = Ruby;
         let mut parser = tree_sitter::Parser::new();

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -39,3 +39,87 @@ impl LanguageSupport for Rust {
         "operator"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
+
+    #[test]
+    fn test_rust_extension_detection() {
+        let rs = Rust;
+        assert_eq!(rs.extensions(), &["rs"]);
+        assert_eq!(rs.name(), "rust");
+    }
+
+    #[test]
+    fn test_rust_parse_binary_expression() {
+        let rs = Rust;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&rs.tree_sitter_language()).unwrap();
+
+        let code = "fn f() -> i32 { a + b }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found = false;
+        let mut cursor = root.walk();
+        walk_for_kind(&mut cursor, rs.binary_expression_node(), &mut found);
+        assert!(
+            found,
+            "Expected to find '{}' node in Rust AST",
+            rs.binary_expression_node()
+        );
+    }
+
+    #[test]
+    fn test_rust_parse_if_expression() {
+        let rs = Rust;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&rs.tree_sitter_language()).unwrap();
+
+        let code = "fn f() { if x < 10 { return; } }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found = false;
+        let mut cursor = root.walk();
+        walk_for_kind(&mut cursor, rs.if_statement_node(), &mut found);
+        assert!(
+            found,
+            "Expected to find '{}' node in Rust AST",
+            rs.if_statement_node()
+        );
+    }
+
+    #[test]
+    fn test_rust_parse_function_with_return() {
+        let rs = Rust;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&rs.tree_sitter_language()).unwrap();
+
+        let code = "fn add(a: i32, b: i32) -> i32 { return a + b; }\n";
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+
+        let mut found_return = false;
+        let mut found_binary = false;
+        let mut cursor = root.walk();
+        walk_for_two_kinds(
+            &mut cursor,
+            rs.return_statement_node(),
+            rs.binary_expression_node(),
+            &mut found_return,
+            &mut found_binary,
+        );
+        assert!(found_return, "Expected return_expression node");
+        assert!(found_binary, "Expected binary_expression node");
+    }
+
+    #[test]
+    fn test_rust_if_node_is_expression() {
+        let rs = Rust;
+        assert_eq!(rs.if_statement_node(), "if_expression");
+        assert_eq!(rs.return_statement_node(), "return_expression");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub mod parser;
 pub mod report;
 pub mod runner;
 
+#[cfg(test)]
+pub mod test_helpers;
+
 use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -100,4 +103,73 @@ pub struct MutationReport {
     pub survived: usize,
     pub timeout: usize,
     pub build_errors: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ts_row_to_line_converts_zero_indexed() {
+        assert_eq!(ts_row_to_line(0), 1);
+        assert_eq!(ts_row_to_line(9), 10);
+        assert_eq!(ts_row_to_line(99), 100);
+    }
+
+    #[test]
+    fn mutation_result_display() {
+        assert_eq!(MutationResult::Killed.to_string(), "killed");
+        assert_eq!(MutationResult::Survived.to_string(), "survived");
+        assert_eq!(MutationResult::Timeout.to_string(), "timeout");
+        assert_eq!(MutationResult::BuildError.to_string(), "build error");
+    }
+
+    #[test]
+    fn line_range_construction() {
+        let r = LineRange { start: 5, end: 10 };
+        assert_eq!(r.start, 5);
+        assert_eq!(r.end, 10);
+    }
+
+    #[test]
+    fn line_range_equality() {
+        let a = LineRange { start: 1, end: 3 };
+        let b = LineRange { start: 1, end: 3 };
+        let c = LineRange { start: 1, end: 4 };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn changed_file_construction() {
+        let cf = ChangedFile {
+            path: PathBuf::from("src/main.go"),
+            hunks: vec![
+                LineRange { start: 1, end: 5 },
+                LineRange { start: 10, end: 15 },
+            ],
+        };
+        assert_eq!(cf.path, PathBuf::from("src/main.go"));
+        assert_eq!(cf.hunks.len(), 2);
+    }
+
+    #[test]
+    fn mutation_construction() {
+        let m = Mutation {
+            id: 0,
+            file: PathBuf::from("test.go"),
+            language: "go".into(),
+            line: 5,
+            column: 3,
+            operator: "lt_to_lte".into(),
+            description: "replace < with <=".into(),
+            original: "<".into(),
+            replacement: "<=".into(),
+            byte_range: 10..11,
+        };
+        assert_eq!(m.id, 0);
+        assert_eq!(m.line, 5);
+        assert_eq!(m.original, "<");
+        assert_eq!(m.replacement, "<=");
+    }
 }

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -151,4 +151,184 @@ mod tests {
             kinds
         );
     }
+
+    #[test]
+    fn multiple_overlapping_ranges() {
+        let source = b"package main\n\nfunc f(a, b int) int {\n\tif a > 0 {\n\t\treturn a + b\n\t}\n\treturn a - b\n}\n";
+        // Lines: 1=package, 2=empty, 3=func, 4=if a>0, 5=return a+b, 6=}, 7=return a-b, 8=}
+        let tree = parse_go(source);
+        // Two ranges that both touch the function body
+        let changed = vec![
+            LineRange { start: 4, end: 5 },
+            LineRange { start: 5, end: 7 },
+        ];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        // Should find binary expressions from both return statements
+        let binary_count = kinds.iter().filter(|k| **k == "binary_expression").count();
+        assert!(
+            binary_count >= 2,
+            "Expected at least 2 binary_expression nodes from overlapping ranges, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn finds_return_statement_on_changed_line() {
+        let source = b"package main\n\nfunc f() int {\n\treturn 42\n}\n";
+        // Lines: 1=package, 2=empty, 3=func, 4=return 42, 5=}
+        let tree = parse_go(source);
+        let changed = vec![LineRange { start: 4, end: 4 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        // Deepest mutable node inside `return 42` is the int_literal
+        assert!(
+            kinds.contains(&"int_literal") || kinds.contains(&"return_statement"),
+            "Expected return_statement or int_literal, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn finds_assignment_on_changed_line() {
+        let source =
+            b"package main\n\nfunc f() {\n\tx := 1\n\tx = x + 2\n}\n";
+        // Lines: 1=package, 2=empty, 3=func, 4=x:=1, 5=x=x+2, 6=}
+        let tree = parse_go(source);
+        let changed = vec![LineRange { start: 5, end: 5 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        // Should find the binary_expression (deepest) or assignment-related node
+        assert!(
+            kinds.contains(&"binary_expression")
+                || kinds.contains(&"assignment_statement")
+                || kinds.contains(&"expression_statement")
+                || kinds.contains(&"int_literal"),
+            "Expected mutable node on assignment line, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn nested_if_inside_if() {
+        let source = b"package main\n\nfunc f(a, b int) int {\n\tif a > 0 {\n\t\tif b > 0 {\n\t\t\treturn a + b\n\t\t}\n\t}\n\treturn 0\n}\n";
+        // Lines: 1=package, 2=empty, 3=func, 4=if a>0, 5=if b>0, 6=return a+b, 7=}, 8=}, 9=return 0, 10=}
+        let tree = parse_go(source);
+        // Only the inner if line is changed
+        let changed = vec![LineRange { start: 5, end: 6 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        // Should find deepest mutable nodes (binary_expression, int_literal) not outer if
+        assert!(
+            kinds.contains(&"binary_expression") || kinds.contains(&"int_literal"),
+            "Expected deepest nested nodes, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn binary_expression_inside_function_call() {
+        let source = b"package main\n\nimport \"fmt\"\n\nfunc f(a, b int) {\n\tfmt.Println(a + b)\n}\n";
+        // Lines: 1=package, 2=empty, 3=import, 4=empty, 5=func, 6=fmt.Println(a+b), 7=}
+        let tree = parse_go(source);
+        let changed = vec![LineRange { start: 6, end: 6 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        // Should find the binary_expression nested inside the call
+        assert!(
+            kinds.contains(&"binary_expression"),
+            "Expected binary_expression inside call, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn comment_only_lines_return_no_mutable_nodes() {
+        let source = b"package main\n\n// this is a comment\n// another comment\nfunc f() {}\n";
+        // Lines: 1=package, 2=empty, 3=comment, 4=comment, 5=func
+        let tree = parse_go(source);
+        let changed = vec![LineRange { start: 3, end: 4 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(
+            nodes.is_empty(),
+            "Comments should not produce mutable nodes, got: {:?}",
+            nodes.iter().map(|n| n.kind()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn package_declaration_returns_no_mutable_nodes() {
+        let source = b"package main\n\nfunc f() {\n\treturn\n}\n";
+        // Lines: 1=package, 2=empty, 3=func, 4=return, 5=}
+        let tree = parse_go(source);
+        // Only the package line is changed
+        let changed = vec![LineRange { start: 1, end: 1 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(
+            nodes.is_empty(),
+            "Package declaration should not produce mutable nodes, got: {:?}",
+            nodes.iter().map(|n| n.kind()).collect::<Vec<_>>()
+        );
+    }
+
+    fn parse_rust(source: &[u8]) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_rust::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn rust_return_expression_on_changed_line() {
+        let source = b"fn add(a: i32, b: i32) -> i32 {\n    return a + b;\n}\n";
+        // Lines: 1=fn, 2=return a+b, 3=}
+        let tree = parse_rust(source);
+        let changed = vec![LineRange { start: 2, end: 2 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            kinds.contains(&"binary_expression") || kinds.contains(&"return_expression") || kinds.contains(&"integer_literal"),
+            "Expected mutable node from Rust return line, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn rust_nested_if_expression() {
+        let source = b"fn f(a: i32, b: i32) -> i32 {\n    if a > 0 {\n        if b > 0 {\n            return a + b;\n        }\n    }\n    0\n}\n";
+        // Lines: 1=fn, 2=if a>0, 3=if b>0, 4=return a+b, 5=}, 6=}, 7=0, 8=}
+        let tree = parse_rust(source);
+        let changed = vec![LineRange { start: 3, end: 4 }];
+
+        let nodes = find_mutable_nodes(&tree, source, &changed);
+
+        assert!(!nodes.is_empty());
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            kinds.contains(&"binary_expression") || kinds.contains(&"integer_literal"),
+            "Expected deepest nodes from nested Rust if, got: {:?}",
+            kinds
+        );
+    }
 }

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -196,8 +196,7 @@ mod tests {
 
     #[test]
     fn finds_assignment_on_changed_line() {
-        let source =
-            b"package main\n\nfunc f() {\n\tx := 1\n\tx = x + 2\n}\n";
+        let source = b"package main\n\nfunc f() {\n\tx := 1\n\tx = x + 2\n}\n";
         // Lines: 1=package, 2=empty, 3=func, 4=x:=1, 5=x=x+2, 6=}
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 5, end: 5 }];
@@ -239,7 +238,8 @@ mod tests {
 
     #[test]
     fn binary_expression_inside_function_call() {
-        let source = b"package main\n\nimport \"fmt\"\n\nfunc f(a, b int) {\n\tfmt.Println(a + b)\n}\n";
+        let source =
+            b"package main\n\nimport \"fmt\"\n\nfunc f(a, b int) {\n\tfmt.Println(a + b)\n}\n";
         // Lines: 1=package, 2=empty, 3=import, 4=empty, 5=func, 6=fmt.Println(a+b), 7=}
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 6, end: 6 }];
@@ -308,7 +308,9 @@ mod tests {
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
         assert!(
-            kinds.contains(&"binary_expression") || kinds.contains(&"return_expression") || kinds.contains(&"integer_literal"),
+            kinds.contains(&"binary_expression")
+                || kinds.contains(&"return_expression")
+                || kinds.contains(&"integer_literal"),
             "Expected mutable node from Rust return line, got: {:?}",
             kinds
         );

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -164,7 +164,8 @@ mod tests {
         ];
 
         let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
-        let files: std::collections::HashSet<_> = mutations.iter().map(|m| m.file.clone()).collect();
+        let files: std::collections::HashSet<_> =
+            mutations.iter().map(|m| m.file.clone()).collect();
         assert!(
             files.len() >= 2,
             "expected mutations from both files, got files: {:?}",

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -144,6 +144,84 @@ mod tests {
     }
 
     #[test]
+    fn generates_mutations_for_multiple_files() {
+        let tmp = TempDir::new().unwrap();
+        let go_src = "package main\n\nfunc f() bool {\n\treturn true\n}\n";
+        let go_rel = write_go_file(tmp.path(), "a.go", go_src);
+
+        let go_src2 = "package main\n\nfunc g(x, y int) bool {\n\treturn x < y\n}\n";
+        let go_rel2 = write_go_file(tmp.path(), "b.go", go_src2);
+
+        let changed = vec![
+            ChangedFile {
+                path: go_rel,
+                hunks: vec![LineRange { start: 1, end: 5 }],
+            },
+            ChangedFile {
+                path: go_rel2,
+                hunks: vec![LineRange { start: 1, end: 5 }],
+            },
+        ];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        let files: std::collections::HashSet<_> = mutations.iter().map(|m| m.file.clone()).collect();
+        assert!(
+            files.len() >= 2,
+            "expected mutations from both files, got files: {:?}",
+            files
+        );
+    }
+
+    #[test]
+    fn generates_mutations_for_python_file() {
+        let tmp = TempDir::new().unwrap();
+        let py_src = "def check(x, y):\n    return x < y\n";
+        let rel = write_go_file(tmp.path(), "test.py", py_src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 2 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        assert!(!mutations.is_empty(), "expected mutations for Python file");
+        assert_eq!(mutations[0].language, "python");
+    }
+
+    #[test]
+    fn generates_mutations_for_rust_file() {
+        let tmp = TempDir::new().unwrap();
+        let rs_src = "fn check(x: i32, y: i32) -> bool {\n    x < y\n}\n";
+        let rel = write_go_file(tmp.path(), "lib.rs", rs_src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 3 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        assert!(!mutations.is_empty(), "expected mutations for Rust file");
+        assert_eq!(mutations[0].language, "rust");
+    }
+
+    #[test]
+    fn mutation_ids_are_sequential() {
+        let tmp = TempDir::new().unwrap();
+        let src = "package main\n\nfunc f(x, y int) bool {\n\tif x < y {\n\t\treturn true\n\t}\n\treturn false\n}\n";
+        let rel = write_go_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 8 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        for (i, m) in mutations.iter().enumerate() {
+            assert_eq!(m.id, i as u32, "mutation ids should be sequential");
+        }
+    }
+
+    #[test]
     fn skips_unsupported_file_types() {
         let tmp = TempDir::new().unwrap();
         let rel = write_go_file(tmp.path(), "notes.txt", "hello world");

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -217,6 +217,7 @@ mod tests {
         }];
 
         let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        assert!(!mutations.is_empty(), "expected at least one mutation");
         for (i, m) in mutations.iter().enumerate() {
             assert_eq!(m.id, i as u32, "mutation ids should be sequential");
         }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -75,3 +75,82 @@ pub fn mutation_diff(mutation: &Mutation) -> Option<String> {
 
     Some(diff.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_mutation(dir: &std::path::Path, filename: &str, content: &str, line: usize, column: usize, original: &str, replacement: &str) -> Mutation {
+        let path = dir.join(filename);
+        std::fs::write(&path, content).unwrap();
+        Mutation {
+            id: 0,
+            file: path,
+            language: "go".into(),
+            line,
+            column,
+            operator: "test_op".into(),
+            description: "test".into(),
+            original: original.into(),
+            replacement: replacement.into(),
+            byte_range: 0..0,
+        }
+    }
+
+    #[test]
+    fn mutation_diff_basic() {
+        let tmp = TempDir::new().unwrap();
+        let content = "package main\n\nfunc f() bool {\n\treturn true\n}\n";
+        let m = make_mutation(tmp.path(), "main.go", content, 4, 9, "true", "false");
+        let diff = mutation_diff(&m).unwrap();
+        assert!(diff.contains("-\treturn true"), "diff should show original line: {diff}");
+        assert!(diff.contains("+\treturn false"), "diff should show mutated line: {diff}");
+    }
+
+    #[test]
+    fn mutation_diff_empty_replacement() {
+        let tmp = TempDir::new().unwrap();
+        let content = "x = 1 + 2\ny = 3\n";
+        let m = make_mutation(tmp.path(), "test.py", content, 1, 7, "+ 2", "");
+        let diff = mutation_diff(&m).unwrap();
+        assert!(diff.contains("-x = 1 + 2"), "diff should show original: {diff}");
+        assert!(diff.contains("+x = 1"), "diff should show removal: {diff}");
+    }
+
+    #[test]
+    fn mutation_diff_replacement_at_start() {
+        let tmp = TempDir::new().unwrap();
+        let content = "true\n";
+        let m = make_mutation(tmp.path(), "t.go", content, 1, 1, "true", "false");
+        let diff = mutation_diff(&m).unwrap();
+        assert!(diff.contains("-true"), "{diff}");
+        assert!(diff.contains("+false"), "{diff}");
+    }
+
+    #[test]
+    fn mutation_diff_replacement_at_end() {
+        let tmp = TempDir::new().unwrap();
+        let content = "a = true\n";
+        let m = make_mutation(tmp.path(), "t.py", content, 1, 5, "true", "false");
+        let diff = mutation_diff(&m).unwrap();
+        assert!(diff.contains("-a = true"), "{diff}");
+        assert!(diff.contains("+a = false"), "{diff}");
+    }
+
+    #[test]
+    fn mutation_diff_invalid_line_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let content = "one line\n";
+        let m = make_mutation(tmp.path(), "t.go", content, 99, 1, "x", "y");
+        assert!(mutation_diff(&m).is_none());
+    }
+
+    #[test]
+    fn mutation_diff_line_zero_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let content = "hello\n";
+        let m = make_mutation(tmp.path(), "t.go", content, 0, 1, "h", "H");
+        assert!(mutation_diff(&m).is_none());
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -81,7 +81,15 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_mutation(dir: &std::path::Path, filename: &str, content: &str, line: usize, column: usize, original: &str, replacement: &str) -> Mutation {
+    fn make_mutation(
+        dir: &std::path::Path,
+        filename: &str,
+        content: &str,
+        line: usize,
+        column: usize,
+        original: &str,
+        replacement: &str,
+    ) -> Mutation {
         let path = dir.join(filename);
         std::fs::write(&path, content).unwrap();
         Mutation {
@@ -104,8 +112,14 @@ mod tests {
         let content = "package main\n\nfunc f() bool {\n\treturn true\n}\n";
         let m = make_mutation(tmp.path(), "main.go", content, 4, 9, "true", "false");
         let diff = mutation_diff(&m).unwrap();
-        assert!(diff.contains("-\treturn true"), "diff should show original line: {diff}");
-        assert!(diff.contains("+\treturn false"), "diff should show mutated line: {diff}");
+        assert!(
+            diff.contains("-\treturn true"),
+            "diff should show original line: {diff}"
+        );
+        assert!(
+            diff.contains("+\treturn false"),
+            "diff should show mutated line: {diff}"
+        );
     }
 
     #[test]
@@ -114,7 +128,10 @@ mod tests {
         let content = "x = 1 + 2\ny = 3\n";
         let m = make_mutation(tmp.path(), "test.py", content, 1, 7, "+ 2", "");
         let diff = mutation_diff(&m).unwrap();
-        assert!(diff.contains("-x = 1 + 2"), "diff should show original: {diff}");
+        assert!(
+            diff.contains("-x = 1 + 2"),
+            "diff should show original: {diff}"
+        );
         assert!(diff.contains("+x = 1"), "diff should show removal: {diff}");
     }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,69 @@
+/// Shared test utilities for tree-sitter parsing and node lookup.
+
+/// Parse Go source code into a tree-sitter tree.
+pub fn parse_go(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_go::LANGUAGE;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
+/// Recursively find the first node matching `kind` in the tree.
+pub fn find_node_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_node_by_kind(child, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Walk a tree cursor looking for a node of the given kind.
+pub fn walk_for_kind(cursor: &mut tree_sitter::TreeCursor, target: &str, found: &mut bool) {
+    if cursor.node().kind() == target {
+        *found = true;
+        return;
+    }
+    if cursor.goto_first_child() {
+        loop {
+            walk_for_kind(cursor, target, found);
+            if *found || !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}
+
+/// Walk a tree cursor looking for two node kinds simultaneously.
+pub fn walk_for_two_kinds(
+    cursor: &mut tree_sitter::TreeCursor,
+    kind_a: &str,
+    kind_b: &str,
+    found_a: &mut bool,
+    found_b: &mut bool,
+) {
+    let kind = cursor.node().kind();
+    if kind == kind_a {
+        *found_a = true;
+    }
+    if kind == kind_b {
+        *found_b = true;
+    }
+    if cursor.goto_first_child() {
+        loop {
+            walk_for_two_kinds(cursor, kind_a, kind_b, found_a, found_b);
+            if (*found_a && *found_b) || !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}


### PR DESCRIPTION
## Summary
- Add extension/parsing tests for all 7 language implementations (go, rust, c, cpp, csharp, java, ruby)
- Add mapper edge case tests (overlapping ranges, nested ifs, comments, assignments, cross-language)
- Add mutator tests (multi-file, Python/Rust support, sequential IDs)
- Add report/mod.rs `mutation_diff()` tests (basic, empty replacement, boundaries, invalid lines)
- Add lib.rs type construction and display tests
- Introduce shared `test_helpers` module (`parse_go`, `find_node_by_kind`, `walk_for_kind`, `walk_for_two_kinds`)

142 → 186 tests (+44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across many language support modules to validate metadata and parsing for C, C++, C#, Go, Java, Ruby, and Rust.
  * Added extensive tests for mutation detection, mutation generation, and diff formatting to improve correctness.
  * Introduced new test helpers and utilities to support broader parsing and node-discovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->