### PR TITLE
perf: integrate mutation result cache into runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.swo
 .DS_Store
 .togi.lock
+.togi-cache/
 .claude/
 togi.toml

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,6 @@
 // Parallel test execution with timeouts
 
+use crate::cache::{self, CacheKey, CachedResult};
 use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
@@ -8,6 +9,24 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
+
+fn to_cached(r: MutationResult) -> CachedResult {
+    match r {
+        MutationResult::Killed => CachedResult::Killed,
+        MutationResult::Survived => CachedResult::Survived,
+        MutationResult::Timeout => CachedResult::Timeout,
+        MutationResult::BuildError => CachedResult::BuildError,
+    }
+}
+
+fn from_cached(r: CachedResult) -> MutationResult {
+    match r {
+        CachedResult::Killed => MutationResult::Killed,
+        CachedResult::Survived => MutationResult::Survived,
+        CachedResult::Timeout => MutationResult::Timeout,
+        CachedResult::BuildError => MutationResult::BuildError,
+    }
+}
 
 pub struct TestRunner {
     pub command: Vec<String>,
@@ -74,6 +93,8 @@ impl TestRunner {
             let max_tested = self.max_tested;
             let show_output = self.show_output;
 
+            let cmd_str = command.join(" ");
+
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
                 for mutation in file_mutations {
@@ -83,6 +104,36 @@ impl TestRunner {
                     {
                         break;
                     }
+
+                    // Check cache before running
+                    let file_path = project_root.join(&mutation.file);
+                    let file_content = std::fs::read(&file_path).ok();
+                    let cache_key = file_content.as_ref().map(|content| {
+                        CacheKey::new(content, &mutation.description, &cmd_str)
+                    });
+                    if let Some(ref key) = cache_key {
+                        if let Some(cached) = cache::lookup(&project_root, key) {
+                            let result = from_cached(cached);
+                            if result != MutationResult::BuildError {
+                                tested_counter.fetch_add(1, Ordering::Relaxed);
+                            }
+                            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                            if verbose {
+                                eprintln!(
+                                    "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
+                                    n, total, mutation.file.display(), mutation.line, mutation.operator
+                                );
+                            } else if is_tty {
+                                eprint!("\r  [{}/{}] testing mutations...", n, total);
+                                let _ = std::io::stderr().flush();
+                            } else if n == total || (total >= 4 && n % (total / 4) == 0) {
+                                eprintln!("  [{}/{}] testing mutations...", n, total);
+                            }
+                            results.push((mutation, result));
+                            continue;
+                        }
+                    }
+
                     // Semaphore is never closed, so acquire cannot fail
                     let _permit = sem.acquire().await.unwrap();
                     let outcome = run_single_mutation(
@@ -94,6 +145,12 @@ impl TestRunner {
                         show_output,
                     )
                     .await;
+
+                    // Store result in cache
+                    if let Some(ref key) = cache_key {
+                        cache::store(&project_root, key, to_cached(outcome.result));
+                    }
+
                     if outcome.result != MutationResult::BuildError {
                         tested_counter.fetch_add(1, Ordering::Relaxed);
                     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -108,9 +108,9 @@ impl TestRunner {
                     // Check cache before running
                     let file_path = project_root.join(&mutation.file);
                     let file_content = std::fs::read(&file_path).ok();
-                    let cache_key = file_content.as_ref().map(|content| {
-                        CacheKey::new(content, &mutation.description, &cmd_str)
-                    });
+                    let cache_key = file_content
+                        .as_ref()
+                        .map(|content| CacheKey::new(content, &mutation.description, &cmd_str));
                     if let Some(ref key) = cache_key {
                         if let Some(cached) = cache::lookup(&project_root, key) {
                             let result = from_cached(cached);
@@ -121,7 +121,11 @@ impl TestRunner {
                             if verbose {
                                 eprintln!(
                                     "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
-                                    n, total, mutation.file.display(), mutation.line, mutation.operator
+                                    n,
+                                    total,
+                                    mutation.file.display(),
+                                    mutation.line,
+                                    mutation.operator
                                 );
                             } else if is_tty {
                                 eprint!("\r  [{}/{}] testing mutations...", n, total);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -111,31 +111,31 @@ impl TestRunner {
                     let cache_key = file_content
                         .as_ref()
                         .map(|content| CacheKey::new(content, &mutation.description, &cmd_str));
-                    if let Some(ref key) = cache_key {
-                        if let Some(cached) = cache::lookup(&project_root, key) {
-                            let result = from_cached(cached);
-                            if result != MutationResult::BuildError {
-                                tested_counter.fetch_add(1, Ordering::Relaxed);
-                            }
-                            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                            if verbose {
-                                eprintln!(
-                                    "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
-                                    n,
-                                    total,
-                                    mutation.file.display(),
-                                    mutation.line,
-                                    mutation.operator
-                                );
-                            } else if is_tty {
-                                eprint!("\r  [{}/{}] testing mutations...", n, total);
-                                let _ = std::io::stderr().flush();
-                            } else if n == total || (total >= 4 && n % (total / 4) == 0) {
-                                eprintln!("  [{}/{}] testing mutations...", n, total);
-                            }
-                            results.push((mutation, result));
-                            continue;
+                    if let Some(ref key) = cache_key
+                        && let Some(cached) = cache::lookup(&project_root, key)
+                    {
+                        let result = from_cached(cached);
+                        if result != MutationResult::BuildError {
+                            tested_counter.fetch_add(1, Ordering::Relaxed);
                         }
+                        let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                        if verbose {
+                            eprintln!(
+                                "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
+                                n,
+                                total,
+                                mutation.file.display(),
+                                mutation.line,
+                                mutation.operator
+                            );
+                        } else if is_tty {
+                            eprint!("\r  [{}/{}] testing mutations...", n, total);
+                            let _ = std::io::stderr().flush();
+                        } else if n == total || (total >= 4 && n % (total / 4) == 0) {
+                            eprintln!("  [{}/{}] testing mutations...", n, total);
+                        }
+                        results.push((mutation, result));
+                        continue;
                     }
 
                     // Semaphore is never closed, so acquire cannot fail


### PR DESCRIPTION
Closes #152

- Wire existing `cache::lookup()`/`store()` into the per-mutation loop in runner
- Cache hit skips file mutation, build check, and test execution entirely
- Cache key: `(file_content_hash, mutation_description, test_command_hash)`
- Cache misses run normally and store the result for next time
- Verbose mode shows `↻ cached` for cache hits
- Add `.togi-cache/` to `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude cache directories from version control.

* **Refactor**
  * Implemented caching mechanism for mutation test execution results to enhance performance and reduce redundant computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->