### PR TITLE
feat: add --fail-fast flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,10 @@ pub enum Commands {
         /// Override build check command (e.g., 'cargo check')
         #[arg(long)]
         build_cmd: Option<String>,
+
+        /// Stop test suite on first failure per mutation (faster kills)
+        #[arg(long)]
+        fail_fast: bool,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,21 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
     }
 }
 
+/// Returns failfast args to append to a test command, based on the test runner.
+pub fn failfast_args(command: &[String]) -> Vec<String> {
+    match command.first().map(|s| s.as_str()) {
+        Some("go") => vec!["-failfast".into()],
+        Some("pytest") => vec!["-x".into()],
+        Some("npx") => vec!["--bail".into()],
+        Some("npm") => vec!["--".into(), "--bail".into()],
+        Some("mvn") => vec!["--fail-fast".into()],
+        Some("./gradlew") | Some("gradlew") => vec!["--fail-fast".into()],
+        Some("bundle") => vec!["--fail-fast".into()],
+        Some("dotnet") => vec!["--".into(), "--fail-fast".into()],
+        _ => vec![],
+    }
+}
+
 pub fn detect_build_command(project_root: &Path) -> Vec<String> {
     if project_root.join("Cargo.toml").exists() {
         return vec!["cargo".into(), "check".into()];

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ struct CheckConfig {
     test_cmd: Option<String>,
     coverage_file: Option<PathBuf>,
     build_cmd: Option<String>,
+    fail_fast: bool,
 }
 
 #[tokio::main]
@@ -38,6 +39,7 @@ async fn main() {
             test_cmd,
             coverage_file,
             build_cmd,
+            fail_fast,
         } => {
             let cfg = CheckConfig {
                 all,
@@ -52,6 +54,7 @@ async fn main() {
                 test_cmd,
                 coverage_file,
                 build_cmd,
+                fail_fast,
             };
             if let Err(e) = run_check(cfg).await {
                 eprintln!("Error: {e:#}");
@@ -80,12 +83,21 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let show_output = cfg.show_output;
     let output_format = cfg.output_format.clone();
 
-    let mut config = resolve_config(cfg)?;
+    let (mut config, fail_fast) = resolve_config(cfg)?;
     let project_root = get_project_root()?;
     let _lock = togi::lock::acquire(&project_root)?;
 
     config.resolve_test_command(&project_root);
     config.resolve_build_command(&project_root);
+
+    if fail_fast {
+        let args = togi::config::failfast_args(&config.test.command);
+        config.test.command.extend(args);
+        for lang_config in config.test.languages.values_mut() {
+            let args = togi::config::failfast_args(&lang_config.command);
+            lang_config.command.extend(args);
+        }
+    }
 
     let all_langs = togi::languages::all();
     let known: Vec<&str> = all_langs.iter().map(|l| l.name()).collect();
@@ -125,8 +137,9 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn resolve_config(cfg: CheckConfig) -> anyhow::Result<togi::config::Config> {
+fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, bool)> {
     let mut config = togi::config::Config::load(cfg.config_path.as_deref())?;
+    let has_custom_test_cmd = cfg.test_cmd.is_some();
 
     if let Some(b) = cfg.base {
         config.diff.base = b;
@@ -149,7 +162,8 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<togi::config::Config> {
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?;
     }
 
-    Ok(config)
+    let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
+    Ok((config, fail_fast))
 }
 
 /// Collects files to mutate. Returns an empty vec with user-facing messages


### PR DESCRIPTION
## Summary
- Adds `--fail-fast` CLI flag (opt-in, off by default) that appends language-specific early-exit flags to the test command
- Supported: Go (`-failfast`), Python (`-x`), npm (`-- --bail`), npx (`--bail`), Maven/Gradle/rspec (`--fail-fast`), dotnet (`-- --fail-fast`)
- Skipped when `--test-cmd` is provided (user owns the command)
- `cargo test` has no equivalent, so no flag is appended for Rust

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added `--fail-fast` flag to the `check` command to terminate test execution immediately upon detecting the first failure during mutation testing. This feature significantly reduces feedback time by preventing unnecessary test runs once a mutation-induced failure is identified, helping developers focus on addressing issues more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->