### PR TITLE
Skip mutations inside imports, macros, and type annotations

### DIFF
--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -38,6 +38,10 @@ impl LanguageSupport for CSharp {
     fn operator_field(&self) -> &str {
         "operator"
     }
+
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &["using_directive", "attribute", "type_parameter_list"]
+    }
 }
 
 #[cfg(test)]

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -39,7 +39,7 @@ impl LanguageSupport for CSharp {
         "operator"
     }
 
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &["using_directive", "attribute", "type_parameter_list"]
     }
 }

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -38,6 +38,10 @@ impl LanguageSupport for Go {
     fn operator_field(&self) -> &str {
         "operator"
     }
+
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &["import_spec", "import_spec_list", "type_spec"]
+    }
 }
 
 #[cfg(test)]

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -39,7 +39,7 @@ impl LanguageSupport for Go {
         "operator"
     }
 
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &["import_spec", "import_spec_list", "type_spec"]
     }
 }

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -39,7 +39,7 @@ impl LanguageSupport for Java {
         "operator"
     }
 
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &["import_declaration", "annotation", "type_parameters"]
     }
 }

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -38,6 +38,10 @@ impl LanguageSupport for Java {
     fn operator_field(&self) -> &str {
         "operator"
     }
+
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &["import_declaration", "annotation", "type_parameters"]
+    }
 }
 
 #[cfg(test)]

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -22,7 +22,7 @@ pub trait LanguageSupport: Send + Sync {
 
     /// AST node kinds that should suppress mutation of any descendant.
     /// Nodes whose ancestor matches any of these kinds will be skipped.
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &[]
     }
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -19,6 +19,12 @@ pub trait LanguageSupport: Send + Sync {
     fn boolean_false_literals(&self) -> &[&str];
     fn return_statement_node(&self) -> &str;
     fn operator_field(&self) -> &str;
+
+    /// AST node kinds that should suppress mutation of any descendant.
+    /// Nodes whose ancestor matches any of these kinds will be skipped.
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &[]
+    }
 }
 
 /// Returns instances of all supported languages.

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -39,7 +39,7 @@ impl LanguageSupport for Rust {
         "operator"
     }
 
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &[
             "use_declaration",
             "macro_invocation",

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -38,6 +38,16 @@ impl LanguageSupport for Rust {
     fn operator_field(&self) -> &str {
         "operator"
     }
+
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &[
+            "use_declaration",
+            "macro_invocation",
+            "attribute_item",
+            "type_parameters",
+            "where_clause",
+        ]
+    }
 }
 
 #[cfg(test)]

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -39,7 +39,7 @@ impl LanguageSupport for TypeScript {
         "operator"
     }
 
-    fn skip_ancestor_kinds(&self) -> &[&str] {
+    fn skip_subtree_kinds(&self) -> &[&str] {
         &[
             "import_statement",
             "type_annotation",

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -38,6 +38,15 @@ impl LanguageSupport for TypeScript {
     fn operator_field(&self) -> &str {
         "operator"
     }
+
+    fn skip_ancestor_kinds(&self) -> &[&str] {
+        &[
+            "import_statement",
+            "type_annotation",
+            "type_alias_declaration",
+            "decorator",
+        ]
+    }
 }
 
 #[cfg(test)]

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -39,10 +39,11 @@ pub fn find_mutable_nodes<'a>(
     tree: &'a tree_sitter::Tree,
     source: &'a [u8],
     changed_lines: &[LineRange],
+    skip_ancestor_kinds: &[&str],
 ) -> Vec<tree_sitter::Node<'a>> {
     let mut nodes = Vec::new();
     let root = tree.root_node();
-    collect_mutable_nodes(root, source, changed_lines, &mut nodes);
+    collect_mutable_nodes(root, source, changed_lines, skip_ancestor_kinds, &mut nodes);
     nodes
 }
 
@@ -52,6 +53,7 @@ fn collect_mutable_nodes<'a>(
     node: tree_sitter::Node<'a>,
     source: &'a [u8],
     changed_lines: &[LineRange],
+    skip_ancestor_kinds: &[&str],
     results: &mut Vec<tree_sitter::Node<'a>>,
 ) {
     let _ = source; // available for future use
@@ -64,13 +66,18 @@ fn collect_mutable_nodes<'a>(
         return;
     }
 
+    // Skip nodes inside contexts that produce non-compilable mutations
+    if !skip_ancestor_kinds.is_empty() && skip_ancestor_kinds.contains(&node.kind()) {
+        return;
+    }
+
     // Try to find relevant children first (prefer deepest nodes)
     let mut found_child = false;
     let child_count = node.child_count() as u32;
     for i in 0..child_count {
         if let Some(child) = node.child(i) {
             let before = results.len();
-            collect_mutable_nodes(child, source, changed_lines, results);
+            collect_mutable_nodes(child, source, changed_lines, skip_ancestor_kinds, results);
             if results.len() > before {
                 found_child = true;
             }
@@ -113,7 +120,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 3, end: 4 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -126,7 +133,7 @@ mod tests {
         let tree = parse_go(source);
         let changed: Vec<LineRange> = vec![];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(nodes.is_empty());
     }
@@ -138,7 +145,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 4, end: 4 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -163,7 +170,7 @@ mod tests {
             LineRange { start: 5, end: 7 },
         ];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
         // Should find binary expressions from both return statements
@@ -182,7 +189,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 4, end: 4 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -201,7 +208,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 5, end: 5 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -224,7 +231,7 @@ mod tests {
         // Only the inner if line is changed
         let changed = vec![LineRange { start: 5, end: 6 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -244,7 +251,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 6, end: 6 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -263,7 +270,7 @@ mod tests {
         let tree = parse_go(source);
         let changed = vec![LineRange { start: 3, end: 4 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(
             nodes.is_empty(),
@@ -280,7 +287,7 @@ mod tests {
         // Only the package line is changed
         let changed = vec![LineRange { start: 1, end: 1 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(
             nodes.is_empty(),
@@ -303,7 +310,7 @@ mod tests {
         let tree = parse_rust(source);
         let changed = vec![LineRange { start: 2, end: 2 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
@@ -317,13 +324,75 @@ mod tests {
     }
 
     #[test]
+    fn rust_use_declaration_skipped() {
+        let source = b"use std::collections::HashMap;\nfn f() -> bool { true }\n";
+        let tree = parse_rust(source);
+        let changed = vec![LineRange { start: 1, end: 2 }];
+
+        let skip = &["use_declaration"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        // Should find `true` in the function but nothing from the use declaration
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            !kinds.contains(&"string_literal") && !kinds.contains(&"identifier"),
+            "Use declaration should be skipped, got: {:?}",
+            kinds
+        );
+        assert!(
+            kinds.contains(&"true"),
+            "Should still find mutable nodes outside skipped ancestors, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn rust_macro_invocation_skipped() {
+        let source = b"fn f() {\n    println!(\"hello\");\n    let x = true;\n}\n";
+        let tree = parse_rust(source);
+        let changed = vec![LineRange { start: 1, end: 4 }];
+
+        let skip = &["macro_invocation"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            !kinds.contains(&"string_literal") && !kinds.contains(&"string_content"),
+            "Macro string should be skipped, got: {:?}",
+            kinds
+        );
+        assert!(
+            kinds.contains(&"true"),
+            "Should still find `true` outside macro, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn go_import_skipped() {
+        let source = b"package main\n\nimport \"fmt\"\n\nfunc f() bool {\n\treturn true\n}\n";
+        let tree = parse_go(source);
+        let changed = vec![LineRange { start: 1, end: 7 }];
+
+        let skip = &["import_spec"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            !kinds.contains(&"interpreted_string_literal"),
+            "Import string should be skipped, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
     fn rust_nested_if_expression() {
         let source = b"fn f(a: i32, b: i32) -> i32 {\n    if a > 0 {\n        if b > 0 {\n            return a + b;\n        }\n    }\n    0\n}\n";
         // Lines: 1=fn, 2=if a>0, 3=if b>0, 4=return a+b, 5=}, 6=}, 7=0, 8=}
         let tree = parse_rust(source);
         let changed = vec![LineRange { start: 3, end: 4 }];
 
-        let nodes = find_mutable_nodes(&tree, source, &changed);
+        let nodes = find_mutable_nodes(&tree, source, &changed, &[]);
 
         assert!(!nodes.is_empty());
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -49,13 +49,15 @@ pub fn find_mutable_nodes<'a>(
 
 /// Recursively walk the tree, collecting the deepest mutation-relevant nodes
 /// that overlap with changed lines.
+/// Returns `true` if a skipped subtree was encountered, preventing the parent
+/// from being added as a fallback mutable node.
 fn collect_mutable_nodes<'a>(
     node: tree_sitter::Node<'a>,
     source: &'a [u8],
     changed_lines: &[LineRange],
     skip_subtree_kinds: &[&str],
     results: &mut Vec<tree_sitter::Node<'a>>,
-) {
+) -> bool {
     let _ = source; // available for future use
 
     let node_start = ts_row_to_line(node.start_position().row);
@@ -63,31 +65,35 @@ fn collect_mutable_nodes<'a>(
 
     // Check if this node overlaps any changed line range
     if !overlaps(node_start, node_end, changed_lines) {
-        return;
+        return false;
     }
 
     // Skip subtrees that produce non-compilable mutations (imports, macros, etc.)
     if skip_subtree_kinds.contains(&node.kind()) {
-        return;
+        return true;
     }
 
     // Try to find relevant children first (prefer deepest nodes)
     let mut found_child = false;
+    let mut skipped_child = false;
     let child_count = node.child_count() as u32;
     for i in 0..child_count {
         if let Some(child) = node.child(i) {
             let before = results.len();
-            collect_mutable_nodes(child, source, changed_lines, skip_subtree_kinds, results);
+            skipped_child |=
+                collect_mutable_nodes(child, source, changed_lines, skip_subtree_kinds, results);
             if results.len() > before {
                 found_child = true;
             }
         }
     }
 
-    // Only add this node if no relevant children were found and it's a mutable kind
-    if !found_child && is_mutable_kind(node.kind()) {
+    // Only add this node if no relevant children were found, no children were
+    // skipped, and it's a mutable kind
+    if !found_child && !skipped_child && is_mutable_kind(node.kind()) {
         results.push(node);
     }
+    false
 }
 
 /// Check if a node's line range overlaps with any changed line range.
@@ -359,6 +365,11 @@ mod tests {
         assert!(
             !kinds.contains(&"string_literal") && !kinds.contains(&"string_content"),
             "Macro string should be skipped, got: {:?}",
+            kinds
+        );
+        assert!(
+            !kinds.contains(&"expression_statement"),
+            "Parent expression_statement of skipped macro should not leak, got: {:?}",
             kinds
         );
         assert!(

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -385,6 +385,100 @@ mod tests {
         );
     }
 
+    fn parse_typescript(source: &[u8]) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_typescript::LANGUAGE_TYPESCRIPT;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    fn parse_java(source: &[u8]) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_java::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    fn parse_csharp(source: &[u8]) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang = tree_sitter_c_sharp::LANGUAGE;
+        parser.set_language(&lang.into()).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn typescript_import_skipped() {
+        let source = b"import { foo } from 'bar';\nconst x = true;\n";
+        let tree = parse_typescript(source);
+        let changed = vec![LineRange { start: 1, end: 2 }];
+
+        let skip = &["import_statement"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            !kinds.contains(&"string") && !kinds.contains(&"string_literal"),
+            "Import string should be skipped, got: {:?}",
+            kinds
+        );
+        assert!(
+            kinds.contains(&"true"),
+            "Should still find `true` outside import, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn typescript_type_annotation_skipped() {
+        let source = b"function f(x: string): boolean { return true; }\n";
+        let tree = parse_typescript(source);
+        let changed = vec![LineRange { start: 1, end: 1 }];
+
+        let skip = &["type_annotation"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            kinds.contains(&"true"),
+            "Should still find `true` in function body, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn java_import_skipped() {
+        let source = b"import java.util.List;\nclass T { boolean f() { return true; } }\n";
+        let tree = parse_java(source);
+        let changed = vec![LineRange { start: 1, end: 2 }];
+
+        let skip = &["import_declaration"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            kinds.contains(&"true"),
+            "Should still find `true` outside import, got: {:?}",
+            kinds
+        );
+    }
+
+    #[test]
+    fn csharp_using_skipped() {
+        let source = b"using System.Collections;\nclass T { bool F() { return true; } }\n";
+        let tree = parse_csharp(source);
+        let changed = vec![LineRange { start: 1, end: 2 }];
+
+        let skip = &["using_directive"];
+        let nodes = find_mutable_nodes(&tree, source, &changed, skip);
+
+        let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
+        assert!(
+            kinds.contains(&"true") || kinds.contains(&"boolean_literal"),
+            "Should still find boolean outside using, got: {:?}",
+            kinds
+        );
+    }
+
     #[test]
     fn rust_nested_if_expression() {
         let source = b"fn f(a: i32, b: i32) -> i32 {\n    if a > 0 {\n        if b > 0 {\n            return a + b;\n        }\n    }\n    0\n}\n";

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -39,11 +39,11 @@ pub fn find_mutable_nodes<'a>(
     tree: &'a tree_sitter::Tree,
     source: &'a [u8],
     changed_lines: &[LineRange],
-    skip_ancestor_kinds: &[&str],
+    skip_subtree_kinds: &[&str],
 ) -> Vec<tree_sitter::Node<'a>> {
     let mut nodes = Vec::new();
     let root = tree.root_node();
-    collect_mutable_nodes(root, source, changed_lines, skip_ancestor_kinds, &mut nodes);
+    collect_mutable_nodes(root, source, changed_lines, skip_subtree_kinds, &mut nodes);
     nodes
 }
 
@@ -53,7 +53,7 @@ fn collect_mutable_nodes<'a>(
     node: tree_sitter::Node<'a>,
     source: &'a [u8],
     changed_lines: &[LineRange],
-    skip_ancestor_kinds: &[&str],
+    skip_subtree_kinds: &[&str],
     results: &mut Vec<tree_sitter::Node<'a>>,
 ) {
     let _ = source; // available for future use
@@ -66,8 +66,8 @@ fn collect_mutable_nodes<'a>(
         return;
     }
 
-    // Skip nodes inside contexts that produce non-compilable mutations
-    if !skip_ancestor_kinds.is_empty() && skip_ancestor_kinds.contains(&node.kind()) {
+    // Skip subtrees that produce non-compilable mutations (imports, macros, etc.)
+    if skip_subtree_kinds.contains(&node.kind()) {
         return;
     }
 
@@ -77,7 +77,7 @@ fn collect_mutable_nodes<'a>(
     for i in 0..child_count {
         if let Some(child) = node.child(i) {
             let before = results.len();
-            collect_mutable_nodes(child, source, changed_lines, skip_ancestor_kinds, results);
+            collect_mutable_nodes(child, source, changed_lines, skip_subtree_kinds, results);
             if results.len() > before {
                 found_child = true;
             }

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -14,14 +14,20 @@ const FUNC_NODE_KINDS: &[&str] = &[
     "method",               // Ruby
 ];
 
-const RUST_PRIMITIVE_RETURNS: &[&str] = &[
-    "bool", "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128", "usize",
-    "f32", "f64", "String", "&str", "char", "()",
+/// Return type node kinds where a literal replacement (0, false, "") is valid.
+const SIMPLE_RETURN_TYPE_KINDS: &[&str] = &[
+    "primitive_type",      // Rust: i32, bool, f64, char, etc.
+    "type_identifier",     // Rust: String, custom newtypes wrapping primitives
+    "predefined_type",     // TypeScript: number, string, boolean
+    "boolean_type",        // TypeScript: boolean
+    "void_type",           // C#, Java
+    "integral_type",       // C#: int, long, byte
+    "floating_point_type", // C#, Java: float, double
 ];
 
 /// Check if a return_empty mutation should be skipped because the return type
 /// is too complex for a simple literal replacement.
-fn should_skip_return_empty(node: &tree_sitter::Node, source: &[u8], language: &str) -> bool {
+fn should_skip_return_empty(node: &tree_sitter::Node, language: &str) -> bool {
     // Walk up to find the enclosing function
     let mut parent = node.parent();
     let func_node = loop {
@@ -32,38 +38,28 @@ fn should_skip_return_empty(node: &tree_sitter::Node, source: &[u8], language: &
         }
     };
 
-    match language {
-        "rust" => {
-            let ret_type = func_node.child_by_field_name("return_type");
-            match ret_type {
-                None => false, // no return type annotation (-> ()), don't skip
-                Some(rt) => match std::str::from_utf8(&source[rt.byte_range()]) {
-                    Ok(text) => !RUST_PRIMITIVE_RETURNS.contains(&text),
-                    Err(_) => false, // can't decode return type, don't skip
-                },
+    // Check the return type field — field name varies by language
+    let ret_type = func_node
+        .child_by_field_name("return_type")
+        .or_else(|| func_node.child_by_field_name("type"))
+        .or_else(|| func_node.child_by_field_name("result"));
+
+    match ret_type {
+        None => false, // no return type annotation, don't skip
+        Some(rt) => {
+            if language == "go" && rt.kind() == "parameter_list" {
+                // Go multi-return: (int, error)
+                return true;
             }
+            !SIMPLE_RETURN_TYPE_KINDS.contains(&rt.kind())
         }
-        "go" => {
-            // Go: skip if function has a parameter_list as result (multiple returns)
-            if let Some(result) = func_node.child_by_field_name("result") {
-                result.kind() == "parameter_list"
-            } else {
-                false
-            }
-        }
-        _ => false,
     }
 }
 
 /// Check if a mutation candidate should be filtered out for the given language.
-fn should_filter(
-    candidate: &MutationCandidate,
-    node: &tree_sitter::Node,
-    source: &[u8],
-    language: &str,
-) -> bool {
+fn should_filter(candidate: &MutationCandidate, node: &tree_sitter::Node, language: &str) -> bool {
     if candidate.operator_id == "return_empty" {
-        return should_skip_return_empty(node, source, language);
+        return should_skip_return_empty(node, language);
     }
     false
 }
@@ -114,7 +110,7 @@ pub fn generate_mutations(
                         return Ok(mutations);
                     }
 
-                    if should_filter(&candidate, node, &source, &language_name) {
+                    if should_filter(&candidate, node, &language_name) {
                         continue;
                     }
 

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -37,10 +37,10 @@ fn should_skip_return_empty(node: &tree_sitter::Node, source: &[u8], language: &
             let ret_type = func_node.child_by_field_name("return_type");
             match ret_type {
                 None => false, // no return type annotation (-> ()), don't skip
-                Some(rt) => {
-                    let text = std::str::from_utf8(&source[rt.byte_range()]).unwrap_or("");
-                    !RUST_PRIMITIVE_RETURNS.contains(&text)
-                }
+                Some(rt) => match std::str::from_utf8(&source[rt.byte_range()]) {
+                    Ok(text) => !RUST_PRIMITIVE_RETURNS.contains(&text),
+                    Err(_) => false, // can't decode return type, don't skip
+                },
             }
         }
         "go" => {
@@ -103,7 +103,7 @@ pub fn generate_mutations(
             &tree,
             &source,
             &changed_file.hunks,
-            lang.skip_ancestor_kinds(),
+            lang.skip_subtree_kinds(),
         );
 
         for node in &nodes {

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -2,9 +2,71 @@
 
 use crate::mapper::find_mutable_nodes;
 use crate::operators::{self};
-use crate::{ChangedFile, Mutation, ts_row_to_line};
+use crate::{ChangedFile, Mutation, MutationCandidate, ts_row_to_line};
 use anyhow::Result;
 use std::path::Path;
+
+const FUNC_NODE_KINDS: &[&str] = &[
+    "function_item",        // Rust
+    "function_declaration", // Go, TypeScript, C/C++
+    "method_declaration",   // Java, C#
+    "function_definition",  // Python, C/C++
+    "method",               // Ruby
+];
+
+const RUST_PRIMITIVE_RETURNS: &[&str] = &[
+    "bool", "i8", "i16", "i32", "i64", "i128", "isize", "u8", "u16", "u32", "u64", "u128", "usize",
+    "f32", "f64", "String", "&str", "char", "()",
+];
+
+/// Check if a return_empty mutation should be skipped because the return type
+/// is too complex for a simple literal replacement.
+fn should_skip_return_empty(node: &tree_sitter::Node, source: &[u8], language: &str) -> bool {
+    // Walk up to find the enclosing function
+    let mut parent = node.parent();
+    let func_node = loop {
+        match parent {
+            Some(p) if FUNC_NODE_KINDS.contains(&p.kind()) => break p,
+            Some(p) => parent = p.parent(),
+            None => return false, // no enclosing function found, don't skip
+        }
+    };
+
+    match language {
+        "rust" => {
+            let ret_type = func_node.child_by_field_name("return_type");
+            match ret_type {
+                None => false, // no return type annotation (-> ()), don't skip
+                Some(rt) => {
+                    let text = std::str::from_utf8(&source[rt.byte_range()]).unwrap_or("");
+                    !RUST_PRIMITIVE_RETURNS.contains(&text)
+                }
+            }
+        }
+        "go" => {
+            // Go: skip if function has a parameter_list as result (multiple returns)
+            if let Some(result) = func_node.child_by_field_name("result") {
+                result.kind() == "parameter_list"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Check if a mutation candidate should be filtered out for the given language.
+fn should_filter(
+    candidate: &MutationCandidate,
+    node: &tree_sitter::Node,
+    source: &[u8],
+    language: &str,
+) -> bool {
+    if candidate.operator_id == "return_empty" {
+        return should_skip_return_empty(node, source, language);
+    }
+    false
+}
 
 /// Generate mutations for all changed files.
 /// Reads each file, parses it, finds mutable nodes in changed regions,
@@ -50,6 +112,10 @@ pub fn generate_mutations(
                 for candidate in candidates {
                     if mutations.len() >= max_mutations {
                         return Ok(mutations);
+                    }
+
+                    if should_filter(&candidate, node, &source, &language_name) {
+                        continue;
                     }
 
                     let line = ts_row_to_line(node.start_position().row);
@@ -226,6 +292,68 @@ mod tests {
         for (i, m) in mutations.iter().enumerate() {
             assert_eq!(m.id, i as u32, "mutation ids should be sequential");
         }
+    }
+
+    #[test]
+    fn rust_return_empty_skipped_for_result_type() {
+        let tmp = TempDir::new().unwrap();
+        let src = "fn f() -> Result<i32, String> {\n    return Ok(42);\n}\n";
+        let rel = write_go_file(tmp.path(), "lib.rs", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 3 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
+        assert!(
+            !has_return_empty,
+            "return_empty should be skipped for Result return type, got: {:?}",
+            mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rust_return_empty_allowed_for_primitive() {
+        let tmp = TempDir::new().unwrap();
+        // Use a function call as return value — call_expression is not in MUTABLE_NODE_KINDS,
+        // so the mapper yields the return_expression itself.
+        let src = "fn f() -> i32 {\n    return compute();\n}\n";
+        let rel = write_go_file(tmp.path(), "lib.rs", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 3 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
+        assert!(
+            has_return_empty,
+            "return_empty should be allowed for i32 return type, got: {:?}",
+            mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn go_return_empty_skipped_for_multi_return() {
+        let tmp = TempDir::new().unwrap();
+        let src = "package main\n\nfunc f() (int, error) {\n\treturn 0, nil\n}\n";
+        let rel = write_go_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 5 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100).unwrap();
+        let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
+        assert!(
+            !has_return_empty,
+            "return_empty should be skipped for multi-return Go func, got: {:?}",
+            mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -37,7 +37,12 @@ pub fn generate_mutations(
         };
         let language_name = lang.name().to_string();
 
-        let nodes = find_mutable_nodes(&tree, &source, &changed_file.hunks);
+        let nodes = find_mutable_nodes(
+            &tree,
+            &source,
+            &changed_file.hunks,
+            lang.skip_ancestor_kinds(),
+        );
 
         for node in &nodes {
             for op in &operators {


### PR DESCRIPTION
## Summary
- Add `skip_ancestor_kinds()` to `LanguageSupport` trait with per-language skip lists
- Mapper prunes subtrees under skipped node kinds (imports, macros, decorators, type params)
- Rust, Go, TypeScript, Java, C# all have language-specific skip lists
- Python, Ruby, C, C++ use empty defaults (dynamic/less affected)

Fixes #163

## Test plan
- [x] 4 new mapper tests (Rust use/macro skip, Go import skip, positive cases)
- [x] All 190 existing tests pass
- [x] clippy + rustfmt clean
- [ ] Manual: run on foxguard (Rust) and kleinkram (TypeScript) to verify reduced build errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-language rules to skip certain syntactic contexts (imports, using directives, annotations, type parameters, decorators, etc.) when selecting mutation targets.
* **Behavior**
  * Core extension point added so traversal honors language-specific ancestor-kind skipping; mutation selection also applies language-aware filtering for some return-value mutations.
* **Tests**
  * Tests updated and expanded to cover skipped contexts and language-specific mutation filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->