### PR TITLE
Skip build check for interpreted languages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let show_output = cfg.show_output;
     let output_format = cfg.output_format.clone();
 
-    let (mut config, fail_fast) = resolve_config(cfg)?;
+    let (mut config, fail_fast, has_explicit_build_cmd) = resolve_config(cfg)?;
     let project_root = get_project_root()?;
     let _lock = togi::lock::acquire(&project_root)?;
 
@@ -125,7 +125,15 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
 
     eprintln!("Running {} mutations...", mutations.len());
 
-    let report = execute(mutations, config, project_root, verbose, show_output).await;
+    let report = execute(
+        mutations,
+        config,
+        project_root,
+        verbose,
+        show_output,
+        has_explicit_build_cmd,
+    )
+    .await;
 
     togi::report::print_report(&report, &output_format)?;
 
@@ -137,9 +145,10 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, bool)> {
+fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, bool, bool)> {
     let mut config = togi::config::Config::load(cfg.config_path.as_deref())?;
     let has_custom_test_cmd = cfg.test_cmd.is_some();
+    let has_cli_build_cmd = cfg.build_cmd.is_some();
 
     if let Some(b) = cfg.base {
         config.diff.base = b;
@@ -162,8 +171,9 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?;
     }
 
+    let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
-    Ok((config, fail_fast))
+    Ok((config, fail_fast, has_explicit_build_cmd))
 }
 
 /// Collects files to mutate. Returns an empty vec with user-facing messages
@@ -285,6 +295,7 @@ async fn execute(
     project_root: PathBuf,
     verbose: bool,
     show_output: bool,
+    build_command_explicit: bool,
 ) -> MutationReport {
     let language_commands: std::collections::HashMap<String, Vec<String>> = config
         .test
@@ -297,6 +308,7 @@ async fn execute(
         command: config.test.command,
         language_commands,
         build_command: config.test.build_command,
+        build_command_explicit,
         timeout: Duration::from_secs(config.test.timeout),
         parallelism: config.test.jobs,
         project_root,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -103,6 +103,8 @@ impl TestRunner {
             let show_output = self.show_output;
 
             let cmd_str = command.join(" ");
+            let build_str = build_command.join(" ");
+            let cache_ctx = format!("{};build={}", cmd_str, build_str);
 
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
@@ -119,7 +121,7 @@ impl TestRunner {
                     let file_content = std::fs::read(&file_path).ok();
                     let cache_key = file_content
                         .as_ref()
-                        .map(|content| CacheKey::new(content, &mutation.description, &cmd_str));
+                        .map(|content| CacheKey::new(content, &mutation.description, &cache_ctx));
                     if let Some(ref key) = cache_key
                         && let Some(cached) = cache::lookup(&project_root, key)
                     {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,6 +10,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
+/// Languages that don't need a build/compile check before running tests.
+const INTERPRETED_LANGUAGES: &[&str] = &["python", "ruby", "javascript", "typescript"];
+
 fn to_cached(r: MutationResult) -> CachedResult {
     match r {
         MutationResult::Killed => CachedResult::Killed,
@@ -87,7 +90,11 @@ impl TestRunner {
                 .clone();
             let timeout = self.timeout;
             let project_root = project_root.clone();
-            let build_command = build_command.clone();
+            let build_command = if INTERPRETED_LANGUAGES.contains(&language) {
+                Arc::new(vec![])
+            } else {
+                build_command.clone()
+            };
             let counter = counter.clone();
             let tested_counter = tested_counter.clone();
             let max_tested = self.max_tested;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -35,6 +35,7 @@ pub struct TestRunner {
     pub command: Vec<String>,
     pub language_commands: HashMap<String, Vec<String>>,
     pub build_command: Vec<String>,
+    pub build_command_explicit: bool,
     pub timeout: Duration,
     pub parallelism: usize,
     pub project_root: PathBuf,
@@ -90,11 +91,12 @@ impl TestRunner {
                 .clone();
             let timeout = self.timeout;
             let project_root = project_root.clone();
-            let build_command = if INTERPRETED_LANGUAGES.contains(&language) {
-                Arc::new(vec![])
-            } else {
-                build_command.clone()
-            };
+            let build_command =
+                if !self.build_command_explicit && INTERPRETED_LANGUAGES.contains(&language) {
+                    Arc::new(vec![])
+                } else {
+                    build_command.clone()
+                };
             let counter = counter.clone();
             let tested_counter = tested_counter.clone();
             let max_tested = self.max_tested;
@@ -677,6 +679,7 @@ mod tests {
             command: vec!["true".into()],
             language_commands: HashMap::new(),
             build_command: vec![],
+            build_command_explicit: false,
             timeout: Duration::from_secs(5),
             parallelism: 1,
             project_root: dir.path().to_path_buf(),
@@ -712,6 +715,7 @@ mod tests {
             command: vec!["true".into()],
             language_commands: lang_cmds,
             build_command: vec![],
+            build_command_explicit: false,
             timeout: Duration::from_secs(5),
             parallelism: 2,
             project_root: dir.path().to_path_buf(),
@@ -744,6 +748,7 @@ mod tests {
             command: vec!["true".into()], // default would survive
             language_commands: lang_cmds,
             build_command: vec![],
+            build_command_explicit: false,
             timeout: Duration::from_secs(5),
             parallelism: 1,
             project_root: dir.path().to_path_buf(),

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -90,6 +90,7 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
         project_root: root,
         verbose: false,
         build_command: vec![],
+        build_command_explicit: false,
         max_tested: None,
         show_output: false,
     };


### PR DESCRIPTION
## Summary
- Skip build/compile check for Python, Ruby, JavaScript, TypeScript mutations
- Uses existing `if !build_command.is_empty()` guard — just passes empty vec for interpreted languages
- Saves ~500ms per mutation on interpreted language projects

Fixes #157

## Test plan
- [x] All 196 tests pass
- [x] clippy + rustfmt clean
- [ ] Manual: run on kleinkram (TypeScript) to verify no build checks run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build/compile check is now conditionally skipped for interpreted languages (e.g., Python, Ruby, JavaScript, TypeScript); other languages continue using the configured build command.

* **New Features**
  * Tool detects when a build command was explicitly provided and applies that explicitness to runner behavior.

* **Tests**
  * Integration tests updated to reflect the explicit-build-command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->