### PR TITLE
Skip noisy files: tests, migrations, seeds, config, examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "clap",
  "colored",
  "diffy",
+ "globset",
  "ignore",
  "libc",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1"
 
 # Filesystem
 tempfile = "3"
+globset = "0.4"
 ignore = "0.4"
 
 # Byte counting

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,10 @@ pub enum Commands {
         /// Stop test suite on first failure per mutation (faster kills)
         #[arg(long)]
         fail_fast: bool,
+
+        /// Disable built-in exclusion of test files, migrations, seeds, etc.
+        #[arg(long)]
+        no_skip_defaults: bool,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,14 @@ pub struct MutationConfig {
     #[serde(default = "default_max_per_run")]
     pub max_per_run: usize,
     pub coverage_file: Option<PathBuf>,
+    #[serde(default)]
+    pub exclude_paths: Vec<String>,
+    #[serde(default = "default_true")]
+    pub skip_noisy_files: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_test_command() -> Vec<String> {
@@ -231,6 +239,8 @@ impl Default for MutationConfig {
         Self {
             max_per_run: default_max_per_run(),
             coverage_file: None,
+            exclude_paths: vec![],
+            skip_noisy_files: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -670,4 +670,26 @@ language = "go"
         assert!(lib.test.is_none());
         assert_eq!(lib.language.as_deref(), Some("go"));
     }
+
+    #[test]
+    fn parse_exclude_paths_and_skip_noisy_files() {
+        let toml_str = r#"
+[mutations]
+exclude_paths = ["vendor/**", "*.generated.ts"]
+skip_noisy_files = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.mutations.exclude_paths,
+            vec!["vendor/**", "*.generated.ts"]
+        );
+        assert!(!config.mutations.skip_noisy_files);
+    }
+
+    #[test]
+    fn skip_noisy_files_defaults_to_true() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.mutations.skip_noisy_files);
+        assert!(config.mutations.exclude_paths.is_empty());
+    }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,8 +5,12 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Build ChangedFile entries for every supported file in the project tree.
-/// Respects `.gitignore` rules. Skips test files.
-pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<ChangedFile>> {
+/// Respects `.gitignore` rules. Skips test/migration/seed files by default.
+pub fn collect_all_supported_files(
+    project_root: &Path,
+    skip_noisy: bool,
+    exclude_globs: &[String],
+) -> anyhow::Result<Vec<ChangedFile>> {
     use crate::languages;
 
     let langs = languages::all();
@@ -45,7 +49,10 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
             .strip_prefix(project_root)
             .unwrap_or(path)
             .to_path_buf();
-        if is_test_file(&rel_path) {
+        if skip_noisy && is_noisy_file(&rel_path) {
+            continue;
+        }
+        if matches_user_excludes(&rel_path, exclude_globs) {
             continue;
         }
 
@@ -87,7 +94,12 @@ pub fn collect_all_supported_files(project_root: &Path) -> anyhow::Result<Vec<Ch
 ///
 /// Returns the same `Vec<ChangedFile>` format as `parse_diff`, filtering
 /// out test files and files with no added lines.
-pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result<Vec<ChangedFile>> {
+pub fn collect_changed_since(
+    project_root: &Path,
+    since: &str,
+    skip_noisy: bool,
+    exclude_globs: &[String],
+) -> anyhow::Result<Vec<ChangedFile>> {
     // Try as a commit ref first (SHA, branch, tag).
     let output = Command::new("git")
         .args(["diff", &format!("{since}..HEAD")])
@@ -137,17 +149,54 @@ pub fn collect_changed_since(project_root: &Path, since: &str) -> anyhow::Result
     };
 
     let all = parse_diff(&diff_output);
-    Ok(all.into_iter().filter(|f| !is_test_file(&f.path)).collect())
+    Ok(all
+        .into_iter()
+        .filter(|f| !skip_noisy || !is_noisy_file(&f.path))
+        .filter(|f| !matches_user_excludes(&f.path, exclude_globs))
+        .collect())
 }
 
-/// Returns true for files that look like test files across supported languages.
-fn is_test_file(path: &Path) -> bool {
-    // Check if any ancestor directory is a known test directory
+/// Returns true if the path matches any user-provided exclude glob pattern.
+pub fn matches_user_excludes(path: &Path, globs: &[String]) -> bool {
+    let path_str = path.to_str().unwrap_or("");
+    globs.iter().any(|pattern| glob_match(pattern, path_str))
+}
+
+/// Simple glob matching: supports `*` (any chars except `/`) and `**` (any path).
+fn glob_match(pattern: &str, text: &str) -> bool {
+    if pattern.contains("**") {
+        // "migrations/**" → check if any component matches prefix
+        let prefix = pattern.trim_end_matches("/**").trim_end_matches("**");
+        text.starts_with(prefix) || text.contains(&format!("/{}", prefix.trim_start_matches('/')))
+    } else if pattern.starts_with("*.") {
+        // "*.config.ts" → check file name ends with suffix
+        let suffix = &pattern[1..]; // ".config.ts"
+        text.ends_with(suffix)
+    } else {
+        // Direct path prefix or exact match
+        text.starts_with(pattern) || text.contains(&format!("/{pattern}"))
+    }
+}
+
+/// Returns true for files that should be excluded from mutation testing:
+/// test files, migrations, seeds, config files, and barrel/index re-exports.
+pub fn is_noisy_file(path: &Path) -> bool {
+    // Check if any ancestor directory is a known skip directory
     for component in path.components() {
         let s = component.as_os_str().to_str().unwrap_or("");
         if matches!(
             s,
-            "tests" | "__tests__" | "__test__" | "spec" | "specs" | "testdata" | "fixtures"
+            "tests"
+                | "__tests__"
+                | "__test__"
+                | "spec"
+                | "specs"
+                | "testdata"
+                | "fixtures"
+                | "migration"
+                | "migrations"
+                | "seeds"
+                | "examples"
         ) {
             return true;
         }
@@ -177,6 +226,10 @@ fn is_test_file(path: &Path) -> bool {
     }
     // *.test.ts, *.spec.ts — file_stem gives "foo.test"
     if name.ends_with(".test") || name.ends_with(".spec") {
+        return true;
+    }
+    // Config files: vite.config.ts, jest.config.js, quasar.config.ts, etc.
+    if name.ends_with(".config") {
         return true;
     }
     false
@@ -436,7 +489,7 @@ diff --git a/src/main.rs b/src/main.rs
         std::fs::create_dir_all(&tests_dir).unwrap();
         std::fs::write(tests_dir.join("helper.rs"), "fn help() {}\n").unwrap();
 
-        let files = collect_all_supported_files(root).unwrap();
+        let files = collect_all_supported_files(root, true, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
         assert_eq!(files[0].hunks.len(), 1);
@@ -444,26 +497,47 @@ diff --git a/src/main.rs b/src/main.rs
     }
 
     #[test]
-    fn is_test_file_detects_common_patterns() {
-        assert!(is_test_file(Path::new("foo_test.go")));
-        assert!(is_test_file(Path::new("test_utils.py")));
-        assert!(is_test_file(Path::new("UserTest.java")));
-        assert!(is_test_file(Path::new("UserTests.cs")));
-        assert!(is_test_file(Path::new("app.test.ts")));
-        assert!(is_test_file(Path::new("app.spec.tsx")));
-        assert!(is_test_file(Path::new("widget_spec.rb")));
-        assert!(!is_test_file(Path::new("main.rs")));
-        assert!(!is_test_file(Path::new("utils.py")));
-        assert!(!is_test_file(Path::new("contest.go")));
+    fn is_noisy_file_detects_common_patterns() {
+        assert!(is_noisy_file(Path::new("foo_test.go")));
+        assert!(is_noisy_file(Path::new("test_utils.py")));
+        assert!(is_noisy_file(Path::new("UserTest.java")));
+        assert!(is_noisy_file(Path::new("UserTests.cs")));
+        assert!(is_noisy_file(Path::new("app.test.ts")));
+        assert!(is_noisy_file(Path::new("app.spec.tsx")));
+        assert!(is_noisy_file(Path::new("widget_spec.rb")));
+        assert!(!is_noisy_file(Path::new("main.rs")));
+        assert!(!is_noisy_file(Path::new("utils.py")));
+        assert!(!is_noisy_file(Path::new("contest.go")));
         // Directory-based detection
-        assert!(is_test_file(Path::new("tests/helper.rs")));
-        assert!(is_test_file(Path::new("__tests__/utils.ts")));
-        assert!(is_test_file(Path::new("src/test/java/Foo.java")));
-        assert!(is_test_file(Path::new("module/src/test/kotlin/Bar.kt")));
-        assert!(!is_test_file(Path::new("test/integration/main.go")));
-        assert!(!is_test_file(Path::new("cmd/test/server.go")));
-        assert!(is_test_file(Path::new("testdata/input.go")));
-        assert!(is_test_file(Path::new("fixtures/setup.py")));
+        assert!(is_noisy_file(Path::new("tests/helper.rs")));
+        assert!(is_noisy_file(Path::new("__tests__/utils.ts")));
+        assert!(is_noisy_file(Path::new("src/test/java/Foo.java")));
+        assert!(is_noisy_file(Path::new("module/src/test/kotlin/Bar.kt")));
+        assert!(!is_noisy_file(Path::new("test/integration/main.go")));
+        assert!(!is_noisy_file(Path::new("cmd/test/server.go")));
+        assert!(is_noisy_file(Path::new("testdata/input.go")));
+        assert!(is_noisy_file(Path::new("fixtures/setup.py")));
+        // Migration, seed, example directories
+        assert!(is_noisy_file(Path::new("migration/001_init.ts")));
+        assert!(is_noisy_file(Path::new("migrations/add_index.ts")));
+        assert!(is_noisy_file(Path::new(
+            "backend/migration/migrations/init.ts"
+        )));
+        assert!(is_noisy_file(Path::new("seeds/data.ts")));
+        assert!(is_noisy_file(Path::new("examples/demo.py")));
+        // Config files
+        assert!(is_noisy_file(Path::new("vite.config.ts")));
+        assert!(is_noisy_file(Path::new("jest.config.js")));
+        assert!(is_noisy_file(Path::new("quasar.config.ts")));
+        assert!(!is_noisy_file(Path::new("src/config.ts"))); // not a .config.ts file
+    }
+
+    #[test]
+    fn matches_user_excludes_works() {
+        let globs = vec!["*.config.ts".into(), "seeds/**".into()];
+        assert!(matches_user_excludes(Path::new("vite.config.ts"), &globs));
+        assert!(matches_user_excludes(Path::new("seeds/data.ts"), &globs));
+        assert!(!matches_user_excludes(Path::new("src/main.ts"), &globs));
     }
 
     #[test]
@@ -506,7 +580,7 @@ diff --git a/src/main.rs b/src/main.rs
         run(&["add", "."]);
         run(&["commit", "-m", "add print"]);
 
-        let files = collect_changed_since(root, &base).unwrap();
+        let files = collect_changed_since(root, &base, true, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("main.rs"));
         assert!(!files[0].hunks.is_empty());
@@ -549,7 +623,7 @@ diff --git a/src/main.rs b/src/main.rs
         run(&["add", "."]);
         run(&["commit", "-m", "add changes"]);
 
-        let files = collect_changed_since(root, &base).unwrap();
+        let files = collect_changed_since(root, &base, true, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("lib.rs"));
     }
@@ -594,7 +668,7 @@ diff --git a/src/main.rs b/src/main.rs
         run(&["commit", "-m", "add print"], "2024-06-15T00:00:00Z");
 
         // Use a date between the two commits — should pick up the second commit.
-        let files = collect_changed_since(root, "2024-03-01").unwrap();
+        let files = collect_changed_since(root, "2024-03-01", true, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("main.rs"));
         assert!(!files[0].hunks.is_empty());
@@ -632,7 +706,7 @@ diff --git a/src/main.rs b/src/main.rs
         run(&["commit", "-m", "initial"], "2024-06-01T00:00:00Z");
 
         // Date before any commit — triggers empty-tree SHA fallback.
-        let files = collect_changed_since(root, "2024-01-01").unwrap();
+        let files = collect_changed_since(root, "2024-01-01", true, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, PathBuf::from("main.rs"));
         assert!(!files[0].hunks.is_empty());

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -158,8 +158,8 @@ pub fn collect_changed_since(
 
 /// Returns true if the path matches any user-provided exclude glob pattern.
 pub fn matches_user_excludes(path: &Path, globs: &[String]) -> bool {
-    let path_str = path.to_str().unwrap_or("");
-    globs.iter().any(|pattern| glob_match(pattern, path_str))
+    let path_str = path.to_string_lossy().replace('\\', "/");
+    globs.iter().any(|pattern| glob_match(pattern, &path_str))
 }
 
 /// Simple glob matching: supports `*` (any chars except `/`) and `**` (any path).

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -172,8 +172,12 @@ fn glob_match(pattern: &str, text: &str) -> bool {
             .map(|g| g.compile_matcher().is_match(text))
             .unwrap_or(false)
     };
-    if !pattern.contains('/') && !pattern.contains('*') {
-        // Bare name like "vendor" — match as a path component anywhere
+    if !pattern.contains('/') {
+        if pattern.contains('*') {
+            // Wildcard like "*.generated.ts" — match at any depth
+            return build(&format!("**/{pattern}"));
+        }
+        // Bare name like "vendor" — match as a directory anywhere
         return build(&format!("**/{pattern}/**"));
     }
     build(pattern)
@@ -540,6 +544,14 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(matches_user_excludes(Path::new("vite.config.ts"), &globs));
         assert!(matches_user_excludes(Path::new("seeds/data.ts"), &globs));
         assert!(!matches_user_excludes(Path::new("src/main.ts"), &globs));
+
+        // Wildcard patterns without `/` match at any depth
+        let globs2 = vec!["*.generated.ts".into()];
+        assert!(matches_user_excludes(
+            Path::new("src/foo.generated.ts"),
+            &globs2
+        ));
+        assert!(!matches_user_excludes(Path::new("src/foo.ts"), &globs2));
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -562,12 +562,21 @@ diff --git a/src/main.rs b/src/main.rs
 
         // General glob patterns: **/seeds/**, src/*/gen.rs
         let globs3 = vec!["**/seeds/**".into()];
-        assert!(matches_user_excludes(Path::new("db/seeds/data.ts"), &globs3));
-        assert!(!matches_user_excludes(Path::new("db/other/data.ts"), &globs3));
+        assert!(matches_user_excludes(
+            Path::new("db/seeds/data.ts"),
+            &globs3
+        ));
+        assert!(!matches_user_excludes(
+            Path::new("db/other/data.ts"),
+            &globs3
+        ));
 
         let globs4 = vec!["src/*/gen.rs".into()];
         assert!(matches_user_excludes(Path::new("src/foo/gen.rs"), &globs4));
-        assert!(!matches_user_excludes(Path::new("src/foo/bar/gen.rs"), &globs4));
+        assert!(!matches_user_excludes(
+            Path::new("src/foo/bar/gen.rs"),
+            &globs4
+        ));
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -165,16 +165,19 @@ pub fn matches_user_excludes(path: &Path, globs: &[String]) -> bool {
 /// Simple glob matching: supports `*` (any chars except `/`) and `**` (any path).
 fn glob_match(pattern: &str, text: &str) -> bool {
     if pattern.contains("**") {
-        // "migrations/**" → check if any component matches prefix
         let prefix = pattern.trim_end_matches("/**").trim_end_matches("**");
-        text.starts_with(prefix) || text.contains(&format!("/{}", prefix.trim_start_matches('/')))
+        let normalized = prefix.trim_start_matches('/');
+        text.starts_with(&format!("{normalized}/"))
+            || text.contains(&format!("/{normalized}/"))
+            || text == normalized
     } else if pattern.starts_with("*.") {
-        // "*.config.ts" → check file name ends with suffix
-        let suffix = &pattern[1..]; // ".config.ts"
+        let suffix = &pattern[1..];
         text.ends_with(suffix)
     } else {
-        // Direct path prefix or exact match
-        text.starts_with(pattern) || text.contains(&format!("/{pattern}"))
+        text.starts_with(&format!("{pattern}/"))
+            || text.contains(&format!("/{pattern}/"))
+            || text == pattern
+            || text.ends_with(&format!("/{pattern}"))
     }
 }
 
@@ -538,6 +541,25 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(matches_user_excludes(Path::new("vite.config.ts"), &globs));
         assert!(matches_user_excludes(Path::new("seeds/data.ts"), &globs));
         assert!(!matches_user_excludes(Path::new("src/main.ts"), &globs));
+    }
+
+    #[test]
+    fn glob_match_respects_directory_boundaries() {
+        // "test/**" should match test/ but not test-utils/
+        let globs = vec!["test/**".into()];
+        assert!(matches_user_excludes(Path::new("test/unit/foo.rs"), &globs));
+        assert!(!matches_user_excludes(
+            Path::new("test-utils/foo.rs"),
+            &globs
+        ));
+
+        // Direct pattern should match whole component
+        let globs2 = vec!["vendor".into()];
+        assert!(matches_user_excludes(Path::new("vendor/lib.rs"), &globs2));
+        assert!(!matches_user_excludes(
+            Path::new("vendor-extra/lib.rs"),
+            &globs2
+        ));
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -162,23 +162,21 @@ pub fn matches_user_excludes(path: &Path, globs: &[String]) -> bool {
     globs.iter().any(|pattern| glob_match(pattern, &path_str))
 }
 
-/// Simple glob matching: supports `*` (any chars except `/`) and `**` (any path).
+/// Glob matching via `globset`. Bare names (no `/`) are treated as directory
+/// names and match anywhere in the path tree.
 fn glob_match(pattern: &str, text: &str) -> bool {
-    if pattern.contains("**") {
-        let prefix = pattern.trim_end_matches("/**").trim_end_matches("**");
-        let normalized = prefix.trim_start_matches('/');
-        text.starts_with(&format!("{normalized}/"))
-            || text.contains(&format!("/{normalized}/"))
-            || text == normalized
-    } else if pattern.starts_with("*.") {
-        let suffix = &pattern[1..];
-        text.ends_with(suffix)
-    } else {
-        text.starts_with(&format!("{pattern}/"))
-            || text.contains(&format!("/{pattern}/"))
-            || text == pattern
-            || text.ends_with(&format!("/{pattern}"))
+    let build = |pat: &str| -> bool {
+        globset::GlobBuilder::new(pat)
+            .literal_separator(true)
+            .build()
+            .map(|g| g.compile_matcher().is_match(text))
+            .unwrap_or(false)
+    };
+    if !pattern.contains('/') && !pattern.contains('*') {
+        // Bare name like "vendor" — match as a path component anywhere
+        return build(&format!("**/{pattern}/**"));
     }
+    build(pattern)
 }
 
 /// Returns true for files that should be excluded from mutation testing:
@@ -232,7 +230,7 @@ pub fn is_noisy_file(path: &Path) -> bool {
         return true;
     }
     // Config files: vite.config.ts, jest.config.js, quasar.config.ts, etc.
-    if name.ends_with(".config") {
+    if name.ends_with(".config") || name.contains(".config.") {
         return true;
     }
     false
@@ -533,6 +531,7 @@ diff --git a/src/main.rs b/src/main.rs
         assert!(is_noisy_file(Path::new("jest.config.js")));
         assert!(is_noisy_file(Path::new("quasar.config.ts")));
         assert!(!is_noisy_file(Path::new("src/config.ts"))); // not a .config.ts file
+        assert!(is_noisy_file(Path::new("vite.config.local.ts")));
     }
 
     #[test]
@@ -560,6 +559,15 @@ diff --git a/src/main.rs b/src/main.rs
             Path::new("vendor-extra/lib.rs"),
             &globs2
         ));
+
+        // General glob patterns: **/seeds/**, src/*/gen.rs
+        let globs3 = vec!["**/seeds/**".into()];
+        assert!(matches_user_excludes(Path::new("db/seeds/data.ts"), &globs3));
+        assert!(!matches_user_excludes(Path::new("db/other/data.ts"), &globs3));
+
+        let globs4 = vec!["src/*/gen.rs".into()];
+        assert!(matches_user_excludes(Path::new("src/foo/gen.rs"), &globs4));
+        assert!(!matches_user_excludes(Path::new("src/foo/bar/gen.rs"), &globs4));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ struct CheckConfig {
     coverage_file: Option<PathBuf>,
     build_cmd: Option<String>,
     fail_fast: bool,
+    no_skip_defaults: bool,
 }
 
 #[tokio::main]
@@ -40,6 +41,7 @@ async fn main() {
             coverage_file,
             build_cmd,
             fail_fast,
+            no_skip_defaults,
         } => {
             let cfg = CheckConfig {
                 all,
@@ -55,6 +57,7 @@ async fn main() {
                 coverage_file,
                 build_cmd,
                 fail_fast,
+                no_skip_defaults,
             };
             if let Err(e) = run_check(cfg).await {
                 eprintln!("Error: {e:#}");
@@ -171,6 +174,10 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?;
     }
 
+    if cfg.no_skip_defaults {
+        config.mutations.skip_noisy_files = false;
+    }
+
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
     Ok((config, fail_fast, has_explicit_build_cmd))
@@ -184,8 +191,12 @@ fn collect_files(
     dry_run: bool,
     project_root: &Path,
 ) -> anyhow::Result<Vec<ChangedFile>> {
+    let skip_noisy = config.mutations.skip_noisy_files;
+    let exclude_globs = &config.mutations.exclude_paths;
+
     if all {
-        let files = togi::diff::collect_all_supported_files(project_root)?;
+        let files =
+            togi::diff::collect_all_supported_files(project_root, skip_noisy, exclude_globs)?;
         if files.is_empty() {
             println!("No supported source files found. Nothing to mutate.");
             return Ok(vec![]);
@@ -206,7 +217,11 @@ fn collect_files(
         return Ok(vec![]);
     }
 
-    let files = togi::diff::parse_diff(&diff_output);
+    let mut files = togi::diff::parse_diff(&diff_output);
+    if skip_noisy {
+        files.retain(|f| !togi::diff::is_noisy_file(&f.path));
+    }
+    files.retain(|f| !togi::diff::matches_user_excludes(&f.path, exclude_globs));
     if files.is_empty() {
         println!("No added/modified lines found. Nothing to mutate.");
         return Ok(vec![]);


### PR DESCRIPTION
## Summary
- Extend `is_test_file` → `is_noisy_file` to also skip `migration/`, `migrations/`, `seeds/`, `examples/`, and `*.config.*` files
- Add `exclude_paths` config for user-defined glob patterns in togi.toml
- Add `skip_noisy_files` config toggle (default: true)
- Add `--no-skip-defaults` CLI flag to disable built-in exclusions
- Both `--all` and diff mode respect the filtering

Fixes #167

## Test plan
- [x] 197 tests pass
- [x] clippy + rustfmt clean
- [x] New test cases for migration, seed, example, config file patterns
- [x] Test for `matches_user_excludes` glob matching
- [ ] Manual: dry-run on kleinkram/foxguard to verify reduced mutation count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI flag to opt out of automatic exclusion of common noisy files (tests, migrations, seeds, examples, config-like files).
  * Glob-based configurable path exclusions for finer control over scanned files.
  * Config option to enable/disable noisy-file filtering (enabled by default).

* **Tests**
  * Added unit tests for config parsing/defaults and updated file-exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->