### PR TITLE
fix: correct build error handling in scoring and reports

### DIFF
--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 
 struct FileStats {
     total: usize,
+    build_errors: usize,
     killed: usize,
     mutations: Vec<MutationEntry>,
 }
@@ -30,15 +31,20 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             MutationResult::BuildError => "build_error",
         };
         let killed = matches!(result, MutationResult::Killed);
+        let build_error = matches!(result, MutationResult::BuildError);
 
         let stats = files.entry(file_path).or_insert(FileStats {
             total: 0,
+            build_errors: 0,
             killed: 0,
             mutations: Vec::new(),
         });
         stats.total += 1;
         if killed {
             stats.killed += 1;
+        }
+        if build_error {
+            stats.build_errors += 1;
         }
         stats.mutations.push(MutationEntry {
             line: mutation.line,
@@ -53,8 +59,10 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     let tested = report.total - report.build_errors;
     let score_pct = if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else {
+    } else if report.total == 0 {
         100.0
+    } else {
+        0.0
     };
 
     let mut html = String::new();
@@ -79,7 +87,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
          &mdash; {:.2}s</div></header>",
         score_pct,
         report.killed,
-        report.total,
+        tested,
         report.survived,
         report.timeout,
         report.build_errors,
@@ -91,10 +99,13 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     write!(html, "<h2>Files</h2><ul>")?;
 
     for (path, stats) in &files {
-        let file_pct = if stats.total > 0 {
-            (stats.killed as f64 / stats.total as f64) * 100.0
-        } else {
+        let file_tested = stats.total.saturating_sub(stats.build_errors);
+        let file_pct = if file_tested > 0 {
+            (stats.killed as f64 / file_tested as f64) * 100.0
+        } else if stats.total == 0 {
             100.0
+        } else {
+            0.0
         };
         let class = score_class(file_pct);
         write!(
@@ -105,7 +116,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             class,
             html_escape(path),
             stats.killed,
-            stats.total
+            file_tested
         )?;
     }
 
@@ -113,10 +124,13 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
 
     // Per-file sections
     for (path, stats) in &files {
-        let file_pct = if stats.total > 0 {
-            (stats.killed as f64 / stats.total as f64) * 100.0
-        } else {
+        let file_tested = stats.total.saturating_sub(stats.build_errors);
+        let file_pct = if file_tested > 0 {
+            (stats.killed as f64 / file_tested as f64) * 100.0
+        } else if stats.total == 0 {
             100.0
+        } else {
+            0.0
         };
 
         write!(

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -10,6 +10,23 @@ struct FileStats {
     mutations: Vec<MutationEntry>,
 }
 
+impl FileStats {
+    fn score_pct(&self) -> f64 {
+        let tested = self.total.saturating_sub(self.build_errors);
+        if tested > 0 {
+            (self.killed as f64 / tested as f64) * 100.0
+        } else if self.total == 0 {
+            100.0
+        } else {
+            0.0
+        }
+    }
+
+    fn tested(&self) -> usize {
+        self.total.saturating_sub(self.build_errors)
+    }
+}
+
 struct MutationEntry {
     line: usize,
     operator: String,
@@ -99,15 +116,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     write!(html, "<h2>Files</h2><ul>")?;
 
     for (path, stats) in &files {
-        let file_tested = stats.total.saturating_sub(stats.build_errors);
-        let file_pct = if file_tested > 0 {
-            (stats.killed as f64 / file_tested as f64) * 100.0
-        } else if stats.total == 0 {
-            100.0
-        } else {
-            0.0
-        };
-        let class = score_class(file_pct);
+        let class = score_class(stats.score_pct());
         write!(
             html,
             "<li><a href=\"#{}\" class=\"{}\"><code>{}</code> \
@@ -116,7 +125,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             class,
             html_escape(path),
             stats.killed,
-            file_tested
+            stats.tested()
         )?;
     }
 
@@ -124,23 +133,14 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
 
     // Per-file sections
     for (path, stats) in &files {
-        let file_tested = stats.total.saturating_sub(stats.build_errors);
-        let file_pct = if file_tested > 0 {
-            (stats.killed as f64 / file_tested as f64) * 100.0
-        } else if stats.total == 0 {
-            100.0
-        } else {
-            0.0
-        };
-
         write!(
             html,
             "<section id=\"{}\"><h3><code>{}</code> \
              <span class=\"score-inline {}\">({:.0}%)</span></h3>",
             slug(path),
             html_escape(path),
-            score_class(file_pct),
-            file_pct
+            score_class(stats.score_pct()),
+            stats.score_pct()
         )?;
 
         write!(

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -50,8 +50,9 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         });
     }
 
-    let score_pct = if report.total > 0 {
-        (report.killed as f64 / report.total as f64) * 100.0
+    let tested = report.total - report.build_errors;
+    let score_pct = if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
     } else {
         100.0
     };

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -10,6 +10,7 @@ struct JsonReport {
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    mutation_score: f64,
     duration_ms: u128,
     mutations: Vec<JsonMutation>,
 }
@@ -75,13 +76,20 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         })
         .collect();
 
+    let tested = report.total - report.build_errors;
+    let mutation_score = if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
+    } else {
+        100.0
+    };
     let json_report = JsonReport {
         total: report.total,
-        tested: report.total - report.build_errors,
+        tested,
         killed: report.killed,
         survived: report.survived,
         timeout: report.timeout,
         build_errors: report.build_errors,
+        mutation_score,
         duration_ms: report.duration.as_millis(),
         mutations,
     };
@@ -159,6 +167,7 @@ mod tests {
         assert_eq!(value["survived"], 1);
         assert_eq!(value["timeout"], 0);
         assert_eq!(value["build_errors"], 0);
+        assert_eq!(value["mutation_score"], 50.0);
         assert_eq!(value["duration_ms"], 1234);
 
         let mutations = value["mutations"].as_array().unwrap();

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -79,8 +79,10 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
     let tested = report.total - report.build_errors;
     let mutation_score = if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else {
+    } else if report.total == 0 {
         100.0
+    } else {
+        0.0
     };
     let json_report = JsonReport {
         total: report.total,

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -182,6 +182,54 @@ mod tests {
     }
 
     #[test]
+    fn json_score_zero_when_all_build_errors() {
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 1,
+                    file: PathBuf::from("src/a.rs"),
+                    language: String::new(),
+                    line: 1,
+                    column: 1,
+                    operator: "op".to_string(),
+                    description: "d".to_string(),
+                    original: "x".to_string(),
+                    replacement: "y".to_string(),
+                    byte_range: 0..1,
+                },
+                MutationResult::BuildError,
+            )],
+            duration: Duration::from_millis(100),
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 1,
+        };
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(value["mutation_score"], 0.0);
+        assert_eq!(value["tested"], 0);
+    }
+
+    #[test]
+    fn json_score_100_when_empty_report() {
+        let report = MutationReport {
+            results: vec![],
+            duration: Duration::from_millis(0),
+            total: 0,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 0,
+        };
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(value["mutation_score"], 100.0);
+        assert_eq!(value["total"], 0);
+    }
+
+    #[test]
     fn json_survived_includes_diff_fields() {
         let report = sample_report();
         let json_str = to_json_string(&report).unwrap();

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -2,6 +2,17 @@ use crate::{MutationReport, MutationResult};
 #[allow(unused_imports)]
 use colored::Colorize;
 
+fn mutation_score(report: &MutationReport) -> f64 {
+    let tested = report.total - report.build_errors;
+    if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
+    } else if report.total == 0 {
+        100.0
+    } else {
+        0.0
+    }
+}
+
 pub fn print_report(report: &MutationReport) {
     println!();
 
@@ -81,15 +92,7 @@ pub fn print_report(report: &MutationReport) {
         "Results: {} killed, {} survived, {} timeout, {} build errors",
         report.killed, report.survived, report.timeout, report.build_errors
     );
-    let tested = report.total - report.build_errors;
-    let score = if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
-        100.0
-    } else {
-        0.0
-    };
-    println!("Mutation score (test kills only): {:.1}%", score);
+    println!("Mutation score (test kills only): {:.1}%", mutation_score(report));
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
 }
@@ -155,15 +158,7 @@ pub fn format_report_plain(report: &MutationReport) -> String {
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
-    let tested = report.total - report.build_errors;
-    let score = if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
-        100.0
-    } else {
-        0.0
-    };
-    writeln!(out, "Mutation score (test kills only): {:.1}%", score).unwrap();
+    writeln!(out, "Mutation score (test kills only): {:.1}%", mutation_score(report)).unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{}", separator).unwrap();
 
@@ -236,6 +231,69 @@ mod tests {
         assert!(output.contains("✗ SURVIVED"));
         assert!(output.contains("src/handler.rs:15"));
         assert!(output.contains("Your tests don't catch this mutation."));
+    }
+
+    #[test]
+    fn terminal_output_summary_with_timeout_and_build_errors() {
+        let report = MutationReport {
+            results: vec![
+                (
+                    Mutation {
+                        id: 1,
+                        file: PathBuf::from("src/a.rs"),
+                        language: String::new(),
+                        line: 1,
+                        column: 1,
+                        operator: "op".to_string(),
+                        description: "d".to_string(),
+                        original: "x".to_string(),
+                        replacement: "y".to_string(),
+                        byte_range: 0..1,
+                    },
+                    MutationResult::Killed,
+                ),
+                (
+                    Mutation {
+                        id: 2,
+                        file: PathBuf::from("src/b.rs"),
+                        language: String::new(),
+                        line: 2,
+                        column: 1,
+                        operator: "op".to_string(),
+                        description: "d".to_string(),
+                        original: "x".to_string(),
+                        replacement: "y".to_string(),
+                        byte_range: 0..1,
+                    },
+                    MutationResult::Timeout,
+                ),
+                (
+                    Mutation {
+                        id: 3,
+                        file: PathBuf::from("src/c.rs"),
+                        language: String::new(),
+                        line: 3,
+                        column: 1,
+                        operator: "op".to_string(),
+                        description: "d".to_string(),
+                        original: "x".to_string(),
+                        replacement: "y".to_string(),
+                        byte_range: 0..1,
+                    },
+                    MutationResult::BuildError,
+                ),
+            ],
+            duration: Duration::from_millis(500),
+            total: 3,
+            killed: 1,
+            survived: 0,
+            timeout: 1,
+            build_errors: 1,
+        };
+        let output = format_report_plain(&report);
+        assert!(output.contains("Results: 1 killed, 0 survived, 1 timeout, 1 build errors"));
+        // tested = 3 - 1 = 2, score = 1/2 = 50%
+        assert!(output.contains("Mutation score (test kills only): 50.0%"));
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -92,7 +92,10 @@ pub fn print_report(report: &MutationReport) {
         "Results: {} killed, {} survived, {} timeout, {} build errors",
         report.killed, report.survived, report.timeout, report.build_errors
     );
-    println!("Mutation score (test kills only): {:.1}%", mutation_score(report));
+    println!(
+        "Mutation score (test kills only): {:.1}%",
+        mutation_score(report)
+    );
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
 }
@@ -158,7 +161,12 @@ pub fn format_report_plain(report: &MutationReport) -> String {
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
-    writeln!(out, "Mutation score (test kills only): {:.1}%", mutation_score(report)).unwrap();
+    writeln!(
+        out,
+        "Mutation score (test kills only): {:.1}%",
+        mutation_score(report)
+    )
+    .unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{}", separator).unwrap();
 

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -77,17 +77,17 @@ pub fn print_report(report: &MutationReport) {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     println!("{}", separator);
-    let tested = report.total - report.build_errors;
     println!(
-        "Results: {}/{} mutations killed ({} survived)",
-        report.killed, tested, report.survived
+        "Results: {} killed, {} build errors, {} survived",
+        report.killed, report.build_errors, report.survived
     );
-    if report.build_errors > 0 {
-        println!(
-            "Build errors: {} (filtered, not counted in score)",
-            report.build_errors
-        );
-    }
+    let tested = report.total - report.build_errors;
+    let score = if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
+    } else {
+        100.0
+    };
+    println!("Mutation score (test kills only): {:.1}%", score);
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
 }
@@ -147,21 +147,19 @@ pub fn format_report_plain(report: &MutationReport) -> String {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     writeln!(out, "{}", separator).unwrap();
-    let tested = report.total - report.build_errors;
     writeln!(
         out,
-        "Results: {}/{} mutations killed ({} survived)",
-        report.killed, tested, report.survived
+        "Results: {} killed, {} build errors, {} survived",
+        report.killed, report.build_errors, report.survived
     )
     .unwrap();
-    if report.build_errors > 0 {
-        writeln!(
-            out,
-            "Build errors: {} (filtered, not counted in score)",
-            report.build_errors
-        )
-        .unwrap();
-    }
+    let tested = report.total - report.build_errors;
+    let score = if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
+    } else {
+        100.0
+    };
+    writeln!(out, "Mutation score (test kills only): {:.1}%", score).unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{}", separator).unwrap();
 
@@ -240,7 +238,8 @@ mod tests {
     fn terminal_output_contains_summary() {
         let report = sample_report();
         let output = format_report_plain(&report);
-        assert!(output.contains("Results: 1/2 mutations killed (1 survived)"));
+        assert!(output.contains("Results: 1 killed, 0 build errors, 1 survived"));
+        assert!(output.contains("Mutation score (test kills only): 50.0%"));
         assert!(output.contains("Duration: 1.23s"));
     }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -78,14 +78,16 @@ pub fn print_report(report: &MutationReport) {
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     println!("{}", separator);
     println!(
-        "Results: {} killed, {} build errors, {} survived",
-        report.killed, report.build_errors, report.survived
+        "Results: {} killed, {} survived, {} timeout, {} build errors",
+        report.killed, report.survived, report.timeout, report.build_errors
     );
     let tested = report.total - report.build_errors;
     let score = if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else {
+    } else if report.total == 0 {
         100.0
+    } else {
+        0.0
     };
     println!("Mutation score (test kills only): {:.1}%", score);
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
@@ -149,15 +151,17 @@ pub fn format_report_plain(report: &MutationReport) -> String {
     writeln!(out, "{}", separator).unwrap();
     writeln!(
         out,
-        "Results: {} killed, {} build errors, {} survived",
-        report.killed, report.build_errors, report.survived
+        "Results: {} killed, {} survived, {} timeout, {} build errors",
+        report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
     let tested = report.total - report.build_errors;
     let score = if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else {
+    } else if report.total == 0 {
         100.0
+    } else {
+        0.0
     };
     writeln!(out, "Mutation score (test kills only): {:.1}%", score).unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
@@ -238,7 +242,7 @@ mod tests {
     fn terminal_output_contains_summary() {
         let report = sample_report();
         let output = format_report_plain(&report);
-        assert!(output.contains("Results: 1 killed, 0 build errors, 1 survived"));
+        assert!(output.contains("Results: 1 killed, 1 survived, 0 timeout, 0 build errors"));
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
         assert!(output.contains("Duration: 1.23s"));
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,9 +10,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
-/// Languages that don't need a build/compile check before running tests.
-const INTERPRETED_LANGUAGES: &[&str] = &["python", "ruby", "javascript", "typescript"];
-
 fn to_cached(r: MutationResult) -> CachedResult {
     match r {
         MutationResult::Killed => CachedResult::Killed,
@@ -91,12 +88,7 @@ impl TestRunner {
                 .clone();
             let timeout = self.timeout;
             let project_root = project_root.clone();
-            let build_command =
-                if !self.build_command_explicit && INTERPRETED_LANGUAGES.contains(&language) {
-                    Arc::new(vec![])
-                } else {
-                    build_command.clone()
-                };
+            let build_command = build_command.clone();
             let counter = counter.clone();
             let tested_counter = tested_counter.clone();
             let max_tested = self.max_tested;


### PR DESCRIPTION
## Summary
- Remove `INTERPRETED_LANGUAGES` skip so build commands always run (auto-detected empty commands are already no-ops)
- Fix HTML/JSON score denominator to use `total - build_errors` instead of `total`
- Add `mutation_score` percentage field to JSON output
- Update terminal summary to show `Results: X killed, Y build errors, Z survived` + `Mutation score (test kills only): N%`

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation score now excludes build errors from the denominator and uses clear fallbacks when no mutations or no tested mutations exist.
  * Summary outputs now report killed, survived, timeout, and build errors separately.

* **New Features**
  * Added a dedicated mutation score metric surfaced in terminal, plain-text and JSON reports.

* **Refactor**
  * Build verification is applied uniformly across all languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->