### PR TITLE
refactor: deduplicate scoring, test helpers, and constants

### DIFF
--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -1,48 +1,14 @@
-use crate::languages::LanguageSupport;
-
-pub struct C;
-
-impl LanguageSupport for C {
-    fn name(&self) -> &str {
-        "c"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["c", "h"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_c::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-}
+crate::languages::define_language!(
+    C,
+    name: "c",
+    extensions: ["c", "h"],
+    ts_language: tree_sitter_c::LANGUAGE,
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
 
     #[test]
     fn test_c_extension_detection() {

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -1,48 +1,14 @@
-use crate::languages::LanguageSupport;
-
-pub struct Cpp;
-
-impl LanguageSupport for Cpp {
-    fn name(&self) -> &str {
-        "cpp"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["cpp", "cc", "cxx", "hpp", "hxx"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_cpp::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-}
+crate::languages::define_language!(
+    Cpp,
+    name: "cpp",
+    extensions: ["cpp", "cc", "cxx", "hpp", "hxx"],
+    ts_language: tree_sitter_cpp::LANGUAGE,
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
 
     #[test]
     fn test_cpp_extension_detection() {

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -1,52 +1,15 @@
-use crate::languages::LanguageSupport;
-
-pub struct CSharp;
-
-impl LanguageSupport for CSharp {
-    fn name(&self) -> &str {
-        "c_sharp"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["cs"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_c_sharp::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-
-    fn skip_subtree_kinds(&self) -> &[&str] {
-        &["using_directive", "attribute", "type_parameter_list"]
-    }
-}
+crate::languages::define_language!(
+    CSharp,
+    name: "c_sharp",
+    extensions: ["cs"],
+    ts_language: tree_sitter_c_sharp::LANGUAGE,
+    skip_subtree_kinds: ["using_directive", "attribute", "type_parameter_list"],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
 
     #[test]
     fn test_csharp_extension_detection() {

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -1,52 +1,15 @@
-use crate::languages::LanguageSupport;
-
-pub struct Go;
-
-impl LanguageSupport for Go {
-    fn name(&self) -> &str {
-        "go"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["go"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_go::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-
-    fn skip_subtree_kinds(&self) -> &[&str] {
-        &["import_spec", "import_spec_list", "type_spec"]
-    }
-}
+crate::languages::define_language!(
+    Go,
+    name: "go",
+    extensions: ["go"],
+    ts_language: tree_sitter_go::LANGUAGE,
+    skip_subtree_kinds: ["import_spec", "import_spec_list", "type_spec"],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
     use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
 
     #[test]

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -1,52 +1,15 @@
-use crate::languages::LanguageSupport;
-
-pub struct Java;
-
-impl LanguageSupport for Java {
-    fn name(&self) -> &str {
-        "java"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["java"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_java::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-
-    fn skip_subtree_kinds(&self) -> &[&str] {
-        &["import_declaration", "annotation", "type_parameters"]
-    }
-}
+crate::languages::define_language!(
+    Java,
+    name: "java",
+    extensions: ["java"],
+    ts_language: tree_sitter_java::LANGUAGE,
+    skip_subtree_kinds: ["import_declaration", "annotation", "type_parameters"],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
 
     #[test]
     fn test_java_extension_detection() {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -8,6 +8,71 @@ pub mod ruby;
 pub mod rust_lang;
 pub mod typescript;
 
+/// Generates a `LanguageSupport` impl from declarative config.
+///
+/// Required: struct name, language name, extensions, tree-sitter language path.
+/// Optional overrides (with defaults matching C-family languages):
+///   binary_expression: "binary_expression"
+///   if_statement: "if_statement"
+///   return_statement: "return_statement"
+///   bool_true: ["true"]
+///   bool_false: ["false"]
+///   operator_field: "operator"
+///   skip_subtree_kinds: []
+macro_rules! define_language {
+    (
+        $struct:ident,
+        name: $name:expr,
+        extensions: [$($ext:expr),* $(,)?],
+        ts_language: $ts_lang:expr
+        $(, binary_expression: $bin:expr)?
+        $(, if_statement: $if_node:expr)?
+        $(, return_statement: $ret:expr)?
+        $(, bool_true: [$($bt:expr),* $(,)?])?
+        $(, bool_false: [$($bf:expr),* $(,)?])?
+        $(, operator_field: $op:expr)?
+        $(, skip_subtree_kinds: [$($sk:expr),* $(,)?])?
+        $(,)?
+    ) => {
+        pub struct $struct;
+
+        impl $crate::languages::LanguageSupport for $struct {
+            fn name(&self) -> &str { $name }
+            fn extensions(&self) -> &[&str] { &[$($ext),*] }
+            fn tree_sitter_language(&self) -> tree_sitter::Language { $ts_lang.into() }
+            fn binary_expression_node(&self) -> &str {
+                $crate::languages::define_language!(@first $($bin)? ; "binary_expression")
+            }
+            fn if_statement_node(&self) -> &str {
+                $crate::languages::define_language!(@first $($if_node)? ; "if_statement")
+            }
+            fn return_statement_node(&self) -> &str {
+                $crate::languages::define_language!(@first $($ret)? ; "return_statement")
+            }
+            fn boolean_true_literals(&self) -> &[&str] {
+                $crate::languages::define_language!(@arr [$($($bt),*)?] ; ["true"])
+            }
+            fn boolean_false_literals(&self) -> &[&str] {
+                $crate::languages::define_language!(@arr [$($($bf),*)?] ; ["false"])
+            }
+            fn operator_field(&self) -> &str {
+                $crate::languages::define_language!(@first $($op)? ; "operator")
+            }
+            fn skip_subtree_kinds(&self) -> &[&str] {
+                $crate::languages::define_language!(@arr [$($($sk),*)?] ; [])
+            }
+        }
+    };
+    // Helper: return first value if present, otherwise default
+    (@first $val:expr ; $default:expr) => { $val };
+    (@first ; $default:expr) => { $default };
+    // Helper: return array if non-empty, otherwise default
+    (@arr [$($val:expr),+] ; [$($default:expr),*]) => { &[$($val),+] };
+    (@arr [] ; [$($default:expr),*]) => { &[$($default),*] };
+}
+
+pub(crate) use define_language;
+
 /// Language-specific configuration for tree-sitter parsing and node identification
 pub trait LanguageSupport: Send + Sync {
     fn name(&self) -> &str;

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -1,48 +1,17 @@
-use crate::languages::LanguageSupport;
-
-pub struct Python;
-
-impl LanguageSupport for Python {
-    fn name(&self) -> &str {
-        "python"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["py"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_python::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_operator"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["True"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["False"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-}
+crate::languages::define_language!(
+    Python,
+    name: "python",
+    extensions: ["py"],
+    ts_language: tree_sitter_python::LANGUAGE,
+    binary_expression: "binary_operator",
+    bool_true: ["True"],
+    bool_false: ["False"],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
     use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
 
     #[test]

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -1,48 +1,17 @@
-use crate::languages::LanguageSupport;
-
-pub struct Ruby;
-
-impl LanguageSupport for Ruby {
-    fn name(&self) -> &str {
-        "ruby"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["rb"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_ruby::LANGUAGE.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-}
+crate::languages::define_language!(
+    Ruby,
+    name: "ruby",
+    extensions: ["rb"],
+    ts_language: tree_sitter_ruby::LANGUAGE,
+    binary_expression: "binary",
+    if_statement: "if",
+    return_statement: "return",
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
 
     #[test]
     fn test_ruby_extension_detection() {

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -6,39 +6,30 @@ impl LanguageSupport for Rust {
     fn name(&self) -> &str {
         "rust"
     }
-
     fn extensions(&self) -> &[&str] {
         &["rs"]
     }
-
     fn tree_sitter_language(&self) -> tree_sitter::Language {
         tree_sitter_rust::LANGUAGE.into()
     }
-
     fn binary_expression_node(&self) -> &str {
         "binary_expression"
     }
-
     fn if_statement_node(&self) -> &str {
         "if_expression"
     }
-
     fn boolean_true_literals(&self) -> &[&str] {
         &["true"]
     }
-
     fn boolean_false_literals(&self) -> &[&str] {
         &["false"]
     }
-
     fn return_statement_node(&self) -> &str {
         "return_expression"
     }
-
     fn operator_field(&self) -> &str {
         "operator"
     }
-
     fn skip_subtree_kinds(&self) -> &[&str] {
         &[
             "use_declaration",
@@ -48,7 +39,6 @@ impl LanguageSupport for Rust {
             "where_clause",
         ]
     }
-
     fn should_skip_node(&self, node: &tree_sitter::Node, source: &[u8]) -> bool {
         match node.kind() {
             "mod_item" => has_attribute(node, source, |attr| attr == "#[cfg(test)]"),

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -1,57 +1,15 @@
-use crate::languages::LanguageSupport;
-
-pub struct TypeScript;
-
-impl LanguageSupport for TypeScript {
-    fn name(&self) -> &str {
-        "typescript"
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["ts", "tsx"]
-    }
-
-    fn tree_sitter_language(&self) -> tree_sitter::Language {
-        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
-    }
-
-    fn binary_expression_node(&self) -> &str {
-        "binary_expression"
-    }
-
-    fn if_statement_node(&self) -> &str {
-        "if_statement"
-    }
-
-    fn boolean_true_literals(&self) -> &[&str] {
-        &["true"]
-    }
-
-    fn boolean_false_literals(&self) -> &[&str] {
-        &["false"]
-    }
-
-    fn return_statement_node(&self) -> &str {
-        "return_statement"
-    }
-
-    fn operator_field(&self) -> &str {
-        "operator"
-    }
-
-    fn skip_subtree_kinds(&self) -> &[&str] {
-        &[
-            "import_statement",
-            "type_annotation",
-            "type_alias_declaration",
-            "decorator",
-        ]
-    }
-}
+crate::languages::define_language!(
+    TypeScript,
+    name: "typescript",
+    extensions: ["ts", "tsx"],
+    ts_language: tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
+    skip_subtree_kinds: ["import_statement", "type_annotation", "type_alias_declaration", "decorator"],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
     use tree_sitter::Parser;
 
     #[test]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -219,7 +219,7 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
-    fn write_go_file(dir: &Path, rel_path: &str, content: &str) -> PathBuf {
+    fn write_test_file(dir: &Path, rel_path: &str, content: &str) -> PathBuf {
         let full = dir.join(rel_path);
         std::fs::create_dir_all(full.parent().unwrap()).unwrap();
         std::fs::write(&full, content).unwrap();
@@ -231,7 +231,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // Use `x < y` (no literal children) so the mapper returns binary_expression
         let source = "package main\n\nfunc check(x, y int) bool {\n\tif x < y {\n\t\treturn true\n\t}\n\treturn false\n}\n";
-        let rel = write_go_file(tmp.path(), "src/main.go", source);
+        let rel = write_test_file(tmp.path(), "src/main.go", source);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -258,7 +258,7 @@ mod tests {
     fn respects_max_mutations() {
         let tmp = TempDir::new().unwrap();
         let source = "package main\n\nfunc check(x int) bool {\n\tif x < 10 {\n\t\treturn true\n\t}\n\treturn false\n}\n";
-        let rel = write_go_file(tmp.path(), "main.go", source);
+        let rel = write_test_file(tmp.path(), "main.go", source);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -286,10 +286,10 @@ mod tests {
     fn generates_mutations_for_multiple_files() {
         let tmp = TempDir::new().unwrap();
         let go_src = "package main\n\nfunc f() bool {\n\treturn true\n}\n";
-        let go_rel = write_go_file(tmp.path(), "a.go", go_src);
+        let go_rel = write_test_file(tmp.path(), "a.go", go_src);
 
         let go_src2 = "package main\n\nfunc g(x, y int) bool {\n\treturn x < y\n}\n";
-        let go_rel2 = write_go_file(tmp.path(), "b.go", go_src2);
+        let go_rel2 = write_test_file(tmp.path(), "b.go", go_src2);
 
         let changed = vec![
             ChangedFile {
@@ -316,7 +316,7 @@ mod tests {
     fn generates_mutations_for_python_file() {
         let tmp = TempDir::new().unwrap();
         let py_src = "def check(x, y):\n    return x < y\n";
-        let rel = write_go_file(tmp.path(), "test.py", py_src);
+        let rel = write_test_file(tmp.path(), "test.py", py_src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -332,7 +332,7 @@ mod tests {
     fn generates_mutations_for_rust_file() {
         let tmp = TempDir::new().unwrap();
         let rs_src = "fn check(x: i32, y: i32) -> bool {\n    x < y\n}\n";
-        let rel = write_go_file(tmp.path(), "lib.rs", rs_src);
+        let rel = write_test_file(tmp.path(), "lib.rs", rs_src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -348,7 +348,7 @@ mod tests {
     fn mutation_ids_are_sequential() {
         let tmp = TempDir::new().unwrap();
         let src = "package main\n\nfunc f(x, y int) bool {\n\tif x < y {\n\t\treturn true\n\t}\n\treturn false\n}\n";
-        let rel = write_go_file(tmp.path(), "main.go", src);
+        let rel = write_test_file(tmp.path(), "main.go", src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -366,7 +366,7 @@ mod tests {
     fn rust_return_empty_skipped_for_result_type() {
         let tmp = TempDir::new().unwrap();
         let src = "fn f() -> Result<i32, String> {\n    return Ok(42);\n}\n";
-        let rel = write_go_file(tmp.path(), "lib.rs", src);
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -388,7 +388,7 @@ mod tests {
         // Use a function call as return value — call_expression is not in MUTABLE_NODE_KINDS,
         // so the mapper yields the return_expression itself.
         let src = "fn f() -> i32 {\n    return compute();\n}\n";
-        let rel = write_go_file(tmp.path(), "lib.rs", src);
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -408,7 +408,7 @@ mod tests {
     fn go_return_empty_skipped_for_multi_return() {
         let tmp = TempDir::new().unwrap();
         let src = "package main\n\nfunc f() (int, error) {\n\treturn 0, nil\n}\n";
-        let rel = write_go_file(tmp.path(), "main.go", src);
+        let rel = write_test_file(tmp.path(), "main.go", src);
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -427,7 +427,7 @@ mod tests {
     #[test]
     fn skips_unsupported_file_types() {
         let tmp = TempDir::new().unwrap();
-        let rel = write_go_file(tmp.path(), "notes.txt", "hello world");
+        let rel = write_test_file(tmp.path(), "notes.txt", "hello world");
 
         let changed = vec![ChangedFile {
             path: rel,
@@ -443,7 +443,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // File with many mutable nodes
         let src = "package main\n\nfunc f(a, b, c, d int) bool {\n\tif a < b {\n\t\treturn true\n\t}\n\tif c < d {\n\t\treturn false\n\t}\n\treturn a > c\n}\n";
-        let rel = write_go_file(tmp.path(), "main.go", src);
+        let rel = write_test_file(tmp.path(), "main.go", src);
 
         let changed = vec![ChangedFile {
             path: rel,

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -11,7 +11,7 @@ pub trait MutationOperator: Send + Sync {
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate>;
 }
 
-const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
+pub(crate) const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
 const RETURN_KINDS: &[&str] = &["return_statement", "return_expression"];
 
 /// Negate a condition: remove `!` if present, otherwise wrap with `!(...)`

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -1,7 +1,5 @@
-use super::MutationOperator;
+use super::{IF_STMT_KINDS, MutationOperator};
 use crate::MutationCandidate;
-
-const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
 
 pub struct RemoveIfBody;
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -73,7 +73,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         });
     }
 
-    let tested = report.total - report.build_errors;
+    let tested = report.total.saturating_sub(report.build_errors);
     let score_pct = super::mutation_score(report);
 
     let mut html = String::new();

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -74,13 +74,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     }
 
     let tested = report.total - report.build_errors;
-    let score_pct = if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
-        100.0
-    } else {
-        0.0
-    };
+    let score_pct = super::mutation_score(report);
 
     let mut html = String::new();
     write!(
@@ -249,51 +243,9 @@ a.score-good,a.score-ok,a.score-bad{color:inherit}
 mod tests {
     use super::*;
     use crate::Mutation;
+    use crate::test_helpers::sample_report;
     use std::path::PathBuf;
     use std::time::Duration;
-
-    fn sample_report() -> MutationReport {
-        MutationReport {
-            results: vec![
-                (
-                    Mutation {
-                        id: 1,
-                        file: PathBuf::from("src/auth.rs"),
-                        language: "rust".to_string(),
-                        line: 47,
-                        column: 10,
-                        operator: "binary/lt_to_lte".to_string(),
-                        description: "changed < to <=".to_string(),
-                        original: "<".to_string(),
-                        replacement: "<=".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::Killed,
-                ),
-                (
-                    Mutation {
-                        id: 2,
-                        file: PathBuf::from("src/handler.rs"),
-                        language: "rust".to_string(),
-                        line: 15,
-                        column: 5,
-                        operator: "binary/eq_to_neq".to_string(),
-                        description: "changed == to !=".to_string(),
-                        original: "==".to_string(),
-                        replacement: "!=".to_string(),
-                        byte_range: 0..2,
-                    },
-                    MutationResult::Survived,
-                ),
-            ],
-            duration: Duration::from_millis(1234),
-            total: 2,
-            killed: 1,
-            survived: 1,
-            timeout: 0,
-            build_errors: 0,
-        }
-    }
 
     #[test]
     fn html_contains_doctype() {

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -76,7 +76,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         })
         .collect();
 
-    let tested = report.total - report.build_errors;
+    let tested = report.total.saturating_sub(report.build_errors);
     let json_report = JsonReport {
         total: report.total,
         tested,

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -77,13 +77,6 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         .collect();
 
     let tested = report.total - report.build_errors;
-    let mutation_score = if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
-        100.0
-    } else {
-        0.0
-    };
     let json_report = JsonReport {
         total: report.total,
         tested,
@@ -91,7 +84,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         survived: report.survived,
         timeout: report.timeout,
         build_errors: report.build_errors,
-        mutation_score,
+        mutation_score: super::mutation_score(report),
         duration_ms: report.duration.as_millis(),
         mutations,
     };
@@ -103,51 +96,9 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
 mod tests {
     use super::*;
     use crate::Mutation;
+    use crate::test_helpers::sample_report;
     use std::path::PathBuf;
     use std::time::Duration;
-
-    fn sample_report() -> MutationReport {
-        MutationReport {
-            results: vec![
-                (
-                    Mutation {
-                        id: 1,
-                        file: PathBuf::from("src/auth.rs"),
-                        language: String::new(),
-                        line: 47,
-                        column: 10,
-                        operator: "binary/lt_to_lte".to_string(),
-                        description: "changed < to <=".to_string(),
-                        original: "<".to_string(),
-                        replacement: "<=".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::Killed,
-                ),
-                (
-                    Mutation {
-                        id: 2,
-                        file: PathBuf::from("src/handler.rs"),
-                        language: String::new(),
-                        line: 15,
-                        column: 5,
-                        operator: "binary/eq_to_neq".to_string(),
-                        description: "changed == to !=".to_string(),
-                        original: "==".to_string(),
-                        replacement: "!=".to_string(),
-                        byte_range: 0..2,
-                    },
-                    MutationResult::Survived,
-                ),
-            ],
-            duration: Duration::from_millis(1234),
-            total: 2,
-            killed: 1,
-            survived: 1,
-            timeout: 0,
-            build_errors: 0,
-        }
-    }
 
     #[test]
     fn json_output_is_valid_json() {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -7,7 +7,7 @@ use std::fs;
 
 /// Compute mutation score as a percentage, excluding build errors from the denominator.
 pub fn mutation_score(report: &MutationReport) -> f64 {
-    let tested = report.total - report.build_errors;
+    let tested = report.total.saturating_sub(report.build_errors);
     if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
     } else if report.total == 0 {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,8 +2,20 @@ pub mod html;
 pub mod json;
 pub mod terminal;
 
-use crate::Mutation;
+use crate::{Mutation, MutationReport};
 use std::fs;
+
+/// Compute mutation score as a percentage, excluding build errors from the denominator.
+pub fn mutation_score(report: &MutationReport) -> f64 {
+    let tested = report.total - report.build_errors;
+    if tested > 0 {
+        (report.killed as f64 / tested as f64) * 100.0
+    } else if report.total == 0 {
+        100.0
+    } else {
+        0.0
+    }
+}
 
 pub fn print_report(report: &crate::MutationReport, format: &str) -> anyhow::Result<()> {
     match format {

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -2,17 +2,6 @@ use crate::{MutationReport, MutationResult};
 #[allow(unused_imports)]
 use colored::Colorize;
 
-fn mutation_score(report: &MutationReport) -> f64 {
-    let tested = report.total - report.build_errors;
-    if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
-        100.0
-    } else {
-        0.0
-    }
-}
-
 pub fn print_report(report: &MutationReport) {
     println!();
 
@@ -94,7 +83,7 @@ pub fn print_report(report: &MutationReport) {
     );
     println!(
         "Mutation score (test kills only): {:.1}%",
-        mutation_score(report)
+        super::mutation_score(report)
     );
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
@@ -164,7 +153,7 @@ pub fn format_report_plain(report: &MutationReport) -> String {
     writeln!(
         out,
         "Mutation score (test kills only): {:.1}%",
-        mutation_score(report)
+        super::mutation_score(report)
     )
     .unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
@@ -177,51 +166,9 @@ pub fn format_report_plain(report: &MutationReport) -> String {
 mod tests {
     use super::*;
     use crate::Mutation;
+    use crate::test_helpers::sample_report;
     use std::path::PathBuf;
     use std::time::Duration;
-
-    fn sample_report() -> MutationReport {
-        MutationReport {
-            results: vec![
-                (
-                    Mutation {
-                        id: 1,
-                        file: PathBuf::from("src/auth.rs"),
-                        language: String::new(),
-                        line: 47,
-                        column: 10,
-                        operator: "binary/lt_to_lte".to_string(),
-                        description: "changed < to <=".to_string(),
-                        original: "<".to_string(),
-                        replacement: "<=".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::Killed,
-                ),
-                (
-                    Mutation {
-                        id: 2,
-                        file: PathBuf::from("src/handler.rs"),
-                        language: String::new(),
-                        line: 15,
-                        column: 5,
-                        operator: "binary/eq_to_neq".to_string(),
-                        description: "changed == to !=".to_string(),
-                        original: "==".to_string(),
-                        replacement: "!=".to_string(),
-                        byte_range: 0..2,
-                    },
-                    MutationResult::Survived,
-                ),
-            ],
-            duration: Duration::from_millis(1234),
-            total: 2,
-            killed: 1,
-            survived: 1,
-            timeout: 0,
-            build_errors: 0,
-        }
-    }
 
     #[test]
     fn terminal_output_contains_killed() {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,5 +1,52 @@
-/// Shared test utilities for tree-sitter parsing and node lookup.
-/// Used across operator and language tests to avoid duplication.
+/// Shared test utilities.
+/// Used across operator, language, and report tests to avoid duplication.
+use crate::{Mutation, MutationReport, MutationResult};
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// A standard two-mutation report for testing report formatters.
+pub fn sample_report() -> MutationReport {
+    MutationReport {
+        results: vec![
+            (
+                Mutation {
+                    id: 1,
+                    file: PathBuf::from("src/auth.rs"),
+                    language: String::new(),
+                    line: 47,
+                    column: 10,
+                    operator: "binary/lt_to_lte".to_string(),
+                    description: "changed < to <=".to_string(),
+                    original: "<".to_string(),
+                    replacement: "<=".to_string(),
+                    byte_range: 0..1,
+                },
+                MutationResult::Killed,
+            ),
+            (
+                Mutation {
+                    id: 2,
+                    file: PathBuf::from("src/handler.rs"),
+                    language: String::new(),
+                    line: 15,
+                    column: 5,
+                    operator: "binary/eq_to_neq".to_string(),
+                    description: "changed == to !=".to_string(),
+                    original: "==".to_string(),
+                    replacement: "!=".to_string(),
+                    byte_range: 0..2,
+                },
+                MutationResult::Survived,
+            ),
+        ],
+        duration: Duration::from_millis(1234),
+        total: 2,
+        killed: 1,
+        survived: 1,
+        timeout: 0,
+        build_errors: 0,
+    }
+}
 
 /// Parse Go source code into a tree-sitter tree.
 pub fn parse_go(src: &str) -> tree_sitter::Tree {


### PR DESCRIPTION
## Summary
- Extract `mutation_score()` to `report/mod.rs` — was copy-pasted in terminal/json/html
- Move `sample_report()` to `test_helpers.rs` — was duplicated across 3 report test modules
- Deduplicate `IF_STMT_KINDS` — was identical in `operators/mod.rs` and `operators/removal.rs`
- Rename `write_go_file` → `write_test_file` — it writes Python, Rust, and text files too

Net: +84 -177

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated mutation score calculation for consistent reporting across formats.
  * Centralized shared constants and reduced duplicated lists.
  * Replaced repetitive language implementations with a macro-driven declaration to simplify language support.
  * Unified sample report creation in test helpers and renamed internal test utilities to reduce duplication.

* **Bug Fix**
  * Fixed score and tested-count computations to avoid underflow, ensuring stable report values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->