### PR TITLE
fix: validate UTF-8 boundaries on mutation byte ranges

### DIFF
--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -108,6 +108,12 @@ pub fn generate_mutations(
                         continue;
                     }
 
+                    if candidate.byte_range.start > candidate.byte_range.end
+                        || candidate.byte_range.end > source.len()
+                    {
+                        continue;
+                    }
+
                     let line = ts_row_to_line(node.start_position().row);
                     let column = node.start_position().column + 1;
                     let original =

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -49,6 +49,9 @@ pub fn mutation_diff(mutation: &Mutation) -> Option<String> {
     if byte_end > original_line.len() {
         return None;
     }
+    if !original_line.is_char_boundary(byte_start) || !original_line.is_char_boundary(byte_end) {
+        return None;
+    }
     let mutated_line = format!(
         "{}{}{}",
         &original_line[..byte_start],
@@ -180,6 +183,28 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let content = "hello\n";
         let m = make_mutation(tmp.path(), "t.go", content, 0, 1, "h", "H");
+        assert!(mutation_diff(&m).is_none());
+    }
+
+    #[test]
+    fn mutation_diff_multibyte_chars() {
+        let tmp = TempDir::new().unwrap();
+        // "日本語 = true\n" — CJK chars are 3 bytes each
+        let content = "日本語 = true\n";
+        // "true" starts at byte offset 12 (9 bytes for CJK + 3 for " = ")
+        // column is 1-indexed byte offset: 13
+        let m = make_mutation(tmp.path(), "t.rs", content, 1, 13, "true", "false");
+        let diff = mutation_diff(&m).unwrap();
+        assert!(diff.contains("-日本語 = true"), "{diff}");
+        assert!(diff.contains("+日本語 = false"), "{diff}");
+    }
+
+    #[test]
+    fn mutation_diff_invalid_char_boundary_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let content = "日本語\n";
+        // column 2 (1-indexed) → byte_start 1, which is mid-character
+        let m = make_mutation(tmp.path(), "t.rs", content, 1, 2, "x", "y");
         assert!(mutation_diff(&m).is_none());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -288,7 +288,7 @@ async fn run_single_mutation(
     // Apply mutation
     let mut mutated = original.clone();
     let range = mutation.byte_range.clone();
-    if range.end > mutated.len() {
+    if range.start > range.end || range.end > mutated.len() {
         return MutationOutcome {
             result: MutationResult::BuildError,
             test_output: None,


### PR DESCRIPTION
## Summary
- Add `is_char_boundary` checks in `mutation_diff` before string slicing to prevent panics on multibyte characters
- Validate `range.start <= range.end` in runner before splice (catch inverted ranges)
- Validate byte range bounds in mutator before extracting original text
- Add tests for multibyte chars and invalid boundary detection

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent crashes when processing mutations with invalid ranges or special characters.
  * Stricter boundary checks during mutation application to catch invalid positions early.

* **Tests**
  * Extended test coverage for edge cases involving special character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->