### PR TITLE
fix: Python/Ruby mutations, zombie processes, silent panics

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -6,14 +6,19 @@ use crate::{LineRange, ts_row_to_line};
 /// Node kinds that are relevant for mutation testing.
 const MUTABLE_NODE_KINDS: &[&str] = &[
     "binary_expression",
+    "binary_operator", // Python
+    "binary",          // Ruby
     "if_statement",
     "if_expression",
+    "if", // Ruby
     "return_statement",
     "return_expression",
+    "return", // Ruby
     "true",
     "false",
     "integer_literal",
     "int_literal",
+    "integer", // Ruby
     "number",
     "number_literal",
     "unary_expression",
@@ -93,7 +98,7 @@ fn collect_mutable_nodes<'a>(
 
     // Only add this node if no relevant children were found, no children were
     // skipped, and it's a mutable kind
-    if !found_child && !skipped_child && is_mutable_kind(node.kind()) {
+    if !found_child && !skipped_child && node.is_named() && is_mutable_kind(node.kind()) {
         results.push(node);
     }
     false
@@ -395,7 +400,7 @@ mod tests {
             kinds
         );
         assert!(
-            kinds.contains(&"true"),
+            kinds.contains(&"true") || kinds.contains(&"boolean_literal"),
             "Should still find mutable nodes outside skipped ancestors, got: {:?}",
             kinds
         );
@@ -422,8 +427,8 @@ mod tests {
             kinds
         );
         assert!(
-            kinds.contains(&"true"),
-            "Should still find `true` outside macro, got: {:?}",
+            kinds.contains(&"true") || kinds.contains(&"boolean_literal"),
+            "Should still find boolean literal outside macro, got: {:?}",
             kinds
         );
     }
@@ -567,8 +572,8 @@ mod tests {
         // Should find `true` in prod() but nothing from mod tests
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
         assert!(
-            kinds.contains(&"true"),
-            "Should find `true` in production code, got: {:?}",
+            kinds.contains(&"true") || kinds.contains(&"boolean_literal"),
+            "Should find boolean literal in production code, got: {:?}",
             kinds
         );
         // All nodes should be from line 1 (prod function), none from line 4+
@@ -592,8 +597,8 @@ mod tests {
         let nodes = find_mutable_nodes(&tree, source, &changed, &lang);
         let kinds: Vec<&str> = nodes.iter().map(|n| n.kind()).collect();
         assert!(
-            kinds.contains(&"true"),
-            "Should find `true` in production code, got: {:?}",
+            kinds.contains(&"true") || kinds.contains(&"boolean_literal"),
+            "Should find boolean literal in production code, got: {:?}",
             kinds
         );
         for node in &nodes {

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,7 +1,13 @@
 use super::MutationOperator;
 use crate::MutationCandidate;
 
-const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
+const BINARY_EXPR_KINDS: &[&str] = &[
+    "binary_expression",
+    "binary_expr",
+    "comparison_expression",
+    "binary_operator", // Python
+    "binary",          // Ruby
+];
 
 pub fn find_operator_child(
     node: &tree_sitter::Node,

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -2,7 +2,13 @@ use super::MutationOperator;
 use super::binary::find_operator_child;
 use crate::MutationCandidate;
 
-const BINARY_EXPR_KINDS: &[&str] = &["binary_expression", "binary_expr", "comparison_expression"];
+const BINARY_EXPR_KINDS: &[&str] = &[
+    "binary_expression",
+    "binary_expr",
+    "comparison_expression",
+    "binary_operator", // Python
+    "binary",          // Ruby
+];
 
 fn is_binary_expr(node: &tree_sitter::Node) -> bool {
     BINARY_EXPR_KINDS.contains(&node.kind())

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -1,9 +1,15 @@
 use super::MutationOperator;
 use crate::MutationCandidate;
 
-const TRUE_KINDS: &[&str] = &["true", "True", "TRUE"];
-const FALSE_KINDS: &[&str] = &["false", "False", "FALSE"];
-const INT_LITERAL_KINDS: &[&str] = &["integer_literal", "int_literal", "number", "number_literal"];
+const TRUE_KINDS: &[&str] = &["true", "True", "TRUE", "boolean_literal"];
+const FALSE_KINDS: &[&str] = &["false", "False", "FALSE", "boolean_literal"];
+const INT_LITERAL_KINDS: &[&str] = &[
+    "integer_literal",
+    "int_literal",
+    "integer", // Ruby
+    "number",
+    "number_literal",
+];
 const STRING_LITERAL_KINDS: &[&str] = &[
     "interpreted_string_literal",
     "raw_string_literal",

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -11,8 +11,17 @@ pub trait MutationOperator: Send + Sync {
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate>;
 }
 
-pub(crate) const IF_STMT_KINDS: &[&str] = &["if_statement", "if_expression", "if_expr"];
-const RETURN_KINDS: &[&str] = &["return_statement", "return_expression"];
+pub(crate) const IF_STMT_KINDS: &[&str] = &[
+    "if_statement",
+    "if_expression",
+    "if_expr",
+    "if", // Ruby
+];
+const RETURN_KINDS: &[&str] = &[
+    "return_statement",
+    "return_expression",
+    "return", // Ruby
+];
 
 /// Negate a condition: remove `!` if present, otherwise wrap with `!(...)`
 pub struct NegateCondition;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -210,8 +210,9 @@ impl TestRunner {
 
         let mut all_results = Vec::new();
         for handle in handles {
-            if let Ok(results) = handle.await {
-                all_results.extend(results);
+            match handle.await {
+                Ok(results) => all_results.extend(results),
+                Err(e) => eprintln!("warning: mutation task panicked: {e}"),
             }
         }
 
@@ -343,6 +344,7 @@ async fn run_command(
         cmd.stderr(std::process::Stdio::null());
     }
 
+    cmd.kill_on_drop(true);
     let child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
## Summary
- **Python/Ruby broken mutations**: Add missing node kinds (`binary_operator`, `binary`, `if`, `return`, `integer`) to mapper and operator constants. Add `node.is_named()` guard to prevent keyword tokens from shadowing statement nodes.
- **Zombie processes on timeout**: Set `kill_on_drop(true)` on spawned child processes so they're killed when the timeout future is dropped.
- **Silent panic swallowing**: Log warning when a mutation task panics instead of silently dropping results.

## Test plan
- [x] `cargo test` — all 213 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Verified `generates_mutations_for_python_file` and `rust_return_empty_allowed_for_primitive` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Extended mutation detection support for Ruby and Python code with recognition of additional language syntax patterns for binary operations, conditionals, and literals

**Bug Fixes**
- Improved error handling and reporting for mutation detection tasks that encounter failures
- Enhanced resource cleanup to properly terminate background processes during analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->