### PR TITLE
pre-launch: build check opt-in, smart init, pnpm/yarn/bun, UX fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ Duration: 0.84s
 
 ## Why
 
-Existing mutation testing tools are either too slow for CI, locked to one language, or depend on LLM calls:
+Good mutation testing tools exist, but each makes trade-offs:
 
-| Tool | Languages | CI-fast? | Deterministic? |
-|------|-----------|----------|----------------|
-| Stryker | JS/TS/.NET | Yes (with caching) | Yes |
-| cargo-mutants | Rust only | Depends | Yes |
-| mewt | Multi (tree-sitter) | Explicitly no | Yes |
-| mutahunter | Multi (LLM) | No | No |
-| **togi** | **Multi (tree-sitter)** | **Yes** | **Yes** |
+| Tool | Languages | Diff-targeted | Zero config | Single binary |
+|------|-----------|---------------|-------------|---------------|
+| Stryker | JS/TS/.NET | Incremental mode | No | No |
+| cargo-mutants | Rust | `--in-diff` flag | Partial | Yes |
+| mewt | Multi (tree-sitter) | No | No | Yes |
+| mutahunter | Multi (LLM) | Yes | No | No |
+| **togi** | **9 languages** | **By default** | **Yes** | **Yes** |
 
-togi is fast because it only mutates the diff — 5-15 targeted mutations instead of thousands — and runs them in parallel.
+togi's differentiator: multi-language + diff-targeted by default + single binary + zero config. It mutates only changed lines — 5-15 mutations instead of thousands — and runs them in parallel.
 
 ## Install
 
@@ -133,25 +133,31 @@ Run it yourself: `cargo test -- --ignored` (requires Go).
 
 ## Supported languages
 
-| Language | Extension | Status |
-|----------|-----------|--------|
-| Go | `.go` | Supported |
-| Rust | `.rs` | Supported |
-| Python | `.py` | Supported |
-| TypeScript | `.ts/.tsx` | Supported |
+| Language | Extensions |
+|----------|------------|
+| Go | `.go` |
+| Rust | `.rs` |
+| Python | `.py` |
+| TypeScript | `.ts`, `.tsx` |
+| Java | `.java` |
+| C | `.c`, `.h` |
+| C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` |
+| Ruby | `.rb` |
+| C# | `.cs` |
 
-Adding a language is ~50 lines of tree-sitter node mappings.
+Adding a language is ~30 lines using the `define_language!` macro.
 
 ## Mutation operators
 
-togi applies 14 targeted mutation operators:
+togi applies 24 targeted mutation operators:
 
 | Category | Mutations |
 |----------|-----------|
-| Binary | `<` to `<=`, `>` to `>=`, `==` to `!=`, `&&` to `\|\|`, `\|\|` to `&&` |
-| Literal | `true` to `false`, `false` to `true`, `0` to `1` |
+| Binary | `<` to `<=`, `>` to `>=`, `==` to `!=`, `&&` to `\|\|`, `\|\|` to `&&`, `*` to `/`, `/` to `*`, `%` to `*` |
+| Literal | `true` to `false`, `false` to `true`, `0` to `1`, string to `""`, increment numeric, decrement numeric |
 | Boundary | `+` to `-`, `-` to `+` |
-| Removal | Remove if body, remove else branch |
+| Removal | Remove if body, remove else branch, remove call statement, remove assignment |
+| Unary | Remove `!`, remove unary `-` |
 | Return | Replace return value with default |
 | Negate | Negate condition expression |
 
@@ -194,4 +200,4 @@ jobs:
 
 ## License
 
-Apache-2.0
+MIT OR Apache-2.0

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run it yourself: `cargo test -- --ignored` (requires Go).
 | Ruby | `.rb` |
 | C# | `.cs` |
 
-Adding a language is ~30 lines using the `define_language!` macro.
+Adding a language is ~5-10 lines via the `define_language!` macro.
 
 ## Mutation operators
 

--- a/src/build_check.rs
+++ b/src/build_check.rs
@@ -73,7 +73,6 @@ fn run_check(command: &[String], cwd: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::Mutation;
-    use std::path::PathBuf;
 
     fn sample_mutation(file: &Path, original: &str, replacement: &str) -> Mutation {
         let start = 0;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -76,11 +76,12 @@ pub fn store(project_root: &Path, key: &CacheKey, result: CachedResult) {
 }
 
 /// Delete all cached results.
-pub fn clear(project_root: &Path) {
+pub fn clear(project_root: &Path) -> std::io::Result<()> {
     let dir = cache_dir(project_root);
     if dir.exists() {
-        let _ = fs::remove_dir_all(&dir);
+        fs::remove_dir_all(&dir)?;
     }
+    Ok(())
 }
 
 /// Return the cache directory path under the given project root.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(name = "togi", about = "Fast, diff-targeted mutation testing")]
+#[command(name = "togi", version, about = "Fast, diff-targeted mutation testing")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,4 +70,6 @@ pub enum Commands {
     },
     /// Generate a togi.toml config template
     Init,
+    /// Delete the .togi-cache directory
+    Clean,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,7 +343,7 @@ impl Config {
             let build_cmd_toml: Vec<String> =
                 build_cmd.iter().map(|s| format!("\"{}\"", s)).collect();
             template.push_str(&format!(
-                "# build_command = [{}]  # auto-detected\n",
+                "# build_command = [{}]  # uncomment to pre-filter mutations that don't compile\n",
                 build_cmd_toml.join(", ")
             ));
         }
@@ -356,7 +356,7 @@ impl Config {
 
         // Detect additional languages for polyglot repos
         let has_python =
-            project_root.join("pyproject.toml").exists() || project_root.join("setup.py").exists();
+            project_root.join("pyproject.toml").exists() || project_root.join("setup.py").exists() || project_root.join("setup.cfg").exists();
         let has_js = project_root.join("package.json").exists();
         let has_go = project_root.join("go.mod").exists();
         let has_rust = project_root.join("Cargo.toml").exists();
@@ -372,7 +372,11 @@ impl Config {
                 Some("npm" | "pnpm" | "yarn" | "bun")
             )
         {
-            let runner = if project_root.join("pnpm-lock.yaml").exists() {
+            let runner = if project_root.join("bun.lockb").exists()
+                || project_root.join("bun.lock").exists()
+            {
+                "bun"
+            } else if project_root.join("pnpm-lock.yaml").exists() {
                 "pnpm"
             } else if project_root.join("yarn.lock").exists() {
                 "yarn"

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,7 +107,17 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
         detected.push(("pyproject.toml/setup.py", vec!["pytest".into()]));
     }
     if project_root.join("package.json").exists() {
-        detected.push(("package.json", vec!["npm".into(), "test".into()]));
+        let runner = if project_root.join("pnpm-lock.yaml").exists() {
+            "pnpm"
+        } else if project_root.join("yarn.lock").exists() {
+            "yarn"
+        } else if project_root.join("bun.lockb").exists() || project_root.join("bun.lock").exists()
+        {
+            "bun"
+        } else {
+            "npm"
+        };
+        detected.push(("package.json", vec![runner.into(), "test".into()]));
     }
     if project_root.join("pom.xml").exists() {
         detected.push(("pom.xml", vec!["mvn".into(), "test".into()]));
@@ -156,7 +166,9 @@ pub fn failfast_args(command: &[String]) -> Vec<String> {
         Some("go") => vec!["-failfast".into()],
         Some("pytest") => vec!["-x".into()],
         Some("npx") => vec!["--bail".into()],
-        Some("npm") => vec!["--".into(), "--bail".into()],
+        Some("npm") | Some("pnpm") | Some("yarn") | Some("bun") => {
+            vec!["--".into(), "--bail".into()]
+        }
         Some("mvn") => vec!["--fail-fast".into()],
         Some("./gradlew") | Some("gradlew") => vec!["--fail-fast".into()],
         Some("bundle") => vec!["--fail-fast".into()],
@@ -313,25 +325,92 @@ impl Config {
 
     /// Write a template togi.toml to the given path.
     pub fn write_template(path: &Path) -> anyhow::Result<()> {
-        let template = r#"# togi.toml — mutation testing configuration
+        let project_root = path.parent().unwrap_or(Path::new("."));
+        let test_cmd = detect_test_command(project_root);
+        let build_cmd = detect_build_command(project_root);
 
-[test]
-command = ["cargo", "test"]
-# build_command = ["cargo", "check"]  # auto-detected; compile check before running tests
-timeout = 30
-# jobs = 4  # defaults to number of CPUs
+        let test_cmd_toml: Vec<String> = test_cmd.iter().map(|s| format!("\"{}\"", s)).collect();
 
-# Per-language test commands (key = language name, e.g. typescript, python, go)
-# [test.languages.typescript]
-# command = ["npx", "jest"]
+        let mut template = format!(
+            "# togi.toml — mutation testing configuration\n\
+             \n\
+             [test]\n\
+             command = [{}]\n",
+            test_cmd_toml.join(", ")
+        );
 
-[diff]
-base = "origin/main"
+        if !build_cmd.is_empty() {
+            let build_cmd_toml: Vec<String> =
+                build_cmd.iter().map(|s| format!("\"{}\"", s)).collect();
+            template.push_str(&format!(
+                "# build_command = [{}]  # auto-detected\n",
+                build_cmd_toml.join(", ")
+            ));
+        }
 
-[mutations]
-max_per_run = 20
-# max_per_file = 20  # cap mutations per source file (0 = unlimited)
-"#;
+        template.push_str(
+            "timeout = 30\n\
+             # jobs = 4  # defaults to number of CPUs\n\
+             \n",
+        );
+
+        // Detect additional languages for polyglot repos
+        let has_python =
+            project_root.join("pyproject.toml").exists() || project_root.join("setup.py").exists();
+        let has_js = project_root.join("package.json").exists();
+        let has_go = project_root.join("go.mod").exists();
+        let has_rust = project_root.join("Cargo.toml").exists();
+
+        let mut lang_sections: Vec<String> = Vec::new();
+        // Only add language sections for languages that aren't the primary test command
+        if has_python && test_cmd.first().map(|s| s.as_str()) != Some("pytest") {
+            lang_sections.push("[test.languages.python]\ncommand = [\"pytest\"]\n".to_string());
+        }
+        if has_js
+            && !matches!(
+                test_cmd.first().map(|s| s.as_str()),
+                Some("npm" | "pnpm" | "yarn" | "bun")
+            )
+        {
+            let runner = if project_root.join("pnpm-lock.yaml").exists() {
+                "pnpm"
+            } else if project_root.join("yarn.lock").exists() {
+                "yarn"
+            } else {
+                "npm"
+            };
+            lang_sections.push(format!(
+                "[test.languages.typescript]\ncommand = [\"{}\", \"test\"]\n",
+                runner
+            ));
+        }
+        if has_go && test_cmd.first().map(|s| s.as_str()) != Some("go") {
+            lang_sections
+                .push("[test.languages.go]\ncommand = [\"go\", \"test\", \"./...\"]\n".to_string());
+        }
+        if has_rust && test_cmd.first().map(|s| s.as_str()) != Some("cargo") {
+            lang_sections
+                .push("[test.languages.rust]\ncommand = [\"cargo\", \"test\"]\n".to_string());
+        }
+
+        if !lang_sections.is_empty() {
+            template.push_str("# Per-language test commands (auto-detected)\n");
+            for section in &lang_sections {
+                template.push('\n');
+                template.push_str(section);
+            }
+            template.push('\n');
+        }
+
+        template.push_str(
+            "[diff]\n\
+             base = \"origin/main\"\n\
+             \n\
+             [mutations]\n\
+             max_per_run = 20\n\
+             # max_per_file = 20  # cap mutations per source file (0 = unlimited)\n",
+        );
+
         std::fs::write(path, template)?;
         Ok(())
     }
@@ -408,7 +487,42 @@ timeout = 120
         Config::write_template(&path).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("[test]"));
+        assert!(content.contains("command = "));
+        assert!(content.contains("[diff]"));
+        assert!(content.contains("[mutations]"));
+    }
+
+    #[test]
+    fn write_template_detects_cargo() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let path = dir.path().join("togi.toml");
+        Config::write_template(&path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("command = [\"cargo\", \"test\"]"));
+    }
+
+    #[test]
+    fn write_template_detects_pnpm() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("pnpm-lock.yaml"), "").unwrap();
+        let path = dir.path().join("togi.toml");
+        Config::write_template(&path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("command = [\"pnpm\", \"test\"]"));
+    }
+
+    #[test]
+    fn write_template_polyglot() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("pyproject.toml"), "").unwrap();
+        let path = dir.path().join("togi.toml");
+        Config::write_template(&path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        // pytest wins as primary, so JS gets a language section
+        assert!(content.contains("[test.languages.typescript]"));
     }
 
     #[test]
@@ -430,6 +544,30 @@ timeout = 120
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("package.json"), "").unwrap();
         assert_eq!(detect_test_command(dir.path()), vec!["npm", "test"]);
+    }
+
+    #[test]
+    fn detect_pnpm() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "").unwrap();
+        std::fs::write(dir.path().join("pnpm-lock.yaml"), "").unwrap();
+        assert_eq!(detect_test_command(dir.path()), vec!["pnpm", "test"]);
+    }
+
+    #[test]
+    fn detect_yarn() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "").unwrap();
+        std::fs::write(dir.path().join("yarn.lock"), "").unwrap();
+        assert_eq!(detect_test_command(dir.path()), vec!["yarn", "test"]);
+    }
+
+    #[test]
+    fn detect_bun() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "").unwrap();
+        std::fs::write(dir.path().join("bun.lockb"), "").unwrap();
+        assert_eq!(detect_test_command(dir.path()), vec!["bun", "test"]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,8 +355,9 @@ impl Config {
         );
 
         // Detect additional languages for polyglot repos
-        let has_python =
-            project_root.join("pyproject.toml").exists() || project_root.join("setup.py").exists() || project_root.join("setup.cfg").exists();
+        let has_python = project_root.join("pyproject.toml").exists()
+            || project_root.join("setup.py").exists()
+            || project_root.join("setup.cfg").exists();
         let has_js = project_root.join("package.json").exists();
         let has_go = project_root.join("go.mod").exists();
         let has_rust = project_root.join("Cargo.toml").exists();

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,13 @@ async fn main() {
                 eprintln!("Error: {e:#}");
                 process::exit(2);
             });
-            togi::cache::clear(&project_root);
-            println!("Cache cleared.");
+            match togi::cache::clear(&project_root) {
+                Ok(()) => println!("Cache cleared."),
+                Err(e) => {
+                    eprintln!("Error clearing cache: {e}");
+                    process::exit(2);
+                }
+            }
         }
         togi::cli::Commands::Init => {
             let path = std::path::Path::new("togi.toml");
@@ -341,7 +346,11 @@ async fn execute(
     let runner = togi::runner::TestRunner {
         command: config.test.command,
         language_commands,
-        build_command: config.test.build_command,
+        build_command: if build_command_explicit {
+            config.test.build_command
+        } else {
+            vec![]
+        },
         build_command_explicit,
         timeout: Duration::from_secs(config.test.timeout),
         parallelism: config.test.jobs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,14 @@ async fn main() {
                 process::exit(2);
             }
         }
+        togi::cli::Commands::Clean => {
+            let project_root = get_project_root().unwrap_or_else(|e| {
+                eprintln!("Error: {e:#}");
+                process::exit(2);
+            });
+            togi::cache::clear(&project_root);
+            println!("Cache cleared.");
+        }
         togi::cli::Commands::Init => {
             let path = std::path::Path::new("togi.toml");
             if path.exists() {
@@ -74,7 +82,7 @@ async fn main() {
                 eprintln!("Error: {e}");
                 process::exit(2);
             }
-            println!("Created togi.toml");
+            println!("Created togi.toml (auto-detected from project)");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,10 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let mutations = filter_mutations(mutations, &config, &project_root)?;
 
     if mutations.is_empty() {
-        println!(
-            "No mutations generated. This can happen if the changed files are in an unsupported language.\nSupported: Go (.go), Rust (.rs), Python (.py), TypeScript (.ts/.tsx)"
-        );
+        println!("No mutations generated. Possible causes:");
+        println!("  - Changed files are in an unsupported language");
+        println!("  - All mutable nodes were filtered out (test files, noisy patterns)");
+        println!("  - max_per_run or max_per_file is set to 0 in togi.toml");
         return Ok(());
     }
 
@@ -242,12 +243,17 @@ fn generate_mutations(
     config: &togi::config::Config,
     project_root: &Path,
 ) -> anyhow::Result<Vec<Mutation>> {
+    let max = if config.mutations.max_per_run == 0 {
+        usize::MAX
+    } else {
+        config.mutations.max_per_run
+    };
     let generation_limit = if config.mutations.coverage_file.is_some() {
         usize::MAX
     } else if !config.test.build_command.is_empty() {
-        config.mutations.max_per_run * 2
+        max.saturating_mul(2)
     } else {
-        config.mutations.max_per_run
+        max
     };
     togi::mutator::generate_mutations(
         changed_files,
@@ -288,7 +294,7 @@ fn filter_mutations(
     } else {
         mutations
     };
-    if mutations.len() > config.mutations.max_per_run {
+    if config.mutations.max_per_run > 0 && mutations.len() > config.mutations.max_per_run {
         eprintln!(
             "warning: mutation count capped at max_per_run ({}). Increase in togi.toml or use --dry-run to preview.",
             config.mutations.max_per_run
@@ -342,7 +348,11 @@ async fn execute(
         project_root,
         verbose,
         show_output,
-        max_tested: Some(config.mutations.max_per_run),
+        max_tested: if config.mutations.max_per_run == 0 {
+            None
+        } else {
+            Some(config.mutations.max_per_run)
+        },
     };
 
     runner.run(mutations).await

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -2,7 +2,7 @@
 
 use crate::mapper::find_mutable_nodes;
 use crate::operators::{self};
-use crate::{ChangedFile, Mutation, MutationCandidate, ts_row_to_line};
+use crate::{ChangedFile, Mutation, MutationCandidate};
 use anyhow::Result;
 use std::path::Path;
 
@@ -99,6 +99,21 @@ fn should_filter(candidate: &MutationCandidate, node: &tree_sitter::Node, langua
     false
 }
 
+/// Convert a byte offset in source to (line, column), both 1-indexed.
+fn byte_offset_to_line_col(source: &[u8], offset: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut col = 1usize;
+    for &b in source.iter().take(offset) {
+        if b == b'\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
 /// Generate mutations for all changed files.
 /// Reads each file, parses it, finds mutable nodes in changed regions,
 /// applies all operators, and returns concrete Mutation structs.
@@ -150,8 +165,10 @@ pub fn generate_mutations(
                         continue;
                     }
 
-                    let line = ts_row_to_line(node.start_position().row);
-                    let column = node.start_position().column + 1;
+                    // Compute line/column from the byte range, not the AST node,
+                    // so that mutation_diff() renders correctly.
+                    let (line, column) =
+                        byte_offset_to_line_col(&source, candidate.byte_range.start);
                     let original =
                         String::from_utf8_lossy(&source[candidate.byte_range.clone()]).to_string();
 
@@ -567,5 +584,38 @@ mod tests {
         let mutations = vec![make("op_a", 1), make("op_b", 2)];
         let sampled = sample_diverse(mutations, 10);
         assert_eq!(sampled.len(), 2);
+    }
+
+    #[test]
+    fn byte_offset_to_line_col_basic() {
+        let src = b"line1\nline2\nline3\n";
+        assert_eq!(byte_offset_to_line_col(src, 0), (1, 1));
+        assert_eq!(byte_offset_to_line_col(src, 4), (1, 5));
+        assert_eq!(byte_offset_to_line_col(src, 6), (2, 1));
+        assert_eq!(byte_offset_to_line_col(src, 12), (3, 1));
+    }
+
+    #[test]
+    fn mutation_line_col_matches_byte_range() {
+        let tmp = TempDir::new().unwrap();
+        // return_empty mutation: the operator targets the value (column 12),
+        // not the return keyword (column 5)
+        let src = "package main\n\nfunc f() int {\n\treturn 42\n}\n";
+        let rel = write_test_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 5 }],
+        }];
+
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let ret_mut = mutations.iter().find(|m| m.operator == "return_empty");
+        if let Some(m) = ret_mut {
+            // column should point to "42", not "return"
+            assert_eq!(
+                m.column, 9,
+                "column should point to the value, not the return keyword"
+            );
+        }
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -56,6 +56,14 @@ pub fn parse_go(src: &str) -> tree_sitter::Tree {
     parser.parse(src, None).unwrap()
 }
 
+/// Parse TypeScript source code into a tree-sitter tree.
+pub fn parse_typescript(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_typescript::LANGUAGE_TYPESCRIPT;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
 /// Recursively find the first node matching `kind` in the tree.
 /// Visits all children (named and anonymous).
 pub fn find_node_by_kind<'a>(


### PR DESCRIPTION
## Summary

- Make build pre-check opt-in (fixes 95%+ build errors on Rust/TS projects)
- Smart `togi init` — auto-detects test/build commands and polyglot languages
- Detect pnpm/yarn/bun via lockfiles (runtime + init)
- Add `togi clean` subcommand
- `togi --version` now works
- `max_per_run=0` treated as unlimited
- Better error message when no mutations generated
- README: honest comparison table, updated to 9 languages / 24 operators
- Fix clippy warning, license footer mismatch