### PR TITLE
feat: --operators flag to include/exclude operators

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Run mutation testing on the current diff
     Check {
@@ -67,6 +68,12 @@ pub enum Commands {
         /// Disable built-in exclusion of test files, migrations, seeds, etc.
         #[arg(long)]
         no_skip_defaults: bool,
+
+        /// Filter operators: category or id, prefix with - to exclude
+        /// e.g. --operators=-string_to_empty,-increment_numeric
+        /// Categories: binary, literal, boundary, removal, unary, negate, return
+        #[arg(long, value_delimiter = ',')]
+        operators: Option<Vec<String>>,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ pub struct MutationConfig {
     pub exclude_paths: Vec<String>,
     #[serde(default = "default_true")]
     pub skip_noisy_files: bool,
+    #[serde(default)]
+    pub operators: Vec<String>,
 }
 
 fn default_true() -> bool {
@@ -260,6 +262,7 @@ impl Default for MutationConfig {
             coverage_file: None,
             exclude_paths: vec![],
             skip_noisy_files: true,
+            operators: vec![],
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ struct CheckConfig {
     build_cmd: Option<String>,
     fail_fast: bool,
     no_skip_defaults: bool,
+    operators: Option<Vec<String>>,
 }
 
 #[tokio::main]
@@ -42,6 +43,7 @@ async fn main() {
             build_cmd,
             fail_fast,
             no_skip_defaults,
+            operators,
         } => {
             let cfg = CheckConfig {
                 all,
@@ -58,6 +60,7 @@ async fn main() {
                 build_cmd,
                 fail_fast,
                 no_skip_defaults,
+                operators,
             };
             if let Err(e) = run_check(cfg).await {
                 eprintln!("Error: {e:#}");
@@ -191,6 +194,9 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
     if cfg.no_skip_defaults {
         config.mutations.skip_noisy_files = false;
     }
+    if let Some(ops) = cfg.operators {
+        config.mutations.operators = ops;
+    }
 
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
@@ -265,6 +271,7 @@ fn generate_mutations(
         project_root,
         generation_limit,
         config.mutations.max_per_file,
+        &config.mutations.operators,
     )
 }
 

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -122,8 +122,9 @@ pub fn generate_mutations(
     project_root: &Path,
     max_mutations: usize,
     max_per_file: usize,
+    operator_filters: &[String],
 ) -> Result<Vec<Mutation>> {
-    let operators = operators::all_operators();
+    let operators = operators::filter_operators(operators::all_operators(), operator_filters);
     let mut mutations = Vec::new();
     let mut next_id: u32 = 0;
 
@@ -297,7 +298,7 @@ mod tests {
             hunks: vec![LineRange { start: 4, end: 5 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(!mutations.is_empty());
 
         let operators: Vec<&str> = mutations.iter().map(|m| m.operator.as_str()).collect();
@@ -324,7 +325,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 8 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 2, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 2, 0, &[]).unwrap();
         assert_eq!(mutations.len(), 2);
     }
 
@@ -337,7 +338,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 5 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(mutations.is_empty());
     }
 
@@ -361,7 +362,7 @@ mod tests {
             },
         ];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let files: std::collections::HashSet<_> =
             mutations.iter().map(|m| m.file.clone()).collect();
         assert!(
@@ -382,7 +383,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 2 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(!mutations.is_empty(), "expected mutations for Python file");
         assert_eq!(mutations[0].language, "python");
     }
@@ -398,7 +399,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 3 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(!mutations.is_empty(), "expected mutations for Rust file");
         assert_eq!(mutations[0].language, "rust");
     }
@@ -414,7 +415,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 8 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(!mutations.is_empty(), "expected at least one mutation");
         for (i, m) in mutations.iter().enumerate() {
             assert_eq!(m.id, i as u32, "mutation ids should be sequential");
@@ -432,7 +433,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 3 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
         assert!(
             !has_return_empty,
@@ -454,7 +455,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 3 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
         assert!(
             has_return_empty,
@@ -474,7 +475,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 5 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let has_return_empty = mutations.iter().any(|m| m.operator == "return_empty");
         assert!(
             !has_return_empty,
@@ -493,7 +494,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 1 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         assert!(mutations.is_empty());
     }
 
@@ -509,8 +510,8 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 11 }],
         }];
 
-        let uncapped = generate_mutations(&changed, tmp.path(), 1000, 0).unwrap();
-        let capped = generate_mutations(&changed, tmp.path(), 1000, 3).unwrap();
+        let uncapped = generate_mutations(&changed, tmp.path(), 1000, 0, &[]).unwrap();
+        let capped = generate_mutations(&changed, tmp.path(), 1000, 3, &[]).unwrap();
 
         assert!(
             uncapped.len() > 3,
@@ -608,7 +609,7 @@ mod tests {
             hunks: vec![LineRange { start: 1, end: 5 }],
         }];
 
-        let mutations = generate_mutations(&changed, tmp.path(), 100, 0).unwrap();
+        let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let ret_mut = mutations.iter().find(|m| m.operator == "return_empty");
         if let Some(m) = ret_mut {
             // column should point to "42", not "return"

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -126,6 +126,66 @@ impl MutationOperator for ReturnEmpty {
 }
 
 /// Returns all mutation operators
+/// Return the category for an operator ID.
+pub fn operator_category(id: &str) -> &str {
+    match id {
+        "lt_to_lte" | "gt_to_gte" | "eq_to_neq" | "and_to_or" | "or_to_and" | "mul_to_div"
+        | "div_to_mul" | "mod_to_mul" => "binary",
+        "true_to_false" | "false_to_true" | "zero_to_one" | "string_to_empty"
+        | "increment_numeric" | "decrement_numeric" => "literal",
+        "plus_to_minus" | "minus_to_plus" => "boundary",
+        "remove_if_body" | "remove_else" | "remove_call_statement" | "remove_assignment" => {
+            "removal"
+        }
+        "remove_unary_not" | "remove_unary_neg" => "unary",
+        "negate_condition" => "negate",
+        "return_empty" => "return",
+        _ => "other",
+    }
+}
+
+/// Filter operators based on include/exclude patterns.
+/// Patterns can be operator IDs or category names.
+/// Prefix with `-` to exclude. If any non-exclude pattern exists,
+/// only matching operators are included.
+pub fn filter_operators(
+    operators: Vec<Box<dyn MutationOperator>>,
+    patterns: &[String],
+) -> Vec<Box<dyn MutationOperator>> {
+    if patterns.is_empty() {
+        return operators;
+    }
+
+    let excludes: Vec<&str> = patterns
+        .iter()
+        .filter(|p| p.starts_with('-'))
+        .map(|p| p.trim_start_matches('-'))
+        .collect();
+    let includes: Vec<&str> = patterns
+        .iter()
+        .filter(|p| !p.starts_with('-'))
+        .map(|s| s.as_str())
+        .collect();
+
+    operators
+        .into_iter()
+        .filter(|op| {
+            let id = op.id();
+            let cat = operator_category(id);
+
+            // Check excludes first
+            if excludes.contains(&id) || excludes.contains(&cat) {
+                return false;
+            }
+            // If includes specified, must match
+            if !includes.is_empty() {
+                return includes.contains(&id) || includes.contains(&cat);
+            }
+            true
+        })
+        .collect()
+}
+
 pub fn all_operators() -> Vec<Box<dyn MutationOperator>> {
     vec![
         Box::new(binary::LtToLte),

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -158,13 +158,14 @@ pub fn filter_operators(
 
     let excludes: Vec<&str> = patterns
         .iter()
+        .map(|p| p.trim())
         .filter(|p| p.starts_with('-'))
         .map(|p| p.trim_start_matches('-'))
         .collect();
     let includes: Vec<&str> = patterns
         .iter()
+        .map(|p| p.trim())
         .filter(|p| !p.starts_with('-'))
-        .map(|s| s.as_str())
         .collect();
 
     operators
@@ -287,5 +288,71 @@ func f() string { return "hello" }"#;
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
         let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes());
         assert!(candidates.is_empty());
+    }
+
+    // Stub operator for filter tests
+    struct StubOp(&'static str);
+    impl MutationOperator for StubOp {
+        fn id(&self) -> &str {
+            self.0
+        }
+        fn description(&self) -> &str {
+            ""
+        }
+        fn apply(&self, _: &tree_sitter::Node, _: &[u8]) -> Vec<crate::MutationCandidate> {
+            vec![]
+        }
+    }
+
+    fn stub_ops() -> Vec<Box<dyn MutationOperator>> {
+        vec![
+            Box::new(StubOp("lt_to_lte")),        // binary
+            Box::new(StubOp("string_to_empty")),  // literal
+            Box::new(StubOp("plus_to_minus")),    // boundary
+            Box::new(StubOp("remove_if_body")),   // removal
+            Box::new(StubOp("remove_unary_not")), // unary
+            Box::new(StubOp("negate_condition")), // negate
+            Box::new(StubOp("return_empty")),     // return
+        ]
+    }
+
+    fn ids(ops: &[Box<dyn MutationOperator>]) -> Vec<&str> {
+        ops.iter().map(|o| o.id()).collect()
+    }
+
+    #[test]
+    fn filter_include_only() {
+        let ops = filter_operators(stub_ops(), &["binary".into(), "removal".into()]);
+        assert_eq!(ids(&ops), vec!["lt_to_lte", "remove_if_body"]);
+    }
+
+    #[test]
+    fn filter_exclude_only() {
+        let ops = filter_operators(stub_ops(), &["-literal".into(), "-boundary".into()]);
+        let result = ids(&ops);
+        assert!(!result.contains(&"string_to_empty"));
+        assert!(!result.contains(&"plus_to_minus"));
+        assert!(result.contains(&"lt_to_lte"));
+        assert!(result.contains(&"return_empty"));
+    }
+
+    #[test]
+    fn filter_mixed_exclude_wins() {
+        // Include binary category but exclude lt_to_lte specifically
+        let ops = filter_operators(stub_ops(), &["binary".into(), "-lt_to_lte".into()]);
+        assert!(ids(&ops).is_empty());
+    }
+
+    #[test]
+    fn filter_category_matches() {
+        let ops = filter_operators(stub_ops(), &["literal".into()]);
+        assert_eq!(ids(&ops), vec!["string_to_empty"]);
+    }
+
+    #[test]
+    fn filter_whitespace_trimmed() {
+        let ops = filter_operators(stub_ops(), &[" -literal ".into()]);
+        assert!(!ids(&ops).contains(&"string_to_empty"));
+        assert!(ids(&ops).contains(&"lt_to_lte"));
     }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -159,12 +159,14 @@ pub fn filter_operators(
     let excludes: Vec<&str> = patterns
         .iter()
         .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
         .filter(|p| p.starts_with('-'))
         .map(|p| p.trim_start_matches('-'))
         .collect();
     let includes: Vec<&str> = patterns
         .iter()
         .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
         .filter(|p| !p.starts_with('-'))
         .collect();
 

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -16,7 +16,7 @@ fn generates_mutations_for_go_fixture() {
         hunks: vec![LineRange { start: 1, end: 32 }],
     }];
 
-    let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0).unwrap();
+    let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0, &[]).unwrap();
     assert!(
         !mutations.is_empty(),
         "expected mutations to be generated for calc.go"
@@ -79,7 +79,7 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
         hunks: vec![LineRange { start: 1, end: 32 }],
     }];
 
-    let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0).unwrap();
+    let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0, &[]).unwrap();
     assert!(!mutations.is_empty());
 
     let runner = togi::runner::TestRunner {


### PR DESCRIPTION
## Summary

- Add `--operators` CLI flag and `operators` config key
- Filter by category or individual operator ID
- Prefix with `-` to exclude: `--operators=-string_to_empty,-literal`
- Categories: binary, literal, boundary, removal, unary, negate, return

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add operator filtering for mutation generation via a CLI flag and configuration option; accepts comma-separated IDs or category names with optional `-`-prefixed exclusions.
  * Category-based selection and trimming of patterns are supported; exclusions take precedence over inclusions.

* **Tests**
  * Updated tests to cover operator-filtering behavior and preserve previous default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->