### PR TITLE
fix: helpful message when all mutations are build errors

### DIFF
--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -87,6 +87,15 @@ pub fn print_report(report: &MutationReport) {
     );
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
+
+    if report.build_errors > 0 && report.build_errors == report.total {
+        println!();
+        println!("All mutations caused build errors — no mutations were testable.");
+        println!("This typically happens with strictly-typed languages where mutations");
+        println!("break compilation. Try:");
+        println!("  togi check --operators=-string_to_empty    (skip string mutations)");
+        println!("  togi check --operators=binary,removal       (only logic operators)");
+    }
 }
 
 /// Format report as a plain-text string (no ANSI colors, for testing).

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -88,14 +88,26 @@ pub fn print_report(report: &MutationReport) {
     println!("Duration: {:.2}s", report.duration.as_secs_f64());
     println!("{}", separator);
 
-    if report.build_errors > 0 && report.build_errors == report.total {
+    if let Some(guidance) = all_build_error_guidance(report) {
         println!();
-        println!("All mutations caused build errors — no mutations were testable.");
-        println!("This typically happens with strictly-typed languages where mutations");
-        println!("break compilation. Try:");
-        println!("  togi check --operators=-string_to_empty    (skip string mutations)");
-        println!("  togi check --operators=binary,removal       (only logic operators)");
+        print!("{guidance}");
     }
+}
+
+/// Guidance text when every mutation is a build error.
+fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
+    if report.build_errors == 0 || report.build_errors != report.total {
+        return None;
+    }
+    Some(
+        "All mutations caused build errors — no mutations were testable.\n\
+         This typically happens with strictly-typed languages where mutations\n\
+         break compilation. Try:\n\
+         \x20 togi check --operators=-string_to_empty    (skip string mutations)\n\
+         \x20 togi check --operators=binary,removal       (only logic operators)\n\
+         \x20 togi check --build-cmd='cargo check'        (custom build check)\n"
+            .to_string(),
+    )
 }
 
 /// Format report as a plain-text string (no ANSI colors, for testing).
@@ -167,6 +179,11 @@ pub fn format_report_plain(report: &MutationReport) -> String {
     .unwrap();
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{}", separator).unwrap();
+
+    if let Some(guidance) = all_build_error_guidance(report) {
+        writeln!(out).unwrap();
+        write!(out, "{guidance}").unwrap();
+    }
 
     out
 }
@@ -267,5 +284,51 @@ mod tests {
         assert!(output.contains("Results: 1 killed, 1 survived, 0 timeout, 0 build errors"));
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
         assert!(output.contains("Duration: 1.23s"));
+    }
+
+    #[test]
+    fn all_build_errors_shows_guidance() {
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 0,
+                    file: PathBuf::from("test.rs"),
+                    line: 1,
+                    column: 1,
+                    operator: "eq_to_neq".into(),
+                    description: "test".into(),
+                    original: "==".into(),
+                    replacement: "!=".into(),
+                    byte_range: 0..2,
+                    language: "rust".into(),
+                },
+                MutationResult::BuildError,
+            )],
+            duration: Duration::from_secs(1),
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 1,
+        };
+        let output = format_report_plain(&report);
+        assert!(output.contains("All mutations caused build errors"));
+        assert!(output.contains("--operators="));
+        assert!(output.contains("--build-cmd="));
+    }
+
+    #[test]
+    fn partial_build_errors_no_guidance() {
+        let report = MutationReport {
+            results: vec![],
+            duration: Duration::from_secs(1),
+            total: 2,
+            killed: 1,
+            survived: 0,
+            timeout: 0,
+            build_errors: 1,
+        };
+        let output = format_report_plain(&report);
+        assert!(!output.contains("All mutations caused build errors"));
     }
 }


### PR DESCRIPTION
When every mutation causes a build error, print actionable guidance
instead of just the score. Suggests --operators flag to filter.

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal report now detects when every mutation fails to build and displays an explanatory guidance block with specific `togi check` operator/build-command suggestions to help diagnose and resolve the issue.

* **Tests**
  * Added tests to verify the guidance appears when all mutations are build errors and is absent otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->