### PR TITLE
feat: --path flag to scope --all to subdirectories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Single Rust binary. Pipeline: diff → parse → map → mutate → run → repo
 - `src/runner.rs` — parallel test execution with timeouts and file guards
 - `src/report/` — terminal and JSON output
 - `src/operators/` — mutation operators (binary, literal, boundary, removal)
+- `src/operators/mod.rs` — `operator_category()` and `filter_operators()` for `--operators` flag
 - `src/languages/` — per-language tree-sitter node mappings
 - `src/config.rs` — togi.toml parsing with auto-detection
 - `src/cli.rs` — clap CLI definitions
@@ -23,6 +24,7 @@ Single Rust binary. Pipeline: diff → parse → map → mutate → run → repo
 - All changes via PR, never direct to main.
 - `cargo test` must pass. `cargo clippy -- -D warnings` must pass.
 - `cargo fmt` enforced.
+- Build check is opt-in. Auto-detected build commands are NOT used as pre-filters unless explicitly configured in `togi.toml` or via `--build-cmd`.
 
 ## Adding a language
 
@@ -37,6 +39,13 @@ Single Rust binary. Pipeline: diff → parse → map → mutate → run → repo
 1. Implement `MutationOperator` trait in the appropriate file under `src/operators/`
 2. Add to `all_operators()` in `src/operators/mod.rs`
 3. The operator checks `node.kind()` and returns `MutationCandidate` with byte range and replacement
+4. Update `operator_category()` in `src/operators/mod.rs` to map your operator ID to its category
+
+## CLI subcommands
+
+- `togi check` — run mutation testing (default)
+- `togi init` — generate `togi.toml` with auto-detected settings
+- `togi clean` — remove leftover mutant files from interrupted runs
 
 ## Test command
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ togi check --all
 # Adjust parallelism and timeout
 togi check --jobs 8 --timeout 60
 
+# Scope to a directory
+togi check --all --path src/rules/
+
+# Exclude noisy operators
+togi check --operators=-string_to_empty
+
+# Include only specific categories
+togi check --operators=binary,removal
+
+# Stop on first test failure per mutation
+togi check --fail-fast
+
+# Show each mutation as it runs
+togi check --verbose
+
+# Clear mutation cache
+togi clean
+
 # Generate a config file
 togi init
 ```
@@ -79,6 +97,8 @@ togi init
 
 Optional. togi works with zero config — it auto-detects your language and test command.
 
+Run `togi init` to auto-detect your language, test runner (including pnpm/yarn/bun), and generate a `togi.toml`. For polyglot repos it creates per-language sections automatically.
+
 Create a `togi.toml` for customization:
 
 ```toml
@@ -86,12 +106,19 @@ Create a `togi.toml` for customization:
 command = ["go", "test", "./..."]
 timeout = 30
 jobs = 4
+# build_command = ["cargo", "check"]
+
+[test.languages.python]
+command = ["pytest"]
 
 [diff]
 base = "origin/main"
 
 [mutations]
 max_per_run = 20
+max_per_file = 20
+operators = ["-string_to_empty"]
+exclude_paths = ["vendor/**"]
 ```
 
 ## Example: finding real test gaps
@@ -151,15 +178,15 @@ Adding a language is ~5-10 lines via the `define_language!` macro.
 
 togi applies 24 targeted mutation operators:
 
-| Category | Mutations |
-|----------|-----------|
-| Binary | `<` to `<=`, `>` to `>=`, `==` to `!=`, `&&` to `\|\|`, `\|\|` to `&&`, `*` to `/`, `/` to `*`, `%` to `*` |
-| Literal | `true` to `false`, `false` to `true`, `0` to `1`, string to `""`, increment numeric, decrement numeric |
-| Boundary | `+` to `-`, `-` to `+` |
-| Removal | Remove if body, remove else branch, remove call statement, remove assignment |
-| Unary | Remove `!`, remove unary `-` |
-| Return | Replace return value with default |
-| Negate | Negate condition expression |
+| Category (--operators name) | Mutations |
+|-----------------------------|-----------|
+| `binary` | `<` to `<=`, `>` to `>=`, `==` to `!=`, `&&` to `\|\|`, `\|\|` to `&&`, `*` to `/`, `/` to `*`, `%` to `*` |
+| `literal` | `true` to `false`, `false` to `true`, `0` to `1`, string to `""`, increment numeric, decrement numeric |
+| `boundary` | `+` to `-`, `-` to `+` |
+| `removal` | Remove if body, remove else branch, remove call statement, remove assignment |
+| `unary` | Remove `!`, remove unary `-` |
+| `return` | Replace return value with default |
+| `negate` | Negate condition expression |
 
 ## How it works
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,10 @@ pub enum Commands {
         #[arg(long, conflicts_with = "base")]
         all: bool,
 
+        /// Limit --all to files under this path (repeatable)
+        #[arg(long, requires = "all")]
+        path: Vec<PathBuf>,
+
         /// Base branch to diff against
         #[arg(long)]
         base: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use togi::{ChangedFile, Mutation, MutationReport};
 
 struct CheckConfig {
     all: bool,
+    paths: Vec<PathBuf>,
     base: Option<String>,
     config_path: Option<PathBuf>,
     output_format: String,
@@ -30,6 +31,7 @@ async fn main() {
     match cli.command {
         togi::cli::Commands::Check {
             all,
+            path,
             base,
             config,
             format,
@@ -47,6 +49,7 @@ async fn main() {
         } => {
             let cfg = CheckConfig {
                 all,
+                paths: path,
                 base,
                 config_path: config,
                 output_format: format,
@@ -97,6 +100,7 @@ async fn main() {
 
 async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let all = cfg.all;
+    let paths = cfg.paths.clone();
     let dry_run = cfg.dry_run;
     let verbose = cfg.verbose;
     let show_output = cfg.show_output;
@@ -122,7 +126,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let known: Vec<&str> = all_langs.iter().map(|l| l.name()).collect();
     config.warn_unknown_languages(&known);
 
-    let changed_files = collect_files(&config, all, dry_run, &project_root)?;
+    let changed_files = collect_files(&config, all, &paths, dry_run, &project_root)?;
     if changed_files.is_empty() {
         return Ok(());
     }
@@ -208,6 +212,7 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
 fn collect_files(
     config: &togi::config::Config,
     all: bool,
+    paths: &[PathBuf],
     dry_run: bool,
     project_root: &Path,
 ) -> anyhow::Result<Vec<ChangedFile>> {
@@ -215,8 +220,11 @@ fn collect_files(
     let exclude_globs = &config.mutations.exclude_paths;
 
     if all {
-        let files =
+        let mut files =
             togi::diff::collect_all_supported_files(project_root, skip_noisy, exclude_globs)?;
+        if !paths.is_empty() {
+            files.retain(|f| paths.iter().any(|p| f.path.starts_with(p)));
+        }
         if files.is_empty() {
             println!("No supported source files found. Nothing to mutate.");
             return Ok(vec![]);


### PR DESCRIPTION
## Summary

Add `--path` flag (repeatable) to limit `--all` to specific directories:

```bash
togi check --all --path src/rules/
togi check --all --path src/ --path tests/
```

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --path option to the check command to limit file checks to specific paths when used with --all.
* **Documentation**
  * Updated docs and README: added CLI option references (including --operators, --fail-fast, --verbose), cache/clean instructions, expanded init/config guidance (e.g., max_per_file, exclude_paths), and clarified operator selection and build-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->