### PR TITLE
perf: binary search for line overlap, reuse parser across files

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -105,8 +105,14 @@ fn collect_mutable_nodes<'a>(
 }
 
 /// Check if a node's line range overlaps with any changed line range.
-/// Uses binary search since changed_lines is sorted by start.
+/// Requires: changed_lines sorted with non-decreasing `end` values,
+/// and each range satisfies `start <= end`. Produced by `parse_diff`.
 fn overlaps(node_start: usize, node_end: usize, changed_lines: &[LineRange]) -> bool {
+    debug_assert!(
+        changed_lines.windows(2).all(|w| w[0].end <= w[1].end)
+            && changed_lines.iter().all(|r| r.start <= r.end),
+        "changed_lines must be sorted with non-decreasing end values"
+    );
     // Find first range whose end >= node_start (could overlap)
     let idx = changed_lines.partition_point(|r| r.end < node_start);
     // Check if that range's start <= node_end (actual overlap)

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -105,13 +105,15 @@ fn collect_mutable_nodes<'a>(
 }
 
 /// Check if a node's line range overlaps with any changed line range.
-/// Requires: changed_lines sorted with non-decreasing `end` values,
+/// Requires: changed_lines sorted with non-decreasing start and end values,
 /// and each range satisfies `start <= end`. Produced by `parse_diff`.
 fn overlaps(node_start: usize, node_end: usize, changed_lines: &[LineRange]) -> bool {
     debug_assert!(
-        changed_lines.windows(2).all(|w| w[0].end <= w[1].end)
+        changed_lines
+            .windows(2)
+            .all(|w| w[0].start <= w[1].start && w[0].end <= w[1].end)
             && changed_lines.iter().all(|r| r.start <= r.end),
-        "changed_lines must be sorted with non-decreasing end values"
+        "changed_lines must be sorted with non-decreasing start and end values"
     );
     // Find first range whose end >= node_start (could overlap)
     let idx = changed_lines.partition_point(|r| r.end < node_start);

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -105,10 +105,12 @@ fn collect_mutable_nodes<'a>(
 }
 
 /// Check if a node's line range overlaps with any changed line range.
+/// Uses binary search since changed_lines is sorted by start.
 fn overlaps(node_start: usize, node_end: usize, changed_lines: &[LineRange]) -> bool {
-    changed_lines
-        .iter()
-        .any(|range| node_start <= range.end && node_end >= range.start)
+    // Find first range whose end >= node_start (could overlap)
+    let idx = changed_lines.partition_point(|r| r.end < node_start);
+    // Check if that range's start <= node_end (actual overlap)
+    idx < changed_lines.len() && changed_lines[idx].start <= node_end
 }
 
 /// Check if a node kind is relevant for mutation.

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -127,6 +127,7 @@ pub fn generate_mutations(
     let operators = operators::filter_operators(operators::all_operators(), operator_filters);
     let mut mutations = Vec::new();
     let mut next_id: u32 = 0;
+    let mut parser = tree_sitter::Parser::new();
 
     for changed_file in changed_files {
         let file_path = project_root.join(&changed_file.path);
@@ -135,16 +136,17 @@ pub fn generate_mutations(
         }
 
         let source = std::fs::read(&file_path)?;
-        let (tree, lang) = match crate::parser::parse_file(&changed_file.path, &source) {
-            Ok(result) => result,
-            Err(_) => {
-                eprintln!(
-                    "warning: skipping {} — unsupported language",
-                    changed_file.path.display()
-                );
-                continue;
-            }
-        };
+        let (tree, lang) =
+            match crate::parser::parse_file_with_parser(&mut parser, &changed_file.path, &source) {
+                Ok(result) => result,
+                Err(_) => {
+                    eprintln!(
+                        "warning: skipping {} — unsupported language",
+                        changed_file.path.display()
+                    );
+                    continue;
+                }
+            };
         let language_name = lang.name().to_string();
 
         let nodes = find_mutable_nodes(&tree, &source, &changed_file.hunks, lang.as_ref());

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -139,10 +139,11 @@ pub fn generate_mutations(
         let (tree, lang) =
             match crate::parser::parse_file_with_parser(&mut parser, &changed_file.path, &source) {
                 Ok(result) => result,
-                Err(_) => {
+                Err(err) => {
                     eprintln!(
-                        "warning: skipping {} — unsupported language",
-                        changed_file.path.display()
+                        "warning: skipping {} — {}",
+                        changed_file.path.display(),
+                        err
                     );
                     continue;
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,20 @@ pub fn parse_file(
     Ok((tree, lang))
 }
 
+/// Parse with a reusable parser instance (avoids repeated allocation).
+pub fn parse_file_with_parser(
+    parser: &mut tree_sitter::Parser,
+    path: &Path,
+    source: &[u8],
+) -> Result<(tree_sitter::Tree, Box<dyn LanguageSupport>)> {
+    let lang = detect_language(path)?;
+    parser.set_language(&lang.tree_sitter_language())?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| anyhow!("failed to parse {}", path.display()))?;
+    Ok((tree, lang))
+}
+
 /// Detect language from file extension.
 fn detect_language(path: &Path) -> Result<Box<dyn LanguageSupport>> {
     let ext = path


### PR DESCRIPTION
## Summary

- `overlaps()` now uses `partition_point` (binary search) instead of linear scan — O(log n) vs O(n) per node
- Parser instance reused across files instead of allocating per file

The operator dispatch table (item 1 in #169) is deferred — each operator already returns an empty vec instantly when node kind doesn't match, so the overhead is minimal virtual dispatch. Can revisit if profiling shows it matters.

Partially addresses #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reused parser instances across files to reduce overhead and improve parsing performance
  * Optimized overlap detection for faster range checks and added debug-time assertions to ensure range validity

* **Bug Fixes**
  * Improved parse-time warnings to include actual error text rather than a generic message
<!-- end of auto-generated comment: release notes by coderabbit.ai -->