### PR TITLE
feat: GitHub Actions annotations for survived mutations

### DIFF
--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -1,0 +1,33 @@
+use crate::{MutationReport, MutationResult};
+
+/// Print GitHub Actions workflow annotations for survived mutations.
+/// These show inline on PR diffs.
+pub fn print_report(report: &MutationReport) {
+    for (mutation, result) in &report.results {
+        if *result != MutationResult::Survived {
+            continue;
+        }
+        let file = mutation.file.display();
+        let line = mutation.line;
+        let operator = &mutation.operator;
+        let desc = &mutation.description;
+        println!(
+            "::warning file={},line={}::Survived mutation: {} ({})",
+            file, line, operator, desc
+        );
+    }
+
+    let tested = report.total.saturating_sub(report.build_errors);
+    let score = super::mutation_score(report);
+    eprintln!(
+        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors)",
+        score, report.killed, report.survived, report.timeout, report.build_errors
+    );
+
+    if report.survived > 0 && tested > 0 {
+        eprintln!(
+            "::error::Mutation score {:.1}% — {} mutations survived",
+            score, report.survived
+        );
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,3 +1,4 @@
+pub mod github;
 pub mod html;
 pub mod json;
 pub mod terminal;
@@ -20,6 +21,7 @@ pub fn mutation_score(report: &MutationReport) -> f64 {
 pub fn print_report(report: &crate::MutationReport, format: &str) -> anyhow::Result<()> {
     match format {
         "json" => json::print_report(report)?,
+        "github" => github::print_report(report),
         "html" => {
             let path = std::path::Path::new("togi-report.html");
             html::write_report(report, path)?;


### PR DESCRIPTION
## Summary

- New format: `togi check --format github`
- Emits `::warning file=path,line=N::Survived mutation: operator (desc)` for each survived mutation
- Shows inline on PR diffs in GitHub Actions
- Emits `::error::` summary if any mutations survive

Usage in CI:
```yaml
- run: togi check --format github
```

Closes #185