### PR TITLE
fix: atomic file writes, Windows locking, acquire/release ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -722,6 +722,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -736,7 +737,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1002,7 +1003,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1013,12 +1014,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -722,7 +722,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -737,7 +737,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1014,85 +1014,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ siphasher = "1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ siphasher = "1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -29,7 +29,26 @@ fn try_flock(file: &File) -> bool {
     unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn try_flock(file: &File) -> bool {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+    };
+    unsafe {
+        let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED = std::mem::zeroed();
+        LockFileEx(
+            file.as_raw_handle() as isize,
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut overlapped,
+        ) != 0
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn try_flock(_file: &File) -> bool {
     true
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,6 +10,17 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
+/// Write `data` to `path` atomically: write to a temp file in the same
+/// directory, fsync, then rename over the target.
+fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let dir = path.parent().unwrap_or(Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(data)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path)?;
+    Ok(())
+}
+
 fn to_cached(r: MutationResult) -> CachedResult {
     match r {
         MutationResult::Killed => CachedResult::Killed,
@@ -48,8 +59,12 @@ struct FileGuard {
 
 impl Drop for FileGuard {
     fn drop(&mut self) {
-        if let Err(e) = std::fs::write(&self.path, &self.original) {
-            eprintln!("error: failed to restore {}: {}", self.path.display(), e);
+        if let Err(e) = atomic_write(&self.path, &self.original) {
+            eprintln!(
+                "error: failed to restore {}: {} — file may be corrupted, check git status",
+                self.path.display(),
+                e
+            );
         }
     }
 }
@@ -103,7 +118,7 @@ impl TestRunner {
                 for mutation in file_mutations {
                     // Stop if enough mutations have been tested
                     if let Some(max) = max_tested
-                        && tested_counter.load(Ordering::Relaxed) >= max
+                        && tested_counter.load(Ordering::Acquire) >= max
                     {
                         break;
                     }
@@ -119,7 +134,7 @@ impl TestRunner {
                     {
                         let result = from_cached(cached);
                         if result != MutationResult::BuildError {
-                            tested_counter.fetch_add(1, Ordering::Relaxed);
+                            tested_counter.fetch_add(1, Ordering::Release);
                         }
                         let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
                         if verbose {
@@ -159,7 +174,7 @@ impl TestRunner {
                     }
 
                     if outcome.result != MutationResult::BuildError {
-                        tested_counter.fetch_add(1, Ordering::Relaxed);
+                        tested_counter.fetch_add(1, Ordering::Release);
                     }
                     let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
                     if verbose {
@@ -297,7 +312,7 @@ async fn run_single_mutation(
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
-    if let Err(e) = std::fs::write(&file_path, &mutated) {
+    if let Err(e) = atomic_write(&file_path, &mutated) {
         eprintln!("warning: could not write {}: {e}", file_path.display());
         return MutationOutcome {
             result: MutationResult::BuildError,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,1 +1,2 @@
 mod mutations;
+mod verify;

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -31,12 +31,6 @@ async fn verify_mutation_outcomes_match_independent_replay() {
     let root = fixture_path();
     let calc_path = root.join("calc.go");
 
-    // Disable Go build+test caching so each mutation gets a fresh compile
-    unsafe {
-        std::env::set_var("GOFLAGS", "-count=1");
-        std::env::set_var("GOCACHE", "off");
-    }
-
     let changed = vec![ChangedFile {
         path: PathBuf::from("calc.go"),
         hunks: vec![LineRange { start: 1, end: 32 }],
@@ -44,6 +38,17 @@ async fn verify_mutation_outcomes_match_independent_replay() {
 
     let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0, &[]).unwrap();
     assert!(!mutations.is_empty());
+
+    // Capture pristine fixture before runner.run() touches it
+    let original = std::fs::read(&calc_path).expect("failed to read calc.go");
+
+    // Disable Go build+test caching via env on each spawned process.
+    // togi's runner inherits process env, so these reach `go test`.
+    let go_env = [("GOFLAGS", "-count=1"), ("GOCACHE", "off")];
+    // Set for togi's runner (it spawns child processes that inherit env)
+    for (k, v) in &go_env {
+        unsafe { std::env::set_var(k, v) };
+    }
 
     let runner = togi::runner::TestRunner {
         command: vec!["go".into(), "test".into(), "./...".into()],
@@ -59,7 +64,13 @@ async fn verify_mutation_outcomes_match_independent_replay() {
     };
 
     let report = runner.run(mutations).await;
-    let original = std::fs::read(&calc_path).expect("failed to read calc.go");
+
+    // Verify runner restored the file
+    let after_run = std::fs::read(&calc_path).expect("failed to re-read calc.go");
+    assert_eq!(
+        after_run, original,
+        "runner did not restore calc.go to its original contents"
+    );
 
     let mut verified = 0;
     let mut mismatches = Vec::new();
@@ -70,16 +81,28 @@ async fn verify_mutation_outcomes_match_independent_replay() {
         }
 
         let range = mutation.byte_range.clone();
-        if range.end > original.len() {
-            continue;
-        }
+        assert!(
+            range.start <= range.end && range.end <= original.len(),
+            "mutation {} has invalid byte range {:?} for calc.go (len {})",
+            mutation.id,
+            range,
+            original.len(),
+        );
+        assert_eq!(
+            &original[range.clone()],
+            mutation.original.as_bytes(),
+            "mutation {} byte_range does not match original source bytes",
+            mutation.id,
+        );
 
         let mut mutated = original.clone();
         mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
         std::fs::write(&calc_path, &mutated).expect("failed to write mutated file");
 
+        // Replay with same cache-defeating env
         let output = Command::new("go")
             .args(["test", "./..."])
+            .envs(go_env)
             .current_dir(&root)
             .output()
             .expect("failed to run go test");

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -65,9 +65,7 @@ async fn verify_mutation_outcomes_match_independent_replay() {
     let mut mismatches = Vec::new();
 
     for (mutation, togi_result) in &report.results {
-        if *togi_result == MutationResult::BuildError
-            || *togi_result == MutationResult::Timeout
-        {
+        if *togi_result == MutationResult::BuildError || *togi_result == MutationResult::Timeout {
             continue;
         }
 

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -1,0 +1,120 @@
+//! Mutation verification: replay each mutation independently and confirm
+//! togi's reported outcome matches the actual test result.
+//!
+//! Sets GOCACHE=off because Go's build cache can return stale binaries
+//! when source files change rapidly via atomic rename.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+use togi::{ChangedFile, LineRange, MutationResult};
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/go")
+}
+
+fn classify_result(status: std::process::ExitStatus) -> MutationResult {
+    if status.success() {
+        MutationResult::Survived
+    } else {
+        MutationResult::Killed
+    }
+}
+
+/// Generate mutations, run them via togi, then replay each one independently
+/// and assert the outcomes match.
+///
+/// Requires `go` to be installed. Run with: cargo test -- --ignored
+#[tokio::test]
+#[ignore]
+async fn verify_mutation_outcomes_match_independent_replay() {
+    let root = fixture_path();
+    let calc_path = root.join("calc.go");
+
+    // Disable Go build+test caching so each mutation gets a fresh compile
+    unsafe {
+        std::env::set_var("GOFLAGS", "-count=1");
+        std::env::set_var("GOCACHE", "off");
+    }
+
+    let changed = vec![ChangedFile {
+        path: PathBuf::from("calc.go"),
+        hunks: vec![LineRange { start: 1, end: 32 }],
+    }];
+
+    let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0, &[]).unwrap();
+    assert!(!mutations.is_empty());
+
+    let runner = togi::runner::TestRunner {
+        command: vec!["go".into(), "test".into(), "./...".into()],
+        language_commands: std::collections::HashMap::new(),
+        timeout: Duration::from_secs(30),
+        parallelism: 1,
+        project_root: root.clone(),
+        verbose: false,
+        build_command: vec![],
+        build_command_explicit: false,
+        max_tested: None,
+        show_output: false,
+    };
+
+    let report = runner.run(mutations).await;
+    let original = std::fs::read(&calc_path).expect("failed to read calc.go");
+
+    let mut verified = 0;
+    let mut mismatches = Vec::new();
+
+    for (mutation, togi_result) in &report.results {
+        if *togi_result == MutationResult::BuildError
+            || *togi_result == MutationResult::Timeout
+        {
+            continue;
+        }
+
+        let range = mutation.byte_range.clone();
+        if range.end > original.len() {
+            continue;
+        }
+
+        let mut mutated = original.clone();
+        mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
+        std::fs::write(&calc_path, &mutated).expect("failed to write mutated file");
+
+        let output = Command::new("go")
+            .args(["test", "./..."])
+            .current_dir(&root)
+            .output()
+            .expect("failed to run go test");
+
+        let actual_result = classify_result(output.status);
+        std::fs::write(&calc_path, &original).expect("failed to restore calc.go");
+        verified += 1;
+
+        if actual_result != *togi_result {
+            mismatches.push(format!(
+                "  [{}] {}:{} {} '{}' → '{}': togi={}, actual={}",
+                mutation.id,
+                mutation.file.display(),
+                mutation.line,
+                mutation.operator,
+                mutation.original,
+                mutation.replacement,
+                togi_result,
+                actual_result,
+            ));
+        }
+    }
+
+    std::fs::write(&calc_path, &original).expect("failed to restore calc.go");
+
+    if !mismatches.is_empty() {
+        panic!(
+            "mutation verification failed — {}/{} mismatches:\n{}",
+            mismatches.len(),
+            verified,
+            mismatches.join("\n")
+        );
+    }
+
+    println!("verified {verified} mutations: all outcomes match independent replay");
+}

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -128,6 +128,11 @@ async fn verify_mutation_outcomes_match_independent_replay() {
 
     std::fs::write(&calc_path, &original).expect("failed to restore calc.go");
 
+    assert!(
+        verified > 0,
+        "no mutations were actually compared — all were build errors or timeouts"
+    );
+
     if !mismatches.is_empty() {
         panic!(
             "mutation verification failed — {}/{} mismatches:\n{}",


### PR DESCRIPTION
## Summary
- Atomic writes via temp file + fsync + rename prevents corruption on crash or parallel runs
- Real `LockFileEx` on Windows instead of no-op `true` fallback
- `tested_counter` uses `Acquire`/`Release` ordering to prevent overshooting `--max-tested`

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable file updates via atomic write operations.
  * Clearer error messaging calling out potential file corruption.
  * Added native file-locking on Windows for safer concurrent access.

* **Tests**
  * New (ignored) integration verification test that replays mutations and cross-checks outcomes.

* **Stability**
  * Improved synchronization for mutation counting to strengthen concurrent run robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->