### PR TITLE
fix: validate --format as enum, reject unknown togi.toml fields

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,13 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Terminal,
+    Json,
+    Github,
+    Html,
+}
 
 #[derive(Parser)]
 #[command(name = "togi", version, about = "Fast, diff-targeted mutation testing")]
@@ -31,7 +39,7 @@ pub enum Commands {
 
         /// Output format
         #[arg(short, long, default_value = "terminal")]
-        format: String,
+        format: OutputFormat,
 
         /// Number of parallel jobs
         #[arg(short, long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub test: TestConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ struct CheckConfig {
     paths: Vec<PathBuf>,
     base: Option<String>,
     config_path: Option<PathBuf>,
-    output_format: String,
+    output_format: togi::cli::OutputFormat,
     jobs: Option<usize>,
     timeout: Option<u64>,
     dry_run: bool,
@@ -104,7 +104,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let dry_run = cfg.dry_run;
     let verbose = cfg.verbose;
     let show_output = cfg.show_output;
-    let output_format = cfg.output_format.clone();
+    let output_format = cfg.output_format;
 
     let (mut config, fail_fast, has_explicit_build_cmd) = resolve_config(cfg)?;
     let project_root = get_project_root()?;
@@ -159,7 +159,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     )
     .await;
 
-    togi::report::print_report(&report, &output_format)?;
+    togi::report::print_report(&report, output_format)?;
 
     if report.survived > 0 {
         drop(_lock);

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -18,16 +18,20 @@ pub fn mutation_score(report: &MutationReport) -> f64 {
     }
 }
 
-pub fn print_report(report: &crate::MutationReport, format: &str) -> anyhow::Result<()> {
+pub fn print_report(
+    report: &crate::MutationReport,
+    format: crate::cli::OutputFormat,
+) -> anyhow::Result<()> {
+    use crate::cli::OutputFormat;
     match format {
-        "json" => json::print_report(report)?,
-        "github" => github::print_report(report),
-        "html" => {
+        OutputFormat::Json => json::print_report(report)?,
+        OutputFormat::Github => github::print_report(report),
+        OutputFormat::Html => {
             let path = std::path::Path::new("togi-report.html");
             html::write_report(report, path)?;
             eprintln!("HTML report written to {}", path.display());
         }
-        _ => terminal::print_report(report),
+        OutputFormat::Terminal => terminal::print_report(report),
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `--format` is now a clap `ValueEnum` — typos like `--format=jon` error with possible values instead of silently falling back to terminal
- `Config` uses `#[serde(deny_unknown_fields)]` — typos like `[tets]` in `togi.toml` produce a clear error listing valid sections

Closes #214