### PR TITLE
feat: validate operator names, add list-operators subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,4 +91,6 @@ pub enum Commands {
     Init,
     /// Delete the .togi-cache directory
     Clean,
+    /// List all available mutation operators
+    ListOperators,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ async fn main() {
                 }
             }
         }
+        togi::cli::Commands::ListOperators => {
+            print_operators();
+        }
         togi::cli::Commands::Init => {
             let path = std::path::Path::new("togi.toml");
             if path.exists() {
@@ -95,6 +98,26 @@ async fn main() {
             }
             println!("Created togi.toml (auto-detected from project)");
         }
+    }
+}
+
+fn print_operators() {
+    let ops = togi::operators::all_operators();
+    let mut by_category: std::collections::BTreeMap<&str, Vec<(&str, &str)>> =
+        std::collections::BTreeMap::new();
+    for op in &ops {
+        let cat = togi::operators::operator_category(op.id());
+        by_category
+            .entry(cat)
+            .or_default()
+            .push((op.id(), op.description()));
+    }
+    for (category, ops) in &by_category {
+        println!("{category}:");
+        for (id, desc) in ops {
+            println!("  {id:<30} {desc}");
+        }
+        println!();
     }
 }
 

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -124,7 +124,11 @@ pub fn generate_mutations(
     max_per_file: usize,
     operator_filters: &[String],
 ) -> Result<Vec<Mutation>> {
-    let operators = operators::filter_operators(operators::all_operators(), operator_filters);
+    let all = operators::all_operators();
+    if !operator_filters.is_empty() {
+        operators::validate_patterns(&all, operator_filters).map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    let operators = operators::filter_operators(all, operator_filters);
     let mut mutations = Vec::new();
     let mut next_id: u32 = 0;
     let mut parser = tree_sitter::Parser::new();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -144,6 +144,61 @@ pub fn operator_category(id: &str) -> &str {
     }
 }
 
+/// All known category names.
+const CATEGORIES: &[&str] = &[
+    "binary", "literal", "boundary", "removal", "unary", "negate", "return",
+];
+
+/// Validate that every pattern in `patterns` matches a known operator ID or category.
+/// Returns the first unknown pattern as an error with did-you-mean suggestions.
+pub fn validate_patterns(
+    operators: &[Box<dyn MutationOperator>],
+    patterns: &[String],
+) -> Result<(), String> {
+    let known_ids: Vec<&str> = operators.iter().map(|o| o.id()).collect();
+    for raw in patterns {
+        let trimmed = raw.trim().trim_start_matches('-');
+        if trimmed.is_empty() {
+            continue;
+        }
+        if known_ids.contains(&trimmed) || CATEGORIES.contains(&trimmed) {
+            continue;
+        }
+        let mut candidates: Vec<(&str, usize)> = known_ids
+            .iter()
+            .chain(CATEGORIES.iter())
+            .map(|k| (*k, edit_distance(trimmed, k)))
+            .filter(|(_, d)| *d <= 3)
+            .collect();
+        candidates.sort_by_key(|(_, d)| *d);
+        let suggestion = candidates
+            .first()
+            .map(|(k, _)| format!(" Did you mean '{k}'?"))
+            .unwrap_or_default();
+        return Err(format!(
+            "unknown operator or category '{trimmed}'.{suggestion}"
+        ));
+    }
+    Ok(())
+}
+
+/// Simple Levenshtein distance for did-you-mean suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
 /// Filter operators based on include/exclude patterns.
 /// Patterns can be operator IDs or category names.
 /// Prefix with `-` to exclude. If any non-exclude pattern exists,
@@ -356,5 +411,23 @@ func f() string { return "hello" }"#;
         let ops = filter_operators(stub_ops(), &[" -literal ".into()]);
         assert!(!ids(&ops).contains(&"string_to_empty"));
         assert!(ids(&ops).contains(&"lt_to_lte"));
+    }
+
+    #[test]
+    fn validate_accepts_known_ids_and_categories() {
+        assert!(validate_patterns(&stub_ops(), &["lt_to_lte".into(), "binary".into()]).is_ok());
+        assert!(validate_patterns(&stub_ops(), &["-removal".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_pattern() {
+        let err = validate_patterns(&stub_ops(), &["invalid_name".into()]).unwrap_err();
+        assert!(err.contains("unknown operator or category 'invalid_name'"));
+    }
+
+    #[test]
+    fn validate_suggests_similar_name() {
+        let err = validate_patterns(&stub_ops(), &["litral".into()]).unwrap_err();
+        assert!(err.contains("Did you mean 'literal'?"), "{err}");
     }
 }


### PR DESCRIPTION
## Summary
- `--operators=invalid_name` now errors with did-you-mean suggestions instead of silently producing zero mutations
- `togi list-operators` prints all 24 operators grouped by category with descriptions

```
$ togi check --operators=tru_to_false
Error: unknown operator or category 'tru_to_false'. Did you mean 'true_to_false'?

$ togi list-operators
binary:
  lt_to_lte                      Replace < with <=
  ...
```

Closes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New CLI command to list all available mutation operators organized by category, with IDs and descriptions.
  * Operator filter validation with helpful error messages and suggested corrections for invalid patterns.

* **Bug Fixes**
  * Operator filters are now validated against available operators before being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->