### PR TITLE
feat: LCOV branch coverage parsing + graceful fallback

### DIFF
--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -45,12 +45,25 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
             if let Some(ref file) = current_file {
                 let parts: Vec<&str> = brda.split(',').collect();
                 if parts.len() >= 4 {
-                    if let Ok(line_no) = parts[0].parse::<usize>() {
-                        // taken is "-" for never executed, or a count
-                        let taken = parts[3].trim();
-                        if taken != "-" && taken != "0" {
+                    let Ok(line_no) = parts[0].parse::<usize>() else {
+                        eprintln!(
+                            "warning: malformed BRDA line number at line {} in coverage file: {line}",
+                            line_num + 1
+                        );
+                        continue;
+                    };
+                    let taken = parts[3].trim();
+                    if taken == "-" || taken == "0" {
+                        // Never executed or zero count — not covered
+                    } else if let Ok(count) = taken.parse::<u64>() {
+                        if count > 0 {
                             map.entry(file.clone()).or_default().insert(line_no);
                         }
+                    } else {
+                        eprintln!(
+                            "warning: malformed BRDA taken value at line {} in coverage file: {line}",
+                            line_num + 1
+                        );
                     }
                 } else {
                     eprintln!(

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -29,9 +29,10 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
                 if let (Some(line_str), Some(count_str)) = (parts.next(), parts.next())
                     && let (Ok(line_no), Ok(count)) =
                         (line_str.parse::<usize>(), count_str.parse::<u64>())
-                    && count > 0
                 {
-                    map.entry(file.clone()).or_default().insert(line_no);
+                    if count > 0 {
+                        map.entry(file.clone()).or_default().insert(line_no);
+                    }
                 } else {
                     eprintln!(
                         "warning: malformed DA record at line {} in coverage file: {line}",

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -7,11 +7,14 @@ use std::path::{Path, PathBuf};
 pub type CoverageMap = HashMap<PathBuf, HashSet<usize>>;
 
 /// Parse an LCOV file and return a coverage map with paths relative to `project_root`.
+///
+/// Parses both `DA:` (line coverage) and `BRDA:` (branch coverage) records.
+/// Malformed records are logged as warnings and skipped.
 pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
     let mut map = CoverageMap::new();
     let mut current_file: Option<PathBuf> = None;
 
-    for line in content.lines() {
+    for (line_num, line) in content.lines().enumerate() {
         let line = line.trim();
         if let Some(path_str) = line.strip_prefix("SF:") {
             let abs = PathBuf::from(path_str);
@@ -29,6 +32,30 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
                     && count > 0
                 {
                     map.entry(file.clone()).or_default().insert(line_no);
+                } else {
+                    eprintln!(
+                        "warning: malformed DA record at line {} in coverage file: {line}",
+                        line_num + 1
+                    );
+                }
+            }
+        } else if let Some(brda) = line.strip_prefix("BRDA:") {
+            // BRDA:line,block,branch,taken
+            if let Some(ref file) = current_file {
+                let parts: Vec<&str> = brda.split(',').collect();
+                if parts.len() >= 4 {
+                    if let Ok(line_no) = parts[0].parse::<usize>() {
+                        // taken is "-" for never executed, or a count
+                        let taken = parts[3].trim();
+                        if taken != "-" && taken != "0" {
+                            map.entry(file.clone()).or_default().insert(line_no);
+                        }
+                    }
+                } else {
+                    eprintln!(
+                        "warning: malformed BRDA record at line {} in coverage file: {line}",
+                        line_num + 1
+                    );
                 }
             }
         } else if line == "end_of_record" {
@@ -40,11 +67,14 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
 }
 
 /// Filter mutations to only those on lines present in the coverage map.
+/// Warns about files that have mutations but are missing from coverage data.
 pub fn filter_by_coverage(
     mutations: Vec<crate::Mutation>,
     coverage: &CoverageMap,
     project_root: &Path,
 ) -> Vec<crate::Mutation> {
+    let mut warned_files: HashSet<PathBuf> = HashSet::new();
+
     mutations
         .into_iter()
         .filter(|m| {
@@ -53,9 +83,19 @@ pub fn filter_by_coverage(
                 .strip_prefix(project_root)
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|_| m.file.clone());
-            coverage
-                .get(&rel)
-                .is_some_and(|lines| lines.contains(&m.line))
+            match coverage.get(&rel) {
+                Some(lines) => lines.contains(&m.line),
+                None => {
+                    if warned_files.insert(rel.clone()) {
+                        eprintln!(
+                            "warning: {} has mutations but is missing from coverage data — \
+                             all its mutations will be filtered out",
+                            rel.display()
+                        );
+                    }
+                    false
+                }
+            }
         })
         .collect()
 }
@@ -99,6 +139,39 @@ end_of_record
         let lcov = "SF:src/lib.rs\nDA:5,1\nend_of_record\n";
         let map = parse_lcov(lcov, Path::new("/project"));
         assert!(map.contains_key(Path::new("src/lib.rs")));
+    }
+
+    #[test]
+    fn parse_lcov_brda_covered() {
+        let lcov = "\
+SF:/project/src/main.go
+BRDA:10,0,0,5
+BRDA:10,0,1,0
+BRDA:15,1,0,-
+end_of_record
+";
+        let root = Path::new("/project");
+        let map = parse_lcov(lcov, root);
+        let lines = map.get(Path::new("src/main.go")).unwrap();
+        // Line 10 has a taken branch (count=5)
+        assert!(lines.contains(&10));
+        // Line 15 has only untaken branches ("-")
+        assert!(!lines.contains(&15));
+    }
+
+    #[test]
+    fn parse_lcov_brda_supplements_da() {
+        let lcov = "\
+SF:/project/src/main.go
+DA:10,1
+BRDA:20,0,0,3
+end_of_record
+";
+        let root = Path::new("/project");
+        let map = parse_lcov(lcov, root);
+        let lines = map.get(Path::new("src/main.go")).unwrap();
+        assert!(lines.contains(&10)); // from DA
+        assert!(lines.contains(&20)); // from BRDA
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,23 +317,29 @@ fn filter_mutations(
         } else {
             PathBuf::from(cov_path)
         };
-        let cov_content = std::fs::read_to_string(&resolved_cov_path).map_err(|e| {
-            anyhow::anyhow!(
-                "Could not read coverage file {}: {e}",
-                resolved_cov_path.display()
-            )
-        })?;
-        let coverage = togi::coverage::parse_lcov(&cov_content, project_root);
-        let before = mutations.len();
-        let filtered = togi::coverage::filter_by_coverage(mutations, &coverage, project_root);
-        if before > filtered.len() {
-            eprintln!(
-                "Coverage filter: {} of {} mutations on covered lines",
-                filtered.len(),
-                before
-            );
+        match std::fs::read_to_string(&resolved_cov_path) {
+            Ok(cov_content) => {
+                let coverage = togi::coverage::parse_lcov(&cov_content, project_root);
+                let before = mutations.len();
+                let filtered =
+                    togi::coverage::filter_by_coverage(mutations, &coverage, project_root);
+                if before > filtered.len() {
+                    eprintln!(
+                        "Coverage filter: {} of {} mutations on covered lines",
+                        filtered.len(),
+                        before
+                    );
+                }
+                filtered
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: could not read coverage file {}: {e} — running all mutations",
+                    resolved_cov_path.display()
+                );
+                mutations
+            }
         }
-        filtered
     } else {
         mutations
     };


### PR DESCRIPTION
## Summary
- Parse `BRDA:` records (branch coverage) alongside `DA:` (line coverage)
- Missing coverage file warns and runs all mutations instead of hard error
- Files with mutations but missing from LCOV warn instead of silently dropping
- Malformed `DA:`/`BRDA:` records warn with line number instead of silent skip

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced branch coverage detection so branch data can mark lines as covered.
  * Coverage parsing now logs warnings for malformed coverage records.

* **Bug Fixes**
  * Missing or unreadable coverage files no longer cause failures; processing continues with a warning.
  * Mutations for files absent from coverage are now explicitly filtered out with a per-file warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->