### PR TITLE
refactor: unify result enums, extract CommandConfig, add concurrency test

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,25 +4,15 @@
 //! description, test command hash) so unchanged mutations can be skipped
 //! on subsequent runs. Results are stored as JSON files in `.togi-cache/`.
 
+use crate::MutationResult;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use siphasher::sip::SipHasher;
 
-use serde::{Deserialize, Serialize};
-
 /// Directory where cache entries are stored.
 const CACHE_DIR: &str = ".togi-cache";
-
-/// A cached mutation test result.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CachedResult {
-    Killed,
-    Survived,
-    Timeout,
-    BuildError,
-}
 
 /// Components that form a unique cache key.
 pub struct CacheKey {
@@ -57,7 +47,7 @@ impl CacheKey {
 /// Look up a previously cached result.
 ///
 /// Returns `None` on cache miss or any I/O / deserialization error.
-pub fn lookup(project_root: &Path, key: &CacheKey) -> Option<CachedResult> {
+pub fn lookup(project_root: &Path, key: &CacheKey) -> Option<MutationResult> {
     let path = entry_path(project_root, key);
     let data = fs::read_to_string(path).ok()?;
     serde_json::from_str(&data).ok()
@@ -67,7 +57,7 @@ pub fn lookup(project_root: &Path, key: &CacheKey) -> Option<CachedResult> {
 ///
 /// Creates the cache directory if it doesn't exist. Silently ignores
 /// write errors so cache failures never break the main pipeline.
-pub fn store(project_root: &Path, key: &CacheKey, result: CachedResult) {
+pub fn store(project_root: &Path, key: &CacheKey, result: MutationResult) {
     let path = entry_path(project_root, key);
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -114,8 +104,8 @@ mod tests {
     fn store_and_lookup() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let key = CacheKey::new(b"fn main() {}", "replace + with -", "cargo test");
-        store(tmp.path(), &key, CachedResult::Killed);
-        assert_eq!(lookup(tmp.path(), &key), Some(CachedResult::Killed));
+        store(tmp.path(), &key, MutationResult::Killed);
+        assert_eq!(lookup(tmp.path(), &key), Some(MutationResult::Killed));
     }
 
     #[test]
@@ -130,19 +120,19 @@ mod tests {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let k1 = CacheKey::new(b"v1", "desc", "cmd");
         let k2 = CacheKey::new(b"v2", "desc", "cmd");
-        store(tmp.path(), &k1, CachedResult::Survived);
-        store(tmp.path(), &k2, CachedResult::Killed);
-        assert_eq!(lookup(tmp.path(), &k1), Some(CachedResult::Survived));
-        assert_eq!(lookup(tmp.path(), &k2), Some(CachedResult::Killed));
+        store(tmp.path(), &k1, MutationResult::Survived);
+        store(tmp.path(), &k2, MutationResult::Killed);
+        assert_eq!(lookup(tmp.path(), &k1), Some(MutationResult::Survived));
+        assert_eq!(lookup(tmp.path(), &k2), Some(MutationResult::Killed));
     }
 
     #[test]
     fn clear_removes_cache() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let key = CacheKey::new(b"code", "desc", "cmd");
-        store(tmp.path(), &key, CachedResult::Timeout);
+        store(tmp.path(), &key, MutationResult::Timeout);
         assert!(cache_dir(tmp.path()).exists());
-        clear(tmp.path());
+        let _ = clear(tmp.path());
         assert!(!cache_dir(tmp.path()).exists());
         assert_eq!(lookup(tmp.path(), &key), None);
     }
@@ -151,10 +141,10 @@ mod tests {
     fn all_result_variants_roundtrip() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         for (i, result) in [
-            CachedResult::Killed,
-            CachedResult::Survived,
-            CachedResult::Timeout,
-            CachedResult::BuildError,
+            MutationResult::Killed,
+            MutationResult::Survived,
+            MutationResult::Timeout,
+            MutationResult::BuildError,
         ]
         .iter()
         .enumerate()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct MutationCandidate {
 }
 
 /// Result of running a single mutation
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MutationResult {
     Killed,
     Survived,

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,15 +388,17 @@ async fn execute(
         .collect();
 
     let runner = togi::runner::TestRunner {
-        command: config.test.command,
-        language_commands,
-        build_command: if build_command_explicit {
-            config.test.build_command
-        } else {
-            vec![]
+        commands: togi::runner::CommandConfig {
+            command: config.test.command,
+            language_commands,
+            build_command: if build_command_explicit {
+                config.test.build_command
+            } else {
+                vec![]
+            },
+            build_command_explicit,
+            timeout: Duration::from_secs(config.test.timeout),
         },
-        build_command_explicit,
-        timeout: Duration::from_secs(config.test.timeout),
         parallelism: config.test.jobs,
         project_root,
         verbose,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,6 @@
 // Parallel test execution with timeouts
 
-use crate::cache::{self, CacheKey, CachedResult};
+use crate::cache::{self, CacheKey};
 use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
@@ -21,30 +21,17 @@ fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
-fn to_cached(r: MutationResult) -> CachedResult {
-    match r {
-        MutationResult::Killed => CachedResult::Killed,
-        MutationResult::Survived => CachedResult::Survived,
-        MutationResult::Timeout => CachedResult::Timeout,
-        MutationResult::BuildError => CachedResult::BuildError,
-    }
-}
-
-fn from_cached(r: CachedResult) -> MutationResult {
-    match r {
-        CachedResult::Killed => MutationResult::Killed,
-        CachedResult::Survived => MutationResult::Survived,
-        CachedResult::Timeout => MutationResult::Timeout,
-        CachedResult::BuildError => MutationResult::BuildError,
-    }
-}
-
-pub struct TestRunner {
+/// Command configuration: what to run and how long to wait.
+pub struct CommandConfig {
     pub command: Vec<String>,
     pub language_commands: HashMap<String, Vec<String>>,
     pub build_command: Vec<String>,
     pub build_command_explicit: bool,
     pub timeout: Duration,
+}
+
+pub struct TestRunner {
+    pub commands: CommandConfig,
     pub parallelism: usize,
     pub project_root: PathBuf,
     pub verbose: bool,
@@ -87,7 +74,7 @@ impl TestRunner {
 
         let semaphore = Arc::new(Semaphore::new(self.parallelism));
         let project_root = Arc::new(self.project_root.clone());
-        let build_command = Arc::new(self.build_command.clone());
+        let build_command = Arc::new(self.commands.build_command.clone());
         let mut handles = Vec::new();
 
         for (_file, file_mutations) in by_file {
@@ -97,11 +84,12 @@ impl TestRunner {
                 .map(|m| m.language.as_str())
                 .unwrap_or("");
             let command = self
+                .commands
                 .language_commands
                 .get(language)
-                .unwrap_or(&self.command)
+                .unwrap_or(&self.commands.command)
                 .clone();
-            let timeout = self.timeout;
+            let timeout = self.commands.timeout;
             let project_root = project_root.clone();
             let build_command = build_command.clone();
             let counter = counter.clone();
@@ -132,7 +120,7 @@ impl TestRunner {
                     if let Some(ref key) = cache_key
                         && let Some(cached) = cache::lookup(&project_root, key)
                     {
-                        let result = from_cached(cached);
+                        let result = cached;
                         if result != MutationResult::BuildError {
                             tested_counter.fetch_add(1, Ordering::Release);
                         }
@@ -170,7 +158,7 @@ impl TestRunner {
 
                     // Store result in cache
                     if let Some(ref key) = cache_key {
-                        cache::store(&project_root, key, to_cached(outcome.result));
+                        cache::store(&project_root, key, outcome.result);
                     }
 
                     if outcome.result != MutationResult::BuildError {
@@ -687,11 +675,13 @@ mod tests {
             .collect();
 
         let runner = TestRunner {
-            command: vec!["true".into()],
-            language_commands: HashMap::new(),
-            build_command: vec![],
-            build_command_explicit: false,
-            timeout: Duration::from_secs(5),
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+            },
             parallelism: 1,
             project_root: dir.path().to_path_buf(),
             verbose: false,
@@ -723,11 +713,13 @@ mod tests {
         lang_cmds.insert("killed_lang".into(), vec!["false".into()]);
 
         let runner = TestRunner {
-            command: vec!["true".into()],
-            language_commands: lang_cmds,
-            build_command: vec![],
-            build_command_explicit: false,
-            timeout: Duration::from_secs(5),
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                language_commands: lang_cmds,
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+            },
             parallelism: 2,
             project_root: dir.path().to_path_buf(),
             verbose: false,
@@ -756,11 +748,13 @@ mod tests {
         lang_cmds.insert("go".into(), vec!["false".into()]); // "false" = always fails = killed
 
         let runner = TestRunner {
-            command: vec!["true".into()], // default would survive
-            language_commands: lang_cmds,
-            build_command: vec![],
-            build_command_explicit: false,
-            timeout: Duration::from_secs(5),
+            commands: CommandConfig {
+                command: vec!["true".into()], // default would survive
+                language_commands: lang_cmds,
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+            },
             parallelism: 1,
             project_root: dir.path().to_path_buf(),
             verbose: false,
@@ -770,5 +764,43 @@ mod tests {
 
         let report = runner.run(vec![mutation]).await;
         assert_eq!(report.killed, 1, "should use language-specific command");
+    }
+
+    #[tokio::test]
+    async fn mutations_on_same_file_run_sequentially() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+
+        // Create 3 mutations on the same file
+        let mutations: Vec<Mutation> = (0..3)
+            .map(|i| {
+                let mut m = make_test_mutation(&file);
+                m.id = i;
+                m
+            })
+            .collect();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+            },
+            parallelism: 4, // high parallelism, but same-file should serialize
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+        };
+
+        let report = runner.run(mutations).await;
+        assert_eq!(report.total, 3);
+        // All should succeed — file is restored between each
+        assert_eq!(report.survived, 3);
+        // File should be restored to original
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -766,24 +766,41 @@ mod tests {
         assert_eq!(report.killed, 1, "should use language-specific command");
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn mutations_on_same_file_run_sequentially() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
+        let lock_file = dir.path().join("running.lock");
 
-        // Create 3 mutations on the same file
-        let mutations: Vec<Mutation> = (0..3)
-            .map(|i| {
-                let mut m = make_test_mutation(&file);
-                m.id = i;
-                m
+        // Each mutation has a unique description so cache can't short-circuit
+        let mutations: Vec<Mutation> = (0..5)
+            .map(|i| Mutation {
+                id: i,
+                file: file.clone(),
+                language: String::new(),
+                line: 1,
+                column: 1,
+                operator: "test".into(),
+                description: format!("unique mutation {i}"),
+                original: "hello".into(),
+                replacement: "world".into(),
+                byte_range: 0..5,
             })
             .collect();
 
+        // Command that creates a lock file, sleeps briefly, then removes it.
+        // If two run concurrently on the same file, the second will see
+        // the lock file and fail (exit 1 = killed).
+        let script = format!(
+            "if [ -f {lock} ]; then exit 1; fi; touch {lock}; sleep 0.05; rm {lock}",
+            lock = lock_file.display()
+        );
+
         let runner = TestRunner {
             commands: CommandConfig {
-                command: vec!["true".into()],
+                command: vec!["sh".into(), "-c".into(), script],
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,
@@ -797,10 +814,12 @@ mod tests {
         };
 
         let report = runner.run(mutations).await;
-        assert_eq!(report.total, 3);
-        // All should succeed — file is restored between each
-        assert_eq!(report.survived, 3);
-        // File should be restored to original
+        assert_eq!(report.total, 5);
+        // All should survive — if any were killed, two ran concurrently
+        assert_eq!(
+            report.killed, 0,
+            "mutations on the same file ran concurrently"
+        );
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 }

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -83,16 +83,18 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
     assert!(!mutations.is_empty());
 
     let runner = togi::runner::TestRunner {
-        command: vec!["go".into(), "test".into(), "./...".into()],
-        language_commands: std::collections::HashMap::new(),
-        timeout: Duration::from_secs(30),
+        commands: togi::runner::CommandConfig {
+            command: vec!["go".into(), "test".into(), "./...".into()],
+            language_commands: std::collections::HashMap::new(),
+            build_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(30),
+        },
         parallelism: 1,
         project_root: root,
         verbose: false,
-        build_command: vec![],
-        build_command_explicit: false,
-        max_tested: None,
         show_output: false,
+        max_tested: None,
     };
 
     let report = runner.run(mutations).await;

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -51,16 +51,18 @@ async fn verify_mutation_outcomes_match_independent_replay() {
     }
 
     let runner = togi::runner::TestRunner {
-        command: vec!["go".into(), "test".into(), "./...".into()],
-        language_commands: std::collections::HashMap::new(),
-        timeout: Duration::from_secs(30),
+        commands: togi::runner::CommandConfig {
+            command: vec!["go".into(), "test".into(), "./...".into()],
+            language_commands: std::collections::HashMap::new(),
+            build_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(30),
+        },
         parallelism: 1,
         project_root: root.clone(),
         verbose: false,
-        build_command: vec![],
-        build_command_explicit: false,
-        max_tested: None,
         show_output: false,
+        max_tested: None,
     };
 
     let report = runner.run(mutations).await;


### PR DESCRIPTION
## Summary
- Remove `CachedResult` enum — `MutationResult` now has `Serialize`/`Deserialize` and is used directly in cache, eliminating the isomorphic enum and `to_cached`/`from_cached` conversions
- Extract `CommandConfig` sub-struct from `TestRunner` (command, language_commands, build_command, build_command_explicit, timeout) — reduces field count from 11 to 6
- Add `mutations_on_same_file_run_sequentially` test verifying file serialization works under high parallelism

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized runner configuration into a nested command configuration for cleaner command/timeout handling.
  * Unified caching to use a shared mutation result type across components.
  * Added serialization/deserialization support to core mutation result types.

* **Tests**
  * Updated unit and integration tests to match configuration and cache changes.
  * Added a test ensuring serialized file mutations and correct restoration under concurrent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->