### PR TITLE
refactor: move language-specific fixup into LanguageSupport trait

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -32,6 +32,7 @@ macro_rules! define_language {
         $(, bool_false: [$($bf:expr),* $(,)?])?
         $(, operator_field: $op:expr)?
         $(, skip_subtree_kinds: [$($sk:expr),* $(,)?])?
+        $(, empty_block_replacement: $ebr:expr)?
         $(,)?
     ) => {
         pub struct $struct;
@@ -61,6 +62,7 @@ macro_rules! define_language {
             fn skip_subtree_kinds(&self) -> &[&str] {
                 $crate::languages::define_language!(@arr [$($($sk),*)?] ; [])
             }
+            $crate::languages::define_language!(@fixup $($ebr)?);
         }
     };
     // Helper: return first value if present, otherwise default
@@ -69,6 +71,15 @@ macro_rules! define_language {
     // Helper: return array if non-empty, otherwise default
     (@arr [$($val:expr),+] ; [$($default:expr),*]) => { &[$($val),+] };
     (@arr [] ; [$($default:expr),*]) => { &[$($default),*] };
+    // Helper: override fixup_replacement if empty_block_replacement is set
+    (@fixup $replacement:expr) => {
+        fn fixup_replacement(&self, candidate: &mut $crate::MutationCandidate) {
+            if candidate.operator_id == "remove_if_body" && candidate.replacement == "{}" {
+                candidate.replacement = $replacement.to_string();
+            }
+        }
+    };
+    (@fixup) => {};
 }
 
 pub(crate) use define_language;
@@ -96,6 +107,10 @@ pub trait LanguageSupport: Send + Sync {
     fn should_skip_node(&self, _node: &tree_sitter::Node, _source: &[u8]) -> bool {
         false
     }
+
+    /// Adjust a mutation candidate's replacement for language-specific syntax.
+    /// For example, Python replaces `{}` (empty block) with `pass`.
+    fn fixup_replacement(&self, _candidate: &mut crate::MutationCandidate) {}
 }
 
 /// Returns instances of all supported languages.

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -6,6 +6,7 @@ crate::languages::define_language!(
     binary_expression: "binary_operator",
     bool_true: ["True"],
     bool_false: ["False"],
+    empty_block_replacement: "pass",
 );
 
 #[cfg(test)]

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -6,6 +6,7 @@ crate::languages::define_language!(
     binary_expression: "binary",
     if_statement: "if",
     return_statement: "return",
+    empty_block_replacement: "nil",
 );
 
 #[cfg(test)]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -77,17 +77,6 @@ fn should_skip_string_to_empty(node: &tree_sitter::Node, language: &str) -> bool
     false
 }
 
-/// Adjust replacement text for language-specific syntax.
-fn fixup_replacement(candidate: &mut MutationCandidate, language: &str) {
-    if candidate.operator_id == "remove_if_body" && candidate.replacement == "{}" {
-        match language {
-            "python" => candidate.replacement = "pass".to_string(),
-            "ruby" => candidate.replacement = "nil".to_string(),
-            _ => {}
-        }
-    }
-}
-
 /// Check if a mutation candidate should be filtered out for the given language.
 fn should_filter(candidate: &MutationCandidate, node: &tree_sitter::Node, language: &str) -> bool {
     if candidate.operator_id == "return_empty" {
@@ -165,7 +154,7 @@ pub fn generate_mutations(
                     if should_filter(&candidate, node, &language_name) {
                         continue;
                     }
-                    fixup_replacement(&mut candidate, &language_name);
+                    lang.fixup_replacement(&mut candidate);
 
                     if candidate.byte_range.start > candidate.byte_range.end
                         || candidate.byte_range.end > source.len()


### PR DESCRIPTION
## Summary
- Add `empty_block_replacement` field to `define_language!` macro and `fixup_replacement` method to `LanguageSupport` trait
- Python (`pass`) and Ruby (`nil`) declare their empty-block replacement via the macro instead of a hardcoded match in `mutator.rs`
- Adding a new language that needs custom block replacement is now one macro field, not a code change in mutator.rs

Closes #199