### PR TITLE
feat: deduplicate terminal report, add per-file regression detection

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -55,6 +55,47 @@ pub fn check_regression(current: &Baseline, baseline: &Baseline) -> bool {
     current_ratio < baseline_ratio
 }
 
+/// A per-file regression: file path and the score drop.
+#[derive(Debug)]
+pub struct FileRegression {
+    pub file: String,
+    pub baseline_pct: f64,
+    pub current_pct: f64,
+}
+
+/// Find files where the mutation score dropped compared to the baseline.
+/// Only reports files present in both the current and baseline runs.
+pub fn per_file_regressions(current: &Baseline, baseline: &Baseline) -> Vec<FileRegression> {
+    let mut regressions = Vec::new();
+    for (file, base_score) in &baseline.files {
+        if base_score.total == 0 {
+            continue;
+        }
+        if let Some(cur_score) = current.files.get(file) {
+            if cur_score.total == 0 {
+                continue;
+            }
+            let base_pct = base_score.killed as f64 / base_score.total as f64 * 100.0;
+            let cur_pct = cur_score.killed as f64 / cur_score.total as f64 * 100.0;
+            if cur_pct < base_pct {
+                regressions.push(FileRegression {
+                    file: file.clone(),
+                    baseline_pct: base_pct,
+                    current_pct: cur_pct,
+                });
+            }
+        }
+    }
+    regressions.sort_by(|a, b| {
+        let a_drop = a.baseline_pct - a.current_pct;
+        let b_drop = b.baseline_pct - b.current_pct;
+        b_drop
+            .partial_cmp(&a_drop)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    regressions
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +173,56 @@ mod tests {
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(load_baseline(dir.path()).is_none());
+    }
+
+    fn make_baseline_with_files(files: Vec<(&str, usize, usize)>) -> Baseline {
+        let mut file_map = HashMap::new();
+        let mut total_killed = 0;
+        let mut total_total = 0;
+        for (path, killed, total) in files {
+            total_killed += killed;
+            total_total += total;
+            file_map.insert(path.to_string(), FileScore { killed, total });
+        }
+        Baseline {
+            files: file_map,
+            killed: total_killed,
+            total: total_total,
+        }
+    }
+
+    #[test]
+    fn per_file_regression_detected() {
+        let baseline = make_baseline_with_files(vec![("src/a.rs", 8, 10), ("src/b.rs", 5, 10)]);
+        let current = make_baseline_with_files(vec![("src/a.rs", 6, 10), ("src/b.rs", 5, 10)]);
+        let regs = per_file_regressions(&current, &baseline);
+        assert_eq!(regs.len(), 1);
+        assert_eq!(regs[0].file, "src/a.rs");
+    }
+
+    #[test]
+    fn per_file_no_regression_when_improved() {
+        let baseline = make_baseline_with_files(vec![("src/a.rs", 5, 10)]);
+        let current = make_baseline_with_files(vec![("src/a.rs", 8, 10)]);
+        assert!(per_file_regressions(&current, &baseline).is_empty());
+    }
+
+    #[test]
+    fn per_file_ignores_new_files() {
+        let baseline = make_baseline_with_files(vec![("src/a.rs", 5, 10)]);
+        let current = make_baseline_with_files(vec![("src/a.rs", 5, 10), ("src/new.rs", 0, 5)]);
+        assert!(per_file_regressions(&current, &baseline).is_empty());
+    }
+
+    #[test]
+    fn per_file_sorted_by_largest_drop() {
+        let baseline = make_baseline_with_files(vec![("src/a.rs", 10, 10), ("src/b.rs", 10, 10)]);
+        let current = make_baseline_with_files(vec![
+            ("src/a.rs", 5, 10), // 50% drop
+            ("src/b.rs", 8, 10), // 20% drop
+        ]);
+        let regs = per_file_regressions(&current, &baseline);
+        assert_eq!(regs.len(), 2);
+        assert_eq!(regs[0].file, "src/a.rs"); // largest drop first
     }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -1,97 +1,115 @@
 use crate::{MutationReport, MutationResult};
-#[allow(unused_imports)]
 use colored::Colorize;
+use std::fmt::Write;
 
 pub fn print_report(report: &MutationReport) {
-    println!();
+    print!("{}", format_report(report, true));
+}
+
+pub fn format_report_plain(report: &MutationReport) -> String {
+    format_report(report, false)
+}
+
+fn format_report(report: &MutationReport, color: bool) -> String {
+    let mut out = String::new();
+    writeln!(out).unwrap();
 
     for (mutation, result) in &report.results {
-        let file = mutation.file.display();
+        let file = mutation.file.display().to_string();
         let line = mutation.line;
         let operator = &mutation.operator;
         let desc = &mutation.description;
 
-        match result {
-            MutationResult::Killed => {
-                println!(
-                    "  {} {}:{}  {} {}: {}",
-                    "✓ KILLED".green(),
-                    file,
-                    line,
-                    "—".dimmed(),
-                    operator.dimmed(),
-                    desc
-                );
-            }
+        let (tag, extra) = match result {
+            MutationResult::Killed => ("✓ KILLED", None),
             MutationResult::Survived => {
-                println!(
-                    "  {} {}:{}  {} {}: {}",
-                    "✗ SURVIVED".red(),
-                    file,
-                    line,
-                    "—".dimmed(),
-                    operator.dimmed(),
-                    desc
-                );
-                println!(
+                let mut detail = String::new();
+                writeln!(
+                    detail,
                     "              {}",
-                    "Your tests don't catch this mutation.".red()
-                );
+                    if color {
+                        "Your tests don't catch this mutation.".red().to_string()
+                    } else {
+                        "Your tests don't catch this mutation.".to_string()
+                    }
+                )
+                .unwrap();
                 if let Some(diff) = super::mutation_diff(mutation) {
                     for diff_line in diff.lines() {
-                        if diff_line.starts_with('-') {
-                            println!("              {}", diff_line.red());
-                        } else if diff_line.starts_with('+') {
-                            println!("              {}", diff_line.green());
+                        if color {
+                            if diff_line.starts_with('-') {
+                                writeln!(detail, "              {}", diff_line.red())
+                            } else if diff_line.starts_with('+') {
+                                writeln!(detail, "              {}", diff_line.green())
+                            } else {
+                                writeln!(detail, "              {}", diff_line.dimmed())
+                            }
                         } else {
-                            println!("              {}", diff_line.dimmed());
+                            writeln!(detail, "              {diff_line}")
                         }
+                        .unwrap();
                     }
                 }
+                ("✗ SURVIVED", Some(detail))
             }
-            MutationResult::Timeout => {
-                println!(
-                    "  {} {}:{}  {} {}: {}",
-                    "⏱ TIMEOUT".yellow(),
-                    file,
-                    line,
-                    "—".dimmed(),
-                    operator.dimmed(),
-                    desc
-                );
-            }
-            MutationResult::BuildError => {
-                println!(
-                    "  {} {}:{}  {} {}: {}",
-                    "⚠ BUILD ERROR".yellow(),
-                    file,
-                    line,
-                    "—".dimmed(),
-                    operator.dimmed(),
-                    desc
-                );
-            }
+            MutationResult::Timeout => ("⏱ TIMEOUT", None),
+            MutationResult::BuildError => ("⚠ BUILD ERROR", None),
+        };
+
+        if color {
+            let tag_colored = match result {
+                MutationResult::Killed => tag.green().to_string(),
+                MutationResult::Survived => tag.red().to_string(),
+                MutationResult::Timeout | MutationResult::BuildError => tag.yellow().to_string(),
+            };
+            writeln!(
+                out,
+                "  {} {}:{}  {} {}: {}",
+                tag_colored,
+                file,
+                line,
+                "—".dimmed(),
+                operator.dimmed(),
+                desc
+            )
+        } else {
+            writeln!(
+                out,
+                "  {:<14}{}:{} — {}: {}",
+                tag, file, line, operator, desc
+            )
         }
-        println!();
+        .unwrap();
+
+        if let Some(detail) = extra {
+            write!(out, "{detail}").unwrap();
+        }
+        writeln!(out).unwrap();
     }
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
-    println!("{}", separator);
-    println!(
+    writeln!(out, "{separator}").unwrap();
+    writeln!(
+        out,
         "Results: {} killed, {} survived, {} timeout, {} build errors",
         report.killed, report.survived, report.timeout, report.build_errors
-    );
-    println!(
+    )
+    .unwrap();
+    writeln!(
+        out,
         "Mutation score (test kills only): {:.1}%",
         super::mutation_score(report)
-    );
-    println!("Duration: {:.2}s", report.duration.as_secs_f64());
-    println!("{}", separator);
+    )
+    .unwrap();
+    writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
+    writeln!(out, "{separator}").unwrap();
 
     if let Some(guidance) = all_build_error_guidance(report) {
-        println!();
-        print!("{guidance}");
+        writeln!(out).unwrap();
+        write!(out, "{guidance}").unwrap();
     }
+
+    out
 }
 
 /// Guidance text when every mutation is a build error.
@@ -108,84 +126,6 @@ fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
          \x20 togi check --build-cmd='cargo check'        (custom build check)\n"
             .to_string(),
     )
-}
-
-/// Format report as a plain-text string (no ANSI colors, for testing).
-pub fn format_report_plain(report: &MutationReport) -> String {
-    use std::fmt::Write;
-    let mut out = String::new();
-
-    for (mutation, result) in &report.results {
-        let file = mutation.file.display();
-        let line = mutation.line;
-        let operator = &mutation.operator;
-        let desc = &mutation.description;
-
-        match result {
-            MutationResult::Killed => {
-                writeln!(
-                    out,
-                    "  ✓ KILLED    {}:{} — {}: {}",
-                    file, line, operator, desc
-                )
-                .unwrap();
-            }
-            MutationResult::Survived => {
-                writeln!(
-                    out,
-                    "  ✗ SURVIVED  {}:{} — {}: {}",
-                    file, line, operator, desc
-                )
-                .unwrap();
-                writeln!(out, "              Your tests don't catch this mutation.").unwrap();
-                if let Some(diff) = super::mutation_diff(mutation) {
-                    for diff_line in diff.lines() {
-                        writeln!(out, "              {}", diff_line).unwrap();
-                    }
-                }
-            }
-            MutationResult::Timeout => {
-                writeln!(
-                    out,
-                    "  ⏱ TIMEOUT   {}:{} — {}: {}",
-                    file, line, operator, desc
-                )
-                .unwrap();
-            }
-            MutationResult::BuildError => {
-                writeln!(
-                    out,
-                    "  ⚠ BUILD ERROR {}:{} — {}: {}",
-                    file, line, operator, desc
-                )
-                .unwrap();
-            }
-        }
-    }
-
-    let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
-    writeln!(out, "{}", separator).unwrap();
-    writeln!(
-        out,
-        "Results: {} killed, {} survived, {} timeout, {} build errors",
-        report.killed, report.survived, report.timeout, report.build_errors
-    )
-    .unwrap();
-    writeln!(
-        out,
-        "Mutation score (test kills only): {:.1}%",
-        super::mutation_score(report)
-    )
-    .unwrap();
-    writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
-    writeln!(out, "{}", separator).unwrap();
-
-    if let Some(guidance) = all_build_error_guidance(report) {
-        writeln!(out).unwrap();
-        write!(out, "{guidance}").unwrap();
-    }
-
-    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **Terminal dedup**: `print_report()` and `format_report_plain()` unified into single `format_report(report, color: bool)` — eliminates ~80 lines of near-identical code
- **Per-file regression**: `per_file_regressions()` compares current vs baseline per-file scores and returns files where mutation score dropped, sorted by largest drop first
- HTML report already exists and is complete (file tree, per-file tables, score badges) — no changes needed

Closes #216