### PR TITLE
feat: per-language timeouts in togi.toml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -696,6 +696,33 @@ command = ["pytest"]
     }
 
     #[test]
+    fn parse_per_language_timeout() {
+        let toml_str = r#"
+[test]
+command = ["cargo", "test"]
+
+[test.languages.java]
+command = ["mvn", "test"]
+timeout = 120
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.test.languages["java"].timeout, Some(120));
+    }
+
+    #[test]
+    fn parse_per_language_timeout_absent() {
+        let toml_str = r#"
+[test]
+command = ["cargo", "test"]
+
+[test.languages.go]
+command = ["go", "test", "./..."]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.test.languages["go"].timeout, None);
+    }
+
+    #[test]
     fn command_for_language_resolution() {
         let toml_str = r#"
 [test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,8 @@ pub struct ProjectTestConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct LanguageTestConfig {
     pub command: Vec<String>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,12 +380,16 @@ async fn execute(
     show_output: bool,
     build_command_explicit: bool,
 ) -> MutationReport {
-    let language_commands: std::collections::HashMap<String, Vec<String>> = config
-        .test
-        .languages
-        .into_iter()
-        .map(|(k, v)| (k, v.command))
-        .collect();
+    let mut language_commands: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut language_timeouts: std::collections::HashMap<String, Duration> =
+        std::collections::HashMap::new();
+    for (lang, lang_config) in config.test.languages {
+        language_commands.insert(lang.clone(), lang_config.command);
+        if let Some(t) = lang_config.timeout {
+            language_timeouts.insert(lang, Duration::from_secs(t));
+        }
+    }
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
@@ -398,6 +402,7 @@ async fn execute(
             },
             build_command_explicit,
             timeout: Duration::from_secs(config.test.timeout),
+            language_timeouts,
         },
         parallelism: config.test.jobs,
         project_root,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,6 +28,7 @@ pub struct CommandConfig {
     pub build_command: Vec<String>,
     pub build_command_explicit: bool,
     pub timeout: Duration,
+    pub language_timeouts: HashMap<String, Duration>,
 }
 
 pub struct TestRunner {
@@ -89,7 +90,12 @@ impl TestRunner {
                 .get(language)
                 .unwrap_or(&self.commands.command)
                 .clone();
-            let timeout = self.commands.timeout;
+            let timeout = self
+                .commands
+                .language_timeouts
+                .get(language)
+                .copied()
+                .unwrap_or(self.commands.timeout);
             let project_root = project_root.clone();
             let build_command = build_command.clone();
             let counter = counter.clone();
@@ -681,6 +687,7 @@ mod tests {
                 build_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
             },
             parallelism: 1,
             project_root: dir.path().to_path_buf(),
@@ -719,6 +726,7 @@ mod tests {
                 build_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
             },
             parallelism: 2,
             project_root: dir.path().to_path_buf(),
@@ -754,6 +762,7 @@ mod tests {
                 build_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
             },
             parallelism: 1,
             project_root: dir.path().to_path_buf(),
@@ -805,6 +814,7 @@ mod tests {
                 build_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
             },
             parallelism: 4, // high parallelism, but same-file should serialize
             project_root: dir.path().to_path_buf(),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -105,7 +105,12 @@ impl TestRunner {
 
             let cmd_str = command.join(" ");
             let build_str = build_command.join(" ");
-            let cache_ctx = format!("{};build={}", cmd_str, build_str);
+            let cache_ctx = format!(
+                "{};build={};timeout={}",
+                cmd_str,
+                build_str,
+                timeout.as_secs()
+            );
 
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
@@ -831,5 +836,59 @@ mod tests {
             "mutations on the same file ran concurrently"
         );
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn per_language_timeout_overrides_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+
+        // "slow_lang" gets a 100ms timeout → sleep 1s will timeout
+        // "fast_lang" uses the default 5s → sleep 0.01s will survive
+        let mut language_timeouts = HashMap::new();
+        language_timeouts.insert("slow_lang".into(), Duration::from_millis(100));
+
+        let mut m_slow = make_test_mutation(&file);
+        m_slow.language = "slow_lang".into();
+        m_slow.description = "slow".into();
+
+        let mut m_fast = make_test_mutation(&file);
+        m_fast.id = 2;
+        m_fast.file = dir.path().join("test2.txt");
+        std::fs::write(&m_fast.file, b"hello world").unwrap();
+        m_fast.language = "fast_lang".into();
+        m_fast.description = "fast".into();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["sleep".into(), "1".into()],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts,
+            },
+            parallelism: 2,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+        };
+
+        let report = runner.run(vec![m_slow, m_fast]).await;
+        let slow_result = report
+            .results
+            .iter()
+            .find(|(m, _)| m.description == "slow")
+            .map(|(_, r)| *r);
+        let fast_result = report
+            .results
+            .iter()
+            .find(|(m, _)| m.description == "fast")
+            .map(|(_, r)| *r);
+
+        assert_eq!(slow_result, Some(MutationResult::Timeout));
+        assert_eq!(fast_result, Some(MutationResult::Survived));
     }
 }

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -89,6 +89,7 @@ async fn end_to_end_go_fixture_some_mutations_survive() {
             build_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
+            language_timeouts: std::collections::HashMap::new(),
         },
         parallelism: 1,
         project_root: root,

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -57,6 +57,7 @@ async fn verify_mutation_outcomes_match_independent_replay() {
             build_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
+            language_timeouts: std::collections::HashMap::new(),
         },
         parallelism: 1,
         project_root: root.clone(),


### PR DESCRIPTION
## Summary
- Add optional `timeout` field to `[test.languages.<lang>]` config
- Per-language timeout overrides the global timeout for that language's mutations
- Falls back to global `[test].timeout` when not specified

```toml
[test.languages.java]
command = ["mvn", "test"]
timeout = 120  # JVM startup is slow

[test.languages.go]
command = ["go", "test", "./..."]
timeout = 10   # Go is fast
```

Closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-language timeout configuration: specify optional timeout per language; falls back to the global timeout when omitted.
  * Cache behavior now respects resolved per-language timeouts so results reflect configured time limits.

* **Tests**
  * Tests updated to cover presence/absence of per-language timeouts and timeout-driven outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->