### PR TITLE
feat: wire baseline regression into CLI

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -19,6 +19,36 @@ pub struct Baseline {
     pub total: usize,
 }
 
+/// Build a baseline from a mutation report.
+pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Baseline {
+    let mut files: HashMap<String, FileScore> = HashMap::new();
+    for (mutation, result) in &report.results {
+        let rel = mutation
+            .file
+            .strip_prefix(project_root)
+            .unwrap_or(&mutation.file)
+            .display()
+            .to_string();
+        let entry = files.entry(rel).or_insert(FileScore {
+            killed: 0,
+            total: 0,
+        });
+        if *result != crate::MutationResult::BuildError {
+            entry.total += 1;
+            if *result == crate::MutationResult::Killed {
+                entry.killed += 1;
+            }
+        }
+    }
+    let killed = report.killed;
+    let total = report.total.saturating_sub(report.build_errors);
+    Baseline {
+        files,
+        killed,
+        total,
+    }
+}
+
 /// Persist a baseline snapshot to `.togi-baseline` inside `dir`.
 pub fn save_baseline(baseline: &Baseline, dir: &Path) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(baseline)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,11 +96,11 @@ pub enum Commands {
         shard: Option<String>,
 
         /// Save current results as baseline for future regression checks
-        #[arg(long)]
+        #[arg(long, conflicts_with = "check_baseline")]
         save_baseline: bool,
 
         /// Compare results against saved baseline, exit non-zero on regression
-        #[arg(long)]
+        #[arg(long, conflicts_with = "save_baseline")]
         check_baseline: bool,
     },
     /// Generate a togi.toml config template

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,14 @@ pub enum Commands {
         /// Run only a subset of mutations for parallel CI (e.g. --shard 1/4)
         #[arg(long)]
         shard: Option<String>,
+
+        /// Save current results as baseline for future regression checks
+        #[arg(long)]
+        save_baseline: bool,
+
+        /// Compare results against saved baseline, exit non-zero on regression
+        #[arg(long)]
+        check_baseline: bool,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ struct CheckConfig {
     operators: Option<Vec<String>>,
     fail_under: Option<f64>,
     shard: Option<String>,
+    save_baseline: bool,
+    check_baseline: bool,
 }
 
 #[tokio::main]
@@ -50,6 +52,8 @@ async fn main() {
             operators,
             fail_under,
             shard,
+            save_baseline,
+            check_baseline,
         } => {
             let cfg = CheckConfig {
                 all,
@@ -70,6 +74,8 @@ async fn main() {
                 operators,
                 fail_under,
                 shard,
+                save_baseline,
+                check_baseline,
             };
             if let Err(e) = run_check(cfg).await {
                 eprintln!("Error: {e:#}");
@@ -136,6 +142,8 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let output_format = cfg.output_format;
     let fail_under = cfg.fail_under;
     let shard = cfg.shard.as_deref().map(parse_shard).transpose()?;
+    let save_baseline = cfg.save_baseline;
+    let check_baseline = cfg.check_baseline;
 
     let (mut config, fail_fast, has_explicit_build_cmd) = resolve_config(cfg)?;
     let project_root = get_project_root()?;
@@ -186,6 +194,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
 
     eprintln!("Running {} mutations...", mutations.len());
 
+    let project_root_ref = project_root.clone();
     let report = execute(
         mutations,
         config,
@@ -197,6 +206,32 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     .await;
 
     togi::report::print_report(&report, output_format)?;
+
+    let current = togi::baseline::from_report(&report, &project_root_ref);
+
+    if save_baseline {
+        togi::baseline::save_baseline(&current, &project_root_ref)?;
+        eprintln!("Baseline saved to .togi-baseline");
+    }
+
+    if check_baseline {
+        if let Some(baseline) = togi::baseline::load_baseline(&project_root_ref) {
+            if togi::baseline::check_regression(&current, &baseline) {
+                let regressions = togi::baseline::per_file_regressions(&current, &baseline);
+                eprintln!("Mutation score regression detected!");
+                for r in &regressions {
+                    eprintln!(
+                        "  {} — {:.1}% → {:.1}%",
+                        r.file, r.baseline_pct, r.current_pct
+                    );
+                }
+                drop(_lock);
+                process::exit(1);
+            }
+        } else {
+            eprintln!("warning: no baseline found — use --save-baseline first");
+        }
+    }
 
     let score = togi::report::mutation_score(&report);
     if let Some(threshold) = fail_under {


### PR DESCRIPTION
## Summary
- `--save-baseline` saves current mutation results to `.togi-baseline`
- `--check-baseline` compares against the saved baseline and exits non-zero on regression, printing per-file score drops sorted by largest drop

```bash
# First run: establish baseline
togi check --all --save-baseline

# Future runs: check for regressions
togi check --check-baseline
```

Uses the existing `baseline.rs` code (save/load/check_regression/per_file_regressions) — this PR just wires it into the CLI.

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added baseline regression testing: use --save-baseline to persist current mutation test results for future comparisons.
  * Added --check-baseline to compare current results against a saved baseline, report per-file mutation score changes, warn if no baseline exists, and exit with status 1 when regressions are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->