### PR TITLE
feat: --pr-comment writes markdown summary for CI PR comments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,10 @@ pub enum Commands {
         /// Compare results against saved baseline, exit non-zero on regression
         #[arg(long, conflicts_with = "save_baseline")]
         check_baseline: bool,
+
+        /// Write a PR comment as markdown to a file (e.g. --pr-comment togi-pr-comment.md)
+        #[arg(long)]
+        pr_comment: Option<PathBuf>,
     },
     /// Generate a togi.toml config template
     Init,

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,14 +212,17 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     togi::report::print_report(&report, output_format)?;
 
     let current = togi::baseline::from_report(&report, &project_root_ref);
+    let mut should_fail = false;
 
     if save_baseline {
         togi::baseline::save_baseline(&current, &project_root_ref)?;
         eprintln!("Baseline saved to .togi-baseline");
     }
 
+    let mut baseline_score: Option<f64> = None;
     if check_baseline {
         if let Some(baseline) = togi::baseline::load_baseline(&project_root_ref) {
+            baseline_score = Some(baseline.killed as f64 / baseline.total.max(1) as f64 * 100.0);
             if togi::baseline::check_regression(&current, &baseline) {
                 let regressions = togi::baseline::per_file_regressions(&current, &baseline);
                 eprintln!("Mutation score regression detected!");
@@ -229,8 +232,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
                         r.file, r.baseline_pct, r.current_pct
                     );
                 }
-                drop(_lock);
-                process::exit(1);
+                should_fail = true;
             }
         } else {
             eprintln!("warning: no baseline found — use --save-baseline first");
@@ -238,12 +240,15 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     }
 
     if let Some(ref path) = pr_comment {
-        togi::report::write_pr_comment(&report, path)?;
+        togi::report::write_pr_comment(&report, path, baseline_score)?;
         eprintln!("PR comment written to {}", path.display());
     }
 
     let score = togi::report::mutation_score(&report);
-    if let Some(threshold) = fail_under {
+    if should_fail {
+        drop(_lock);
+        process::exit(1);
+    } else if let Some(threshold) = fail_under {
         if score < threshold {
             eprintln!("Mutation score {score:.1}% is below --fail-under threshold {threshold:.1}%");
             drop(_lock);

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,11 +211,6 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
 
     togi::report::print_report(&report, output_format)?;
 
-    if let Some(ref path) = pr_comment {
-        togi::report::write_pr_comment(&report, path)?;
-        eprintln!("PR comment written to {}", path.display());
-    }
-
     let current = togi::baseline::from_report(&report, &project_root_ref);
 
     if save_baseline {
@@ -240,6 +235,11 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
         } else {
             eprintln!("warning: no baseline found — use --save-baseline first");
         }
+    }
+
+    if let Some(ref path) = pr_comment {
+        togi::report::write_pr_comment(&report, path)?;
+        eprintln!("PR comment written to {}", path.display());
     }
 
     let score = togi::report::mutation_score(&report);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ struct CheckConfig {
     shard: Option<String>,
     save_baseline: bool,
     check_baseline: bool,
+    pr_comment: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -54,6 +55,7 @@ async fn main() {
             shard,
             save_baseline,
             check_baseline,
+            pr_comment,
         } => {
             let cfg = CheckConfig {
                 all,
@@ -76,6 +78,7 @@ async fn main() {
                 shard,
                 save_baseline,
                 check_baseline,
+                pr_comment,
             };
             if let Err(e) = run_check(cfg).await {
                 eprintln!("Error: {e:#}");
@@ -144,6 +147,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     let shard = cfg.shard.as_deref().map(parse_shard).transpose()?;
     let save_baseline = cfg.save_baseline;
     let check_baseline = cfg.check_baseline;
+    let pr_comment = cfg.pr_comment.clone();
 
     let (mut config, fail_fast, has_explicit_build_cmd) = resolve_config(cfg)?;
     let project_root = get_project_root()?;
@@ -206,6 +210,11 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
     .await;
 
     togi::report::print_report(&report, output_format)?;
+
+    if let Some(ref path) = pr_comment {
+        togi::report::write_pr_comment(&report, path)?;
+        eprintln!("PR comment written to {}", path.display());
+    }
 
     let current = togi::baseline::from_report(&report, &project_root_ref);
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -46,7 +46,8 @@ pub fn format_pr_comment(report: &MutationReport) -> String {
 
     let score = mutation_score(report);
     let tested = report.total.saturating_sub(report.build_errors);
-    let emoji = if report.survived == 0 {
+    // Only ✅ when no survived AND no timeouts (timeouts could hide survivors)
+    let emoji = if report.survived == 0 && report.timeout == 0 {
         "\u{2705}" // ✅
     } else if score >= 80.0 {
         "\u{26a0}\u{fe0f}" // ⚠️
@@ -87,10 +88,10 @@ pub fn format_pr_comment(report: &MutationReport) -> String {
             writeln!(
                 md,
                 "| `{}` | {} | `{}` | {} |",
-                m.file.display(),
+                escape_md_cell(&m.file.display().to_string()),
                 m.line,
-                m.operator,
-                m.description
+                escape_md_cell(&m.operator),
+                escape_md_cell(&m.description)
             )
             .unwrap();
         }
@@ -101,8 +102,16 @@ pub fn format_pr_comment(report: &MutationReport) -> String {
     md
 }
 
+/// Escape characters that break markdown table cells.
+fn escape_md_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\n', " ").replace('\r', "")
+}
+
 /// Write a PR comment markdown file.
 pub fn write_pr_comment(report: &MutationReport, path: &std::path::Path) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     let md = format_pr_comment(report);
     fs::write(path, md)?;
     Ok(())

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -46,13 +46,12 @@ pub fn format_pr_comment(report: &MutationReport) -> String {
 
     let score = mutation_score(report);
     let tested = report.total.saturating_sub(report.build_errors);
-    // Only ✅ when no survived AND no timeouts (timeouts could hide survivors)
     let emoji = if report.survived == 0 && report.timeout == 0 {
-        "\u{2705}" // ✅
+        "✓"
     } else if score >= 80.0 {
-        "\u{26a0}\u{fe0f}" // ⚠️
+        "⚠"
     } else {
-        "\u{274c}" // ❌
+        "✗"
     };
 
     let mut md = String::new();
@@ -340,7 +339,7 @@ mod tests {
             build_errors: 0,
         };
         let md = format_pr_comment(&report);
-        assert!(md.contains("✅"));
+        assert!(md.contains("✓"));
         assert!(!md.contains("<details>"));
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -36,6 +36,78 @@ pub fn print_report(
     Ok(())
 }
 
+/// Generate a markdown PR comment summarizing mutation results.
+///
+/// Includes a hidden marker comment so CI pipelines can find/replace
+/// existing togi comments on subsequent runs.
+pub fn format_pr_comment(report: &MutationReport) -> String {
+    use crate::MutationResult;
+    use std::fmt::Write;
+
+    let score = mutation_score(report);
+    let tested = report.total.saturating_sub(report.build_errors);
+    let emoji = if report.survived == 0 {
+        "\u{2705}" // ✅
+    } else if score >= 80.0 {
+        "\u{26a0}\u{fe0f}" // ⚠️
+    } else {
+        "\u{274c}" // ❌
+    };
+
+    let mut md = String::new();
+    writeln!(md, "<!-- togi-mutation-report -->").unwrap();
+    writeln!(md, "## {emoji} togi mutation report").unwrap();
+    writeln!(md).unwrap();
+    writeln!(
+        md,
+        "**{score:.1}%** mutation score — {}/{tested} killed, {} survived, {} timeout, {} build errors — {:.2}s",
+        report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
+    ).unwrap();
+    writeln!(md).unwrap();
+
+    let survived: Vec<_> = report
+        .results
+        .iter()
+        .filter(|(_, r)| *r == MutationResult::Survived)
+        .collect();
+
+    if !survived.is_empty() {
+        writeln!(md, "<details>").unwrap();
+        writeln!(
+            md,
+            "<summary>{} survived mutation{}</summary>",
+            survived.len(),
+            if survived.len() == 1 { "" } else { "s" }
+        )
+        .unwrap();
+        writeln!(md).unwrap();
+        writeln!(md, "| File | Line | Operator | Description |").unwrap();
+        writeln!(md, "|------|------|----------|-------------|").unwrap();
+        for (m, _) in &survived {
+            writeln!(
+                md,
+                "| `{}` | {} | `{}` | {} |",
+                m.file.display(),
+                m.line,
+                m.operator,
+                m.description
+            )
+            .unwrap();
+        }
+        writeln!(md).unwrap();
+        writeln!(md, "</details>").unwrap();
+    }
+
+    md
+}
+
+/// Write a PR comment markdown file.
+pub fn write_pr_comment(report: &MutationReport, path: &std::path::Path) -> anyhow::Result<()> {
+    let md = format_pr_comment(report);
+    fs::write(path, md)?;
+    Ok(())
+}
+
 /// Generate a unified diff snippet for a survived mutation.
 ///
 /// Reads the source file, extracts context around the mutated line,
@@ -212,5 +284,54 @@ mod tests {
         // column 2 (1-indexed) → byte_start 1, which is mid-character
         let m = make_mutation(tmp.path(), "t.rs", content, 1, 2, "x", "y");
         assert!(mutation_diff(&m).is_none());
+    }
+
+    #[test]
+    fn pr_comment_contains_marker_and_score() {
+        let report = crate::test_helpers::sample_report();
+        let md = format_pr_comment(&report);
+        assert!(md.contains("<!-- togi-mutation-report -->"));
+        assert!(md.contains("50.0%"));
+        assert!(md.contains("togi mutation report"));
+    }
+
+    #[test]
+    fn pr_comment_lists_survived_mutations() {
+        let report = crate::test_helpers::sample_report();
+        let md = format_pr_comment(&report);
+        assert!(md.contains("survived mutation"));
+        assert!(md.contains("src/handler.rs"));
+    }
+
+    #[test]
+    fn pr_comment_no_details_when_all_killed() {
+        use crate::{MutationReport, MutationResult};
+        use std::time::Duration;
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 0,
+                    file: std::path::PathBuf::from("test.rs"),
+                    language: "rust".into(),
+                    line: 1,
+                    column: 1,
+                    operator: "op".into(),
+                    description: "d".into(),
+                    original: "x".into(),
+                    replacement: "y".into(),
+                    byte_range: 0..1,
+                },
+                MutationResult::Killed,
+            )],
+            duration: Duration::from_secs(1),
+            total: 1,
+            killed: 1,
+            survived: 0,
+            timeout: 0,
+            build_errors: 0,
+        };
+        let md = format_pr_comment(&report);
+        assert!(md.contains("✅"));
+        assert!(!md.contains("<details>"));
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -40,7 +40,7 @@ pub fn print_report(
 ///
 /// Includes a hidden marker comment so CI pipelines can find/replace
 /// existing togi comments on subsequent runs.
-pub fn format_pr_comment(report: &MutationReport) -> String {
+pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -> String {
     use crate::MutationResult;
     use std::fmt::Write;
 
@@ -58,9 +58,16 @@ pub fn format_pr_comment(report: &MutationReport) -> String {
     writeln!(md, "<!-- togi-mutation-report -->").unwrap();
     writeln!(md, "## {emoji} togi mutation report").unwrap();
     writeln!(md).unwrap();
+    let delta_str = if let Some(base) = baseline_score {
+        let delta = score - base;
+        let sign = if delta >= 0.0 { "+" } else { "" };
+        format!(" ({sign}{delta:.1}% vs baseline)")
+    } else {
+        String::new()
+    };
     writeln!(
         md,
-        "**{score:.1}%** mutation score — {}/{tested} killed, {} survived, {} timeout, {} build errors — {:.2}s",
+        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors — {:.2}s",
         report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
     ).unwrap();
     writeln!(md).unwrap();
@@ -107,11 +114,15 @@ fn escape_md_cell(s: &str) -> String {
 }
 
 /// Write a PR comment markdown file.
-pub fn write_pr_comment(report: &MutationReport, path: &std::path::Path) -> anyhow::Result<()> {
+pub fn write_pr_comment(
+    report: &MutationReport,
+    path: &std::path::Path,
+    baseline_score: Option<f64>,
+) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let md = format_pr_comment(report);
+    let md = format_pr_comment(report, baseline_score);
     fs::write(path, md)?;
     Ok(())
 }
@@ -297,7 +308,7 @@ mod tests {
     #[test]
     fn pr_comment_contains_marker_and_score() {
         let report = crate::test_helpers::sample_report();
-        let md = format_pr_comment(&report);
+        let md = format_pr_comment(&report, None);
         assert!(md.contains("<!-- togi-mutation-report -->"));
         assert!(md.contains("50.0%"));
         assert!(md.contains("togi mutation report"));
@@ -306,7 +317,7 @@ mod tests {
     #[test]
     fn pr_comment_lists_survived_mutations() {
         let report = crate::test_helpers::sample_report();
-        let md = format_pr_comment(&report);
+        let md = format_pr_comment(&report, None);
         assert!(md.contains("survived mutation"));
         assert!(md.contains("src/handler.rs"));
     }
@@ -338,8 +349,49 @@ mod tests {
             timeout: 0,
             build_errors: 0,
         };
-        let md = format_pr_comment(&report);
+        let md = format_pr_comment(&report, None);
         assert!(md.contains("✓"));
         assert!(!md.contains("<details>"));
+    }
+
+    #[test]
+    fn pr_comment_no_checkmark_when_timeouts() {
+        use crate::{MutationReport, MutationResult};
+        use std::time::Duration;
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 0,
+                    file: std::path::PathBuf::from("test.rs"),
+                    language: "rust".into(),
+                    line: 1,
+                    column: 1,
+                    operator: "op".into(),
+                    description: "d".into(),
+                    original: "x".into(),
+                    replacement: "y".into(),
+                    byte_range: 0..1,
+                },
+                MutationResult::Timeout,
+            )],
+            duration: Duration::from_secs(1),
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: 1,
+            build_errors: 0,
+        };
+        let md = format_pr_comment(&report, None);
+        assert!(!md.contains("✓"), "should not show checkmark with timeouts");
+        assert!(md.contains("1 timeout"));
+        assert!(!md.contains("<details>"));
+    }
+
+    #[test]
+    fn pr_comment_includes_baseline_delta() {
+        let report = crate::test_helpers::sample_report();
+        let md = format_pr_comment(&report, Some(40.0));
+        assert!(md.contains("vs baseline"), "should include baseline delta");
+        assert!(md.contains("+10.0%"), "50% - 40% = +10%");
     }
 }


### PR DESCRIPTION
## Summary
`togi check --pr-comment togi-pr-comment.md` writes a markdown summary file that any CI can post as a PR comment.

Provider-agnostic — works with GitHub, GitLab, Azure DevOps, Bitbucket:

```yaml
# GitHub Actions
- run: togi check --pr-comment togi-pr-comment.md
- run: gh pr comment ${{ github.event.pull_request.number }} --body-file togi-pr-comment.md

# GitLab CI
- togi check --pr-comment togi-pr-comment.md
- glab mr note $CI_MERGE_REQUEST_IID --message "$(cat togi-pr-comment.md)"
```

The generated markdown includes:
- Score with emoji (✅ / ⚠️ / ❌)
- Kill/survived/timeout/build-error counts
- Collapsible table of survived mutants with file/line/operator
- Hidden `<!-- togi-mutation-report -->` marker for find/replace on subsequent runs

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional --pr-comment output that writes a markdown PR comment with mutation testing results.
  * Markdown includes a hidden marker, overall score with emoji status, summary counts and duration, optional baseline delta, and an expandable details table when there are survived mutations.
  * Creates parent directories as needed and reports the resolved path when written.

* **Tests**
  * Added tests validating marker/score, survived-mutation details presence/suppression, emoji/check behavior, and baseline delta formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->