### PR TITLE
feat: loop control operators + equivalent mutant detection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,7 +83,7 @@ pub enum Commands {
 
         /// Filter operators: category or id, prefix with - to exclude
         /// e.g. --operators=-string_to_empty,-increment_numeric
-        /// Categories: binary, literal, boundary, removal, unary, negate, return
+        /// Categories: binary, literal, boundary, removal, unary, loop, negate, return
         #[arg(long, value_delimiter = ',')]
         operators: Option<Vec<String>>,
 

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -38,6 +38,13 @@ const MUTABLE_NODE_KINDS: &[&str] = &[
     "assignment",
     "augmented_assignment",
     "augmented_assignment_expression",
+    // Loop control
+    "break_statement",
+    "break_expression", // Rust
+    "break",            // Ruby
+    "continue_statement",
+    "continue_expression", // Rust
+    "next",                // Ruby
 ];
 
 /// Find AST nodes that overlap with changed line ranges and are candidates for mutation.

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -78,12 +78,34 @@ fn should_skip_string_to_empty(node: &tree_sitter::Node, language: &str) -> bool
 }
 
 /// Check if a mutation candidate should be filtered out for the given language.
-fn should_filter(candidate: &MutationCandidate, node: &tree_sitter::Node, language: &str) -> bool {
+fn should_filter(
+    candidate: &MutationCandidate,
+    node: &tree_sitter::Node,
+    source: &[u8],
+    language: &str,
+) -> bool {
     if candidate.operator_id == "return_empty" {
         return should_skip_return_empty(node, language);
     }
     if candidate.operator_id == "string_to_empty" {
         return should_skip_string_to_empty(node, language);
+    }
+    // Skip arithmetic mutations on expressions like `x * 1` or `1 * x`
+    // where one operand is literal 1 — these produce equivalent mutants.
+    if matches!(candidate.operator_id.as_str(), "mul_to_div" | "div_to_mul") {
+        return has_literal_one_operand(node, source);
+    }
+    false
+}
+
+/// Check if a binary expression has a literal `1` operand.
+fn has_literal_one_operand(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        let text = std::str::from_utf8(&source[child.byte_range()]).unwrap_or("");
+        if text == "1" {
+            return true;
+        }
     }
     false
 }
@@ -151,7 +173,7 @@ pub fn generate_mutations(
             for op in &operators {
                 let candidates = op.apply(node, &source);
                 for mut candidate in candidates {
-                    if should_filter(&candidate, node, &language_name) {
+                    if should_filter(&candidate, node, &source, &language_name) {
                         continue;
                     }
                     lang.fixup_replacement(&mut candidate);

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -93,19 +93,20 @@ fn should_filter(
     // Skip arithmetic mutations on expressions like `x * 1` or `1 * x`
     // where one operand is literal 1 — these produce equivalent mutants.
     if matches!(candidate.operator_id.as_str(), "mul_to_div" | "div_to_mul") {
-        return has_literal_one_operand(node, source);
+        return has_rhs_literal_one(node, source);
     }
     false
 }
 
-/// Check if a binary expression has a literal `1` operand.
-fn has_literal_one_operand(node: &tree_sitter::Node, source: &[u8]) -> bool {
+/// Check if a binary expression has literal `1` as its right-hand operand.
+/// `x * 1` → `x / 1` is equivalent, but `1 * x` → `1 / x` is not.
+fn has_rhs_literal_one(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    // The right operand is the last named child of a binary expression
     let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        let text = std::str::from_utf8(&source[child.byte_range()]).unwrap_or("");
-        if text == "1" {
-            return true;
-        }
+    let children: Vec<_> = node.named_children(&mut cursor).collect();
+    if let Some(rhs) = children.last() {
+        let text = std::str::from_utf8(&source[rhs.byte_range()]).unwrap_or("");
+        return text == "1";
     }
     false
 }

--- a/src/operators/loop_control.rs
+++ b/src/operators/loop_control.rs
@@ -1,0 +1,106 @@
+use super::MutationOperator;
+use crate::MutationCandidate;
+
+const BREAK_KINDS: &[&str] = &[
+    "break_statement",
+    "break_expression", // Rust
+    "break",            // Ruby
+];
+
+const CONTINUE_KINDS: &[&str] = &[
+    "continue_statement",
+    "continue_expression", // Rust
+    "next",                // Ruby
+];
+
+pub struct RemoveBreak;
+
+impl MutationOperator for RemoveBreak {
+    fn id(&self) -> &str {
+        "remove_break"
+    }
+    fn description(&self) -> &str {
+        "Remove break statement from loop"
+    }
+    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+        if !BREAK_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        vec![MutationCandidate {
+            byte_range: node.byte_range(),
+            replacement: String::new(),
+            operator_id: self.id().to_string(),
+            description: self.description().to_string(),
+        }]
+    }
+}
+
+pub struct RemoveContinue;
+
+impl MutationOperator for RemoveContinue {
+    fn id(&self) -> &str {
+        "remove_continue"
+    }
+    fn description(&self) -> &str {
+        "Remove continue statement from loop"
+    }
+    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+        if !CONTINUE_KINDS.contains(&node.kind()) {
+            return vec![];
+        }
+        vec![MutationCandidate {
+            byte_range: node.byte_range(),
+            replacement: String::new(),
+            operator_id: self.id().to_string(),
+            description: self.description().to_string(),
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{find_node_by_kind, parse_go};
+
+    #[test]
+    fn test_remove_break() {
+        let src = "package main\nfunc f() { for { break } }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "break_statement")
+            .expect("should find break_statement");
+        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "");
+    }
+
+    #[test]
+    fn test_remove_break_no_match_on_continue() {
+        let src = "package main\nfunc f() { for { continue } }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "continue_statement")
+            .expect("should find continue_statement");
+        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_remove_continue() {
+        let src = "package main\nfunc f() { for i := 0; i < 10; i++ { continue } }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "continue_statement")
+            .expect("should find continue_statement");
+        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, "");
+    }
+
+    #[test]
+    fn test_remove_continue_no_match_on_break() {
+        let src = "package main\nfunc f() { for { break } }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "break_statement")
+            .expect("should find break_statement");
+        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+}

--- a/src/operators/loop_control.rs
+++ b/src/operators/loop_control.rs
@@ -60,10 +60,11 @@ impl MutationOperator for RemoveContinue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{find_node_by_kind, parse_go};
+    use crate::test_helpers::{find_node_by_kind, parse_go, parse_ruby, parse_rust};
 
+    // Go tests
     #[test]
-    fn test_remove_break() {
+    fn test_remove_break_go() {
         let src = "package main\nfunc f() { for { break } }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "break_statement")
@@ -84,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_continue() {
+    fn test_remove_continue_go() {
         let src = "package main\nfunc f() { for i := 0; i < 10; i++ { continue } }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "continue_statement")
@@ -102,5 +103,45 @@ mod tests {
             .expect("should find break_statement");
         let candidates = RemoveContinue.apply(&node, src.as_bytes());
         assert!(candidates.is_empty());
+    }
+
+    // Rust tests
+    #[test]
+    fn test_remove_break_rust() {
+        let src = "fn f() { loop { break; } }";
+        let tree = parse_rust(src);
+        let node = find_node_by_kind(tree.root_node(), "break_expression")
+            .expect("should find break_expression");
+        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+    }
+
+    #[test]
+    fn test_remove_continue_rust() {
+        let src = "fn f() { for i in 0..10 { continue; } }";
+        let tree = parse_rust(src);
+        let node = find_node_by_kind(tree.root_node(), "continue_expression")
+            .expect("should find continue_expression");
+        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+    }
+
+    // Ruby tests
+    #[test]
+    fn test_remove_break_ruby() {
+        let src = "loop do\n  break\nend";
+        let tree = parse_ruby(src);
+        let node = find_node_by_kind(tree.root_node(), "break").expect("should find break");
+        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
+    }
+
+    #[test]
+    fn test_remove_continue_ruby() {
+        let src = "[1,2,3].each do |x|\n  next\nend";
+        let tree = parse_ruby(src);
+        let node = find_node_by_kind(tree.root_node(), "next").expect("should find next");
+        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        assert_eq!(candidates.len(), 1);
     }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,6 +1,7 @@
 pub mod binary;
 pub mod boundary;
 pub mod literal;
+pub mod loop_control;
 pub mod removal;
 pub mod unary;
 
@@ -138,6 +139,7 @@ pub fn operator_category(id: &str) -> &str {
             "removal"
         }
         "remove_unary_not" | "remove_unary_neg" => "unary",
+        "remove_break" | "remove_continue" => "loop",
         "negate_condition" => "negate",
         "return_empty" => "return",
         _ => "other",
@@ -146,7 +148,7 @@ pub fn operator_category(id: &str) -> &str {
 
 /// All known category names.
 const CATEGORIES: &[&str] = &[
-    "binary", "literal", "boundary", "removal", "unary", "negate", "return",
+    "binary", "literal", "boundary", "removal", "unary", "loop", "negate", "return",
 ];
 
 /// Validate that every pattern in `patterns` matches a known operator ID or category.
@@ -268,6 +270,8 @@ pub fn all_operators() -> Vec<Box<dyn MutationOperator>> {
         Box::new(removal::RemoveAssignment),
         Box::new(unary::RemoveUnaryNot),
         Box::new(unary::RemoveUnaryNeg),
+        Box::new(loop_control::RemoveBreak),
+        Box::new(loop_control::RemoveContinue),
         Box::new(NegateCondition),
         Box::new(ReturnEmpty),
     ]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -64,6 +64,22 @@ pub fn parse_typescript(src: &str) -> tree_sitter::Tree {
     parser.parse(src, None).unwrap()
 }
 
+/// Parse Rust source code into a tree-sitter tree.
+pub fn parse_rust(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_rust::LANGUAGE;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
+/// Parse Ruby source code into a tree-sitter tree.
+pub fn parse_ruby(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_ruby::LANGUAGE;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
 /// Recursively find the first node matching `kind` in the tree.
 /// Visits all children (named and anonymous).
 pub fn find_node_by_kind<'a>(


### PR DESCRIPTION
## Summary
**2 new operators:**
- `remove_break` — removes break statements from loops (forces infinite loop → timeout kills it)
- `remove_continue` — removes continue statements from loops (changes iteration behavior)

Both handle cross-language node naming: Go/Python/TS/Java/C/C# `break_statement`/`continue_statement`, Rust `break_expression`/`continue_expression`, Ruby `break`/`next`.

**1 equivalent mutant heuristic:**
- Skip `mul_to_div`/`div_to_mul` when one operand is literal `1` (e.g. `x * 1` → `x / 1` is semantically identical)

26 operators total (up from 24). New `loop` category for `--operators=loop`.

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loop-control mutation operators to remove break/continue and extended support for Rust and Ruby loop-control constructs.
  * Expanded the set of mutable node kinds to include loop-control statements/expressions.

* **Bug Fixes**
  * Improved filtering to avoid generating equivalent arithmetic mutations when the right operand is the literal 1.

* **Documentation**
  * Updated CLI help to list a new "loop" operator category.

* **Tests**
  * Added parsing helpers and tests for Rust, Ruby, and Go scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->