### PR TITLE
chore: harden CI — integration tests, dogfood, release profile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Format
         run: cargo fmt -- --check
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Integration tests
+        run: cargo test -- --ignored
+
   dogfood:
     name: Dogfood (togi on togi)
     runs-on: ubuntu-latest
@@ -51,4 +64,5 @@ jobs:
       - name: Build togi
         run: cargo build --release
       - name: Run togi on last commit
-        run: ./target/release/togi check --base HEAD~1 --test-cmd "cargo test" --format terminal || true
+        continue-on-error: true
+        run: ./target/release/togi check --base HEAD~1 --test-cmd "cargo test" --format terminal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             name: togi-macos-x86_64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: togi-windows-x86_64
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -31,14 +34,21 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
-      - name: Package
+      - name: Package (unix)
+        if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../${{ matrix.name }}.tar.gz togi
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path target/${{ matrix.target }}/release/togi.exe -DestinationPath ${{ matrix.name }}.zip
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
-          path: ${{ matrix.name }}.tar.gz
+          path: |
+            ${{ matrix.name }}.tar.gz
+            ${{ matrix.name }}.zip
 
   release:
     needs: build
@@ -51,5 +61,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: '*.tar.gz'
+          files: |
+            *.tar.gz
+            *.zip
           generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "togi"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.87"
 description = "Fast, diff-targeted, multi-language mutation testing"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Darkroom4364/togi"
@@ -62,6 +63,10 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }
+
+[profile.release]
+lto = "thin"
+strip = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -38,7 +38,7 @@ fn try_flock(file: &File) -> bool {
     unsafe {
         let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED = std::mem::zeroed();
         LockFileEx(
-            file.as_raw_handle() as isize,
+            file.as_raw_handle(),
             LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
             0,
             1,


### PR DESCRIPTION
## Summary
- Add separate `integration` job running `--ignored` tests with Go
- Replace dogfood `|| true` with `continue-on-error: true` for visibility
- Add `rust-version = "1.87"` and `[profile.release]` (thin LTO + strip)
- Add dependabot for cargo and github-actions

Closes #146 (except Windows builds, tracked separately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency update checks
  * Added integration tests to CI pipeline
  * Optimized release builds with Link Time Optimization and symbol stripping
  * Established minimum Rust version requirement (1.87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->