### PR TITLE
fix: security hardening — signals, path traversal, ref validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -214,6 +229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +252,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
 dependencies = [
  "nu-ansi-term",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -406,6 +444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +478,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -700,6 +765,7 @@ dependencies = [
  "bytecount",
  "clap",
  "colored",
+ "ctrlc",
  "diffy",
  "globset",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ shell-words = "1"
 # Error handling
 anyhow = "1"
 
+# Signal handling
+ctrlc = "3"
+
 # Hashing
 siphasher = "1"
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -100,14 +100,32 @@ pub fn collect_changed_since(
     skip_noisy: bool,
     exclude_globs: &[String],
 ) -> anyhow::Result<Vec<ChangedFile>> {
-    // Try as a commit ref first (SHA, branch, tag).
-    let output = Command::new("git")
-        .args(["diff", &format!("{since}..HEAD")])
+    // Validate the ref before using it in git commands to prevent
+    // arbitrary strings from being passed to git diff.
+    let ref_valid = Command::new("git")
+        .args(["rev-parse", "--verify", &format!("{since}^{{commit}}")])
         .current_dir(project_root)
-        .output()?;
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
 
-    let diff_output = if output.status.success() {
-        String::from_utf8(output.stdout)?
+    // Try as a commit ref first (SHA, branch, tag).
+    let output = if ref_valid {
+        let o = Command::new("git")
+            .args(["diff", &format!("{since}..HEAD")])
+            .current_dir(project_root)
+            .output()?;
+        if o.status.success() {
+            Some(String::from_utf8(o.stdout)?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let diff_output = if let Some(diff) = output {
+        diff
     } else {
         // Fall back to date-based: resolve to a baseline commit, then diff.
         let rev_output = Command::new("git")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use togi::{ChangedFile, Mutation, MutationReport};
@@ -31,6 +33,20 @@ struct CheckConfig {
 
 #[tokio::main]
 async fn main() {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancelled_handler = cancelled.clone();
+
+    // First Ctrl+C sets the flag so the runner can stop gracefully.
+    // Second Ctrl+C force-exits for impatient users.
+    ctrlc::set_handler(move || {
+        if cancelled_handler.swap(true, Ordering::SeqCst) {
+            eprintln!("\nForce exit — files may need manual restoration (check git status)");
+            process::exit(130);
+        }
+        eprintln!("\nInterrupted — finishing current mutation and cleaning up...");
+    })
+    .expect("failed to set Ctrl+C handler");
+
     let cli = togi::cli::Cli::parse();
 
     match cli.command {
@@ -80,7 +96,7 @@ async fn main() {
                 check_baseline,
                 pr_comment,
             };
-            if let Err(e) = run_check(cfg).await {
+            if let Err(e) = run_check(cfg, cancelled).await {
                 eprintln!("Error: {e:#}");
                 process::exit(2);
             }
@@ -136,7 +152,7 @@ fn print_operators() {
     }
 }
 
-async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
+async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()> {
     let all = cfg.all;
     let paths = cfg.paths.clone();
     let dry_run = cfg.dry_run;
@@ -206,6 +222,7 @@ async fn run_check(cfg: CheckConfig) -> anyhow::Result<()> {
         verbose,
         show_output,
         has_explicit_build_cmd,
+        cancelled,
     )
     .await;
 
@@ -470,6 +487,7 @@ async fn execute(
     verbose: bool,
     show_output: bool,
     build_command_explicit: bool,
+    cancelled: Arc<AtomicBool>,
 ) -> MutationReport {
     let mut language_commands: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
@@ -505,6 +523,7 @@ async fn execute(
             Some(config.mutations.max_per_run)
         },
         env: std::collections::HashMap::new(),
+        cancelled,
     };
 
     runner.run(mutations).await

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -298,19 +298,41 @@ async fn run_single_mutation(
 
     // Validate the resolved path stays within project_root to prevent
     // path traversal from crafted diffs (e.g. "../../../etc/passwd").
-    if let Ok(canonical) = file_path.canonicalize() {
-        if let Ok(root) = project_root.canonicalize() {
-            if !canonical.starts_with(&root) {
-                eprintln!(
-                    "warning: path traversal blocked: {} escapes project root",
-                    mutation.file.display()
-                );
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
-            }
+    // Fail closed: if canonicalization fails, treat it as an escape.
+    let canonical = match file_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "warning: path traversal blocked: cannot resolve {}: {e}",
+                mutation.file.display()
+            );
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
         }
+    };
+    let root = match project_root.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "warning: path traversal blocked: cannot resolve project root: {e}",
+            );
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
+    };
+    if !canonical.starts_with(&root) {
+        eprintln!(
+            "warning: path traversal blocked: {} escapes project root",
+            mutation.file.display()
+        );
+        return MutationOutcome {
+            result: MutationResult::BuildError,
+            test_output: None,
+        };
     }
 
     // Read original content

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -315,9 +315,7 @@ async fn run_single_mutation(
     let root = match project_root.canonicalize() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!(
-                "warning: path traversal blocked: cannot resolve project root: {e}",
-            );
+            eprintln!("warning: path traversal blocked: cannot resolve project root: {e}");
             return MutationOutcome {
                 result: MutationResult::BuildError,
                 test_output: None,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
@@ -40,6 +40,8 @@ pub struct TestRunner {
     pub max_tested: Option<usize>,
     /// Extra environment variables passed to every spawned command.
     pub env: HashMap<String, String>,
+    /// Set to true externally (e.g. Ctrl+C handler) to stop spawning new mutations.
+    pub cancelled: Arc<AtomicBool>,
 }
 
 struct FileGuard {
@@ -105,6 +107,7 @@ impl TestRunner {
             let max_tested = self.max_tested;
             let show_output = self.show_output;
             let env = self.env.clone();
+            let cancelled = self.cancelled.clone();
 
             let cmd_str = command.join(" ");
             let build_str = build_command.join(" ");
@@ -121,7 +124,10 @@ impl TestRunner {
             let handle = tokio::spawn(async move {
                 let mut results = Vec::new();
                 for mutation in file_mutations {
-                    // Stop if enough mutations have been tested
+                    // Stop if cancelled (Ctrl+C) or enough mutations have been tested
+                    if cancelled.load(Ordering::Relaxed) {
+                        break;
+                    }
                     if let Some(max) = max_tested
                         && tested_counter.load(Ordering::Acquire) >= max
                     {
@@ -289,6 +295,23 @@ async fn run_single_mutation(
     env: &HashMap<String, String>,
 ) -> MutationOutcome {
     let file_path = project_root.join(&mutation.file);
+
+    // Validate the resolved path stays within project_root to prevent
+    // path traversal from crafted diffs (e.g. "../../../etc/passwd").
+    if let Ok(canonical) = file_path.canonicalize() {
+        if let Ok(root) = project_root.canonicalize() {
+            if !canonical.starts_with(&root) {
+                eprintln!(
+                    "warning: path traversal blocked: {} escapes project root",
+                    mutation.file.display()
+                );
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
+            }
+        }
+    }
 
     // Read original content
     let original = match std::fs::read(&file_path) {
@@ -726,6 +749,7 @@ mod tests {
             show_output: false,
             max_tested: Some(2),
             env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         let report = runner.run(mutations).await;
@@ -766,6 +790,7 @@ mod tests {
             show_output: false,
             max_tested: None,
             env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         let report = runner.run(vec![m_survived, m_killed]).await;
@@ -803,6 +828,7 @@ mod tests {
             show_output: false,
             max_tested: None,
             env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         let report = runner.run(vec![mutation]).await;
@@ -856,6 +882,7 @@ mod tests {
             show_output: false,
             max_tested: None,
             env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         let report = runner.run(mutations).await;
@@ -905,6 +932,7 @@ mod tests {
             show_output: false,
             max_tested: None,
             env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
 
         let report = runner.run(vec![m_slow, m_fast]).await;

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -105,6 +105,7 @@ async fn end_to_end_go_fixture_all_killed_with_cache_off() {
         show_output: false,
         max_tested: None,
         env: go_env,
+        cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let report = runner.run(mutations).await;

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -64,6 +64,7 @@ async fn verify_mutation_outcomes_match_independent_replay() {
         show_output: false,
         max_tested: None,
         env: go_env.clone(),
+        cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let report = runner.run(mutations).await;


### PR DESCRIPTION
## Summary
- **Signal handling**: Ctrl+C now sets a cancellation flag checked by the runner each iteration, ensuring FileGuard drops restore files before exit. Second Ctrl+C force-exits with a warning.
- **Path traversal**: `run_single_mutation` validates that resolved file paths stay within `project_root` via `canonicalize` + `starts_with`, blocking crafted diffs from writing outside the repo.
- **Git ref validation**: `collect_changed_since` validates refs with `git rev-parse --verify` before interpolating into diff commands. Invalid refs fall through to the date-based fallback cleanly.
- **FileGuard ordering**: Confirmed already correct (guard created at line 306, write at line 322) — no change needed.

Closes #267

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: run `togi check` and hit Ctrl+C mid-run — verify files restored
- [ ] Manual: verify crafted diff with `../` path is rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+C interruption: first interrupt requests graceful cancellation, second forces immediate exit.

* **Bug Fixes**
  * Improved git reference validation before collecting diffs.
  * Hardened path handling to prevent accessing files outside the project root.

* **Chores**
  * Added a dependency for handling interrupt signals.

* **Tests**
  * Updated integration tests to include explicit cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->