### PR TITLE
chore: group dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      all-cargo:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Groups all Cargo dependency updates into a single weekly PR
- Groups all GitHub Actions updates into a single weekly PR
- Reduces PR noise from one-per-package to two total

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better organize incoming updates for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->