### PR TITLE
test: PR2 registry integrity + clap unit tests (#271)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,3 +114,87 @@ pub enum Commands {
     /// List all available mutation operators
     ListOperators,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn check_all_conflicts_with_base() {
+        let res = Cli::try_parse_from(["togi", "check", "--all", "--base", "main"]);
+        assert!(res.is_err(), "--all and --base should conflict");
+    }
+
+    #[test]
+    fn check_save_baseline_conflicts_with_check_baseline() {
+        let args = ["togi", "check", "--save-baseline", "--check-baseline"];
+        let res = Cli::try_parse_from(args);
+        assert!(res.is_err(), "save/check baseline should conflict");
+    }
+
+    #[test]
+    fn check_path_requires_all() {
+        let res = Cli::try_parse_from(["togi", "check", "--path", "src/"]);
+        assert!(res.is_err(), "--path should require --all");
+    }
+
+    #[test]
+    fn shard_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--shard", "1/3"]).unwrap();
+        match cli.command {
+            Commands::Check { shard, .. } => {
+                assert_eq!(shard.as_deref(), Some("1/3"));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn operators_flag_splits_on_comma() {
+        let args = ["togi", "check", "--operators=binary,literal"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Commands::Check { operators, .. } => {
+                let expected = vec!["binary".to_string(), "literal".to_string()];
+                assert_eq!(operators, Some(expected));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn operators_flag_accepts_negation() {
+        let args = [
+            "togi",
+            "check",
+            "--operators=-string_to_empty,-increment_numeric",
+        ];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Commands::Check { operators, .. } => {
+                let expected = vec![
+                    "-string_to_empty".to_string(),
+                    "-increment_numeric".to_string(),
+                ];
+                assert_eq!(operators, Some(expected));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn validate_patterns_rejects_unknown_operator() {
+        let ops = crate::operators::all_operators();
+        let res = crate::operators::validate_patterns(&ops, &["arith".into()]);
+        let err = res.unwrap_err();
+        assert!(err.contains("unknown operator or category 'arith'"));
+    }
+
+    #[test]
+    fn validate_patterns_accepts_known_categories() {
+        let ops = crate::operators::all_operators();
+        let patterns = vec!["binary".to_string(), "literal".to_string()];
+        assert!(crate::operators::validate_patterns(&ops, &patterns).is_ok());
+    }
+}

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -211,9 +211,28 @@ mod tests {
 
     #[test]
     fn should_skip_qualified_test_attribute() {
-        // e.g. #[tokio::test] / #[test_case::test(...)]
         let rs = Rust;
         let src = b"#[tokio::test]\nasync fn it_runs() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
+        assert!(rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn should_skip_double_colon_test_attribute() {
+        let rs = Rust;
+        let src = b"#[test_case::test(42)]\nfn generated_case() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
+        assert!(rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn should_skip_plain_test_attribute() {
+        let rs = Rust;
+        let src = b"#[test(foo)]\nfn parameterized_case() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
         let func =
             find_first(tree.root_node(), "function_item").expect("function_item should be present");

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -434,4 +434,22 @@ func f() string { return "hello" }"#;
         let err = validate_patterns(&stub_ops(), &["litral".into()]).unwrap_err();
         assert!(err.contains("Did you mean 'literal'?"), "{err}");
     }
+
+    #[test]
+    fn every_operator_has_known_category() {
+        for op in all_operators() {
+            let cat = operator_category(op.id());
+            assert_ne!(
+                cat, "other",
+                "operator '{}' is missing a category in operator_category()",
+                op.id()
+            );
+            assert!(
+                CATEGORIES.contains(&cat),
+                "operator '{}' has unknown category '{}'",
+                op.id(),
+                cat
+            );
+        }
+    }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -451,7 +451,8 @@ func f() string { return "hello" }"#;
         for op in all_operators() {
             let cat = operator_category(op.id());
             assert_ne!(
-                cat, "other",
+                cat,
+                "other",
                 "operator '{}' is missing a category in operator_category()",
                 op.id()
             );

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -436,6 +436,17 @@ func f() string { return "hello" }"#;
     }
 
     #[test]
+    fn all_operator_ids_are_unique() {
+        let ops = all_operators();
+        let unique: std::collections::HashSet<&str> = ops.iter().map(|o| o.id()).collect();
+        assert_eq!(
+            unique.len(),
+            ops.len(),
+            "duplicate operator id in all_operators()"
+        );
+    }
+
+    #[test]
     fn every_operator_has_known_category() {
         for op in all_operators() {
             let cat = operator_category(op.id());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -163,3 +163,68 @@ fn check_invalid_config_exits_two() {
         .code(2)
         .stderr(predicate::str::contains("Error"));
 }
+
+#[test]
+fn clean_removes_cache_dir() {
+    let dir = setup_git_repo();
+    let cache_dir = dir.path().join(".togi-cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::write(cache_dir.join("entry-1"), "{}").unwrap();
+    fs::write(cache_dir.join("entry-2"), "{}").unwrap();
+    assert!(cache_dir.exists());
+
+    togi()
+        .arg("clean")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cache cleared"));
+
+    assert!(!cache_dir.exists(), ".togi-cache should be removed");
+}
+
+#[test]
+fn clean_succeeds_when_cache_missing() {
+    let dir = setup_git_repo();
+    assert!(!dir.path().join(".togi-cache").exists());
+
+    togi()
+        .arg("clean")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cache cleared"));
+}
+
+#[test]
+fn list_operators_prints_known_ids_and_categories() {
+    let output = togi().arg("list-operators").assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    // Known operator IDs (one per category) should appear in output.
+    for id in [
+        "lt_to_lte",        // binary
+        "true_to_false",    // literal
+        "plus_to_minus",    // boundary
+        "remove_if_body",   // removal
+        "remove_unary_not", // unary
+        "remove_break",     // loop
+        "negate_condition", // negate
+        "return_empty",     // return
+    ] {
+        assert!(
+            stdout.contains(id),
+            "expected list-operators output to contain '{id}', got:\n{stdout}"
+        );
+    }
+
+    // All expected category headers should appear.
+    for cat in [
+        "binary:", "literal:", "boundary:", "removal:", "unary:", "loop:", "negate:", "return:",
+    ] {
+        assert!(
+            stdout.contains(cat),
+            "expected list-operators output to contain category '{cat}', got:\n{stdout}"
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -220,7 +220,14 @@ fn list_operators_prints_known_ids_and_categories() {
 
     // All expected category headers should appear.
     for cat in [
-        "binary:", "literal:", "boundary:", "removal:", "unary:", "loop:", "negate:", "return:",
+        "binary:",
+        "literal:",
+        "boundary:",
+        "removal:",
+        "unary:",
+        "loop:",
+        "negate:",
+        "return:",
     ] {
         assert!(
             stdout.contains(cat),


### PR DESCRIPTION
PR2 of #271 (test suite hardening). Pure additions, no production code changes.

## Commits
- `bd51e7a` test: assert every operator has a known category
- `4d38ca0` test: assert all_operators() ids are unique
- `11e4525` test: clap parsing for mutex flags, --shard, --operators
- `5e6b772` test: cover clean and list-operators subcommands

## Note
Local agent could not run cargo (sandbox). Please verify `cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt --check` in CI / locally before merge. Tests were written against the real APIs (operators::all_operators, operator_category, validate_patterns, Cli::try_parse_from, assert_cmd) — see commit diffs.

Refs #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CLI unit tests covering invalid flag combinations, shard/path/operator parsing semantics, and operator pattern validation errors.
  * Added unit tests ensuring operator registry consistency (no duplicate IDs; each maps to an allowed category).
  * Added integration tests for the clean command behavior and operator listing output.
  * Added language-specific unit tests for attribute-based skip logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->