### PR TITLE
test: PR1 critical test correctness fixes (#271)

### DIFF
--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -175,8 +175,8 @@ mod tests {
         let rs = Rust;
         let src = b"#[test]\nfn it_works() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(rs.should_skip_node(&func, src));
     }
 
@@ -194,8 +194,8 @@ mod tests {
         let rs = Rust;
         let src = b"fn add(a: i32, b: i32) -> i32 { a + b }\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(!rs.should_skip_node(&func, src));
     }
 
@@ -204,8 +204,8 @@ mod tests {
         let rs = Rust;
         let src = b"#[inline]\nfn fast() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(!rs.should_skip_node(&func, src));
     }
 
@@ -215,8 +215,8 @@ mod tests {
         let rs = Rust;
         let src = b"#[tokio::test]\nasync fn it_runs() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(rs.should_skip_node(&func, src));
     }
 
@@ -228,8 +228,8 @@ mod tests {
         let rs = Rust;
         let src = b"#[test]\n#[ignore]\nfn skipped() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(rs.should_skip_node(&func, src));
     }
 
@@ -237,8 +237,8 @@ mod tests {
     fn has_attribute_returns_false_when_no_attribute() {
         let src = b"fn lonely() {}\n";
         let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
-        let func = find_first(tree.root_node(), "function_item")
-            .expect("function_item should be present");
+        let func =
+            find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(!has_attribute(&func, src, |a| a == "#[test]"));
     }
 

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -155,4 +155,99 @@ mod tests {
         assert_eq!(rs.if_statement_node(), "if_expression");
         assert_eq!(rs.return_statement_node(), "return_expression");
     }
+
+    /// Find the first node of the given kind in the tree (depth-first).
+    fn find_first<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == kind {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = find_first(child, kind) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn should_skip_test_function() {
+        let rs = Rust;
+        let src = b"#[test]\nfn it_works() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn should_skip_cfg_test_module() {
+        let rs = Rust;
+        let src = b"#[cfg(test)]\nmod tests { fn x() {} }\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let m = find_first(tree.root_node(), "mod_item").expect("mod_item should be present");
+        assert!(rs.should_skip_node(&m, src));
+    }
+
+    #[test]
+    fn should_not_skip_plain_function() {
+        let rs = Rust;
+        let src = b"fn add(a: i32, b: i32) -> i32 { a + b }\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(!rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn should_not_skip_non_test_attributed_function() {
+        let rs = Rust;
+        let src = b"#[inline]\nfn fast() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(!rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn should_skip_qualified_test_attribute() {
+        // e.g. #[tokio::test] / #[test_case::test(...)]
+        let rs = Rust;
+        let src = b"#[tokio::test]\nasync fn it_runs() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn has_attribute_walks_consecutive_attributes() {
+        // Two attributes precede the function; #[test] is the further one.
+        // should_skip_node uses has_attribute under the hood; it must walk
+        // past #[ignore] to find #[test].
+        let rs = Rust;
+        let src = b"#[test]\n#[ignore]\nfn skipped() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn has_attribute_returns_false_when_no_attribute() {
+        let src = b"fn lonely() {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let func = find_first(tree.root_node(), "function_item")
+            .expect("function_item should be present");
+        assert!(!has_attribute(&func, src, |a| a == "#[test]"));
+    }
+
+    #[test]
+    fn has_attribute_normalizes_whitespace() {
+        // Attribute with extra whitespace should still match the normalized form.
+        let src = b"#[ cfg ( test ) ]\nmod m {}\n";
+        let tree = crate::test_helpers::parse_rust(std::str::from_utf8(src).unwrap());
+        let m = find_first(tree.root_node(), "mod_item").expect("mod_item should be present");
+        assert!(has_attribute(&m, src, |a| a == "#[cfg(test)]"));
+    }
 }

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -629,13 +629,14 @@ mod tests {
         }];
 
         let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
-        let ret_mut = mutations.iter().find(|m| m.operator == "return_empty");
-        if let Some(m) = ret_mut {
-            // column should point to "42", not "return"
-            assert_eq!(
-                m.column, 9,
-                "column should point to the value, not the return keyword"
-            );
-        }
+        let m = mutations
+            .iter()
+            .find(|m| m.operator == "return_empty")
+            .expect("return_empty mutation should be generated");
+        // column should point to "42", not "return"
+        assert_eq!(
+            m.column, 9,
+            "column should point to the value, not the return keyword"
+        );
     }
 }

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -618,14 +618,14 @@ mod tests {
     #[test]
     fn mutation_line_col_matches_byte_range() {
         let tmp = TempDir::new().unwrap();
-        // return_empty mutation: the operator targets the value (column 12),
-        // not the return keyword (column 5)
-        let src = "package main\n\nfunc f() int {\n\treturn 42\n}\n";
+        // return_empty mutation: the operator targets the return value,
+        // not the return keyword.
+        let src = "package main\n\nfunc value() int { return 42 }\n\nfunc f() int {\n\treturn value()\n}\n";
         let rel = write_test_file(tmp.path(), "main.go", src);
 
         let changed = vec![ChangedFile {
             path: rel,
-            hunks: vec![LineRange { start: 1, end: 5 }],
+            hunks: vec![LineRange { start: 6, end: 6 }],
         }];
 
         let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -1,20 +1,32 @@
-use crate::{MutationReport, MutationResult};
+use crate::{Mutation, MutationReport, MutationResult};
+
+/// Format a single GitHub Actions warning annotation for a survived mutation.
+fn format_annotation(mutation: &Mutation) -> String {
+    format!(
+        "::warning file={},line={}::Survived mutation: {} ({})",
+        mutation.file.display(),
+        mutation.line,
+        mutation.operator,
+        mutation.description
+    )
+}
+
+/// Collect warning annotations for every survived mutation in `report`,
+/// in the same order they appear in `report.results`.
+fn annotations(report: &MutationReport) -> Vec<String> {
+    report
+        .results
+        .iter()
+        .filter(|(_, r)| *r == MutationResult::Survived)
+        .map(|(m, _)| format_annotation(m))
+        .collect()
+}
 
 /// Print GitHub Actions workflow annotations for survived mutations.
 /// These show inline on PR diffs.
 pub fn print_report(report: &MutationReport) {
-    for (mutation, result) in &report.results {
-        if *result != MutationResult::Survived {
-            continue;
-        }
-        let file = mutation.file.display();
-        let line = mutation.line;
-        let operator = &mutation.operator;
-        let desc = &mutation.description;
-        println!(
-            "::warning file={},line={}::Survived mutation: {} ({})",
-            file, line, operator, desc
-        );
+    for line in annotations(report) {
+        println!("{line}");
     }
 
     let tested = report.total.saturating_sub(report.build_errors);
@@ -28,6 +40,113 @@ pub fn print_report(report: &MutationReport) {
         eprintln!(
             "::error::Mutation score {:.1}% — {} mutations survived",
             score, report.survived
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn mutation(file: &str, line: usize, operator: &str, description: &str) -> Mutation {
+        Mutation {
+            id: 0,
+            file: PathBuf::from(file),
+            language: String::new(),
+            line,
+            column: 1,
+            operator: operator.into(),
+            description: description.into(),
+            original: "x".into(),
+            replacement: "y".into(),
+            byte_range: 0..1,
+        }
+    }
+
+    fn report_with(results: Vec<(Mutation, MutationResult)>) -> MutationReport {
+        let killed = results
+            .iter()
+            .filter(|(_, r)| *r == MutationResult::Killed)
+            .count();
+        let survived = results
+            .iter()
+            .filter(|(_, r)| *r == MutationResult::Survived)
+            .count();
+        MutationReport {
+            total: results.len(),
+            killed,
+            survived,
+            timeout: 0,
+            build_errors: 0,
+            duration: Duration::from_secs(0),
+            results,
+        }
+    }
+
+    #[test]
+    fn annotation_format_for_survived_mutation() {
+        let m = mutation("src/auth.rs", 47, "binary/lt_to_lte", "changed < to <=");
+        let line = format_annotation(&m);
+        assert_eq!(
+            line,
+            "::warning file=src/auth.rs,line=47::Survived mutation: binary/lt_to_lte (changed < to <=)"
+        );
+    }
+
+    #[test]
+    fn killed_mutations_emit_no_annotations() {
+        let report = report_with(vec![(
+            mutation("src/a.rs", 1, "op", "desc"),
+            MutationResult::Killed,
+        )]);
+        assert!(annotations(&report).is_empty());
+    }
+
+    #[test]
+    fn only_survived_mutations_are_annotated() {
+        let report = report_with(vec![
+            (
+                mutation("src/a.rs", 1, "op_a", "killed one"),
+                MutationResult::Killed,
+            ),
+            (
+                mutation("src/b.rs", 2, "op_b", "survived one"),
+                MutationResult::Survived,
+            ),
+            (
+                mutation("src/c.rs", 3, "op_c", "timed out"),
+                MutationResult::Timeout,
+            ),
+        ]);
+        let lines = annotations(&report);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("file=src/b.rs"));
+        assert!(lines[0].contains("op_b"));
+        assert!(lines[0].contains("survived one"));
+    }
+
+    #[test]
+    fn annotation_preserves_special_chars_in_path_and_message() {
+        // Document current behavior: special chars (commas, colons, percent
+        // signs, newlines) are passed through verbatim. GitHub's worker
+        // command parser may misinterpret these — fixing that is a separate
+        // concern from these tests.
+        let m = mutation(
+            "src/odd,name:thing.rs",
+            10,
+            "op",
+            "msg with %, : and , chars",
+        );
+        let line = format_annotation(&m);
+        assert!(
+            line.starts_with("::warning file=src/odd,name:thing.rs,line=10::"),
+            "path passed through verbatim: {line}"
+        );
+        assert!(
+            line.ends_with("Survived mutation: op (msg with %, : and , chars)"),
+            "message passed through verbatim: {line}"
         );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -861,7 +861,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
-        let lock_file = dir.path().join("running.lock");
+        let lock_dir = dir.path().join("running.lock.d");
 
         // Each mutation has a unique description so cache can't short-circuit
         let mutations: Vec<Mutation> = (0..5)
@@ -879,12 +879,16 @@ mod tests {
             })
             .collect();
 
-        // Command that creates a lock file, sleeps briefly, then removes it.
-        // If two run concurrently on the same file, the second will see
-        // the lock file and fail (exit 1 = killed).
+        // Use `mkdir` as the lock — POSIX guarantees it's atomic and fails
+        // with a non-zero exit if the directory already exists. Replaces the
+        // previous `[ -f ] && touch` check, which has a TOCTOU race window.
+        // If sequential execution is honored, every script sees an empty
+        // lock dir, creates it, removes it, and exits 0. If two scripts run
+        // concurrently, exactly one mkdir succeeds and the loser exits 1
+        // (killed) — deterministically, without depending on sleep timing.
         let script = format!(
-            "if [ -f {lock} ]; then exit 1; fi; touch {lock}; sleep 0.05; rm {lock}",
-            lock = lock_file.display()
+            "mkdir {lock} 2>/dev/null || exit 1; rmdir {lock}",
+            lock = lock_dir.display()
         );
 
         let runner = TestRunner {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -481,6 +481,31 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"original");
     }
 
+    #[test]
+    fn file_guard_restores_content_on_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, b"original").unwrap();
+        let path_for_closure = path.clone();
+
+        let result = std::panic::catch_unwind(move || {
+            let _guard = FileGuard {
+                path: path_for_closure.clone(),
+                original: b"original".to_vec(),
+            };
+            std::fs::write(&path_for_closure, b"mutated").unwrap();
+            assert_eq!(std::fs::read(&path_for_closure).unwrap(), b"mutated");
+            panic!("simulated panic mid-mutation");
+        });
+
+        assert!(result.is_err(), "panic should propagate out of catch_unwind");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"original",
+            "FileGuard must restore original content even when unwinding"
+        );
+    }
+
     fn make_test_mutation(file: &std::path::Path) -> Mutation {
         Mutation {
             id: 1,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -498,7 +498,10 @@ mod tests {
             panic!("simulated panic mid-mutation");
         });
 
-        assert!(result.is_err(), "panic should propagate out of catch_unwind");
+        assert!(
+            result.is_err(),
+            "panic should propagate out of catch_unwind"
+        );
         assert_eq!(
             std::fs::read(&path).unwrap(),
             b"original",
@@ -538,7 +541,7 @@ mod tests {
             &["true".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -557,7 +560,7 @@ mod tests {
             &["false".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -592,7 +595,7 @@ mod tests {
             &["true".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -612,7 +615,7 @@ mod tests {
             &["nonexistent_binary_xyz_12345".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -632,7 +635,7 @@ mod tests {
             &["sleep".to_string(), "10".to_string()],
             &[],
             Duration::from_millis(100),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -658,7 +661,7 @@ mod tests {
             ],
             &["false".to_string()], // build fails
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -679,7 +682,7 @@ mod tests {
             &["false".to_string()], // test fails = killed
             &["true".to_string()],  // build succeeds
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -702,7 +705,7 @@ mod tests {
             &["true".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),
@@ -721,7 +724,7 @@ mod tests {
             &["true".to_string()],
             &[],
             Duration::from_secs(5),
-            &dir.path().to_path_buf(),
+            dir.path(),
             &mutation,
             false,
             &HashMap::new(),


### PR DESCRIPTION
PR1 of #271 — surgical fixes to existing tests + small new tests for previously untested paths.

## Commits
- `fa86562` assert `return_empty` mutation is generated (was a swallowed `if let`)
- `dcfc3dc` use atomic `mkdir` lock for sequential-execution check (drops `sleep 0.05` race)
- `13469ba` add `FileGuard` panic-restoration test via `catch_unwind`
- `3bcfaaa` cover GitHub Actions annotation formatter (extracted `format_annotation`)
- `45b8df5` cover Rust `should_skip_node` / `has_attribute`

## Verification
- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`: NOT run by the agent — `cargo` was blocked by the sandbox in this session. Please run locally before merging.

Refs #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added/expanded tests for Rust attribute and test-function detection.
  - Strengthened mutation detection expectations and related test inputs.
  - Added tests ensuring file-restoration on panic and improved concurrent file-access testing.
  - Added validations for CI annotation formatting and correct handling of special characters.

* **Improvements**
  - CI report annotation generation streamlined for consistent, preserved output ordering and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->