### PR TITLE
test: PR3 operator coverage and byte ranges (#271)

### DIFF
--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -83,74 +83,85 @@ mod tests {
 
     use crate::test_helpers::{find_node_by_kind, parse_go};
 
-    #[test]
-    fn test_lt_to_lte() {
-        let src = "package main\nfunc f() bool { return x < y }";
+    fn apply_to_binary(src: &str, op: &dyn MutationOperator) -> Vec<MutationCandidate> {
         let tree = parse_go(src);
         let root = tree.root_node();
         let bin =
             find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = LtToLte.apply(&bin, src.as_bytes());
+        op.apply(&bin, src.as_bytes())
+    }
+
+    fn assert_single_candidate(
+        candidates: &[MutationCandidate],
+        src: &str,
+        replacement: &str,
+        original: &str,
+    ) {
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "<=");
+        assert_eq!(candidates[0].replacement, replacement);
+        assert_eq!(&src[candidates[0].byte_range.clone()], original);
+    }
+
+    #[test]
+    fn test_lt_to_lte() {
+        let src = "package main\nfunc f() bool { return x < y }";
+        let candidates = apply_to_binary(src, &LtToLte);
+        assert_single_candidate(&candidates, src, "<=", "<");
     }
 
     #[test]
     fn test_gt_to_gte() {
         let src = "package main\nfunc f() bool { return x > y }";
-        let tree = parse_go(src);
-        let root = tree.root_node();
-        let bin =
-            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = GtToGte.apply(&bin, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, ">=");
+        let candidates = apply_to_binary(src, &GtToGte);
+        assert_single_candidate(&candidates, src, ">=", ">");
     }
 
     #[test]
     fn test_eq_to_neq() {
         let src = "package main\nfunc f() bool { return x == y }";
-        let tree = parse_go(src);
-        let root = tree.root_node();
-        let bin =
-            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = EqToNeq.apply(&bin, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "!=");
+        let candidates = apply_to_binary(src, &EqToNeq);
+        assert_single_candidate(&candidates, src, "!=", "==");
     }
 
     #[test]
     fn test_and_to_or() {
         let src = "package main\nfunc f() bool { return x && y }";
-        let tree = parse_go(src);
-        let root = tree.root_node();
-        let bin =
-            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = AndToOr.apply(&bin, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "||");
+        let candidates = apply_to_binary(src, &AndToOr);
+        assert_single_candidate(&candidates, src, "||", "&&");
     }
 
     #[test]
     fn test_or_to_and() {
         let src = "package main\nfunc f() bool { return x || y }";
-        let tree = parse_go(src);
-        let root = tree.root_node();
-        let bin =
-            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = OrToAnd.apply(&bin, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "&&");
+        let candidates = apply_to_binary(src, &OrToAnd);
+        assert_single_candidate(&candidates, src, "&&", "||");
+    }
+
+    #[test]
+    fn test_mul_to_div() {
+        let src = "package main\nfunc f() int { return x * y }";
+        let candidates = apply_to_binary(src, &MulToDiv);
+        assert_single_candidate(&candidates, src, "/", "*");
+    }
+
+    #[test]
+    fn test_div_to_mul() {
+        let src = "package main\nfunc f() int { return x / y }";
+        let candidates = apply_to_binary(src, &DivToMul);
+        assert_single_candidate(&candidates, src, "*", "/");
+    }
+
+    #[test]
+    fn test_mod_to_mul() {
+        let src = "package main\nfunc f() int { return x % y }";
+        let candidates = apply_to_binary(src, &ModToMul);
+        assert_single_candidate(&candidates, src, "*", "%");
     }
 
     #[test]
     fn test_no_match() {
         let src = "package main\nfunc f() bool { return x + y }";
-        let tree = parse_go(src);
-        let root = tree.root_node();
-        let bin =
-            find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        let candidates = LtToLte.apply(&bin, src.as_bytes());
+        let candidates = apply_to_binary(src, &LtToLte);
         assert!(candidates.is_empty());
     }
 }

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -187,6 +187,17 @@ mod tests {
 
     use crate::test_helpers::{find_node_by_kind, parse_go};
 
+    fn assert_single_candidate(
+        candidates: &[MutationCandidate],
+        src: &str,
+        replacement: &str,
+        original: &str,
+    ) {
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, replacement);
+        assert_eq!(&src[candidates[0].byte_range.clone()], original);
+    }
+
     fn collect_all_candidates(
         node: tree_sitter::Node,
         source: &[u8],
@@ -206,8 +217,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "true").expect("should find true node");
         let candidates = TrueToFalse.apply(&node, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "false");
+        assert_single_candidate(&candidates, src, "false", "true");
     }
 
     #[test]
@@ -216,8 +226,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "false").expect("should find false node");
         let candidates = FalseToTrue.apply(&node, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "true");
+        assert_single_candidate(&candidates, src, "true", "false");
     }
 
     #[test]
@@ -227,8 +236,7 @@ mod tests {
         let node = find_node_by_kind(tree.root_node(), "int_literal")
             .expect("should find int_literal node");
         let candidates = ZeroToOne.apply(&node, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "1");
+        assert_single_candidate(&candidates, src, "1", "0");
     }
 
     #[test]
@@ -253,5 +261,68 @@ mod tests {
             &mut candidates,
         );
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_string_to_empty_double_quoted() {
+        let src = r#"package main
+func f() string { return "hello" }"#;
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
+            .expect("should find interpreted_string_literal node");
+        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        assert_single_candidate(&candidates, src, r#""""#, r#""hello""#);
+    }
+
+    #[test]
+    fn test_string_to_empty_raw_string() {
+        let src = "package main\nfunc f() string { return `hello` }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "raw_string_literal")
+            .expect("should find raw_string_literal node");
+        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        assert_single_candidate(&candidates, src, "``", "`hello`");
+    }
+
+    #[test]
+    fn test_string_to_empty_skips_empty_string() {
+        let src = r#"package main
+func f() string { return "" }"#;
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
+            .expect("should find interpreted_string_literal node");
+        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_increment_numeric() {
+        let src = "package main\nfunc f() int { return 41 }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "int_literal")
+            .expect("should find int_literal node");
+        let candidates = IncrementNumeric.apply(&node, src.as_bytes());
+        assert_single_candidate(&candidates, src, "42", "41");
+    }
+
+    #[test]
+    fn test_decrement_numeric() {
+        let src = "package main\nfunc f() int { return 41 }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "int_literal")
+            .expect("should find int_literal node");
+        let candidates = DecrementNumeric.apply(&node, src.as_bytes());
+        assert_single_candidate(&candidates, src, "40", "41");
+    }
+
+    #[test]
+    fn numeric_mutators_skip_non_integer_text() {
+        let src = "package main\nfunc f() float64 { return 4.5 }";
+        let tree = parse_go(src);
+        let node = find_node_by_kind(tree.root_node(), "float_literal")
+            .expect("should find float_literal node");
+
+        assert!(IncrementNumeric.apply(&node, src.as_bytes()).is_empty());
+        assert!(DecrementNumeric.apply(&node, src.as_bytes()).is_empty());
     }
 }

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -150,6 +150,17 @@ mod tests {
 
     use crate::test_helpers::{find_node_by_kind, parse_go};
 
+    fn assert_single_candidate(
+        candidates: &[MutationCandidate],
+        src: &str,
+        replacement: &str,
+        original: &str,
+    ) {
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].replacement, replacement);
+        assert_eq!(&src[candidates[0].byte_range.clone()], original);
+    }
+
     #[test]
     fn test_remove_if_body() {
         let src = r#"package main
@@ -157,8 +168,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
         let candidates = RemoveIfBody.apply(&if_node, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "{}");
+        assert_single_candidate(&candidates, src, "{}", r#"{ println("yes") }"#);
     }
 
     #[test]
@@ -167,11 +177,37 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
         let candidates = RemoveElse.apply(&if_node, src.as_bytes());
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].replacement, "");
-        // The byte range should cover the else clause
-        let removed = &src[candidates[0].byte_range.clone()];
-        assert!(removed.contains("else"));
+        assert_single_candidate(&candidates, src, "", "else { return 0 }");
+    }
+
+    #[test]
+    fn test_remove_call_statement() {
+        let src = "package main\nfunc f() { println(\"hi\") }";
+        let tree = parse_go(src);
+        let stmt = find_node_by_kind(tree.root_node(), "expression_statement")
+            .expect("should find expression_statement node");
+        let candidates = RemoveCallStatement.apply(&stmt, src.as_bytes());
+        assert_single_candidate(&candidates, src, "", r#"println("hi")"#);
+    }
+
+    #[test]
+    fn test_remove_call_statement_no_match_on_binary_expression() {
+        let src = "package main\nfunc f() int { return x + y }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+        let candidates = RemoveCallStatement.apply(&bin, src.as_bytes());
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_remove_assignment() {
+        let src = "package main\nfunc f() { x = 1 }";
+        let tree = parse_go(src);
+        let stmt = find_node_by_kind(tree.root_node(), "assignment_statement")
+            .expect("should find assignment_statement node");
+        let candidates = RemoveAssignment.apply(&stmt, src.as_bytes());
+        assert_single_candidate(&candidates, src, "", "x = 1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cover the remaining binary operators: mul_to_div, div_to_mul, mod_to_mul
- cover string_to_empty, increment_numeric, decrement_numeric literal operators
- cover remove_call_statement and remove_assignment, and tighten removal byte-range assertions
- add exact source-span assertions for binary, literal, and removal operator candidates

## Verification
- cargo fmt --check
- cargo test operators -- --nocapture
- cargo test
- cargo clippy --all-targets -- -D warnings

Part of #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test suite for mutation operators with centralized assertion helpers and expanded coverage for binary arithmetic, string/numeric literal, and statement removal operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->