### PR TITLE
test: PR4 skip logic and helper coverage (#271)

### DIFF
--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -12,6 +12,7 @@ crate::languages::define_language!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MutationCandidate;
     use crate::languages::LanguageSupport;
     use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
 
@@ -84,5 +85,35 @@ mod tests {
         );
         assert!(found_return, "Expected return_statement node");
         assert!(found_binary, "Expected binary_operator node");
+    }
+
+    #[test]
+    fn remove_if_body_replacement_uses_pass() {
+        let py = Python;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..2,
+            replacement: "{}".to_string(),
+            operator_id: "remove_if_body".to_string(),
+            description: String::new(),
+        };
+
+        py.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "pass");
+    }
+
+    #[test]
+    fn non_remove_if_body_replacement_is_unchanged() {
+        let py = Python;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..2,
+            replacement: "{}".to_string(),
+            operator_id: "remove_else".to_string(),
+            description: String::new(),
+        };
+
+        py.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "{}");
     }
 }

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -12,6 +12,7 @@ crate::languages::define_language!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MutationCandidate;
     use crate::languages::LanguageSupport;
 
     #[test]
@@ -42,5 +43,35 @@ mod tests {
         let tree = parser.parse(code, None).unwrap();
         let src = tree.root_node().to_sexp();
         assert!(src.contains("binary"));
+    }
+
+    #[test]
+    fn remove_if_body_replacement_uses_nil() {
+        let lang = Ruby;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..2,
+            replacement: "{}".to_string(),
+            operator_id: "remove_if_body".to_string(),
+            description: String::new(),
+        };
+
+        lang.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "nil");
+    }
+
+    #[test]
+    fn non_remove_if_body_replacement_is_unchanged() {
+        let lang = Ruby;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..2,
+            replacement: "{}".to_string(),
+            operator_id: "remove_else".to_string(),
+            description: String::new(),
+        };
+
+        lang.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "{}");
     }
 }

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -294,6 +294,7 @@ fn sample_diverse(mutations: Vec<Mutation>, cap: usize) -> Vec<Mutation> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python, parse_rust};
     use crate::{ChangedFile, LineRange};
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -303,6 +304,232 @@ mod tests {
         std::fs::create_dir_all(full.parent().unwrap()).unwrap();
         std::fs::write(&full, content).unwrap();
         PathBuf::from(rel_path)
+    }
+
+    fn candidate(operator_id: &str) -> MutationCandidate {
+        MutationCandidate {
+            byte_range: 0..1,
+            replacement: String::new(),
+            operator_id: operator_id.to_string(),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_rust_const_context() {
+        let src = r#"const NAME: &str = "togi";"#;
+        let tree = parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(should_skip_string_to_empty(&string, "rust"));
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_rust_static_context() {
+        let src = r#"static NAME: &str = "togi";"#;
+        let tree = parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(should_skip_string_to_empty(&string, "rust"));
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_rust_match_arm() {
+        let src = r#"fn label(x: i32) -> &'static str {
+    match x {
+        0 => "zero",
+        _ => "other",
+    }
+}"#;
+        let tree = parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(should_skip_string_to_empty(&string, "rust"));
+    }
+
+    #[test]
+    fn string_to_empty_allowed_inside_function_body() {
+        let src = r#"package main
+func f() string {
+	return "hello"
+}"#;
+        let tree = parse_go(src);
+        let string = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
+            .expect("should find interpreted_string_literal node");
+
+        assert!(!should_skip_string_to_empty(&string, "go"));
+    }
+
+    #[test]
+    fn string_to_empty_not_skipped_for_dynamic_languages() {
+        let src = r#"NAME = "togi""#;
+        let tree = parse_python(src);
+        let string =
+            find_node_by_kind(tree.root_node(), "string").expect("should find string node");
+
+        assert!(!should_skip_string_to_empty(&string, "python"));
+    }
+
+    #[test]
+    fn rhs_literal_one_detects_right_hand_one_only() {
+        let src = "package main\nfunc f(x int) int { return x * 1 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn rhs_literal_one_ignores_left_hand_one() {
+        let src = "package main\nfunc f(x int) int { return 1 * x }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn rhs_literal_one_ignores_other_literals() {
+        let src = "package main\nfunc f(x int) int { return x * 2 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn mul_to_div_filter_skips_right_hand_one() {
+        let src = "package main\nfunc f(x int) int { return x * 1 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(should_filter(
+            &candidate("mul_to_div"),
+            &bin,
+            src.as_bytes(),
+            "go"
+        ));
+    }
+
+    #[test]
+    fn mul_to_div_filter_allows_left_hand_one() {
+        let src = "package main\nfunc f(x int) int { return 1 * x }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(!should_filter(
+            &candidate("mul_to_div"),
+            &bin,
+            src.as_bytes(),
+            "go"
+        ));
+    }
+
+    #[test]
+    fn div_to_mul_filter_skips_right_hand_one() {
+        let src = "package main\nfunc f(x int) int { return x / 1 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(should_filter(
+            &candidate("div_to_mul"),
+            &bin,
+            src.as_bytes(),
+            "go"
+        ));
+    }
+
+    #[test]
+    fn string_to_empty_absent_for_go_const_declaration() {
+        let tmp = TempDir::new().unwrap();
+        let src = "package main\n\nconst name = \"togi\"\n";
+        let rel = write_test_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 3, end: 3 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["string_to_empty".into()]).unwrap();
+
+        assert!(
+            mutations.is_empty(),
+            "string_to_empty should be skipped for const declarations, got: {:?}",
+            mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn string_to_empty_present_for_go_function_body() {
+        let tmp = TempDir::new().unwrap();
+        let src = "package main\n\nfunc f() string {\n\treturn \"togi\"\n}\n";
+        let rel = write_test_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 4, end: 4 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["string_to_empty".into()]).unwrap();
+
+        assert!(
+            mutations.iter().any(|m| m.operator == "string_to_empty"),
+            "string_to_empty should be allowed in function bodies, got: {:?}",
+            mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn python_remove_if_body_uses_pass_replacement() {
+        let tmp = TempDir::new().unwrap();
+        let src = "def f(x):\n    if x:\n        return 1\n    return 0\n";
+        let rel = write_test_file(tmp.path(), "test.py", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 2, end: 2 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["remove_if_body".into()]).unwrap();
+        let m = mutations
+            .iter()
+            .find(|m| m.operator == "remove_if_body")
+            .expect("remove_if_body mutation should be generated");
+
+        assert_eq!(m.replacement, "pass");
+    }
+
+    #[test]
+    fn ruby_remove_if_body_uses_nil_replacement() {
+        let tmp = TempDir::new().unwrap();
+        let src = "def f(x)\n  if x\n    1\n  end\nend\n";
+        let rel = write_test_file(tmp.path(), "test.rb", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 2, end: 2 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["remove_if_body".into()]).unwrap();
+        let m = mutations
+            .iter()
+            .find(|m| m.operator == "remove_if_body")
+            .expect("remove_if_body mutation should be generated");
+
+        assert_eq!(m.replacement, "nil");
     }
 
     #[test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -56,6 +56,14 @@ pub fn parse_go(src: &str) -> tree_sitter::Tree {
     parser.parse(src, None).unwrap()
 }
 
+/// Parse Python source code into a tree-sitter tree.
+pub fn parse_python(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    let lang = tree_sitter_python::LANGUAGE;
+    parser.set_language(&lang.into()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
 /// Parse TypeScript source code into a tree-sitter tree.
 pub fn parse_typescript(src: &str) -> tree_sitter::Tree {
     let mut parser = tree_sitter::Parser::new();


### PR DESCRIPTION
## Summary
- cover string_to_empty skip helper branches for const/static/match contexts and allowed function-body strings
- cover arithmetic RHS-literal-one helper and filter behavior for mul_to_div/div_to_mul
- cover Python and Ruby remove_if_body language replacement fixups directly and through generate_mutations
- add parse_python test helper for shared parser-based tests

## Verification
- cargo fmt --check
- cargo test mutator::tests
- cargo test languages::python::tests
- cargo test languages::ruby::tests
- cargo test
- cargo clippy --all-targets -- -D warnings

Part of #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests validating mutation operator behavior across multiple languages.
  * Added tests verifying language-specific filtering and skip logic.
  * Enhanced test infrastructure with new parsing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->