### PR TITLE
test: PR7 prune redundant assertions (#271)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -472,10 +472,18 @@ max_per_run = 50
         let config: Config = toml::from_str("").unwrap();
         // Command is empty sentinel when not explicitly configured
         assert!(config.test.command.is_empty());
+        assert!(config.test.build_command.is_empty());
+        assert!(config.test.languages.is_empty());
         assert_eq!(config.test.timeout, 30);
         assert!(config.test.jobs >= 1);
         assert_eq!(config.diff.base, "origin/main");
         assert_eq!(config.mutations.max_per_run, 20);
+        assert_eq!(config.mutations.max_per_file, 20);
+        assert!(config.mutations.operators.is_empty());
+        assert!(config.mutations.coverage_file.is_none());
+        assert!(config.mutations.exclude_paths.is_empty());
+        assert!(config.mutations.skip_noisy_files);
+        assert!(config.projects.is_empty());
     }
 
     #[test]
@@ -632,12 +640,6 @@ coverage_file = "coverage.lcov"
     }
 
     #[test]
-    fn coverage_file_defaults_to_none() {
-        let config: Config = toml::from_str("").unwrap();
-        assert!(config.mutations.coverage_file.is_none());
-    }
-
-    #[test]
     fn detect_cmake() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("CMakeLists.txt"), "").unwrap();
@@ -663,16 +665,6 @@ coverage_file = "coverage.lcov"
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("pom.xml"), "").unwrap();
         assert_eq!(detect_test_command(dir.path()), vec!["mvn", "test"]);
-    }
-
-    #[test]
-    fn default_max_per_run_is_20() {
-        assert_eq!(default_max_per_run(), 20);
-    }
-
-    #[test]
-    fn default_timeout_is_30() {
-        assert_eq!(default_timeout(), 30);
     }
 
     #[test]
@@ -837,12 +829,6 @@ path = "services/api"
     }
 
     #[test]
-    fn no_projects_by_default() {
-        let config: Config = toml::from_str("").unwrap();
-        assert!(config.projects.is_empty());
-    }
-
-    #[test]
     fn project_without_test_override() {
         let toml_str = r#"
 [projects.lib]
@@ -868,19 +854,6 @@ skip_noisy_files = false
             vec!["vendor/**", "*.generated.ts"]
         );
         assert!(!config.mutations.skip_noisy_files);
-    }
-
-    #[test]
-    fn skip_noisy_files_defaults_to_true() {
-        let config: Config = toml::from_str("").unwrap();
-        assert!(config.mutations.skip_noisy_files);
-        assert!(config.mutations.exclude_paths.is_empty());
-    }
-
-    #[test]
-    fn max_per_file_defaults_to_20() {
-        let config: Config = toml::from_str("").unwrap();
-        assert_eq!(config.mutations.max_per_file, 20);
     }
 
     #[test]

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -316,7 +316,7 @@ func f() string { return "" }"#;
     }
 
     #[test]
-    fn numeric_mutators_skip_non_integer_text() {
+    fn numeric_mutators_skip_float_literals() {
         let src = "package main\nfunc f() float64 { return 4.5 }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "float_literal")

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -182,16 +182,32 @@ mod tests {
 
     #[test]
     fn terminal_output_lists_mutations_with_status_and_location() {
+        let killed_path = PathBuf::from("src").join("a.rs");
+        let survived_path = PathBuf::from("src").join("b.rs");
         let report = report(vec![
-            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
-            (mutation(2, "src/b.rs", 2), MutationResult::Survived),
+            (
+                mutation(1, &killed_path.display().to_string(), 1),
+                MutationResult::Killed,
+            ),
+            (
+                mutation(2, &survived_path.display().to_string(), 2),
+                MutationResult::Survived,
+            ),
         ]);
         let output = format_report_plain(&report);
+        let killed_location = format!("{}:1", killed_path.display());
+        let survived_location = format!("{}:2", survived_path.display());
 
-        assert!(output.contains("KILLED"));
-        assert!(output.contains("src/a.rs:1"));
-        assert!(output.contains("SURVIVED"));
-        assert!(output.contains("src/b.rs:2"));
+        assert!(
+            output
+                .lines()
+                .any(|line| line.contains("KILLED") && line.contains(&killed_location))
+        );
+        assert!(
+            output
+                .lines()
+                .any(|line| line.contains("SURVIVED") && line.contains(&survived_location))
+        );
         assert!(output.contains("Your tests don't catch this mutation."));
     }
 

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -132,125 +132,98 @@ fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
 mod tests {
     use super::*;
     use crate::Mutation;
-    use crate::test_helpers::sample_report;
     use std::path::PathBuf;
     use std::time::Duration;
 
-    #[test]
-    fn terminal_output_contains_killed() {
-        let report = sample_report();
-        let output = format_report_plain(&report);
-        assert!(output.contains("✓ KILLED"));
-        assert!(output.contains("src/auth.rs:47"));
-        assert!(output.contains("binary/lt_to_lte"));
+    fn mutation(id: u32, file: &str, line: usize) -> Mutation {
+        Mutation {
+            id,
+            file: PathBuf::from(file),
+            language: String::new(),
+            line,
+            column: 1,
+            operator: "op".to_string(),
+            description: "d".to_string(),
+            original: "x".to_string(),
+            replacement: "y".to_string(),
+            byte_range: 0..1,
+        }
+    }
+
+    fn report(results: Vec<(Mutation, MutationResult)>) -> MutationReport {
+        let total = results.len();
+        let killed = results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::Killed)
+            .count();
+        let survived = results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::Survived)
+            .count();
+        let timeout = results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::Timeout)
+            .count();
+        let build_errors = results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::BuildError)
+            .count();
+
+        MutationReport {
+            results,
+            duration: Duration::from_millis(500),
+            total,
+            killed,
+            survived,
+            timeout,
+            build_errors,
+        }
     }
 
     #[test]
-    fn terminal_output_contains_survived() {
-        let report = sample_report();
+    fn terminal_output_lists_mutations_with_status_and_location() {
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Survived),
+        ]);
         let output = format_report_plain(&report);
-        assert!(output.contains("✗ SURVIVED"));
-        assert!(output.contains("src/handler.rs:15"));
+
+        assert!(output.contains("KILLED"));
+        assert!(output.contains("src/a.rs:1"));
+        assert!(output.contains("SURVIVED"));
+        assert!(output.contains("src/b.rs:2"));
         assert!(output.contains("Your tests don't catch this mutation."));
     }
 
     #[test]
     fn terminal_output_summary_with_timeout_and_build_errors() {
-        let report = MutationReport {
-            results: vec![
-                (
-                    Mutation {
-                        id: 1,
-                        file: PathBuf::from("src/a.rs"),
-                        language: String::new(),
-                        line: 1,
-                        column: 1,
-                        operator: "op".to_string(),
-                        description: "d".to_string(),
-                        original: "x".to_string(),
-                        replacement: "y".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::Killed,
-                ),
-                (
-                    Mutation {
-                        id: 2,
-                        file: PathBuf::from("src/b.rs"),
-                        language: String::new(),
-                        line: 2,
-                        column: 1,
-                        operator: "op".to_string(),
-                        description: "d".to_string(),
-                        original: "x".to_string(),
-                        replacement: "y".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::Timeout,
-                ),
-                (
-                    Mutation {
-                        id: 3,
-                        file: PathBuf::from("src/c.rs"),
-                        language: String::new(),
-                        line: 3,
-                        column: 1,
-                        operator: "op".to_string(),
-                        description: "d".to_string(),
-                        original: "x".to_string(),
-                        replacement: "y".to_string(),
-                        byte_range: 0..1,
-                    },
-                    MutationResult::BuildError,
-                ),
-            ],
-            duration: Duration::from_millis(500),
-            total: 3,
-            killed: 1,
-            survived: 0,
-            timeout: 1,
-            build_errors: 1,
-        };
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Timeout),
+            (mutation(3, "src/c.rs", 3), MutationResult::BuildError),
+        ]);
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 0 survived, 1 timeout, 1 build errors"));
-        // tested = 3 - 1 = 2, score = 1/2 = 50%
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
     }
 
     #[test]
     fn terminal_output_contains_summary() {
-        let report = sample_report();
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Survived),
+        ]);
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 1 survived, 0 timeout, 0 build errors"));
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
-        assert!(output.contains("Duration: 1.23s"));
     }
 
     #[test]
     fn all_build_errors_shows_guidance() {
-        let report = MutationReport {
-            results: vec![(
-                Mutation {
-                    id: 0,
-                    file: PathBuf::from("test.rs"),
-                    line: 1,
-                    column: 1,
-                    operator: "eq_to_neq".into(),
-                    description: "test".into(),
-                    original: "==".into(),
-                    replacement: "!=".into(),
-                    byte_range: 0..2,
-                    language: "rust".into(),
-                },
-                MutationResult::BuildError,
-            )],
-            duration: Duration::from_secs(1),
-            total: 1,
-            killed: 0,
-            survived: 0,
-            timeout: 0,
-            build_errors: 1,
-        };
+        let report = report(vec![(
+            mutation(1, "src/a.rs", 1),
+            MutationResult::BuildError,
+        )]);
         let output = format_report_plain(&report);
         assert!(output.contains("All mutations caused build errors"));
         assert!(output.contains("--operators="));
@@ -259,15 +232,10 @@ mod tests {
 
     #[test]
     fn partial_build_errors_no_guidance() {
-        let report = MutationReport {
-            results: vec![],
-            duration: Duration::from_secs(1),
-            total: 2,
-            killed: 1,
-            survived: 0,
-            timeout: 0,
-            build_errors: 1,
-        };
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::BuildError),
+        ]);
         let output = format_report_plain(&report);
         assert!(!output.contains("All mutations caused build errors"));
     }


### PR DESCRIPTION
PR7 for issue #271. Verifies the suspect test areas before pruning: keeps the literal nonzero coverage, renames the misleading float-literal numeric test, consolidates config defaults into one golden empty-config contract, and rewrites terminal report tests to keep public behavior checks while removing duplicated fixture boilerplate.

Validation:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated multiple unit tests into a single comprehensive test that verifies default configuration behaviors across sections.
  * Clarified numeric-mutation tests to explicitly validate handling of floating-point literals.
  * Refactored report output tests with new helpers to produce deterministic mutation reports and more precise assertions for status and location formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->