### PR TITLE
refactor: move Go arithmetic filter into language (#257)

### DIFF
--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -4,13 +4,35 @@ crate::languages::define_language!(
     extensions: ["go"],
     ts_language: tree_sitter_go::LANGUAGE,
     skip_subtree_kinds: ["import_spec", "import_spec_list", "type_spec"],
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    source: &[u8],
+) -> bool {
+    // Skip arithmetic mutations on expressions like `x * 1`.
+    // `x * 1` -> `x / 1` is equivalent, but `1 * x` -> `1 / x` is not.
+    matches!(candidate.operator_id.as_str(), "mul_to_div" | "div_to_mul")
+        && has_rhs_literal_one(node, source)
+}
+
+fn has_rhs_literal_one(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    let mut cursor = node.walk();
+    let children: Vec<_> = node.named_children(&mut cursor).collect();
+    if let Some(rhs) = children.last() {
+        let text = std::str::from_utf8(&source[rhs.byte_range()]).unwrap_or("");
+        return text == "1";
+    }
+    false
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::languages::LanguageSupport;
-    use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
+    use crate::test_helpers::{find_node_by_kind, parse_go, walk_for_kind, walk_for_two_kinds};
 
     #[test]
     fn test_go_extension_detection() {
@@ -81,5 +103,35 @@ mod tests {
         );
         assert!(found_return, "Expected return_statement node");
         assert!(found_binary, "Expected binary_expression node");
+    }
+
+    #[test]
+    fn rhs_literal_one_detects_right_hand_one_only() {
+        let src = "package main\nfunc f(x int) int { return x * 1 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn rhs_literal_one_ignores_left_hand_one() {
+        let src = "package main\nfunc f(x int) int { return 1 * x }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn rhs_literal_one_ignores_other_literals() {
+        let src = "package main\nfunc f(x int) int { return x * 2 }";
+        let tree = parse_go(src);
+        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
+            .expect("should find binary_expression node");
+
+        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
     }
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -19,6 +19,7 @@ pub mod typescript;
 ///   bool_false: ["false"]
 ///   operator_field: "operator"
 ///   skip_subtree_kinds: []
+///   filter_candidate: function path
 macro_rules! define_language {
     (
         $struct:ident,
@@ -32,6 +33,7 @@ macro_rules! define_language {
         $(, bool_false: [$($bf:expr),* $(,)?])?
         $(, operator_field: $op:expr)?
         $(, skip_subtree_kinds: [$($sk:expr),* $(,)?])?
+        $(, filter_candidate: $filter:expr)?
         $(, empty_block_replacement: $ebr:expr)?
         $(,)?
     ) => {
@@ -62,6 +64,7 @@ macro_rules! define_language {
             fn skip_subtree_kinds(&self) -> &[&str] {
                 $crate::languages::define_language!(@arr [$($($sk),*)?] ; [])
             }
+            $crate::languages::define_language!(@filter $($filter)?);
             $crate::languages::define_language!(@fixup $($ebr)?);
         }
     };
@@ -71,6 +74,18 @@ macro_rules! define_language {
     // Helper: return array if non-empty, otherwise default
     (@arr [$($val:expr),+] ; [$($default:expr),*]) => { &[$($val),+] };
     (@arr [] ; [$($default:expr),*]) => { &[$($default),*] };
+    // Helper: override should_filter_candidate if filter_candidate is set
+    (@filter $filter:expr) => {
+        fn should_filter_candidate(
+            &self,
+            candidate: &$crate::MutationCandidate,
+            node: &tree_sitter::Node,
+            source: &[u8],
+        ) -> bool {
+            $filter(candidate, node, source)
+        }
+    };
+    (@filter) => {};
     // Helper: override fixup_replacement if empty_block_replacement is set
     (@fixup $replacement:expr) => {
         fn fixup_replacement(&self, candidate: &mut $crate::MutationCandidate) {

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -94,24 +94,6 @@ fn should_filter(
     if candidate.operator_id == "string_to_empty" {
         return should_skip_string_to_empty(node, lang.name());
     }
-    // Skip arithmetic mutations on expressions like `x * 1` or `1 * x`
-    // where one operand is literal 1 — these produce equivalent mutants.
-    if matches!(candidate.operator_id.as_str(), "mul_to_div" | "div_to_mul") {
-        return has_rhs_literal_one(node, source);
-    }
-    false
-}
-
-/// Check if a binary expression has literal `1` as its right-hand operand.
-/// `x * 1` → `x / 1` is equivalent, but `1 * x` → `1 / x` is not.
-fn has_rhs_literal_one(node: &tree_sitter::Node, source: &[u8]) -> bool {
-    // The right operand is the last named child of a binary expression
-    let mut cursor = node.walk();
-    let children: Vec<_> = node.named_children(&mut cursor).collect();
-    if let Some(rhs) = children.last() {
-        let text = std::str::from_utf8(&source[rhs.byte_range()]).unwrap_or("");
-        return text == "1";
-    }
     false
 }
 
@@ -374,36 +356,6 @@ func f() string {
             find_node_by_kind(tree.root_node(), "string").expect("should find string node");
 
         assert!(!should_skip_string_to_empty(&string, "python"));
-    }
-
-    #[test]
-    fn rhs_literal_one_detects_right_hand_one_only() {
-        let src = "package main\nfunc f(x int) int { return x * 1 }";
-        let tree = parse_go(src);
-        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
-            .expect("should find binary_expression node");
-
-        assert!(has_rhs_literal_one(&bin, src.as_bytes()));
-    }
-
-    #[test]
-    fn rhs_literal_one_ignores_left_hand_one() {
-        let src = "package main\nfunc f(x int) int { return 1 * x }";
-        let tree = parse_go(src);
-        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
-            .expect("should find binary_expression node");
-
-        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
-    }
-
-    #[test]
-    fn rhs_literal_one_ignores_other_literals() {
-        let src = "package main\nfunc f(x int) int { return x * 2 }";
-        let tree = parse_go(src);
-        let bin = find_node_by_kind(tree.root_node(), "binary_expression")
-            .expect("should find binary_expression node");
-
-        assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an optional filter_candidate override to the language macro
- move Go's mul/div-by-one equivalent-mutant filter out of mutator.rs and into src/languages/go.rs
- keep existing mutator behavior and relocate direct helper coverage to Go tests

## Notes
This continues #257 with a small behavior-preserving extraction. The remaining mutator-owned language-specific filters are return_empty and string_to_empty.

## Verification
- cargo test languages::go::tests
- cargo test mutator::tests
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured mutation filtering mechanism to be language-specific, enabling more flexible and customizable filtering rules tailored to each programming language's unique characteristics.
  * Enhanced detection of mathematically equivalent mutations for Go arithmetic operations, reducing noise in mutation testing results and improving overall accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->