### PR TITLE
refactor: move Rust and Go string filters into languages (#257)

### DIFF
--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -12,10 +12,15 @@ fn should_filter_candidate(
     node: &tree_sitter::Node,
     source: &[u8],
 ) -> bool {
-    // Skip arithmetic mutations on expressions like `x * 1`.
-    // `x * 1` -> `x / 1` is equivalent, but `1 * x` -> `1 / x` is not.
-    matches!(candidate.operator_id.as_str(), "mul_to_div" | "div_to_mul")
-        && has_rhs_literal_one(node, source)
+    match candidate.operator_id.as_str() {
+        // Skip arithmetic mutations on expressions like `x * 1`.
+        // `x * 1` -> `x / 1` is equivalent, but `1 * x` -> `1 / x` is not.
+        "mul_to_div" | "div_to_mul" => has_rhs_literal_one(node, source),
+        "string_to_empty" => {
+            crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+        }
+        _ => false,
+    }
 }
 
 fn has_rhs_literal_one(node: &tree_sitter::Node, source: &[u8]) -> bool {
@@ -33,6 +38,15 @@ mod tests {
     use super::*;
     use crate::languages::LanguageSupport;
     use crate::test_helpers::{find_node_by_kind, parse_go, walk_for_kind, walk_for_two_kinds};
+
+    fn candidate(operator_id: &str) -> crate::MutationCandidate {
+        crate::MutationCandidate {
+            byte_range: 0..1,
+            replacement: String::new(),
+            operator_id: operator_id.to_string(),
+            description: String::new(),
+        }
+    }
 
     #[test]
     fn test_go_extension_detection() {
@@ -133,5 +147,23 @@ mod tests {
             .expect("should find binary_expression node");
 
         assert!(!has_rhs_literal_one(&bin, src.as_bytes()));
+    }
+
+    #[test]
+    fn string_to_empty_allowed_inside_function_body() {
+        let go = Go;
+        let src = r#"package main
+func f() string {
+	return "hello"
+}"#;
+        let tree = parse_go(src);
+        let string = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
+            .expect("should find interpreted_string_literal node");
+
+        assert!(!go.should_filter_candidate(
+            &candidate("string_to_empty"),
+            &string,
+            src.as_bytes()
+        ));
     }
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -99,6 +99,23 @@ macro_rules! define_language {
 
 pub(crate) use define_language;
 
+pub(crate) fn should_skip_string_to_empty_in_compiled_context(node: &tree_sitter::Node) -> bool {
+    let mut parent = node.parent();
+    while let Some(p) = parent {
+        match p.kind() {
+            "const_item" | "const_declaration" | "static_item" => return true,
+            "match_arm" => return true,
+            "function_item"
+            | "function_declaration"
+            | "method_declaration"
+            | "function_definition"
+            | "method" => return false,
+            _ => parent = p.parent(),
+        }
+    }
+    false
+}
+
 /// Language-specific configuration for tree-sitter parsing and node identification
 pub trait LanguageSupport: Send + Sync {
     fn name(&self) -> &str;

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -51,6 +51,16 @@ impl LanguageSupport for Rust {
             _ => false,
         }
     }
+
+    fn should_filter_candidate(
+        &self,
+        candidate: &crate::MutationCandidate,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+    ) -> bool {
+        candidate.operator_id == "string_to_empty"
+            && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+    }
 }
 
 /// Check if a node has a preceding sibling `attribute_item` matching a predicate.
@@ -76,7 +86,16 @@ fn has_attribute(node: &tree_sitter::Node, source: &[u8], matches: impl Fn(&str)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{walk_for_kind, walk_for_two_kinds};
+    use crate::test_helpers::{find_node_by_kind, walk_for_kind, walk_for_two_kinds};
+
+    fn candidate(operator_id: &str) -> crate::MutationCandidate {
+        crate::MutationCandidate {
+            byte_range: 0..1,
+            replacement: String::new(),
+            operator_id: operator_id.to_string(),
+            description: String::new(),
+        }
+    }
 
     #[test]
     fn test_rust_extension_detection() {
@@ -207,6 +226,44 @@ mod tests {
         let func =
             find_first(tree.root_node(), "function_item").expect("function_item should be present");
         assert!(!rs.should_skip_node(&func, src));
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_const_context() {
+        let rs = Rust;
+        let src = r#"const NAME: &str = "togi";"#;
+        let tree = crate::test_helpers::parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(rs.should_filter_candidate(&candidate("string_to_empty"), &string, src.as_bytes()));
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_static_context() {
+        let rs = Rust;
+        let src = r#"static NAME: &str = "togi";"#;
+        let tree = crate::test_helpers::parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(rs.should_filter_candidate(&candidate("string_to_empty"), &string, src.as_bytes()));
+    }
+
+    #[test]
+    fn string_to_empty_skipped_for_match_arm() {
+        let rs = Rust;
+        let src = r#"fn label(x: i32) -> &'static str {
+    match x {
+        0 => "zero",
+        _ => "other",
+    }
+}"#;
+        let tree = crate::test_helpers::parse_rust(src);
+        let string = find_node_by_kind(tree.root_node(), "string_literal")
+            .expect("should find string_literal node");
+
+        assert!(rs.should_filter_candidate(&candidate("string_to_empty"), &string, src.as_bytes()));
     }
 
     #[test]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -62,20 +62,10 @@ fn should_skip_return_empty(node: &tree_sitter::Node, language: &str) -> bool {
 /// in compiled languages (const items, static items, match arms).
 fn should_skip_string_to_empty(node: &tree_sitter::Node, language: &str) -> bool {
     match language {
-        "rust" | "go" | "c" | "cpp" | "c_sharp" | "java" | "typescript" => {}
+        "c" | "cpp" | "c_sharp" | "java" | "typescript" => {}
         _ => return false,
     }
-    let mut parent = node.parent();
-    while let Some(p) = parent {
-        match p.kind() {
-            "const_item" | "const_declaration" | "static_item" => return true,
-            "match_arm" => return true,
-            // Stop walking at function boundaries
-            k if FUNC_NODE_KINDS.contains(&k) => return false,
-            _ => parent = p.parent(),
-        }
-    }
-    false
+    crate::languages::should_skip_string_to_empty_in_compiled_context(node)
 }
 
 /// Check if a mutation candidate should be filtered out for the given language.
@@ -279,7 +269,7 @@ fn sample_diverse(mutations: Vec<Mutation>, cap: usize) -> Vec<Mutation> {
 mod tests {
     use super::*;
     use crate::languages::go::Go;
-    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python, parse_rust};
+    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python};
     use crate::{ChangedFile, LineRange};
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -298,54 +288,6 @@ mod tests {
             operator_id: operator_id.to_string(),
             description: String::new(),
         }
-    }
-
-    #[test]
-    fn string_to_empty_skipped_for_rust_const_context() {
-        let src = r#"const NAME: &str = "togi";"#;
-        let tree = parse_rust(src);
-        let string = find_node_by_kind(tree.root_node(), "string_literal")
-            .expect("should find string_literal node");
-
-        assert!(should_skip_string_to_empty(&string, "rust"));
-    }
-
-    #[test]
-    fn string_to_empty_skipped_for_rust_static_context() {
-        let src = r#"static NAME: &str = "togi";"#;
-        let tree = parse_rust(src);
-        let string = find_node_by_kind(tree.root_node(), "string_literal")
-            .expect("should find string_literal node");
-
-        assert!(should_skip_string_to_empty(&string, "rust"));
-    }
-
-    #[test]
-    fn string_to_empty_skipped_for_rust_match_arm() {
-        let src = r#"fn label(x: i32) -> &'static str {
-    match x {
-        0 => "zero",
-        _ => "other",
-    }
-}"#;
-        let tree = parse_rust(src);
-        let string = find_node_by_kind(tree.root_node(), "string_literal")
-            .expect("should find string_literal node");
-
-        assert!(should_skip_string_to_empty(&string, "rust"));
-    }
-
-    #[test]
-    fn string_to_empty_allowed_inside_function_body() {
-        let src = r#"package main
-func f() string {
-	return "hello"
-}"#;
-        let tree = parse_go(src);
-        let string = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
-            .expect("should find interpreted_string_literal node");
-
-        assert!(!should_skip_string_to_empty(&string, "go"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move Rust string_to_empty context filtering into Rust language support
- extend Go's language filter hook to cover string_to_empty context filtering
- share the compiled string-context helper from the language module and remove Rust/Go from mutator.rs fallback
- move direct Rust/Go string filter tests into language tests

## Notes
This continues #257 with a minimal behavior-preserving slice. The remaining string_to_empty fallback in mutator.rs still covers C/C++/C#/Java/TypeScript; return_empty remains there for a later PR.

## Verification
- cargo test languages::rust_lang::tests
- cargo test languages::go::tests
- cargo test mutator::tests
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced mutation filtering for string transformations in compiled languages (Go, Rust, C, C++, C#, Java, TypeScript) with improved accuracy in constant, static variable, and pattern matching contexts.

* **Refactor**
  * Consolidated filtering logic across language modules for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->