### PR TITLE
refactor: move compiled string filters into languages (#257)

### DIFF
--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -3,7 +3,17 @@ crate::languages::define_language!(
     name: "c",
     extensions: ["c", "h"],
     ts_language: tree_sitter_c::LANGUAGE,
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    _source: &[u8],
+) -> bool {
+    candidate.operator_id == "string_to_empty"
+        && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -3,7 +3,17 @@ crate::languages::define_language!(
     name: "cpp",
     extensions: ["cpp", "cc", "cxx", "hpp", "hxx"],
     ts_language: tree_sitter_cpp::LANGUAGE,
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    _source: &[u8],
+) -> bool {
+    candidate.operator_id == "string_to_empty"
+        && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -4,7 +4,17 @@ crate::languages::define_language!(
     extensions: ["cs"],
     ts_language: tree_sitter_c_sharp::LANGUAGE,
     skip_subtree_kinds: ["using_directive", "attribute", "type_parameter_list"],
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    _source: &[u8],
+) -> bool {
+    candidate.operator_id == "string_to_empty"
+        && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -4,7 +4,17 @@ crate::languages::define_language!(
     extensions: ["java"],
     ts_language: tree_sitter_java::LANGUAGE,
     skip_subtree_kinds: ["import_declaration", "annotation", "type_parameters"],
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    _source: &[u8],
+) -> bool {
+    candidate.operator_id == "string_to_empty"
+        && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -4,7 +4,17 @@ crate::languages::define_language!(
     extensions: ["ts", "tsx"],
     ts_language: tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
     skip_subtree_kinds: ["import_statement", "type_annotation", "type_alias_declaration", "decorator"],
+    filter_candidate: should_filter_candidate,
 );
+
+fn should_filter_candidate(
+    candidate: &crate::MutationCandidate,
+    node: &tree_sitter::Node,
+    _source: &[u8],
+) -> bool {
+    candidate.operator_id == "string_to_empty"
+        && crate::languages::should_skip_string_to_empty_in_compiled_context(node)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -57,17 +57,6 @@ fn should_skip_return_empty(node: &tree_sitter::Node, language: &str) -> bool {
     }
 }
 
-/// Check if a string_to_empty mutation should be skipped because the string
-/// is inside a context where emptying it almost always causes a build error
-/// in compiled languages (const items, static items, match arms).
-fn should_skip_string_to_empty(node: &tree_sitter::Node, language: &str) -> bool {
-    match language {
-        "c" | "cpp" | "c_sharp" | "java" | "typescript" => {}
-        _ => return false,
-    }
-    crate::languages::should_skip_string_to_empty_in_compiled_context(node)
-}
-
 /// Check if a mutation candidate should be filtered out for the given language.
 fn should_filter(
     candidate: &MutationCandidate,
@@ -80,9 +69,6 @@ fn should_filter(
     }
     if candidate.operator_id == "return_empty" {
         return should_skip_return_empty(node, lang.name());
-    }
-    if candidate.operator_id == "string_to_empty" {
-        return should_skip_string_to_empty(node, lang.name());
     }
     false
 }
@@ -269,7 +255,7 @@ fn sample_diverse(mutations: Vec<Mutation>, cap: usize) -> Vec<Mutation> {
 mod tests {
     use super::*;
     use crate::languages::go::Go;
-    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python};
+    use crate::test_helpers::{find_node_by_kind, parse_go};
     use crate::{ChangedFile, LineRange};
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -288,16 +274,6 @@ mod tests {
             operator_id: operator_id.to_string(),
             description: String::new(),
         }
-    }
-
-    #[test]
-    fn string_to_empty_not_skipped_for_dynamic_languages() {
-        let src = r#"NAME = "togi""#;
-        let tree = parse_python(src);
-        let string =
-            find_node_by_kind(tree.root_node(), "string").expect("should find string node");
-
-        assert!(!should_skip_string_to_empty(&string, "python"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wire string_to_empty filtering into C, C++, C#, Java, and TypeScript language hooks
- remove the remaining string_to_empty fallback from mutator.rs
- keep the existing shared compiled-context helper in languages/mod.rs

## Notes
This continues #257 after #287. mutator.rs no longer owns string_to_empty language filtering; return_empty remains as the final language-specific filter to extract.

## Verification
- cargo test mutator::tests
- cargo test languages::c::tests
- cargo test languages::cpp::tests
- cargo test languages::csharp::tests
- cargo test languages::java::tests
- cargo test languages::typescript::tests
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings