### PR TITLE
test: serialize ignored Go fixture integration tests

### DIFF
--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,2 +1,11 @@
 mod mutations;
 mod verify;
+
+use std::sync::OnceLock;
+
+async fn go_fixture_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -71,6 +71,7 @@ fn generates_mutations_for_go_fixture() {
 #[tokio::test]
 #[ignore]
 async fn end_to_end_go_fixture_all_killed_with_cache_off() {
+    let _fixture_guard = crate::go_fixture_lock().await;
     let root = fixture_path();
     togi::cache::clear(&root).expect("failed to clear togi cache");
 

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -28,6 +28,7 @@ fn classify_result(status: std::process::ExitStatus) -> MutationResult {
 #[tokio::test]
 #[ignore]
 async fn verify_mutation_outcomes_match_independent_replay() {
+    let _fixture_guard = crate::go_fixture_lock().await;
     let root = fixture_path();
     let calc_path = root.join("calc.go");
 


### PR DESCRIPTION
## Summary
- add a shared async mutex for integration tests that mutate tests/fixtures/go/calc.go
- acquire it in both ignored Go fixture mutation tests

## Why
Post-merge CI runs 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 309 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 2 tests
test mutations::end_to_end_go_fixture_all_killed_with_cache_off ... ok
test verify::verify_mutation_outcomes_match_independent_replay ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 1.59s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s, which executes ignored tests in parallel by default. Both ignored integration tests mutate the same Go fixture, so they can interleave and leave calc.go mutated during the verify test's restore assertion.

## Verification
- cargo test -- --ignored
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings