### PR TITLE
refactor: share binary expression helper (#269)

### DIFF
--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,13 +1,5 @@
-use super::MutationOperator;
+use super::{MutationOperator, is_binary_expr};
 use crate::MutationCandidate;
-
-const BINARY_EXPR_KINDS: &[&str] = &[
-    "binary_expression",
-    "binary_expr",
-    "comparison_expression",
-    "binary_operator", // Python
-    "binary",          // Ruby
-];
 
 pub fn find_operator_child(
     node: &tree_sitter::Node,
@@ -32,10 +24,6 @@ pub fn find_operator_child(
         }
     }
     None
-}
-
-fn is_binary_expr(node: &tree_sitter::Node) -> bool {
-    BINARY_EXPR_KINDS.contains(&node.kind())
 }
 
 macro_rules! binary_operator {

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -1,18 +1,6 @@
-use super::MutationOperator;
 use super::binary::find_operator_child;
+use super::{MutationOperator, is_binary_expr};
 use crate::MutationCandidate;
-
-const BINARY_EXPR_KINDS: &[&str] = &[
-    "binary_expression",
-    "binary_expr",
-    "comparison_expression",
-    "binary_operator", // Python
-    "binary",          // Ruby
-];
-
-fn is_binary_expr(node: &tree_sitter::Node) -> bool {
-    BINARY_EXPR_KINDS.contains(&node.kind())
-}
 
 pub struct PlusToMinus;
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -18,11 +18,22 @@ pub(crate) const IF_STMT_KINDS: &[&str] = &[
     "if_expr",
     "if", // Ruby
 ];
+pub(crate) const BINARY_EXPR_KINDS: &[&str] = &[
+    "binary_expression",
+    "binary_expr",
+    "comparison_expression",
+    "binary_operator", // Python
+    "binary",          // Ruby
+];
 const RETURN_KINDS: &[&str] = &[
     "return_statement",
     "return_expression",
     "return", // Ruby
 ];
+
+pub(crate) fn is_binary_expr(node: &tree_sitter::Node) -> bool {
+    BINARY_EXPR_KINDS.contains(&node.kind())
+}
 
 /// Negate a condition: remove `!` if present, otherwise wrap with `!(...)`
 pub struct NegateCondition;


### PR DESCRIPTION
## Summary
- Move the shared binary-expression node kind list into operators/mod.rs
- Reuse the helper from binary and boundary operators

## Tests
- cargo fmt --check
- cargo test operators::

Part of #269.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated binary expression detection logic into a shared utility module, eliminating duplicate implementations across operator handlers while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->