### PR TITLE
feat: explain mutations from JSON reports (#208)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,15 @@ pub enum Commands {
     Init,
     /// Delete the .togi-cache directory
     Clean,
+    /// Explain a mutation from a JSON report
+    Explain {
+        /// Mutation id from `togi check --format json`
+        mutant_id: u32,
+
+        /// JSON report file produced by `togi check --format json`
+        #[arg(short, long, default_value = "togi-report.json")]
+        report: PathBuf,
+    },
     /// List all available mutation operators
     ListOperators,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use serde::Deserialize;
 use togi::{ChangedFile, Mutation, MutationReport};
 
 struct CheckConfig {
@@ -114,6 +115,12 @@ async fn main() {
                 }
             }
         }
+        togi::cli::Commands::Explain { mutant_id, report } => {
+            if let Err(e) = explain_mutation(mutant_id, &report) {
+                eprintln!("Error: {e:#}");
+                process::exit(2);
+            }
+        }
         togi::cli::Commands::ListOperators => {
             print_operators();
         }
@@ -130,6 +137,83 @@ async fn main() {
             println!("Created togi.toml (auto-detected from project)");
         }
     }
+}
+
+#[derive(Deserialize)]
+struct ExplainReport {
+    mutations: Vec<ExplainMutation>,
+}
+
+#[derive(Deserialize)]
+struct ExplainMutation {
+    id: u32,
+    file: String,
+    line: usize,
+    operator: String,
+    description: String,
+    result: String,
+    original: Option<String>,
+    replacement: Option<String>,
+    diff: Option<String>,
+}
+
+fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(report_path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", report_path.display()))?;
+    let report: ExplainReport = serde_json::from_str(&content)
+        .map_err(|e| anyhow::anyhow!("could not parse {} as JSON: {e}", report_path.display()))?;
+    let mutation = report
+        .mutations
+        .iter()
+        .find(|m| m.id == mutant_id)
+        .ok_or_else(|| anyhow::anyhow!("mutation id {mutant_id} not found in report"))?;
+
+    println!("Mutation #{}", mutation.id);
+    println!(
+        "{}:{} — {} ({})",
+        mutation.file, mutation.line, mutation.operator, mutation.result
+    );
+    println!("{}", mutation.description);
+
+    if let (Some(original), Some(replacement)) = (&mutation.original, &mutation.replacement) {
+        println!();
+        println!("Change: {original} -> {replacement}");
+    }
+
+    if let Some(diff) = &mutation.diff {
+        println!();
+        println!("{diff}");
+    }
+
+    println!();
+    match mutation.result.as_str() {
+        "survived" => {
+            println!("Why it survived:");
+            println!("  The configured test command completed successfully with this mutation.");
+            println!(
+                "  Add an assertion that distinguishes the original behavior from the mutated one."
+            );
+        }
+        "killed" => {
+            println!("Why it was killed:");
+            println!(
+                "  The configured test command failed with this mutation, so existing tests caught it."
+            );
+        }
+        "timeout" => {
+            println!("Why it timed out:");
+            println!("  The configured test command exceeded the mutation timeout.");
+        }
+        "build_error" => {
+            println!("Why it was not testable:");
+            println!("  The mutation made the project fail its build check.");
+        }
+        other => {
+            println!("Result: {other}");
+        }
+    }
+
+    Ok(())
 }
 
 fn print_operators() {

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -17,6 +17,7 @@ struct JsonReport {
 
 #[derive(Serialize)]
 struct JsonMutation {
+    id: u32,
     file: String,
     line: usize,
     operator: String,
@@ -46,6 +47,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         .map(|(m, r)| {
             let survived = matches!(r, MutationResult::Survived);
             JsonMutation {
+                id: m.id + 1,
                 file: m.file.display().to_string(),
                 line: m.line,
                 operator: m.operator.clone(),
@@ -134,6 +136,7 @@ mod tests {
 
         let mutations = value["mutations"].as_array().unwrap();
         assert_eq!(mutations.len(), 2);
+        assert_eq!(mutations[0]["id"], 1);
         assert_eq!(mutations[0]["file"], "src/auth.rs");
         assert_eq!(mutations[0]["line"], 47);
         assert_eq!(mutations[0]["operator"], "binary/lt_to_lte");
@@ -165,11 +168,12 @@ mod tests {
         let mutations = value["mutations"].as_array().unwrap();
         assert_object_keys(
             &mutations[0],
-            &["file", "line", "operator", "description", "result"],
+            &["id", "file", "line", "operator", "description", "result"],
         );
         assert_object_keys(
             &mutations[1],
             &[
+                "id",
                 "file",
                 "line",
                 "operator",

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -10,7 +10,7 @@ pub fn sample_report() -> MutationReport {
         results: vec![
             (
                 Mutation {
-                    id: 1,
+                    id: 0,
                     file: PathBuf::from("src/auth.rs"),
                     language: String::new(),
                     line: 47,
@@ -25,7 +25,7 @@ pub fn sample_report() -> MutationReport {
             ),
             (
                 Mutation {
-                    id: 2,
+                    id: 1,
                     file: PathBuf::from("src/handler.rs"),
                     language: String::new(),
                     line: 15,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -152,6 +152,49 @@ fn check_format_json_outputs_valid_json() {
 }
 
 #[test]
+fn explain_reads_json_report() {
+    let dir = TempDir::new().unwrap();
+    let report = r#"{
+  "total": 1,
+  "tested": 1,
+  "killed": 0,
+  "survived": 1,
+  "timeout": 0,
+  "build_errors": 0,
+  "mutation_score": 0.0,
+  "duration_ms": 10,
+  "mutations": [
+    {
+      "id": 1,
+      "file": "src/main.go",
+      "line": 4,
+      "operator": "gt_to_gte",
+      "description": "Replace > with >=",
+      "result": "survived",
+      "original": ">",
+      "replacement": ">=",
+      "diff": "--- a/src/main.go\n+++ b/src/main.go\n@@ -1 +1 @@\n-a > b\n+a >= b\n"
+    }
+  ]
+}"#;
+    let report_path = dir.path().join("togi-report.json");
+    fs::write(&report_path, report).unwrap();
+
+    togi()
+        .args([
+            "explain",
+            "1",
+            "--report",
+            report_path.to_str().expect("report path should be utf-8"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Mutation #1"))
+        .stdout(predicate::str::contains("src/main.go:4"))
+        .stdout(predicate::str::contains("Why it survived"));
+}
+
+#[test]
 fn check_invalid_config_exits_two() {
     let dir = setup_git_repo();
     fs::write(dir.path().join("togi.toml"), "invalid {{{{ toml").unwrap();


### PR DESCRIPTION
## Summary
- Add stable mutation ids to JSON report entries
- Add `togi explain <id> --report <path>` for explaining a mutation from a JSON report
- Include location, operator, result, before/after values, diff when present, and result-specific guidance

## Usage
Run `togi check --format json > togi-report.json`, then `togi explain 1 --report togi-report.json`.

## Tests
- cargo fmt --check
- cargo test report::json::tests
- cargo test --test cli
- cargo clippy --all-targets -- -D warnings

First slice of #208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `explain` CLI command to display detailed mutation information from JSON reports
  * Command accepts a mutation identifier and optional report file path (`-r/--report`), defaulting to `togi-report.json`
  * Shows mutation location, details, and reasoning for behavior (survived, killed, timeout, or build error)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->