### PR TITLE
feat: include mutation details in JSON reports (#208)

### DIFF
--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -44,37 +44,22 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
     let mutations: Vec<JsonMutation> = report
         .results
         .iter()
-        .map(|(m, r)| {
-            let survived = matches!(r, MutationResult::Survived);
-            JsonMutation {
-                id: m.id + 1,
-                file: m.file.display().to_string(),
-                line: m.line,
-                operator: m.operator.clone(),
-                description: m.description.clone(),
-                result: match r {
-                    MutationResult::Killed => "killed".to_string(),
-                    MutationResult::Survived => "survived".to_string(),
-                    MutationResult::Timeout => "timeout".to_string(),
-                    MutationResult::BuildError => "build_error".to_string(),
-                },
-                column: if survived { Some(m.column) } else { None },
-                original: if survived {
-                    Some(m.original.clone())
-                } else {
-                    None
-                },
-                replacement: if survived {
-                    Some(m.replacement.clone())
-                } else {
-                    None
-                },
-                diff: if survived {
-                    super::mutation_diff(m)
-                } else {
-                    None
-                },
-            }
+        .map(|(m, r)| JsonMutation {
+            id: m.id + 1,
+            file: m.file.display().to_string(),
+            line: m.line,
+            operator: m.operator.clone(),
+            description: m.description.clone(),
+            result: match r {
+                MutationResult::Killed => "killed".to_string(),
+                MutationResult::Survived => "survived".to_string(),
+                MutationResult::Timeout => "timeout".to_string(),
+                MutationResult::BuildError => "build_error".to_string(),
+            },
+            column: Some(m.column),
+            original: Some(m.original.clone()),
+            replacement: Some(m.replacement.clone()),
+            diff: super::mutation_diff(m),
         })
         .collect();
 
@@ -168,7 +153,17 @@ mod tests {
         let mutations = value["mutations"].as_array().unwrap();
         assert_object_keys(
             &mutations[0],
-            &["id", "file", "line", "operator", "description", "result"],
+            &[
+                "id",
+                "file",
+                "line",
+                "operator",
+                "description",
+                "result",
+                "column",
+                "original",
+                "replacement",
+            ],
         );
         assert_object_keys(
             &mutations[1],
@@ -235,20 +230,19 @@ mod tests {
     }
 
     #[test]
-    fn json_survived_includes_diff_fields() {
+    fn json_output_includes_mutation_details() {
         let report = sample_report();
         let json_str = to_json_string(&report).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         let mutations = value["mutations"].as_array().unwrap();
 
-        // Killed mutation should NOT have diff fields
-        assert!(mutations[0]["column"].is_null());
-        assert!(mutations[0]["original"].is_null());
-        assert!(mutations[0]["replacement"].is_null());
+        // All mutations should include exact before/after details for `togi explain`.
+        assert_eq!(mutations[0]["column"], 10);
+        assert_eq!(mutations[0]["original"], "<");
+        assert_eq!(mutations[0]["replacement"], "<=");
         assert!(mutations[0]["diff"].is_null());
 
-        // Survived mutation should have original/replacement/column
         assert_eq!(mutations[1]["column"], 5);
         assert_eq!(mutations[1]["original"], "==");
         assert_eq!(mutations[1]["replacement"], "!=");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -155,9 +155,9 @@ fn check_format_json_outputs_valid_json() {
 fn explain_reads_json_report() {
     let dir = TempDir::new().unwrap();
     let report = r#"{
-  "total": 1,
-  "tested": 1,
-  "killed": 0,
+  "total": 2,
+  "tested": 2,
+  "killed": 1,
   "survived": 1,
   "timeout": 0,
   "build_errors": 0,
@@ -166,6 +166,16 @@ fn explain_reads_json_report() {
   "mutations": [
     {
       "id": 1,
+      "file": "src/main.go",
+      "line": 3,
+      "operator": "plus_to_minus",
+      "description": "Replace + with -",
+      "result": "killed",
+      "original": "+",
+      "replacement": "-"
+    },
+    {
+      "id": 2,
       "file": "src/main.go",
       "line": 4,
       "operator": "gt_to_gte",
@@ -183,15 +193,27 @@ fn explain_reads_json_report() {
     togi()
         .args([
             "explain",
+            "2",
+            "--report",
+            report_path.to_str().expect("report path should be utf-8"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Mutation #2"))
+        .stdout(predicate::str::contains("src/main.go:4"))
+        .stdout(predicate::str::contains("Why it survived"));
+
+    togi()
+        .args([
+            "explain",
             "1",
             "--report",
             report_path.to_str().expect("report path should be utf-8"),
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Mutation #1"))
-        .stdout(predicate::str::contains("src/main.go:4"))
-        .stdout(predicate::str::contains("Why it survived"));
+        .stdout(predicate::str::contains("Change: + -> -"))
+        .stdout(predicate::str::contains("Why it was killed"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Include column, original, and replacement for every JSON report mutation
- Keep diff generation available for every mutation when the source file can be read
- Extend `togi explain` CLI coverage to killed mutations, not just survived ones

## Tests
- cargo fmt --check
- cargo test report::json::tests
- cargo test --test cli explain_reads_json_report
- cargo clippy --all-targets -- -D warnings

Follow-up slice for #208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON mutation reports now include detailed information (column, original, replacement, diff) for all mutation results, not just survived ones.
  * Explain command now supports generating explanations for killed mutations.

* **Tests**
  * Updated test coverage for killed mutation explanation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->