### PR TITLE
fix: keep generated mutation paths relative

### DIFF
--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -105,7 +105,7 @@ pub fn generate_mutations(
 
                     file_mutations.push(Mutation {
                         id: 0,
-                        file: file_path.clone(),
+                        file: changed_file.path.clone(),
                         language: lang.name().to_string(),
                         line,
                         column,
@@ -438,6 +438,11 @@ mod tests {
         let mutations = generate_mutations(&changed, tmp.path(), 100, 0, &[]).unwrap();
         let files: std::collections::HashSet<_> =
             mutations.iter().map(|m| m.file.clone()).collect();
+        assert!(
+            files.iter().all(|file| file.is_relative()),
+            "generated mutation paths should stay project-relative: {:?}",
+            files
+        );
         assert!(
             files.len() >= 2,
             "expected mutations from both files, got files: {:?}",


### PR DESCRIPTION
## Summary
- store generated mutation file paths as project-relative paths instead of resolved absolute paths
- add regression coverage that generated paths stay relative

## Why
This is the path-boundary prerequisite for #155. Workspace-copy execution needs mutations to resolve against whichever project root a runner slot uses, not always the original checkout.

## Tests
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo run -- check --all --dry-run

Refs #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mutation file path handling to consistently use project-relative paths instead of absolute paths, improving reliability and consistency across generated mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->