### PR TITLE
Load test selection maps

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,10 @@ pub enum Commands {
         #[arg(long)]
         coverage_file: Option<PathBuf>,
 
+        /// JSON source-line to test-name map for targeted test runs
+        #[arg(long)]
+        test_selection_file: Option<PathBuf>,
+
         /// Override build check command (e.g., 'cargo check')
         #[arg(long)]
         build_cmd: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,7 @@ pub struct MutationConfig {
     #[serde(default = "default_max_per_run")]
     pub max_per_run: usize,
     pub coverage_file: Option<PathBuf>,
+    pub test_selection_file: Option<PathBuf>,
     #[serde(default = "default_max_per_file")]
     pub max_per_file: usize,
     #[serde(default)]
@@ -263,6 +264,7 @@ impl Default for MutationConfig {
             max_per_run: default_max_per_run(),
             max_per_file: default_max_per_file(),
             coverage_file: None,
+            test_selection_file: None,
             exclude_paths: vec![],
             skip_noisy_files: true,
             operators: vec![],
@@ -481,6 +483,10 @@ max_per_run = 50
             config.mutations.coverage_file,
             Some("coverage/lcov.info".into())
         );
+        assert_eq!(
+            config.mutations.test_selection_file,
+            Some("coverage/test-selection.json".into())
+        );
         assert!(config.mutations.skip_noisy_files);
         let project = &config.projects["api"];
         assert_eq!(project.path, PathBuf::from("services/api"));
@@ -501,6 +507,7 @@ max_per_run = 50
         assert_eq!(config.mutations.max_per_file, 20);
         assert!(config.mutations.operators.is_empty());
         assert!(config.mutations.coverage_file.is_none());
+        assert!(config.mutations.test_selection_file.is_none());
         assert!(config.mutations.exclude_paths.is_empty());
         assert!(config.mutations.skip_noisy_files);
         assert!(config.projects.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -21,6 +22,7 @@ struct CheckConfig {
     show_output: bool,
     test_cmd: Option<String>,
     coverage_file: Option<PathBuf>,
+    test_selection_file: Option<PathBuf>,
     build_cmd: Option<String>,
     fail_fast: bool,
     no_skip_defaults: bool,
@@ -64,6 +66,7 @@ async fn main() {
             show_output,
             test_cmd,
             coverage_file,
+            test_selection_file,
             build_cmd,
             fail_fast,
             no_skip_defaults,
@@ -87,6 +90,7 @@ async fn main() {
                 show_output,
                 test_cmd,
                 coverage_file,
+                test_selection_file,
                 build_cmd,
                 fail_fast,
                 no_skip_defaults,
@@ -393,6 +397,9 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
     if let Some(path) = cfg.coverage_file {
         config.mutations.coverage_file = Some(path);
     }
+    if let Some(path) = cfg.test_selection_file {
+        config.mutations.test_selection_file = Some(path);
+    }
     if let Some(cmd) = cfg.build_cmd {
         config.test.build_command =
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?;
@@ -592,6 +599,10 @@ async fn execute(
             language_timeouts.insert(lang, Duration::from_secs(t));
         }
     }
+    let test_selection = load_test_selection(
+        config.mutations.test_selection_file.as_deref(),
+        &project_root,
+    );
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
@@ -605,7 +616,7 @@ async fn execute(
             build_command_explicit,
             timeout: Duration::from_secs(config.test.timeout),
             language_timeouts,
-            test_selection: None,
+            test_selection,
         },
         parallelism: config.test.jobs,
         project_root,
@@ -621,6 +632,57 @@ async fn execute(
     };
 
     runner.run(mutations).await
+}
+
+fn load_test_selection(
+    path: Option<&Path>,
+    project_root: &Path,
+) -> Option<togi::runner::TestSelectionConfig> {
+    let path = path?;
+    let resolved_path = if path.is_relative() {
+        project_root.join(path)
+    } else {
+        path.to_path_buf()
+    };
+
+    match std::fs::read_to_string(&resolved_path)
+        .with_context(|| {
+            format!(
+                "could not read test selection file {}",
+                resolved_path.display()
+            )
+        })
+        .and_then(|content| parse_test_selection_json(&content, project_root))
+    {
+        Ok(selection) => Some(selection),
+        Err(e) => {
+            eprintln!("warning: {e:#} — running full test commands");
+            None
+        }
+    }
+}
+
+fn parse_test_selection_json(
+    content: &str,
+    project_root: &Path,
+) -> anyhow::Result<togi::runner::TestSelectionConfig> {
+    let raw: std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>> =
+        serde_json::from_str(content).context("could not parse test selection JSON")?;
+    let mut selection = togi::runner::TestSelectionConfig::new();
+
+    for (file, lines) in raw {
+        for (line, tests) in lines {
+            let line = line
+                .parse::<usize>()
+                .with_context(|| format!("invalid line number '{line}' for {file}"))?;
+            if line == 0 {
+                anyhow::bail!("invalid line number '0' for {file}");
+            }
+            selection.insert(project_root, Path::new(&file), line, tests);
+        }
+    }
+
+    Ok(selection)
 }
 
 fn get_project_root() -> anyhow::Result<PathBuf> {
@@ -645,4 +707,49 @@ fn get_git_diff(base: &str) -> anyhow::Result<String> {
         );
     }
     Ok(String::from_utf8(output.stdout)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_test_selection_json_accepts_file_line_test_map() {
+        let root = Path::new("/repo");
+        let json = r#"{
+            "src/calc.go": {
+                "12": ["TestAdd", "TestMax"]
+            }
+        }"#;
+
+        assert!(parse_test_selection_json(json, root).is_ok());
+    }
+
+    #[test]
+    fn parse_test_selection_json_rejects_non_numeric_line() {
+        let root = Path::new("/repo");
+        let json = r#"{
+            "src/calc.go": {
+                "line": ["TestAdd"]
+            }
+        }"#;
+
+        let err = parse_test_selection_json(json, root).unwrap_err();
+
+        assert!(err.to_string().contains("invalid line number"));
+    }
+
+    #[test]
+    fn parse_test_selection_json_rejects_zero_line() {
+        let root = Path::new("/repo");
+        let json = r#"{
+            "src/calc.go": {
+                "0": ["TestAdd"]
+            }
+        }"#;
+
+        let err = parse_test_selection_json(json, root).unwrap_err();
+
+        assert_eq!(err.to_string(), "invalid line number '0' for src/calc.go");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -152,6 +152,15 @@ fn check_format_json_outputs_valid_json() {
 }
 
 #[test]
+fn check_help_lists_test_selection_file_flag() {
+    togi()
+        .args(["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--test-selection-file"));
+}
+
+#[test]
 fn explain_reads_json_report() {
     let dir = TempDir::new().unwrap();
     let report = r#"{

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -65,6 +65,11 @@ max_per_file = 20
 # Default: unset
 coverage_file = "coverage/lcov.info"
 
+# Optional JSON source-line to test-name map for targeted test runs.
+# Type: string path
+# Default: unset
+test_selection_file = "coverage/test-selection.json"
+
 # Glob patterns excluded from mutation collection.
 # Type: array of strings
 # Default: []


### PR DESCRIPTION
## Summary
- add `--test-selection-file` and `mutations.test_selection_file`
- parse JSON maps from source file and line to test names
- feed parsed maps into the existing runner test-selection plumbing, with full-command fallback on missing or invalid maps

Expected JSON shape:
```json
{
  "src/calc.go": {
    "12": ["TestAdd", "TestMax"]
  }
}
```

## Tests
- cargo fmt --check
- cargo check
- cargo test parse_test_selection_json
- cargo test example_config_matches_schema
- cargo test defaults_when_empty
- cargo test check_help_lists_test_selection_file_flag
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo test -- --ignored

Refs #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional CLI flag and matching config option to provide a JSON test-selection file (maps source lines to test names) for targeted test execution.
  * If the selection file is missing or invalid, the run continues with full test execution and emits a warning.

* **Tests**
  * Added CLI help validation and unit tests covering parsing and rejection cases for the JSON format.

* **Documentation**
  * Updated example config to document the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->