### PR TITLE
Honor project-specific test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ build_command = ["go", "build", "./..."]
 command = ["pytest"]
 timeout = 45
 
+[projects.api]
+path = "services/api"
+
+[projects.api.test]
+command = ["go", "test", "./services/api/..."]
+timeout = 60
+
 [diff]
 base = "origin/main"
 
@@ -172,6 +179,10 @@ operators = ["-string_to_empty"]
 exclude_paths = ["vendor/**"]
 skip_noisy_files = true
 ```
+
+Test command precedence is: CLI `--test-cmd` / `--timeout`, matching
+`[projects.*.test]` by longest path prefix, matching `[test.languages.*]`,
+then the global `[test]` command.
 
 ## CI workflows
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,15 @@ struct CheckConfig {
     pr_comment: Option<PathBuf>,
 }
 
+struct ExecuteOptions {
+    verbose: bool,
+    show_output: bool,
+    build_command_explicit: bool,
+    force_default_command: bool,
+    force_default_timeout: bool,
+    cancelled: Arc<AtomicBool>,
+}
+
 #[tokio::main]
 async fn main() {
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -269,7 +278,8 @@ async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Resu
     let check_baseline = cfg.check_baseline;
     let pr_comment = cfg.pr_comment.clone();
 
-    let (mut config, fail_fast, has_explicit_build_cmd) = resolve_config(cfg)?;
+    let (mut config, fail_fast, has_explicit_build_cmd, has_custom_test_cmd, has_cli_timeout) =
+        resolve_config(cfg)?;
     let project_root = get_project_root()?;
     let _lock = togi::lock::acquire(&project_root)?;
 
@@ -323,10 +333,14 @@ async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Resu
         mutations,
         config,
         project_root,
-        verbose,
-        show_output,
-        has_explicit_build_cmd,
-        cancelled,
+        ExecuteOptions {
+            verbose,
+            show_output,
+            build_command_explicit: has_explicit_build_cmd,
+            force_default_command: has_custom_test_cmd,
+            force_default_timeout: has_custom_test_cmd || has_cli_timeout,
+            cancelled,
+        },
     )
     .await;
 
@@ -383,10 +397,13 @@ async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Resu
     Ok(())
 }
 
-fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, bool, bool)> {
+fn resolve_config(
+    cfg: CheckConfig,
+) -> anyhow::Result<(togi::config::Config, bool, bool, bool, bool)> {
     let mut config = togi::config::Config::load(cfg.config_path.as_deref())?;
     let has_custom_test_cmd = cfg.test_cmd.is_some();
     let has_cli_build_cmd = cfg.build_cmd.is_some();
+    let has_cli_timeout = cfg.timeout.is_some();
 
     if let Some(b) = cfg.base {
         config.diff.base = b;
@@ -421,7 +438,13 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<(togi::config::Config, boo
 
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
-    Ok((config, fail_fast, has_explicit_build_cmd))
+    Ok((
+        config,
+        fail_fast,
+        has_explicit_build_cmd,
+        has_custom_test_cmd,
+        has_cli_timeout,
+    ))
 }
 
 /// Parse a shard spec like "1/4" into (k, n) where k is 1-indexed.
@@ -591,10 +614,7 @@ async fn execute(
     mutations: Vec<Mutation>,
     config: togi::config::Config,
     project_root: PathBuf,
-    verbose: bool,
-    show_output: bool,
-    build_command_explicit: bool,
-    cancelled: Arc<AtomicBool>,
+    options: ExecuteOptions,
 ) -> MutationReport {
     let mut language_commands: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
@@ -606,6 +626,21 @@ async fn execute(
             language_timeouts.insert(lang, Duration::from_secs(t));
         }
     }
+    let project_commands = config
+        .projects
+        .into_values()
+        .map(|project| {
+            let (command, timeout) = project
+                .test
+                .map(|test| (test.command, test.timeout))
+                .unwrap_or((None, None));
+            togi::runner::ProjectCommandConfig {
+                path: project.path,
+                command,
+                timeout: timeout.map(Duration::from_secs),
+            }
+        })
+        .collect();
     let test_selection = load_test_selection(
         config.mutations.test_selection_file.as_deref(),
         &project_root,
@@ -614,28 +649,31 @@ async fn execute(
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
             command: config.test.command,
+            force_default_command: options.force_default_command,
+            force_default_timeout: options.force_default_timeout,
+            project_commands,
             language_commands,
-            build_command: if build_command_explicit {
+            build_command: if options.build_command_explicit {
                 config.test.build_command
             } else {
                 vec![]
             },
-            build_command_explicit,
+            build_command_explicit: options.build_command_explicit,
             timeout: Duration::from_secs(config.test.timeout),
             language_timeouts,
             test_selection,
         },
         parallelism: config.test.jobs,
         project_root,
-        verbose,
-        show_output,
+        verbose: options.verbose,
+        show_output: options.show_output,
         max_tested: if config.mutations.max_per_run == 0 {
             None
         } else {
             Some(config.mutations.max_per_run)
         },
         env: std::collections::HashMap::new(),
-        cancelled,
+        cancelled: options.cancelled,
     };
 
     runner.run(mutations).await

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -24,13 +24,20 @@ fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
 
 /// Commands and timeouts used while evaluating mutations.
 ///
-/// `command` is the default test command. `language_commands` and
-/// `language_timeouts` override it for mutations generated from a specific
-/// language. `build_command`, when explicitly enabled by the CLI/config, runs
-/// before tests to classify uncompilable mutations as build errors.
+/// `command` is the default test command. Project and language commands can
+/// override it for matching mutations unless `force_default_command` is set
+/// by a CLI command override. `build_command`, when explicitly enabled by the
+/// CLI/config, runs before tests to classify uncompilable mutations as build
+/// errors.
 pub struct CommandConfig {
     /// Default test command, stored as argv.
     pub command: Vec<String>,
+    /// True when the default command came from a CLI override and must win.
+    pub force_default_command: bool,
+    /// True when the default timeout came from a CLI override and must win.
+    pub force_default_timeout: bool,
+    /// Per-project test command and timeout overrides, longest path wins.
+    pub project_commands: Vec<ProjectCommandConfig>,
     /// Per-language test command overrides keyed by `LanguageSupport::name()`.
     pub language_commands: HashMap<String, Vec<String>>,
     /// Optional build-check command, stored as argv.
@@ -43,6 +50,13 @@ pub struct CommandConfig {
     pub language_timeouts: HashMap<String, Duration>,
     /// Optional source-line to test-name map used to narrow test commands.
     pub test_selection: Option<TestSelectionConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectCommandConfig {
+    pub path: PathBuf,
+    pub command: Option<Vec<String>>,
+    pub timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -139,9 +153,19 @@ fn select_test_command(
     commands: &CommandConfig,
     mutation: &Mutation,
 ) -> SelectedTestCommand {
-    let mut argv = commands
-        .language_commands
-        .get(mutation.language.as_str())
+    let project = if commands.force_default_command {
+        None
+    } else {
+        matching_project_command(project_root, commands, mutation)
+    };
+
+    let mut argv = project
+        .and_then(|project| project.command.as_ref())
+        .or_else(|| {
+            (!commands.force_default_command)
+                .then(|| commands.language_commands.get(mutation.language.as_str()))
+                .flatten()
+        })
         .unwrap_or(&commands.command)
         .clone();
 
@@ -153,12 +177,52 @@ fn select_test_command(
 
     SelectedTestCommand {
         argv,
-        timeout: commands
-            .language_timeouts
-            .get(mutation.language.as_str())
-            .copied()
-            .unwrap_or(commands.timeout),
+        timeout: if commands.force_default_timeout {
+            commands.timeout
+        } else {
+            project
+                .and_then(|project| project.timeout)
+                .or_else(|| {
+                    commands
+                        .language_timeouts
+                        .get(mutation.language.as_str())
+                        .copied()
+                })
+                .unwrap_or(commands.timeout)
+        },
     }
+}
+
+fn matching_project_command<'a>(
+    project_root: &Path,
+    commands: &'a CommandConfig,
+    mutation: &Mutation,
+) -> Option<&'a ProjectCommandConfig> {
+    let mutation_path = normalized_cache_path(project_root, &mutation.file);
+    let mutation_parts: Vec<&str> = mutation_path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    commands
+        .project_commands
+        .iter()
+        .filter_map(|project| {
+            let project_path = normalized_cache_path(project_root, &project.path);
+            let project_parts: Vec<&str> = project_path
+                .split('/')
+                .filter(|part| !part.is_empty())
+                .collect();
+            (!project_parts.is_empty()
+                && project_parts.len() <= mutation_parts.len()
+                && mutation_parts
+                    .iter()
+                    .zip(&project_parts)
+                    .all(|(mutation, project)| mutation == project))
+            .then_some((project_parts.len(), project))
+        })
+        .max_by_key(|(len, _)| *len)
+        .map(|(_, project)| project)
 }
 
 fn narrow_go_test_command(mut argv: Vec<String>, tests: &[String]) -> Vec<String> {
@@ -591,7 +655,9 @@ impl TestRunner {
         MutationReport {
             results: all_results,
             duration,
-            test_command: if self.commands.language_commands.is_empty() {
+            test_command: if self.commands.language_commands.is_empty()
+                && self.commands.project_commands.is_empty()
+            {
                 Some(self.commands.command.clone())
             } else {
                 None
@@ -976,6 +1042,9 @@ mod tests {
     fn test_command_config() -> CommandConfig {
         CommandConfig {
             command: vec!["cargo".into(), "test".into()],
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
             language_commands: HashMap::new(),
             build_command: vec![],
             build_command_explicit: false,
@@ -1013,6 +1082,158 @@ mod tests {
 
         assert_eq!(selected.argv, vec!["go", "test", "./..."]);
         assert_eq!(selected.timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn select_test_command_uses_project_command_and_timeout() {
+        let mut commands = test_command_config();
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec![
+                "cargo".into(),
+                "test".into(),
+                "-p".into(),
+                "api".into(),
+            ]),
+            timeout: Some(Duration::from_secs(12)),
+        });
+        let mutation = make_test_mutation(Path::new("services/api/src/lib.rs"));
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["cargo", "test", "-p", "api"]);
+        assert_eq!(selected.timeout, Duration::from_secs(12));
+    }
+
+    #[test]
+    fn select_test_command_project_longest_prefix_wins() {
+        let mut commands = test_command_config();
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services"),
+            command: Some(vec!["make".into(), "test-services".into()]),
+            timeout: Some(Duration::from_secs(10)),
+        });
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec!["make".into(), "test-api".into()]),
+            timeout: Some(Duration::from_secs(20)),
+        });
+        let mutation = make_test_mutation(Path::new("services/api/src/lib.rs"));
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["make", "test-api"]);
+        assert_eq!(selected.timeout, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn select_test_command_project_overrides_language() {
+        let mut commands = test_command_config();
+        commands.language_commands.insert(
+            "go".into(),
+            vec!["go".into(), "test".into(), "./...".into()],
+        );
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_secs(5));
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec![
+                "go".into(),
+                "test".into(),
+                "./services/api/...".into(),
+            ]),
+            timeout: Some(Duration::from_secs(9)),
+        });
+        let mut mutation = make_test_mutation(Path::new("services/api/calc.go"));
+        mutation.language = "go".into();
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["go", "test", "./services/api/..."]);
+        assert_eq!(selected.timeout, Duration::from_secs(9));
+    }
+
+    #[test]
+    fn select_test_command_project_timeout_can_override_language_command() {
+        let mut commands = test_command_config();
+        commands.language_commands.insert(
+            "go".into(),
+            vec!["go".into(), "test".into(), "./...".into()],
+        );
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_secs(5));
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: None,
+            timeout: Some(Duration::from_secs(11)),
+        });
+        let mut mutation = make_test_mutation(Path::new("services/api/calc.go"));
+        mutation.language = "go".into();
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["go", "test", "./..."]);
+        assert_eq!(selected.timeout, Duration::from_secs(11));
+    }
+
+    #[test]
+    fn select_test_command_cli_override_ignores_project_and_language() {
+        let mut commands = test_command_config();
+        commands.command = vec!["make".into(), "ci".into()];
+        commands.timeout = Duration::from_secs(30);
+        commands.force_default_command = true;
+        commands.force_default_timeout = true;
+        commands.language_commands.insert(
+            "go".into(),
+            vec!["go".into(), "test".into(), "./...".into()],
+        );
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_secs(5));
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec![
+                "go".into(),
+                "test".into(),
+                "./services/api/...".into(),
+            ]),
+            timeout: Some(Duration::from_secs(9)),
+        });
+        let mut mutation = make_test_mutation(Path::new("services/api/calc.go"));
+        mutation.language = "go".into();
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["make", "ci"]);
+        assert_eq!(selected.timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn select_test_command_cli_timeout_overrides_project_and_language_timeout() {
+        let mut commands = test_command_config();
+        commands.timeout = Duration::from_secs(30);
+        commands.force_default_timeout = true;
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_secs(5));
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec![
+                "go".into(),
+                "test".into(),
+                "./services/api/...".into(),
+            ]),
+            timeout: Some(Duration::from_secs(9)),
+        });
+        let mut mutation = make_test_mutation(Path::new("services/api/calc.go"));
+        mutation.language = "go".into();
+
+        let selected = select_test_command(Path::new("/repo"), &commands, &mutation);
+
+        assert_eq!(selected.argv, vec!["go", "test", "./services/api/..."]);
+        assert_eq!(selected.timeout, Duration::from_secs(30));
     }
 
     #[test]
@@ -1573,6 +1794,9 @@ mod tests {
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["true".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,
@@ -1615,6 +1839,9 @@ mod tests {
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["true".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: lang_cmds,
                 build_command: vec![],
                 build_command_explicit: false,
@@ -1654,6 +1881,9 @@ mod tests {
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["true".into()], // default would survive
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: lang_cmds,
                 build_command: vec![],
                 build_command_explicit: false,
@@ -1718,6 +1948,9 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["sh".into(), "-c".into(), script],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,
@@ -1790,6 +2023,9 @@ exit 1"#
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["sh".into(), "-c".into(), script],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,
@@ -1841,6 +2077,9 @@ exit 1"#
         let runner = TestRunner {
             commands: CommandConfig {
                 command: vec!["sleep".into(), "1".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -94,6 +94,9 @@ async fn end_to_end_go_fixture_all_killed_with_cache_off() {
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
             command: vec!["go".into(), "test".into(), "./...".into()],
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
             build_command_explicit: false,

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -53,6 +53,9 @@ async fn verify_mutation_outcomes_match_independent_replay() {
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
             command: vec!["go".into(), "test".into(), "./...".into()],
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
             build_command_explicit: false,

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -89,11 +89,13 @@ operators = ["binary", "-string_to_empty"]
 
 [projects.api]
 # Optional monorepo project metadata. The longest matching path wins when
-# looking up project config.
+# looking up project config. Project test config takes precedence over
+# per-language and global test config unless --test-cmd/--timeout are used.
 # Type: string path
 path = "services/api"
 
-# Optional language hint for the project.
+# Optional language hint for the project. Source files are still parsed by
+# extension; this is metadata for humans and future tooling.
 # Type: string
 # Default: unset
 language = "go"


### PR DESCRIPTION
## Summary

- Add project-aware test command and timeout selection in the runner.
- Apply precedence: CLI overrides, longest-matching `[projects.*.test]`, language overrides, then global `[test]`.
- Preserve Go test-selection narrowing after command selection.
- Document project config precedence in README and `togi.toml.example`.

Fixes #316.

## Verification

- `cargo fmt -- --check`
- `cargo test select_test_command`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --ignored`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-project test command and timeout configuration with clear precedence; test reports now show the selected command/timeout.

* **Documentation**
  * README and example config updated with a “Test command precedence” section detailing how CLI options, project-level settings, language defaults, and global defaults interact.

* **Tests**
  * Integration tests expanded to cover project-level command/timeout selection and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->