### PR TITLE
Fix language-aware mutation replacements

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -20,6 +20,7 @@ pub mod typescript;
 ///   operator_field: "operator"
 ///   skip_subtree_kinds: []
 ///   filter_candidate: function path
+///   condition_negation: function path
 macro_rules! define_language {
     (
         $struct:ident,
@@ -34,6 +35,7 @@ macro_rules! define_language {
         $(, operator_field: $op:expr)?
         $(, skip_subtree_kinds: [$($sk:expr),* $(,)?])?
         $(, filter_candidate: $filter:expr)?
+        $(, condition_negation: $negation:expr)?
         $(, empty_block_replacement: $ebr:expr)?
         $(,)?
     ) => {
@@ -64,6 +66,7 @@ macro_rules! define_language {
             fn skip_subtree_kinds(&self) -> &[&str] {
                 $crate::languages::define_language!(@arr [$($($sk),*)?] ; [])
             }
+            $crate::languages::define_language!(@negation $($negation)?);
             $crate::languages::define_language!(@filter $($filter)?);
             $crate::languages::define_language!(@fixup $($ebr)?);
         }
@@ -86,9 +89,17 @@ macro_rules! define_language {
         }
     };
     (@filter) => {};
+    // Helper: override condition negation formatting if condition_negation is set
+    (@negation $negation:expr) => {
+        fn negate_condition_replacement(&self, condition: &str) -> String {
+            $negation(condition)
+        }
+    };
+    (@negation) => {};
     // Helper: override fixup_replacement if empty_block_replacement is set
     (@fixup $replacement:expr) => {
         fn fixup_replacement(&self, candidate: &mut $crate::MutationCandidate) {
+            $crate::languages::fixup_language_replacement(self, candidate);
             if candidate.operator_id == "remove_if_body" && candidate.replacement == "{}" {
                 candidate.replacement = $replacement.to_string();
             }
@@ -164,6 +175,39 @@ pub(crate) fn should_skip_string_to_empty_in_compiled_context(node: &tree_sitter
     false
 }
 
+pub(crate) fn fixup_language_replacement<L: LanguageSupport + ?Sized>(
+    lang: &L,
+    candidate: &mut crate::MutationCandidate,
+) {
+    match candidate.operator_id.as_str() {
+        "true_to_false" => {
+            if let Some(literal) = lang.boolean_false_literals().first() {
+                candidate.replacement = (*literal).to_string();
+            }
+        }
+        "false_to_true" => {
+            if let Some(literal) = lang.boolean_true_literals().first() {
+                candidate.replacement = (*literal).to_string();
+            }
+        }
+        "return_empty" if candidate.replacement == "false" => {
+            if let Some(literal) = lang.boolean_false_literals().first() {
+                candidate.replacement = (*literal).to_string();
+            }
+        }
+        "negate_condition" => {
+            if let Some(condition) = candidate
+                .replacement
+                .strip_prefix("!(")
+                .and_then(|s| s.strip_suffix(')'))
+            {
+                candidate.replacement = lang.negate_condition_replacement(condition);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Describes how to parse and mutate one supported language.
 ///
 /// The mutator uses this trait to choose the tree-sitter grammar, identify
@@ -197,6 +241,11 @@ pub trait LanguageSupport: Send + Sync {
     /// Tree-sitter field name used to find operators when available.
     fn operator_field(&self) -> &str;
 
+    /// Format a replacement that negates an unnegated condition expression.
+    fn negate_condition_replacement(&self, condition: &str) -> String {
+        format!("!({condition})")
+    }
+
     /// AST node kinds that should suppress mutation of any descendant.
     /// Nodes whose ancestor matches any of these kinds will be skipped.
     fn skip_subtree_kinds(&self) -> &[&str] {
@@ -221,7 +270,9 @@ pub trait LanguageSupport: Send + Sync {
 
     /// Adjust a mutation candidate's replacement for language-specific syntax.
     /// For example, Python replaces `{}` (empty block) with `pass`.
-    fn fixup_replacement(&self, _candidate: &mut crate::MutationCandidate) {}
+    fn fixup_replacement(&self, candidate: &mut crate::MutationCandidate) {
+        fixup_language_replacement(self, candidate);
+    }
 }
 
 /// Returns instances of all supported languages.

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -131,6 +131,21 @@ mod tests {
     }
 
     #[test]
+    fn return_empty_boolean_replacement_uses_python_false_literal() {
+        let py = Python;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..4,
+            replacement: "false".to_string(),
+            operator_id: "return_empty".to_string(),
+            description: String::new(),
+        };
+
+        py.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "False");
+    }
+
+    #[test]
     fn condition_negation_uses_python_syntax() {
         let py = Python;
         let mut candidate = MutationCandidate {

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -6,8 +6,13 @@ crate::languages::define_language!(
     binary_expression: "binary_operator",
     bool_true: ["True"],
     bool_false: ["False"],
+    condition_negation: python_negation,
     empty_block_replacement: "pass",
 );
+
+fn python_negation(condition: &str) -> String {
+    format!("not ({condition})")
+}
 
 #[cfg(test)]
 mod tests {
@@ -100,6 +105,44 @@ mod tests {
         py.fixup_replacement(&mut candidate);
 
         assert_eq!(candidate.replacement, "pass");
+    }
+
+    #[test]
+    fn boolean_replacements_use_python_literals() {
+        let py = Python;
+        let mut true_to_false = MutationCandidate {
+            byte_range: 0..4,
+            replacement: "false".to_string(),
+            operator_id: "true_to_false".to_string(),
+            description: String::new(),
+        };
+        let mut false_to_true = MutationCandidate {
+            byte_range: 0..5,
+            replacement: "true".to_string(),
+            operator_id: "false_to_true".to_string(),
+            description: String::new(),
+        };
+
+        py.fixup_replacement(&mut true_to_false);
+        py.fixup_replacement(&mut false_to_true);
+
+        assert_eq!(true_to_false.replacement, "False");
+        assert_eq!(false_to_true.replacement, "True");
+    }
+
+    #[test]
+    fn condition_negation_uses_python_syntax() {
+        let py = Python;
+        let mut candidate = MutationCandidate {
+            byte_range: 0..5,
+            replacement: "!(x > 0)".to_string(),
+            operator_id: "negate_condition".to_string(),
+            description: String::new(),
+        };
+
+        py.fixup_replacement(&mut candidate);
+
+        assert_eq!(candidate.replacement, "not (x > 0)");
     }
 
     #[test]

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -206,7 +206,7 @@ fn sample_diverse(mutations: Vec<Mutation>, cap: usize) -> Vec<Mutation> {
 mod tests {
     use super::*;
     use crate::languages::go::Go;
-    use crate::test_helpers::{find_node_by_kind, parse_go};
+    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python};
     use crate::{ChangedFile, LineRange};
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -225,6 +225,15 @@ mod tests {
             operator_id: operator_id.to_string(),
             description: String::new(),
         }
+    }
+
+    fn apply_mutation(source: &str, mutation: &Mutation) -> String {
+        let mut mutated = source.as_bytes().to_vec();
+        mutated.splice(
+            mutation.byte_range.clone(),
+            mutation.replacement.as_bytes().iter().copied(),
+        );
+        String::from_utf8(mutated).unwrap()
     }
 
     #[test]
@@ -336,6 +345,107 @@ mod tests {
             .expect("remove_if_body mutation should be generated");
 
         assert_eq!(m.replacement, "pass");
+    }
+
+    #[test]
+    fn python_boolean_literal_replacements_use_python_syntax() {
+        let tmp = TempDir::new().unwrap();
+        let src = "def check(x):\n    if x > 0:\n        return True\n    return False\n";
+        let rel = write_test_file(tmp.path(), "test.py", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 4 }],
+        }];
+
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &["true_to_false".into(), "false_to_true".into()],
+        )
+        .unwrap();
+
+        assert!(
+            mutations.iter().any(|m| m.operator == "true_to_false"
+                && m.original == "True"
+                && m.replacement == "False"),
+            "expected Python True -> False mutation, got: {mutations:?}"
+        );
+        assert!(
+            mutations.iter().any(|m| m.operator == "false_to_true"
+                && m.original == "False"
+                && m.replacement == "True"),
+            "expected Python False -> True mutation, got: {mutations:?}"
+        );
+
+        for mutation in &mutations {
+            let mutated = apply_mutation(src, mutation);
+            let tree = parse_python(&mutated);
+            assert!(
+                !tree.root_node().has_error(),
+                "mutation should parse as Python:\n{mutated}"
+            );
+        }
+    }
+
+    #[test]
+    fn python_negate_condition_uses_python_syntax() {
+        let tmp = TempDir::new().unwrap();
+        let src = "def check(x):\n    if x > 0:\n        return True\n    return False\n";
+        let rel = write_test_file(tmp.path(), "test.py", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 2, end: 2 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["negate_condition".into()]).unwrap();
+        let mutation = mutations
+            .iter()
+            .find(|m| m.operator == "negate_condition")
+            .expect("negate_condition mutation should be generated");
+
+        assert_eq!(mutation.original, "x > 0");
+        assert_eq!(mutation.replacement, "not (x > 0)");
+
+        let mutated = apply_mutation(src, mutation);
+        let tree = parse_python(&mutated);
+        assert!(
+            !tree.root_node().has_error(),
+            "mutation should parse as Python:\n{mutated}"
+        );
+    }
+
+    #[test]
+    fn go_negate_condition_keeps_c_family_syntax() {
+        let tmp = TempDir::new().unwrap();
+        let src = "package main\n\nfunc check(x int) bool {\n\tif x > 0 {\n\t\treturn true\n\t}\n\treturn false\n}\n";
+        let rel = write_test_file(tmp.path(), "main.go", src);
+
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 4, end: 4 }],
+        }];
+
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["negate_condition".into()]).unwrap();
+        let mutation = mutations
+            .iter()
+            .find(|m| m.operator == "negate_condition")
+            .expect("negate_condition mutation should be generated");
+
+        assert_eq!(mutation.original, "x > 0");
+        assert_eq!(mutation.replacement, "!(x > 0)");
+
+        let mutated = apply_mutation(src, mutation);
+        let tree = parse_go(&mutated);
+        assert!(
+            !tree.root_node().has_error(),
+            "mutation should parse as Go:\n{mutated}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Make replacement fixups use language boolean literals for literal swaps and boolean return defaults
- Add language-specific condition negation formatting so Python emits `not (...)` while C-family languages keep `!(...)`
- Add generated-mutation parse tests for Python and Go

Fixes #313

## Tests
- `cargo fmt -- --check`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mutation testing: condition negation now produces language-appropriate expressions (e.g., Python uses "not (...)").
  * Mutations now normalize boolean-literal replacements and empty-return mutations per language conventions.

* **Tests**
  * Added tests verifying boolean literal swaps and condition negation produce correct, parseable syntax for each language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->