### PR TITLE
Fix GitHub Action test command argument handling

### DIFF
--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=(
+  check
+  --base "${TOGI_BASE:-origin/main}"
+  --timeout "${TOGI_TIMEOUT:-30}"
+  --format "${TOGI_FORMAT:-terminal}"
+)
+
+if [[ -n "${TOGI_TEST_CMD:-}" ]]; then
+  args+=(--test-cmd "$TOGI_TEST_CMD")
+fi
+
+"${TOGI_BIN:-togi}" "${args[@]}"

--- a/action.yml
+++ b/action.yml
@@ -48,9 +48,10 @@ runs:
 
     - name: Run togi
       shell: bash
+      env:
+        TOGI_BASE: ${{ inputs.base }}
+        TOGI_TIMEOUT: ${{ inputs.timeout }}
+        TOGI_FORMAT: ${{ inputs.format }}
+        TOGI_TEST_CMD: ${{ inputs.test-cmd }}
       run: |
-        ARGS="check --base ${{ inputs.base }} --timeout ${{ inputs.timeout }} --format ${{ inputs.format }}"
-        if [ -n "${{ inputs.test-cmd }}" ]; then
-          ARGS="$ARGS --test-cmd '${{ inputs.test-cmd }}'"
-        fi
-        togi $ARGS
+        bash "${{ github.action_path }}/.github/scripts/run-togi.sh"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,7 +12,8 @@ fn bash_available() -> bool {
     std::process::Command::new("bash")
         .arg("--version")
         .output()
-        .is_ok()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 /// Set up a minimal git repo with a Go file and a diff to test against.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,10 +1,18 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
 
 fn togi() -> Command {
     Command::cargo_bin("togi").unwrap()
+}
+
+fn bash_available() -> bool {
+    std::process::Command::new("bash")
+        .arg("--version")
+        .output()
+        .is_ok()
 }
 
 /// Set up a minimal git repo with a Go file and a diff to test against.
@@ -158,6 +166,63 @@ fn check_help_lists_test_selection_file_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--test-selection-file"));
+}
+
+#[test]
+fn github_action_run_helper_preserves_multiword_test_cmd() {
+    if !bash_available() {
+        eprintln!("skipping action helper test because bash is unavailable");
+        return;
+    }
+
+    assert_action_helper_test_cmd("go test ./...");
+    assert_action_helper_test_cmd("cargo test --workspace --all-features");
+}
+
+fn assert_action_helper_test_cmd(test_cmd: &str) {
+    let dir = TempDir::new().unwrap();
+    let fake_togi = dir.path().join("fake-togi.sh");
+    fs::write(&fake_togi, "#!/usr/bin/env bash\nprintf '<%s>\\n' \"$@\"\n").unwrap();
+    std::process::Command::new("bash")
+        .args(["-c", "chmod +x \"$1\"", "--"])
+        .arg(&fake_togi)
+        .output()
+        .unwrap();
+
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
+    let output = std::process::Command::new("bash")
+        .arg(helper)
+        .env("TOGI_BIN", &fake_togi)
+        .env("TOGI_BASE", "HEAD~1")
+        .env("TOGI_TIMEOUT", "45")
+        .env("TOGI_FORMAT", "json")
+        .env("TOGI_TEST_CMD", test_cmd)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let args: Vec<String> = stdout.lines().map(String::from).collect();
+    assert_eq!(
+        args,
+        vec![
+            "<check>".to_string(),
+            "<--base>".to_string(),
+            "<HEAD~1>".to_string(),
+            "<--timeout>".to_string(),
+            "<45>".to_string(),
+            "<--format>".to_string(),
+            "<json>".to_string(),
+            "<--test-cmd>".to_string(),
+            format!("<{test_cmd}>"),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace the action's shell string argument construction with a Bash array helper
- Pass composite action inputs through environment variables to preserve multiword `test-cmd` values
- Add a regression test that verifies `go test ./...` and `cargo test --workspace --all-features` reach Togi as single `--test-cmd` values

Fixes #315

## Tests
- `cargo fmt -- --check`
- `cargo test --test cli github_action_run_helper_preserves_multiword_test_cmd`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper script to centralize command assembly and execution for the workflow.

* **Refactor**
  * Workflow step now delegates configuration and execution to the helper script (env-based), simplifying the action.

* **Tests**
  * Added integration tests ensuring the helper preserves multi-word test commands and forwards arguments correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->