### PR TITLE
fix: respect ignores in mutation workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ test_selection_file = "coverage/test-selection.json"
 operators = ["-string_to_empty"]
 exclude_paths = ["vendor/**"]
 skip_noisy_files = true
+respect_workspace_ignores = true
 ```
 
 Test command precedence is: CLI `--test-cmd` / `--timeout`, matching
@@ -328,6 +329,15 @@ togi check --check-baseline
 ```
 
 Baselines are stored in `.togi-baseline`.
+
+## Workspace copies
+
+togi runs mutations in temporary workspace copies so parallel jobs do not observe
+each other's edits. These copies respect project ignore rules from `.ignore` and
+`.gitignore`, while always excluding VCS metadata, togi internals, and common
+dependency/build directories such as `node_modules`, `.venv`, `dist`, `build`,
+and `target`. Set `[mutations] respect_workspace_ignores = false` only when a
+test command genuinely needs ignored files copied into the mutation workspace.
 
 ## How it works
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,8 @@ pub struct MutationConfig {
     pub exclude_paths: Vec<String>,
     #[serde(default = "default_true")]
     pub skip_noisy_files: bool,
+    #[serde(default = "default_true")]
+    pub respect_workspace_ignores: bool,
     #[serde(default)]
     pub operators: Vec<String>,
 }
@@ -267,6 +269,7 @@ impl Default for MutationConfig {
             test_selection_file: None,
             exclude_paths: vec![],
             skip_noisy_files: true,
+            respect_workspace_ignores: true,
             operators: vec![],
         }
     }
@@ -421,7 +424,8 @@ impl Config {
              \n\
              [mutations]\n\
              max_per_run = 20\n\
-             # max_per_file = 20  # cap mutations per source file (0 = unlimited)\n",
+             # max_per_file = 20  # cap mutations per source file (0 = unlimited)\n\
+             # respect_workspace_ignores = true  # honor .ignore/.gitignore in mutation workspaces\n",
         );
 
         std::fs::write(path, template)?;
@@ -488,6 +492,7 @@ max_per_run = 50
             Some("coverage/test-selection.json".into())
         );
         assert!(config.mutations.skip_noisy_files);
+        assert!(config.mutations.respect_workspace_ignores);
         let project = &config.projects["api"];
         assert_eq!(project.path, PathBuf::from("services/api"));
         assert_eq!(project.test.as_ref().unwrap().timeout, Some(60));
@@ -510,6 +515,7 @@ max_per_run = 50
         assert!(config.mutations.test_selection_file.is_none());
         assert!(config.mutations.exclude_paths.is_empty());
         assert!(config.mutations.skip_noisy_files);
+        assert!(config.mutations.respect_workspace_ignores);
         assert!(config.projects.is_empty());
     }
 
@@ -874,6 +880,7 @@ language = "go"
 [mutations]
 exclude_paths = ["vendor/**", "*.generated.ts"]
 skip_noisy_files = false
+respect_workspace_ignores = false
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -881,6 +888,7 @@ skip_noisy_files = false
             vec!["vendor/**", "*.generated.ts"]
         );
         assert!(!config.mutations.skip_noisy_files);
+        assert!(!config.mutations.respect_workspace_ignores);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,7 @@ async fn execute(
         } else {
             Some(config.mutations.max_per_run)
         },
+        respect_workspace_ignores: config.mutations.respect_workspace_ignores,
         env: std::collections::HashMap::new(),
         cancelled: options.cancelled,
     };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -112,6 +112,8 @@ pub struct TestRunner {
     pub show_output: bool,
     /// Optional cap on how many non-build-error mutations are tested.
     pub max_tested: Option<usize>,
+    /// Whether workspace copies should honor `.ignore`/`.gitignore` rules.
+    pub respect_workspace_ignores: bool,
     /// Extra environment variables passed to every spawned command.
     pub env: HashMap<String, String>,
     /// Set to true externally (e.g. Ctrl+C handler) to stop spawning new mutations.
@@ -298,11 +300,24 @@ impl WorkspaceCopy {
 }
 
 pub(crate) fn should_skip_workspace_entry(relative: &Path) -> bool {
-    relative
-        .components()
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-        .is_some_and(|name| matches!(name, ".git" | ".togi" | "target"))
+    relative.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            matches!(
+                name,
+                ".git"
+                    | ".togi"
+                    | ".togi-cache"
+                    | ".togi.lock"
+                    | ".codex"
+                    | ".claude"
+                    | "target"
+                    | "node_modules"
+                    | ".venv"
+                    | "dist"
+                    | "build"
+            )
+        })
+    })
 }
 
 fn should_copy_workspace_entry(project_root: &Path, path: &Path) -> bool {
@@ -313,23 +328,31 @@ fn should_copy_workspace_entry(project_root: &Path, path: &Path) -> bool {
 }
 
 pub(crate) fn copy_workspace(project_root: &Path) -> std::io::Result<WorkspaceCopy> {
+    copy_workspace_with_options(project_root, true)
+}
+
+fn copy_workspace_with_options(
+    project_root: &Path,
+    respect_ignores: bool,
+) -> std::io::Result<WorkspaceCopy> {
     let tempdir = tempfile::tempdir()?;
     let root = tempdir.path().join("workspace");
     fs::create_dir(&root)?;
     let project_root_for_filter = project_root.to_path_buf();
 
-    for entry in ignore::WalkBuilder::new(project_root)
+    let mut builder = ignore::WalkBuilder::new(project_root);
+    builder
         .hidden(false)
-        .ignore(false)
-        .git_ignore(false)
-        .git_exclude(false)
-        .git_global(false)
-        .parents(false)
+        .ignore(respect_ignores)
+        .git_ignore(respect_ignores)
+        .git_exclude(respect_ignores)
+        .git_global(respect_ignores)
+        .parents(respect_ignores)
         .filter_entry(move |entry| {
             should_copy_workspace_entry(&project_root_for_filter, entry.path())
-        })
-        .build()
-    {
+        });
+
+    for entry in builder.build() {
         let entry = match entry {
             Ok(entry) => entry,
             Err(err) => {
@@ -370,10 +393,23 @@ pub(crate) struct WorkspacePool {
 
 impl WorkspacePool {
     pub(crate) fn new(project_root: &Path, slots: usize) -> std::io::Result<Self> {
+        Self::new_with_options(project_root, slots, true)
+    }
+
+    fn new_with_options(
+        project_root: &Path,
+        slots: usize,
+        respect_ignores: bool,
+    ) -> std::io::Result<Self> {
         let slots = slots.max(1);
         let mut copies = Vec::with_capacity(slots);
         for _ in 0..slots {
-            copies.push(copy_workspace(project_root)?);
+            let copy = if respect_ignores {
+                copy_workspace(project_root)?
+            } else {
+                copy_workspace_with_options(project_root, false)?
+            };
+            copies.push(copy);
         }
 
         let free_slots = (0..slots).collect();
@@ -440,7 +476,12 @@ impl TestRunner {
         let verbose = self.verbose;
         let is_tty = std::io::stderr().is_terminal();
 
-        let workspace_pool = match WorkspacePool::new(&self.project_root, self.parallelism) {
+        let workspace_pool_result = if self.respect_workspace_ignores {
+            WorkspacePool::new(&self.project_root, self.parallelism)
+        } else {
+            WorkspacePool::new_with_options(&self.project_root, self.parallelism, false)
+        };
+        let workspace_pool = match workspace_pool_result {
             Ok(pool) => Arc::new(pool),
             Err(e) => {
                 eprintln!("warning: could not create isolated mutation workspaces: {e}");
@@ -1416,15 +1457,43 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        std::fs::create_dir_all(root.join(".venv")).unwrap();
+        std::fs::create_dir_all(root.join("dist")).unwrap();
+        std::fs::create_dir_all(root.join("build")).unwrap();
+        std::fs::create_dir_all(root.join("services/api/src")).unwrap();
+        std::fs::create_dir_all(root.join("services/api/node_modules/pkg")).unwrap();
+        std::fs::create_dir_all(root.join("services/api/build")).unwrap();
         std::fs::create_dir_all(root.join("target/debug")).unwrap();
         std::fs::create_dir_all(root.join(".git/objects")).unwrap();
         std::fs::create_dir_all(root.join(".togi")).unwrap();
+        std::fs::create_dir_all(root.join(".togi-cache")).unwrap();
+        std::fs::create_dir_all(root.join(".codex")).unwrap();
+        std::fs::create_dir_all(root.join(".claude")).unwrap();
         std::fs::write(root.join("Cargo.toml"), b"[package]\n").unwrap();
-        std::fs::write(root.join(".ignore"), b"src/lib.rs\n").unwrap();
+        std::fs::write(root.join(".ignore"), b"src/ignored_by_ignore.rs\n").unwrap();
+        std::fs::write(root.join(".gitignore"), b"ignored-by-gitignore.txt\n").unwrap();
         std::fs::write(root.join("src/lib.rs"), b"pub fn f() {}\n").unwrap();
+        std::fs::write(
+            root.join("src/ignored_by_ignore.rs"),
+            b"pub fn ignored() {}\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("ignored-by-gitignore.txt"), b"skip").unwrap();
+        std::fs::write(root.join("node_modules/pkg/index.js"), b"skip").unwrap();
+        std::fs::write(root.join(".venv/pyvenv.cfg"), b"skip").unwrap();
+        std::fs::write(root.join("dist/bundle.js"), b"skip").unwrap();
+        std::fs::write(root.join("build/artifact"), b"skip").unwrap();
+        std::fs::write(root.join("services/api/src/lib.rs"), b"pub fn api() {}\n").unwrap();
+        std::fs::write(root.join("services/api/node_modules/pkg/index.js"), b"skip").unwrap();
+        std::fs::write(root.join("services/api/build/artifact"), b"skip").unwrap();
         std::fs::write(root.join("target/debug/build-artifact"), b"skip").unwrap();
         std::fs::write(root.join(".git/HEAD"), b"skip").unwrap();
         std::fs::write(root.join(".togi/cache"), b"skip").unwrap();
+        std::fs::write(root.join(".togi-cache/cache-entry"), b"skip").unwrap();
+        std::fs::write(root.join(".togi.lock"), b"skip").unwrap();
+        std::fs::write(root.join(".codex/session"), b"skip").unwrap();
+        std::fs::write(root.join(".claude/session"), b"skip").unwrap();
 
         let copy = copy_workspace(root).unwrap();
 
@@ -1433,9 +1502,43 @@ mod tests {
             b"pub fn f() {}\n"
         );
         assert!(copy.root().join("Cargo.toml").exists());
+        assert!(!copy.root().join("src/ignored_by_ignore.rs").exists());
+        assert!(!copy.root().join("ignored-by-gitignore.txt").exists());
+        assert!(!copy.root().join("node_modules").exists());
+        assert!(!copy.root().join(".venv").exists());
+        assert!(!copy.root().join("dist").exists());
+        assert!(!copy.root().join("build").exists());
+        assert!(copy.root().join("services/api/src/lib.rs").exists());
+        assert!(!copy.root().join("services/api/node_modules").exists());
+        assert!(!copy.root().join("services/api/build").exists());
         assert!(!copy.root().join("target").exists());
         assert!(!copy.root().join(".git").exists());
         assert!(!copy.root().join(".togi").exists());
+        assert!(!copy.root().join(".togi-cache").exists());
+        assert!(!copy.root().join(".togi.lock").exists());
+        assert!(!copy.root().join(".codex").exists());
+        assert!(!copy.root().join(".claude").exists());
+    }
+
+    #[test]
+    fn copy_workspace_can_include_ignored_files_when_requested() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        std::fs::write(root.join(".gitignore"), b"ignored.txt\n").unwrap();
+        std::fs::write(root.join("ignored.txt"), b"copy me").unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub fn f() {}\n").unwrap();
+        std::fs::write(root.join("target/debug/build-artifact"), b"skip").unwrap();
+
+        let copy = copy_workspace_with_options(root, false).unwrap();
+
+        assert_eq!(
+            std::fs::read(copy.root().join("ignored.txt")).unwrap(),
+            b"copy me"
+        );
+        assert!(copy.root().join("src/lib.rs").exists());
+        assert!(!copy.root().join("target").exists());
     }
 
     #[tokio::test]
@@ -1805,6 +1908,7 @@ mod tests {
             verbose: false,
             show_output: false,
             max_tested: Some(2),
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };
@@ -1850,6 +1954,7 @@ mod tests {
             verbose: false,
             show_output: false,
             max_tested: None,
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };
@@ -1892,6 +1997,7 @@ mod tests {
             verbose: false,
             show_output: false,
             max_tested: None,
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };
@@ -1959,6 +2065,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             verbose: false,
             show_output: false,
             max_tested: None,
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };
@@ -2034,6 +2141,7 @@ exit 1"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };
@@ -2088,6 +2196,7 @@ exit 1"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
         };

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -109,6 +109,7 @@ async fn end_to_end_go_fixture_all_killed_with_cache_off() {
         verbose: false,
         show_output: false,
         max_tested: None,
+        respect_workspace_ignores: true,
         env: go_env,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -68,6 +68,7 @@ async fn verify_mutation_outcomes_match_independent_replay() {
         verbose: false,
         show_output: false,
         max_tested: None,
+        respect_workspace_ignores: true,
         env: go_env.clone(),
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -80,6 +80,13 @@ exclude_paths = ["vendor/**", "generated/**"]
 # Default: true
 skip_noisy_files = true
 
+# Respect `.ignore`, `.gitignore`, git excludes, and global gitignore when
+# creating temporary mutation workspaces. Built-in excludes for VCS metadata,
+# togi internals, dependency directories, and build outputs always apply.
+# Type: boolean
+# Default: true
+respect_workspace_ignores = true
+
 # Operator filters. Use category names or operator ids; prefix with "-" to
 # exclude. Categories: binary, literal, boundary, removal, unary, loop, negate,
 # return.


### PR DESCRIPTION
## Summary
- Respect `.ignore`, `.gitignore`, git excludes, global gitignore, and parent ignore files when creating mutation workspace copies.
- Keep hard built-in skips for VCS metadata, togi internals, dependency directories, and build outputs.
- Add `[mutations] respect_workspace_ignores = false` as an escape hatch for projects that need ignored files copied.

Fixes #317.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `respect_workspace_ignores` option (enabled by default) to control whether temporary mutation workspaces honor ignore rules.

* **Documentation**
  * Expanded README and example config with a "Workspace copies" section describing ignore behavior and default exclusions for VCS metadata, tool internals, dependency folders, and build outputs.

* **Tests**
  * Updated tests to assert the new option exists and defaults to true.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->