### PR TITLE
fix: make baseline checks fail only on regressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Resu
             drop(_lock);
             process::exit(1);
         }
-    } else if report.survived > 0 {
+    } else if report.survived > 0 && !check_baseline {
         drop(_lock);
         process::exit(1);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -160,6 +160,104 @@ fn check_format_json_outputs_valid_json() {
     assert!(value.get("mutations").is_some());
 }
 
+fn write_baseline(dir: &Path, killed: usize, total: usize) {
+    fs::write(
+        dir.join(".togi-baseline"),
+        format!(
+            r#"{{
+  "files": {{
+    "main.go": {{
+      "killed": {killed},
+      "total": {total}
+    }}
+  }},
+  "killed": {killed},
+  "total": {total}
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn check_baseline_allows_existing_survivors() {
+    let dir = setup_git_repo();
+    write_baseline(dir.path(), 0, 1);
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+            "--check-baseline",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "baseline check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(value["survived"].as_u64().unwrap() > 0);
+}
+
+#[test]
+fn check_baseline_fails_on_regression() {
+    let dir = setup_git_repo();
+    write_baseline(dir.path(), 1, 1);
+
+    togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--test-cmd",
+            "true",
+            "--check-baseline",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "Mutation score regression detected",
+        ));
+}
+
+#[test]
+fn check_baseline_still_honors_fail_under() {
+    let dir = setup_git_repo();
+    write_baseline(dir.path(), 0, 1);
+
+    togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--test-cmd",
+            "true",
+            "--check-baseline",
+            "--fail-under",
+            "1",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("below --fail-under threshold"));
+}
+
 #[test]
 fn check_help_lists_test_selection_file_flag() {
     togi()


### PR DESCRIPTION
## Summary
- Keep the default survivor exit behavior for normal runs.
- Let `--check-baseline` pass when survivors match the saved baseline and no regression is detected.
- Keep explicit `--fail-under` enforcement active during baseline checks.

Fixes #311.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a baseline check mode that accepts previously recorded mutation survivors and detects mutation score regressions against that baseline.
* **Bug Fixes**
  * Adjusted exit behavior so runs only fail for surviving mutations when baseline checking is not enabled; fail-under thresholds remain enforced during baseline checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->