### PR TITLE
fix: resolve action release assets by runner platform

### DIFF
--- a/.github/scripts/install-togi-archive.sh
+++ b/.github/scripts/install-togi-archive.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TOGI_ARCHIVE:?TOGI_ARCHIVE is required}"
+: "${TOGI_BINARY:?TOGI_BINARY is required}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+
+TEMP_ROOT="${RUNNER_TEMP:-.}"
+if command -v cygpath >/dev/null 2>&1; then
+  TEMP_ROOT=$(cygpath -u "$TEMP_ROOT")
+fi
+INSTALL_DIR="${TEMP_ROOT}/togi-bin"
+EXTRACT_DIR="${TEMP_ROOT}/togi-extract"
+ARCHIVE_PATH="${TOGI_ARCHIVE_PATH:-${TEMP_ROOT}/${TOGI_ARCHIVE}}"
+rm -rf "$INSTALL_DIR" "$EXTRACT_DIR"
+mkdir -p "$INSTALL_DIR" "$EXTRACT_DIR"
+
+case "$TOGI_ARCHIVE" in
+  *.tar.gz) tar xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR" ;;
+  *.zip) unzip -q "$ARCHIVE_PATH" -d "$EXTRACT_DIR" ;;
+  *)
+    echo "Unsupported Togi archive format: ${TOGI_ARCHIVE}" >&2
+    exit 1
+    ;;
+esac
+
+TOGI_SOURCE=$(find "$EXTRACT_DIR" -type f -name "$TOGI_BINARY" -print -quit)
+if [ -z "$TOGI_SOURCE" ]; then
+  echo "Downloaded ${TOGI_ARCHIVE}, but ${TOGI_BINARY} was not found" >&2
+  exit 1
+fi
+cp "$TOGI_SOURCE" "$INSTALL_DIR/$TOGI_BINARY"
+chmod +x "$INSTALL_DIR/$TOGI_BINARY"
+
+PATH_ENTRY="$INSTALL_DIR"
+if command -v cygpath >/dev/null 2>&1; then
+  PATH_ENTRY=$(cygpath -w "$INSTALL_DIR")
+fi
+echo "$PATH_ENTRY" >> "$GITHUB_PATH"

--- a/.github/scripts/resolve-togi-asset.sh
+++ b/.github/scripts/resolve-togi-asset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+raw_os="${TOGI_OS:-$(uname -s)}"
+raw_arch="${TOGI_ARCH:-$(uname -m)}"
+os_lc=$(printf '%s' "$raw_os" | tr '[:upper:]' '[:lower:]')
+arch_lc=$(printf '%s' "$raw_arch" | tr '[:upper:]' '[:lower:]')
+
+case "$os_lc" in
+  linux*) os="linux" ;;
+  darwin*) os="macos" ;;
+  mingw* | msys* | cygwin* | windows*) os="windows" ;;
+  *)
+    echo "unsupported OS: ${raw_os}" >&2
+    exit 1
+    ;;
+esac
+
+case "$arch_lc" in
+  x86_64 | amd64) arch="x86_64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *)
+    echo "unsupported architecture: ${raw_arch}" >&2
+    exit 1
+    ;;
+esac
+
+case "${os}-${arch}" in
+  linux-x86_64 | macos-x86_64 | macos-arm64)
+    ext="tar.gz"
+    binary="togi"
+    ;;
+  windows-x86_64)
+    ext="zip"
+    binary="togi.exe"
+    ;;
+  *)
+    echo "unsupported release target: ${os}-${arch}" >&2
+    exit 1
+    ;;
+esac
+
+asset_name="togi-${os}-${arch}"
+printf 'TOGI_ARCHIVE=%q\n' "${asset_name}.${ext}"
+printf 'TOGI_BINARY=%q\n' "${binary}"

--- a/action.yml
+++ b/action.yml
@@ -33,18 +33,23 @@ runs:
       run: |
         VERSION="${{ inputs.version }}"
         if [ "$VERSION" = "latest" ]; then
-          VERSION=$(curl -s https://api.github.com/repos/Darkroom4364/togi/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          VERSION=$(curl -fsSL https://api.github.com/repos/Darkroom4364/togi/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
         fi
-        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-        ARCH=$(uname -m)
-        if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
-          NAME="togi-${OS}-arm64"
-        else
-          NAME="togi-${OS}-x86_64"
+        if [ -z "$VERSION" ]; then
+          echo "Could not resolve latest Togi release version" >&2
+          exit 1
         fi
-        curl -sL "https://github.com/Darkroom4364/togi/releases/download/${VERSION}/${NAME}.tar.gz" | tar xz
-        chmod +x togi
-        sudo mv togi /usr/local/bin/
+
+        eval "$(bash "${{ github.action_path }}/.github/scripts/resolve-togi-asset.sh")"
+        TEMP_ROOT="${RUNNER_TEMP:-.}"
+        if command -v cygpath >/dev/null 2>&1; then
+          TEMP_ROOT=$(cygpath -u "$TEMP_ROOT")
+        fi
+        mkdir -p "$TEMP_ROOT"
+
+        TOGI_ARCHIVE_PATH="${TEMP_ROOT}/${TOGI_ARCHIVE}"
+        curl -fL "https://github.com/Darkroom4364/togi/releases/download/${VERSION}/${TOGI_ARCHIVE}" -o "$TOGI_ARCHIVE_PATH"
+        TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"
 
     - name: Run togi
       shell: bash

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -325,6 +325,246 @@ fn assert_action_helper_test_cmd(test_cmd: &str) {
 }
 
 #[test]
+fn github_action_asset_resolver_matches_release_assets() {
+    if !bash_available() {
+        eprintln!("skipping action asset resolver test because bash is unavailable");
+        return;
+    }
+
+    assert_eq!(
+        resolve_action_asset("Linux", "x86_64"),
+        action_asset("togi-linux-x86_64.tar.gz", "togi")
+    );
+    assert_eq!(
+        resolve_action_asset("Darwin", "arm64"),
+        action_asset("togi-macos-arm64.tar.gz", "togi")
+    );
+    assert_eq!(
+        resolve_action_asset("Darwin", "x86_64"),
+        action_asset("togi-macos-x86_64.tar.gz", "togi")
+    );
+    assert_eq!(
+        resolve_action_asset("MINGW64_NT-10.0", "AMD64"),
+        action_asset("togi-windows-x86_64.zip", "togi.exe")
+    );
+}
+
+#[test]
+fn github_action_install_steps_place_binary_and_update_github_path() {
+    if !bash_available() {
+        eprintln!("skipping action install test because bash is unavailable");
+        return;
+    }
+
+    assert_action_installs_asset(&resolve_action_asset("Linux", "x86_64"), false);
+    assert_action_installs_asset(
+        &resolve_action_asset("MINGW64_NT-10.0", "AMD64"),
+        !cfg!(windows),
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ActionAsset {
+    archive: String,
+    binary: String,
+}
+
+fn action_asset(archive: &str, binary: &str) -> ActionAsset {
+    ActionAsset {
+        archive: archive.to_string(),
+        binary: binary.to_string(),
+    }
+}
+
+fn resolve_action_asset(os: &str, arch: &str) -> ActionAsset {
+    let helper =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/resolve-togi-asset.sh");
+    let output = std::process::Command::new("bash")
+        .arg(helper)
+        .env("TOGI_OS", os)
+        .env("TOGI_ARCH", arch)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "resolver failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut archive = None;
+    let mut binary = None;
+    for line in stdout.lines() {
+        if let Some(value) = line.strip_prefix("TOGI_ARCHIVE=") {
+            archive = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("TOGI_BINARY=") {
+            binary = Some(value.to_string());
+        } else {
+            panic!("unexpected resolver output line: {line}");
+        }
+    }
+
+    ActionAsset {
+        archive: archive.expect("resolver did not emit TOGI_ARCHIVE"),
+        binary: binary.expect("resolver did not emit TOGI_BINARY"),
+    }
+}
+
+fn assert_action_installs_asset(asset: &ActionAsset, fake_cygpath: bool) {
+    let dir = TempDir::new().unwrap();
+    let payload_dir = dir.path().join("payload");
+    fs::create_dir_all(&payload_dir).unwrap();
+    fs::write(
+        payload_dir.join(&asset.binary),
+        "#!/usr/bin/env bash\nexit 0\n",
+    )
+    .unwrap();
+    create_action_archive(asset, &payload_dir, &dir.path().join(&asset.archive));
+
+    let github_path = dir.path().join("github_path");
+    fs::write(&github_path, "").unwrap();
+
+    let mut command = std::process::Command::new("bash");
+    command
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/install-togi-archive.sh"))
+        .env("RUNNER_TEMP", dir.path())
+        .env("TOGI_ARCHIVE", &asset.archive)
+        .env("TOGI_BINARY", &asset.binary)
+        .env("GITHUB_PATH", &github_path);
+
+    if fake_cygpath {
+        let fake_bin = dir.path().join("fake-bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        let fake_cygpath_path = fake_bin.join("cygpath");
+        fs::write(
+            &fake_cygpath_path,
+            "#!/usr/bin/env bash\ncase \"$1\" in\n  -u) printf '%s\\n' \"$2\" ;;\n  -w) printf 'C:\\\\togi\\\\%s\\n' \"$(basename \"$2\")\" ;;\n  *) exit 1 ;;\nesac\n",
+        )
+        .unwrap();
+        chmod_executable(&fake_cygpath_path);
+
+        let mut paths = vec![fake_bin];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        command.env("PATH", std::env::join_paths(paths).unwrap());
+    }
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "install helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let install_dir = dir.path().join("togi-bin");
+    let installed = install_dir.join(&asset.binary);
+    assert!(
+        installed.exists(),
+        "missing installed binary: {installed:?}"
+    );
+    assert_bash_test_x(&installed);
+
+    let github_path_entry = fs::read_to_string(&github_path).unwrap();
+    let github_path_entry = github_path_entry.trim();
+    if fake_cygpath {
+        assert_eq!(github_path_entry, "C:\\togi\\togi-bin");
+    } else if cfg!(windows) {
+        assert!(
+            github_path_entry.contains("\\togi-bin") && !github_path_entry.starts_with('/'),
+            "expected Windows GITHUB_PATH entry, got {github_path_entry}"
+        );
+    } else {
+        assert_eq!(github_path_entry, install_dir.display().to_string());
+    }
+}
+
+fn create_action_archive(asset: &ActionAsset, payload_dir: &Path, archive_path: &Path) {
+    if asset.archive.ends_with(".tar.gz") {
+        assert_command_success(
+            std::process::Command::new("tar")
+                .arg("czf")
+                .arg(archive_path)
+                .arg("-C")
+                .arg(payload_dir)
+                .arg(&asset.binary)
+                .output()
+                .unwrap(),
+            "tar archive creation",
+        );
+    } else {
+        create_zip_archive(payload_dir, archive_path, &asset.binary);
+    }
+}
+
+fn create_zip_archive(payload_dir: &Path, archive_path: &Path, binary: &str) {
+    if cfg!(windows) {
+        assert_command_success(
+            std::process::Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    "Compress-Archive -LiteralPath $env:TOGI_TEST_BINARY -DestinationPath $env:TOGI_TEST_ARCHIVE",
+                ])
+                .env("TOGI_TEST_BINARY", payload_dir.join(binary))
+                .env("TOGI_TEST_ARCHIVE", archive_path)
+                .output()
+                .unwrap(),
+            "zip archive creation",
+        );
+    } else {
+        assert_command_success(
+            std::process::Command::new("zip")
+                .arg("-q")
+                .arg(archive_path)
+                .arg(binary)
+                .current_dir(payload_dir)
+                .output()
+                .unwrap(),
+            "zip archive creation",
+        );
+    }
+}
+
+fn chmod_executable(path: &Path) {
+    assert_command_success(
+        std::process::Command::new("bash")
+            .arg("-c")
+            .arg("chmod +x \"$1\"")
+            .arg("chmod")
+            .arg(path)
+            .output()
+            .unwrap(),
+        "chmod +x",
+    );
+}
+
+fn assert_bash_test_x(path: &Path) {
+    assert_command_success(
+        std::process::Command::new("bash")
+            .arg("-c")
+            .arg("path=$1; if command -v cygpath >/dev/null 2>&1; then path=$(cygpath -u \"$path\"); fi; test -x \"$path\"")
+            .arg("test")
+            .arg(path)
+            .output()
+            .unwrap(),
+        "test -x",
+    );
+}
+
+fn assert_command_success(output: std::process::Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn explain_reads_json_report() {
     let dir = TempDir::new().unwrap();
     let report = r#"{


### PR DESCRIPTION
Summary:
- Add a Bash resolver that maps runner OS/arch to the release workflow asset names.
- Update the composite action install step to download tar.gz or zip assets and add the extracted binary to GITHUB_PATH.
- Add CLI coverage for Linux, macOS, and Windows asset resolution.

Verification:
- cargo fmt --check
- cargo test github_action_asset_resolver_matches_release_assets
- cargo test github_action_run_helper_preserves_multiword_test_cmd
- cargo test
- cargo clippy --all-targets -- -D warnings

Fixes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * More robust install flow that reliably detects OS/architecture, selects the correct release asset and binary, and handles archive formats for Linux, macOS and Windows.
  * Improved download, extraction, executable placement and PATH installation with stricter failure handling and path normalization for non-Linux environments.

* **Tests**
  * Added integration tests validating multi-platform asset resolution and end-to-end install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->