### PR TITLE
fix: parse TSX files with the TSX grammar

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -287,5 +287,6 @@ pub fn all() -> Vec<Box<dyn LanguageSupport>> {
         Box::new(ruby::Ruby),
         Box::new(rust_lang::Rust),
         Box::new(typescript::TypeScript),
+        Box::new(typescript::Tsx),
     ]
 }

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -1,8 +1,17 @@
 crate::languages::define_language!(
     TypeScript,
     name: "typescript",
-    extensions: ["ts", "tsx"],
+    extensions: ["ts"],
     ts_language: tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
+    skip_subtree_kinds: ["import_statement", "type_annotation", "type_alias_declaration", "decorator"],
+    filter_candidate: should_filter_candidate,
+);
+
+crate::languages::define_language!(
+    Tsx,
+    name: "typescript",
+    extensions: ["tsx"],
+    ts_language: tree_sitter_typescript::LANGUAGE_TSX,
     skip_subtree_kinds: ["import_statement", "type_annotation", "type_alias_declaration", "decorator"],
     filter_candidate: should_filter_candidate,
 );
@@ -27,11 +36,26 @@ mod tests {
     use crate::languages::LanguageSupport;
     use tree_sitter::Parser;
 
+    fn find_node<'a>(node: tree_sitter::Node<'a>, kind: &str) -> bool {
+        if node.kind() == kind {
+            return true;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if find_node(child, kind) {
+                return true;
+            }
+        }
+        false
+    }
+
     #[test]
     fn test_extensions() {
         let ts = TypeScript;
+        let tsx = Tsx;
         assert!(ts.extensions().contains(&"ts"));
-        assert!(ts.extensions().contains(&"tsx"));
+        assert!(!ts.extensions().contains(&"tsx"));
+        assert!(tsx.extensions().contains(&"tsx"));
     }
 
     #[test]
@@ -65,19 +89,24 @@ function add(a: number, b: number): number {
         let tree = parser.parse(code, None).unwrap();
         let root = tree.root_node();
 
-        fn find_node<'a>(node: tree_sitter::Node<'a>, kind: &str) -> bool {
-            if node.kind() == kind {
-                return true;
-            }
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                if find_node(child, kind) {
-                    return true;
-                }
-            }
-            false
-        }
-
         assert!(find_node(root, TypeScript.binary_expression_node()));
+    }
+
+    #[test]
+    fn test_parse_tsx_jsx_expression() {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&Tsx.tree_sitter_language())
+            .expect("Error loading TSX parser");
+
+        let code = r#"
+const View = ({ value }: { value: number }) => {
+    return <div>{value > 0 ? "positive" : "zero"}</div>;
+};
+"#;
+        let tree = parser.parse(code, None).unwrap();
+        let root = tree.root_node();
+        assert!(!root.has_error());
+        assert!(find_node(root, Tsx.binary_expression_node()));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,4 +78,25 @@ mod tests {
         assert_eq!(lang.name(), "go");
         assert_eq!(tree.root_node().kind(), "source_file");
     }
+
+    #[test]
+    fn parse_typescript_and_tsx_sources() {
+        let (ts_tree, ts_lang) =
+            parse_file(Path::new("component.ts"), b"const value: number = 1 + 2;\n").unwrap();
+        assert_eq!(ts_lang.name(), "typescript");
+        assert!(!ts_tree.root_node().has_error());
+
+        let tsx_source = br#"
+const View = ({ value }: { value: number }) => {
+    return <div>{value > 0 ? "positive" : "zero"}</div>;
+};
+"#;
+        let (tree, lang) = parse_file(Path::new("component.tsx"), tsx_source).unwrap();
+        assert_eq!(lang.name(), "typescript");
+        assert!(!tree.root_node().has_error());
+        assert!(
+            crate::test_helpers::find_node_by_kind(tree.root_node(), lang.binary_expression_node())
+                .is_some()
+        );
+    }
 }


### PR DESCRIPTION
Summary:
- Split TypeScript language support so .ts uses LANGUAGE_TYPESCRIPT and .tsx uses LANGUAGE_TSX.
- Keep TSX grouped under the existing typescript language name.
- Add parser coverage for .ts plus a JSX .tsx fixture with a mutable binary expression.

Verification:
- cargo fmt --check
- cargo test languages::typescript::tests
- cargo test parser::tests::parse_typescript_and_tsx_sources
- cargo test
- cargo clippy --all-targets -- -D warnings

Fixes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript and TSX files are now handled as separate language configurations, enabling more accurate language detection and parsing.
  * Added dedicated language support for TSX files (.tsx) with TypeScript and JSX syntax, separate from standard TypeScript files (.ts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->