### PR TITLE
fix: warn when fail-fast ignores custom test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ respect_workspace_ignores = true
 Test command precedence is: CLI `--test-cmd` / `--timeout`, matching
 `[projects.*.test]` by longest path prefix, matching `[test.languages.*]`,
 then the global `[test]` command.
+When `--test-cmd` is set, `--fail-fast` does not modify the custom command;
+include runner-specific fail-fast flags in `--test-cmd` instead.
 
 ## CI workflows
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,6 +438,11 @@ fn resolve_config(
 
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
+    if cfg.fail_fast && has_custom_test_cmd {
+        eprintln!(
+            "warning: --fail-fast is ignored when --test-cmd is set; include fail-fast flags in the custom command"
+        );
+    }
     Ok((
         config,
         fail_fast,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -133,6 +133,28 @@ fn check_dry_run_lists_mutations() {
 }
 
 #[test]
+fn check_warns_when_fail_fast_is_ignored_for_custom_test_cmd() {
+    let dir = setup_git_repo();
+
+    togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--dry-run",
+            "--test-cmd",
+            "true",
+            "--fail-fast",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "--fail-fast is ignored when --test-cmd is set",
+        ));
+}
+
+#[test]
 fn check_format_json_outputs_valid_json() {
     let dir = setup_git_repo();
 


### PR DESCRIPTION
Summary:
- Warn when --fail-fast is supplied with --test-cmd because Togi leaves custom commands unchanged.
- Add CLI coverage for the ignored fail-fast warning.
- Document that custom test commands should include their own fail-fast flags.

Verification:
- cargo fmt --check
- cargo test check_warns_when_fail_fast_is_ignored_for_custom_test_cmd
- cargo test
- cargo clippy --all-targets -- -D warnings

Fixes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `togi` CLI behavior: `--fail-fast` flag is ignored when using custom `--test-cmd` commands.

* **Bug Fixes**
  * Added warning message emitted to stderr when `--fail-fast` conflicts with a custom `--test-cmd`.

* **Tests**
  * Added regression test verifying the warning is displayed when `--fail-fast` is used with custom test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->