### PR TITLE
chore: clean up mutation helpers

### DIFF
--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -1,24 +1,10 @@
 // Combine mapper + operators to generate mutations
 
-use crate::languages::LanguageSupport;
 use crate::mapper::find_mutable_nodes;
 use crate::operators::{self};
-use crate::{ChangedFile, Mutation, MutationCandidate};
+use crate::{ChangedFile, Mutation};
 use anyhow::Result;
 use std::path::Path;
-
-/// Check if a mutation candidate should be filtered out for the given language.
-fn should_filter(
-    candidate: &MutationCandidate,
-    node: &tree_sitter::Node,
-    source: &[u8],
-    lang: &dyn LanguageSupport,
-) -> bool {
-    if lang.should_filter_candidate(candidate, node, source) {
-        return true;
-    }
-    false
-}
 
 /// Convert a byte offset in source to (line, column), both 1-indexed.
 fn byte_offset_to_line_col(source: &[u8], offset: usize) -> (usize, usize) {
@@ -85,7 +71,7 @@ pub fn generate_mutations(
             for op in &operators {
                 let candidates = op.apply(node, &source);
                 for mut candidate in candidates {
-                    if should_filter(&candidate, node, &source, lang.as_ref()) {
+                    if lang.should_filter_candidate(&candidate, node, &source) {
                         continue;
                     }
                     lang.fixup_replacement(&mut candidate);
@@ -205,9 +191,10 @@ fn sample_diverse(mutations: Vec<Mutation>, cap: usize) -> Vec<Mutation> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
     use crate::languages::go::Go;
     use crate::test_helpers::{find_node_by_kind, parse_go, parse_python};
-    use crate::{ChangedFile, LineRange};
+    use crate::{ChangedFile, LineRange, MutationCandidate};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -244,12 +231,7 @@ mod tests {
         let bin = find_node_by_kind(tree.root_node(), "binary_expression")
             .expect("should find binary_expression node");
 
-        assert!(should_filter(
-            &candidate("mul_to_div"),
-            &bin,
-            src.as_bytes(),
-            &lang
-        ));
+        assert!(lang.should_filter_candidate(&candidate("mul_to_div"), &bin, src.as_bytes()));
     }
 
     #[test]
@@ -260,12 +242,7 @@ mod tests {
         let bin = find_node_by_kind(tree.root_node(), "binary_expression")
             .expect("should find binary_expression node");
 
-        assert!(!should_filter(
-            &candidate("mul_to_div"),
-            &bin,
-            src.as_bytes(),
-            &lang
-        ));
+        assert!(!lang.should_filter_candidate(&candidate("mul_to_div"), &bin, src.as_bytes()));
     }
 
     #[test]
@@ -276,12 +253,7 @@ mod tests {
         let bin = find_node_by_kind(tree.root_node(), "binary_expression")
             .expect("should find binary_expression node");
 
-        assert!(should_filter(
-            &candidate("div_to_mul"),
-            &bin,
-            src.as_bytes(),
-            &lang
-        ));
+        assert!(lang.should_filter_candidate(&candidate("div_to_mul"), &bin, src.as_bytes()));
     }
 
     #[test]

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -1,4 +1,4 @@
-use super::MutationOperator;
+use super::{MutationOperator, mutation_candidate};
 use crate::MutationCandidate;
 
 const TRUE_KINDS: &[&str] = &["true", "True", "TRUE", "boolean_literal"];
@@ -32,12 +32,7 @@ impl MutationOperator for TrueToFalse {
         if TRUE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "true" || text == "True" || text == "TRUE" {
-                return vec![MutationCandidate {
-                    byte_range: node.byte_range(),
-                    replacement: "false".to_string(),
-                    operator_id: self.id().to_string(),
-                    description: self.description().to_string(),
-                }];
+                return vec![mutation_candidate(self, node.byte_range(), "false")];
             }
         }
         vec![]
@@ -57,12 +52,7 @@ impl MutationOperator for FalseToTrue {
         if FALSE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "false" || text == "False" || text == "FALSE" {
-                return vec![MutationCandidate {
-                    byte_range: node.byte_range(),
-                    replacement: "true".to_string(),
-                    operator_id: self.id().to_string(),
-                    description: self.description().to_string(),
-                }];
+                return vec![mutation_candidate(self, node.byte_range(), "true")];
             }
         }
         vec![]
@@ -82,12 +72,7 @@ impl MutationOperator for ZeroToOne {
         if INT_LITERAL_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "0" {
-                return vec![MutationCandidate {
-                    byte_range: node.byte_range(),
-                    replacement: "1".to_string(),
-                    operator_id: self.id().to_string(),
-                    description: self.description().to_string(),
-                }];
+                return vec![mutation_candidate(self, node.byte_range(), "1")];
             }
         }
         vec![]
@@ -116,12 +101,7 @@ impl MutationOperator for StringToEmpty {
             } else {
                 "\"\"".to_string()
             };
-            return vec![MutationCandidate {
-                byte_range: node.byte_range(),
-                replacement,
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }];
+            return vec![mutation_candidate(self, node.byte_range(), replacement)];
         }
         vec![]
     }
@@ -142,12 +122,11 @@ impl MutationOperator for IncrementNumeric {
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
         if let Ok(n) = text.parse::<i64>() {
-            vec![MutationCandidate {
-                byte_range: node.byte_range(),
-                replacement: (n + 1).to_string(),
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }]
+            vec![mutation_candidate(
+                self,
+                node.byte_range(),
+                (n + 1).to_string(),
+            )]
         } else {
             vec![]
         }
@@ -169,12 +148,11 @@ impl MutationOperator for DecrementNumeric {
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
         if let Ok(n) = text.parse::<i64>() {
-            vec![MutationCandidate {
-                byte_range: node.byte_range(),
-                replacement: (n - 1).to_string(),
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }]
+            vec![mutation_candidate(
+                self,
+                node.byte_range(),
+                (n - 1).to_string(),
+            )]
         } else {
             vec![]
         }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -22,6 +22,19 @@ pub trait MutationOperator: Send + Sync {
     fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate>;
 }
 
+pub(crate) fn mutation_candidate(
+    operator: &dyn MutationOperator,
+    byte_range: std::ops::Range<usize>,
+    replacement: impl Into<String>,
+) -> crate::MutationCandidate {
+    crate::MutationCandidate {
+        byte_range,
+        replacement: replacement.into(),
+        operator_id: operator.id().to_string(),
+        description: operator.description().to_string(),
+    }
+}
+
 pub(crate) const IF_STMT_KINDS: &[&str] = &[
     "if_statement",
     "if_expression",

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -1,4 +1,4 @@
-use super::{IF_STMT_KINDS, MutationOperator};
+use super::{IF_STMT_KINDS, MutationOperator, mutation_candidate};
 use crate::MutationCandidate;
 
 pub struct RemoveIfBody;
@@ -19,12 +19,7 @@ impl MutationOperator for RemoveIfBody {
             .child_by_field_name("consequence")
             .or_else(|| node.child_by_field_name("body"));
         if let Some(body_node) = body {
-            vec![MutationCandidate {
-                byte_range: body_node.byte_range(),
-                replacement: "{}".to_string(),
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }]
+            vec![mutation_candidate(self, body_node.byte_range(), "{}")]
         } else {
             vec![]
         }
@@ -64,12 +59,11 @@ impl MutationOperator for RemoveElse {
                     }
                 }
             }
-            vec![MutationCandidate {
-                byte_range: else_kw_start..else_node.end_byte(),
-                replacement: String::new(),
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }]
+            vec![mutation_candidate(
+                self,
+                else_kw_start..else_node.end_byte(),
+                String::new(),
+            )]
         } else {
             vec![]
         }
@@ -102,12 +96,7 @@ impl MutationOperator for RemoveCallStatement {
             .named_children(&mut cursor)
             .any(|child| CALL_EXPR_KINDS.contains(&child.kind()));
         if has_call {
-            vec![MutationCandidate {
-                byte_range: node.byte_range(),
-                replacement: String::new(),
-                operator_id: self.id().to_string(),
-                description: self.description().to_string(),
-            }]
+            vec![mutation_candidate(self, node.byte_range(), String::new())]
         } else {
             vec![]
         }
@@ -135,12 +124,7 @@ impl MutationOperator for RemoveAssignment {
         if !ASSIGNMENT_KINDS.contains(&node.kind()) {
             return vec![];
         }
-        vec![MutationCandidate {
-            byte_range: node.byte_range(),
-            replacement: String::new(),
-            operator_id: self.id().to_string(),
-            description: self.description().to_string(),
-        }]
+        vec![mutation_candidate(self, node.byte_range(), String::new())]
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,13 +9,8 @@ pub fn parse_file(
     path: &Path,
     source: &[u8],
 ) -> Result<(tree_sitter::Tree, Box<dyn LanguageSupport>)> {
-    let lang = detect_language(path)?;
     let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&lang.tree_sitter_language())?;
-    let tree = parser
-        .parse(source, None)
-        .ok_or_else(|| anyhow!("failed to parse {}", path.display()))?;
-    Ok((tree, lang))
+    parse_file_with_parser(&mut parser, path, source)
 }
 
 /// Parse with a reusable parser instance (avoids repeated allocation).


### PR DESCRIPTION
## Summary
- make parse_file delegate to parse_file_with_parser
- call language candidate filtering directly from mutation generation
- add a small mutation_candidate helper and use it in the densest operator modules

Closes #324.

## Tests
- cargo fmt --check
- cargo test parser::
- cargo test mutator::
- cargo test operators::literal::
- cargo test operators::removal::
- cargo test
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined internal mutation candidate construction and parsing logic for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->