### PR TITLE
refactor: pass language support to operators

### DIFF
--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -69,7 +69,7 @@ pub fn generate_mutations(
 
         for node in &nodes {
             for op in &operators {
-                let candidates = op.apply(node, &source);
+                let candidates = op.apply(node, &source, lang.as_ref());
                 for mut candidate in candidates {
                     if lang.should_filter_candidate(&candidate, node, &source) {
                         continue;

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,13 +1,13 @@
-use super::{MutationOperator, is_binary_expr};
+use super::MutationOperator;
 use crate::MutationCandidate;
 
 pub fn find_operator_child(
     node: &tree_sitter::Node,
     source: &[u8],
+    operator_field: &str,
     target: &str,
 ) -> Option<std::ops::Range<usize>> {
-    // Try field name "operator" first
-    if let Some(op_node) = node.child_by_field_name("operator") {
+    if let Some(op_node) = node.child_by_field_name(operator_field) {
         let text = &source[op_node.byte_range()];
         if text == target.as_bytes() {
             return Some(op_node.byte_range());
@@ -37,11 +37,17 @@ macro_rules! binary_operator {
             fn description(&self) -> &str {
                 $desc
             }
-            fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
-                if !is_binary_expr(node) {
+            fn apply(
+                &self,
+                node: &tree_sitter::Node,
+                source: &[u8],
+                lang: &dyn crate::languages::LanguageSupport,
+            ) -> Vec<MutationCandidate> {
+                if node.kind() != lang.binary_expression_node() {
                     return vec![];
                 }
-                if let Some(range) = find_operator_child(node, source, $from) {
+                if let Some(range) = find_operator_child(node, source, lang.operator_field(), $from)
+                {
                     vec![MutationCandidate {
                         byte_range: range,
                         replacement: $to.to_string(),
@@ -76,7 +82,7 @@ mod tests {
         let root = tree.root_node();
         let bin =
             find_node_by_kind(root, "binary_expression").expect("should find binary_expression");
-        op.apply(&bin, src.as_bytes())
+        op.apply(&bin, src.as_bytes(), &crate::languages::go::Go)
     }
 
     fn assert_single_candidate(

--- a/src/operators/boundary.rs
+++ b/src/operators/boundary.rs
@@ -1,5 +1,5 @@
+use super::MutationOperator;
 use super::binary::find_operator_child;
-use super::{MutationOperator, is_binary_expr};
 use crate::MutationCandidate;
 
 pub struct PlusToMinus;
@@ -11,11 +11,16 @@ impl MutationOperator for PlusToMinus {
     fn description(&self) -> &str {
         "Replace + with -"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
-        if !is_binary_expr(node) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
+        if node.kind() != lang.binary_expression_node() {
             return vec![];
         }
-        if let Some(range) = find_operator_child(node, source, "+") {
+        if let Some(range) = find_operator_child(node, source, lang.operator_field(), "+") {
             vec![MutationCandidate {
                 byte_range: range,
                 replacement: "-".to_string(),
@@ -37,11 +42,16 @@ impl MutationOperator for MinusToPlus {
     fn description(&self) -> &str {
         "Replace - with +"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
-        if !is_binary_expr(node) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
+        if node.kind() != lang.binary_expression_node() {
             return vec![];
         }
-        if let Some(range) = find_operator_child(node, source, "-") {
+        if let Some(range) = find_operator_child(node, source, lang.operator_field(), "-") {
             vec![MutationCandidate {
                 byte_range: range,
                 replacement: "+".to_string(),
@@ -65,7 +75,7 @@ mod tests {
         let src = "package main\nfunc f(a, b int) int { return a + b }";
         let tree = parse_go(src);
         let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
-        let candidates = PlusToMinus.apply(&bin, src.as_bytes());
+        let candidates = PlusToMinus.apply(&bin, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "-");
     }
@@ -75,7 +85,7 @@ mod tests {
         let src = "package main\nfunc f(a, b int) int { return a - b }";
         let tree = parse_go(src);
         let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
-        let candidates = MinusToPlus.apply(&bin, src.as_bytes());
+        let candidates = MinusToPlus.apply(&bin, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "+");
     }
@@ -85,7 +95,7 @@ mod tests {
         let src = "package main\nfunc f(a, b int) bool { return a < b }";
         let tree = parse_go(src);
         let bin = find_node_by_kind(tree.root_node(), "binary_expression").unwrap();
-        let candidates = PlusToMinus.apply(&bin, src.as_bytes());
+        let candidates = PlusToMinus.apply(&bin, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 }

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -28,7 +28,12 @@ impl MutationOperator for TrueToFalse {
     fn description(&self) -> &str {
         "Replace true with false"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if TRUE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "true" || text == "True" || text == "TRUE" {
@@ -48,7 +53,12 @@ impl MutationOperator for FalseToTrue {
     fn description(&self) -> &str {
         "Replace false with true"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if FALSE_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "false" || text == "False" || text == "FALSE" {
@@ -68,7 +78,12 @@ impl MutationOperator for ZeroToOne {
     fn description(&self) -> &str {
         "Replace 0 with 1"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if INT_LITERAL_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "0" {
@@ -88,7 +103,12 @@ impl MutationOperator for StringToEmpty {
     fn description(&self) -> &str {
         "Replace string literal with empty string"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if STRING_LITERAL_KINDS.contains(&node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "\"\"" || text == "''" || text == "``" {
@@ -116,7 +136,12 @@ impl MutationOperator for IncrementNumeric {
     fn description(&self) -> &str {
         "Replace n with n+1"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !INT_LITERAL_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -142,7 +167,12 @@ impl MutationOperator for DecrementNumeric {
     fn description(&self) -> &str {
         "Replace n with n-1"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !INT_LITERAL_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -182,7 +212,7 @@ mod tests {
         op: &dyn MutationOperator,
         out: &mut Vec<MutationCandidate>,
     ) {
-        out.extend(op.apply(&node, source));
+        out.extend(op.apply(&node, source, &crate::languages::go::Go));
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             collect_all_candidates(child, source, op, out);
@@ -194,7 +224,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return true }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "true").expect("should find true node");
-        let candidates = TrueToFalse.apply(&node, src.as_bytes());
+        let candidates = TrueToFalse.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "false", "true");
     }
 
@@ -203,7 +233,7 @@ mod tests {
         let src = "package main\nfunc f() bool { return false }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "false").expect("should find false node");
-        let candidates = FalseToTrue.apply(&node, src.as_bytes());
+        let candidates = FalseToTrue.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "true", "false");
     }
 
@@ -213,7 +243,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "int_literal")
             .expect("should find int_literal node");
-        let candidates = ZeroToOne.apply(&node, src.as_bytes());
+        let candidates = ZeroToOne.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "1", "0");
     }
 
@@ -223,7 +253,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "int_literal")
             .expect("should find int_literal node");
-        let candidates = ZeroToOne.apply(&node, src.as_bytes());
+        let candidates = ZeroToOne.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -248,7 +278,7 @@ func f() string { return "hello" }"#;
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
             .expect("should find interpreted_string_literal node");
-        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        let candidates = StringToEmpty.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, r#""""#, r#""hello""#);
     }
 
@@ -258,7 +288,7 @@ func f() string { return "hello" }"#;
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "raw_string_literal")
             .expect("should find raw_string_literal node");
-        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        let candidates = StringToEmpty.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "``", "`hello`");
     }
 
@@ -269,7 +299,7 @@ func f() string { return "" }"#;
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "interpreted_string_literal")
             .expect("should find interpreted_string_literal node");
-        let candidates = StringToEmpty.apply(&node, src.as_bytes());
+        let candidates = StringToEmpty.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -279,7 +309,7 @@ func f() string { return "" }"#;
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "int_literal")
             .expect("should find int_literal node");
-        let candidates = IncrementNumeric.apply(&node, src.as_bytes());
+        let candidates = IncrementNumeric.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "42", "41");
     }
 
@@ -289,7 +319,7 @@ func f() string { return "" }"#;
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "int_literal")
             .expect("should find int_literal node");
-        let candidates = DecrementNumeric.apply(&node, src.as_bytes());
+        let candidates = DecrementNumeric.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "40", "41");
     }
 
@@ -300,7 +330,15 @@ func f() string { return "" }"#;
         let node = find_node_by_kind(tree.root_node(), "float_literal")
             .expect("should find float_literal node");
 
-        assert!(IncrementNumeric.apply(&node, src.as_bytes()).is_empty());
-        assert!(DecrementNumeric.apply(&node, src.as_bytes()).is_empty());
+        assert!(
+            IncrementNumeric
+                .apply(&node, src.as_bytes(), &crate::languages::go::Go)
+                .is_empty()
+        );
+        assert!(
+            DecrementNumeric
+                .apply(&node, src.as_bytes(), &crate::languages::go::Go)
+                .is_empty()
+        );
     }
 }

--- a/src/operators/loop_control.rs
+++ b/src/operators/loop_control.rs
@@ -22,7 +22,12 @@ impl MutationOperator for RemoveBreak {
     fn description(&self) -> &str {
         "Remove break statement from loop"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !BREAK_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -44,7 +49,12 @@ impl MutationOperator for RemoveContinue {
     fn description(&self) -> &str {
         "Remove continue statement from loop"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !CONTINUE_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -69,7 +79,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "break_statement")
             .expect("should find break_statement");
-        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        let candidates = RemoveBreak.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }
@@ -80,7 +90,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "continue_statement")
             .expect("should find continue_statement");
-        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        let candidates = RemoveBreak.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -90,7 +100,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "continue_statement")
             .expect("should find continue_statement");
-        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        let candidates = RemoveContinue.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }
@@ -101,7 +111,7 @@ mod tests {
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "break_statement")
             .expect("should find break_statement");
-        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        let candidates = RemoveContinue.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -112,7 +122,8 @@ mod tests {
         let tree = parse_rust(src);
         let node = find_node_by_kind(tree.root_node(), "break_expression")
             .expect("should find break_expression");
-        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        let candidates =
+            RemoveBreak.apply(&node, src.as_bytes(), &crate::languages::rust_lang::Rust);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }
@@ -123,7 +134,8 @@ mod tests {
         let tree = parse_rust(src);
         let node = find_node_by_kind(tree.root_node(), "continue_expression")
             .expect("should find continue_expression");
-        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        let candidates =
+            RemoveContinue.apply(&node, src.as_bytes(), &crate::languages::rust_lang::Rust);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }
@@ -134,7 +146,7 @@ mod tests {
         let src = "loop do\n  break\nend";
         let tree = parse_ruby(src);
         let node = find_node_by_kind(tree.root_node(), "break").expect("should find break");
-        let candidates = RemoveBreak.apply(&node, src.as_bytes());
+        let candidates = RemoveBreak.apply(&node, src.as_bytes(), &crate::languages::ruby::Ruby);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }
@@ -144,7 +156,7 @@ mod tests {
         let src = "[1,2,3].each do |x|\n  next\nend";
         let tree = parse_ruby(src);
         let node = find_node_by_kind(tree.root_node(), "next").expect("should find next");
-        let candidates = RemoveContinue.apply(&node, src.as_bytes());
+        let candidates = RemoveContinue.apply(&node, src.as_bytes(), &crate::languages::ruby::Ruby);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "");
     }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -19,7 +19,12 @@ pub trait MutationOperator: Send + Sync {
     fn description(&self) -> &str;
 
     /// Return mutation candidates for `node` using byte ranges from `source`.
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate>;
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<crate::MutationCandidate>;
 }
 
 pub(crate) fn mutation_candidate(
@@ -35,29 +40,6 @@ pub(crate) fn mutation_candidate(
     }
 }
 
-pub(crate) const IF_STMT_KINDS: &[&str] = &[
-    "if_statement",
-    "if_expression",
-    "if_expr",
-    "if", // Ruby
-];
-pub(crate) const BINARY_EXPR_KINDS: &[&str] = &[
-    "binary_expression",
-    "binary_expr",
-    "comparison_expression",
-    "binary_operator", // Python
-    "binary",          // Ruby
-];
-const RETURN_KINDS: &[&str] = &[
-    "return_statement",
-    "return_expression",
-    "return", // Ruby
-];
-
-pub(crate) fn is_binary_expr(node: &tree_sitter::Node) -> bool {
-    BINARY_EXPR_KINDS.contains(&node.kind())
-}
-
 /// Negate a condition: remove `!` if present, otherwise wrap with `!(...)`
 pub struct NegateCondition;
 
@@ -68,8 +50,13 @@ impl MutationOperator for NegateCondition {
     fn description(&self) -> &str {
         "Negate condition expression"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate> {
-        if !IF_STMT_KINDS.contains(&node.kind()) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<crate::MutationCandidate> {
+        if node.kind() != lang.if_statement_node() {
             return vec![];
         }
         let cond = node.child_by_field_name("condition");
@@ -125,8 +112,13 @@ impl MutationOperator for ReturnEmpty {
     fn description(&self) -> &str {
         "Replace return value with default"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<crate::MutationCandidate> {
-        if !RETURN_KINDS.contains(&node.kind()) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<crate::MutationCandidate> {
+        if node.kind() != lang.return_statement_node() {
             return vec![];
         }
         // Find the expression list or value child
@@ -334,6 +326,7 @@ pub fn all_operators() -> Vec<Box<dyn MutationOperator>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::languages::LanguageSupport;
     use crate::test_helpers::{
         find_node_by_kind, parse_go, parse_python, parse_ruby, parse_rust, parse_typescript,
     };
@@ -343,23 +336,25 @@ mod tests {
         parse: fn(&str) -> tree_sitter::Tree,
         node_kind: &str,
         op: &dyn MutationOperator,
+        lang: &dyn LanguageSupport,
     ) -> Vec<crate::MutationCandidate> {
         let tree = parse(src);
         let node = find_node_by_kind(tree.root_node(), node_kind)
             .unwrap_or_else(|| panic!("should find {node_kind} node"));
-        op.apply(&node, src.as_bytes())
+        op.apply(&node, src.as_bytes(), lang)
     }
 
     fn collect_candidates(
         node: tree_sitter::Node,
         source: &[u8],
         op: &dyn MutationOperator,
+        lang: &dyn LanguageSupport,
         out: &mut Vec<crate::MutationCandidate>,
     ) {
-        out.extend(op.apply(&node, source));
+        out.extend(op.apply(&node, source, lang));
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            collect_candidates(child, source, op, out);
+            collect_candidates(child, source, op, lang, out);
         }
     }
 
@@ -367,10 +362,11 @@ mod tests {
         src: &str,
         parse: fn(&str) -> tree_sitter::Tree,
         op: &dyn MutationOperator,
+        lang: &dyn LanguageSupport,
     ) -> Vec<crate::MutationCandidate> {
         let tree = parse(src);
         let mut candidates = Vec::new();
-        collect_candidates(tree.root_node(), src.as_bytes(), op, &mut candidates);
+        collect_candidates(tree.root_node(), src.as_bytes(), op, lang, &mut candidates);
         candidates
     }
 
@@ -390,7 +386,7 @@ mod tests {
         let src = "package main\nfunc f(x int) { if x > 0 { return } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = NegateCondition.apply(&if_node, src.as_bytes());
+        let candidates = NegateCondition.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "!(x > 0)", "x > 0");
     }
 
@@ -399,7 +395,7 @@ mod tests {
         let src = "package main\nfunc f(x bool) { if !x { return } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = NegateCondition.apply(&if_node, src.as_bytes());
+        let candidates = NegateCondition.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "x", "!x");
     }
 
@@ -408,7 +404,7 @@ mod tests {
         let src = "package main\nfunc f() { if !foo() { return } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = NegateCondition.apply(&if_node, src.as_bytes());
+        let candidates = NegateCondition.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "foo()", "!foo()");
     }
 
@@ -417,7 +413,7 @@ mod tests {
         let src = "package main\nfunc f(a, b bool) { if !(a) || (b) { return } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = NegateCondition.apply(&if_node, src.as_bytes());
+        let candidates = NegateCondition.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "(a) || (b)", "!(a) || (b)");
     }
 
@@ -426,7 +422,8 @@ mod tests {
         let src = "package main\nfunc f() int { return 42 }";
         let tree = parse_go(src);
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
-        let candidates = NegateCondition.apply(&ret_node, src.as_bytes());
+        let candidates =
+            NegateCondition.apply(&ret_node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -435,7 +432,7 @@ mod tests {
         let src = "package main\nfunc f() int { return 42 }";
         let tree = parse_go(src);
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
-        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes());
+        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "0");
     }
@@ -446,7 +443,7 @@ mod tests {
 func f() string { return "hello" }"#;
         let tree = parse_go(src);
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
-        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes());
+        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, r#""""#);
     }
@@ -456,7 +453,7 @@ func f() string { return "hello" }"#;
         let src = "package main\nfunc f() bool { return true }";
         let tree = parse_go(src);
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
-        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes());
+        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "false");
     }
@@ -466,74 +463,85 @@ func f() string { return "hello" }"#;
         let src = "package main\nfunc f() { return }";
         let tree = parse_go(src);
         let ret_node = find_node_by_kind(tree.root_node(), "return_statement").unwrap();
-        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes());
+        let candidates = ReturnEmpty.apply(&ret_node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
     #[test]
     fn mul_to_div_works_across_binary_node_kinds() {
-        for (src, parse, node_kind) in [
+        for (src, parse, node_kind, lang) in [
             (
                 "package main\nfunc f(a, b int) int { return a * b }",
                 parse_go as fn(&str) -> tree_sitter::Tree,
                 "binary_expression",
+                Box::new(crate::languages::go::Go) as Box<dyn LanguageSupport>,
             ),
             (
                 "fn f(a: i32, b: i32) -> i32 { a * b }",
                 parse_rust as fn(&str) -> tree_sitter::Tree,
                 "binary_expression",
+                Box::new(crate::languages::rust_lang::Rust),
             ),
             (
                 "def f(a, b):\n    return a * b\n",
                 parse_python as fn(&str) -> tree_sitter::Tree,
                 "binary_operator",
+                Box::new(crate::languages::python::Python),
             ),
             (
                 "def f(a, b)\n  a * b\nend\n",
                 parse_ruby as fn(&str) -> tree_sitter::Tree,
                 "binary",
+                Box::new(crate::languages::ruby::Ruby),
             ),
             (
                 "function f(a: number, b: number): number { return a * b; }",
                 parse_typescript as fn(&str) -> tree_sitter::Tree,
                 "binary_expression",
+                Box::new(crate::languages::typescript::TypeScript),
             ),
         ] {
-            let candidates = apply_to_first_node(src, parse, node_kind, &binary::MulToDiv);
+            let candidates =
+                apply_to_first_node(src, parse, node_kind, &binary::MulToDiv, lang.as_ref());
             assert_single_candidate(&candidates, src, "/", "*");
         }
     }
 
     #[test]
     fn true_to_false_works_across_literal_node_kinds() {
-        for (src, parse, original) in [
+        for (src, parse, original, lang) in [
             (
                 "package main\nfunc f() bool { return true }",
                 parse_go as fn(&str) -> tree_sitter::Tree,
                 "true",
+                Box::new(crate::languages::go::Go) as Box<dyn LanguageSupport>,
             ),
             (
                 "fn f() -> bool { true }",
                 parse_rust as fn(&str) -> tree_sitter::Tree,
                 "true",
+                Box::new(crate::languages::rust_lang::Rust),
             ),
             (
                 "def f():\n    return True\n",
                 parse_python as fn(&str) -> tree_sitter::Tree,
                 "True",
+                Box::new(crate::languages::python::Python),
             ),
             (
                 "def f\n  true\nend\n",
                 parse_ruby as fn(&str) -> tree_sitter::Tree,
                 "true",
+                Box::new(crate::languages::ruby::Ruby),
             ),
             (
                 "const value = true;",
                 parse_typescript as fn(&str) -> tree_sitter::Tree,
                 "true",
+                Box::new(crate::languages::typescript::TypeScript),
             ),
         ] {
-            let candidates = apply_to_tree(src, parse, &literal::TrueToFalse);
+            let candidates = apply_to_tree(src, parse, &literal::TrueToFalse, lang.as_ref());
             assert!(
                 candidates.iter().any(|c| {
                     c.replacement == "false" && &src[c.byte_range.clone()] == original
@@ -545,68 +553,80 @@ func f() string { return "hello" }"#;
 
     #[test]
     fn return_empty_works_across_return_node_kinds() {
-        for (src, parse, node_kind) in [
+        for (src, parse, node_kind, lang) in [
             (
                 "package main\nfunc f() int { return 42 }",
                 parse_go as fn(&str) -> tree_sitter::Tree,
                 "return_statement",
+                Box::new(crate::languages::go::Go) as Box<dyn LanguageSupport>,
             ),
             (
                 "fn f() -> i32 { return 42; }",
                 parse_rust as fn(&str) -> tree_sitter::Tree,
                 "return_expression",
+                Box::new(crate::languages::rust_lang::Rust),
             ),
             (
                 "def f():\n    return 42\n",
                 parse_python as fn(&str) -> tree_sitter::Tree,
                 "return_statement",
+                Box::new(crate::languages::python::Python),
             ),
             (
                 "def f\n  return 42\nend\n",
                 parse_ruby as fn(&str) -> tree_sitter::Tree,
                 "return",
+                Box::new(crate::languages::ruby::Ruby),
             ),
             (
                 "function f(): number { return 42; }",
                 parse_typescript as fn(&str) -> tree_sitter::Tree,
                 "return_statement",
+                Box::new(crate::languages::typescript::TypeScript),
             ),
         ] {
-            let candidates = apply_to_first_node(src, parse, node_kind, &ReturnEmpty);
+            let candidates =
+                apply_to_first_node(src, parse, node_kind, &ReturnEmpty, lang.as_ref());
             assert_single_candidate(&candidates, src, "0", "42");
         }
     }
 
     #[test]
     fn remove_if_body_works_across_if_node_kinds() {
-        for (src, parse, node_kind) in [
+        for (src, parse, node_kind, lang) in [
             (
                 "package main\nfunc f(x bool) { if x { println(x) } }",
                 parse_go as fn(&str) -> tree_sitter::Tree,
                 "if_statement",
+                Box::new(crate::languages::go::Go) as Box<dyn LanguageSupport>,
             ),
             (
                 "fn f(x: bool) { if x { call(); } }",
                 parse_rust as fn(&str) -> tree_sitter::Tree,
                 "if_expression",
+                Box::new(crate::languages::rust_lang::Rust),
             ),
             (
                 "def f(x):\n    if x:\n        call()\n",
                 parse_python as fn(&str) -> tree_sitter::Tree,
                 "if_statement",
+                Box::new(crate::languages::python::Python),
             ),
             (
                 "def f(x)\n  if x\n    call\n  end\nend\n",
                 parse_ruby as fn(&str) -> tree_sitter::Tree,
                 "if",
+                Box::new(crate::languages::ruby::Ruby),
             ),
             (
                 "function f(x: boolean) { if (x) { call(); } }",
                 parse_typescript as fn(&str) -> tree_sitter::Tree,
                 "if_statement",
+                Box::new(crate::languages::typescript::TypeScript),
             ),
         ] {
-            let candidates = apply_to_first_node(src, parse, node_kind, &removal::RemoveIfBody);
+            let candidates =
+                apply_to_first_node(src, parse, node_kind, &removal::RemoveIfBody, lang.as_ref());
             assert_eq!(candidates.len(), 1, "{src}");
             assert_eq!(candidates[0].replacement, "{}");
         }
@@ -621,7 +641,12 @@ func f() string { return "hello" }"#;
         fn description(&self) -> &str {
             ""
         }
-        fn apply(&self, _: &tree_sitter::Node, _: &[u8]) -> Vec<crate::MutationCandidate> {
+        fn apply(
+            &self,
+            _: &tree_sitter::Node,
+            _: &[u8],
+            _: &dyn crate::languages::LanguageSupport,
+        ) -> Vec<crate::MutationCandidate> {
             vec![]
         }
     }

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -1,4 +1,4 @@
-use super::{IF_STMT_KINDS, MutationOperator, mutation_candidate};
+use super::{MutationOperator, mutation_candidate};
 use crate::MutationCandidate;
 
 pub struct RemoveIfBody;
@@ -10,8 +10,13 @@ impl MutationOperator for RemoveIfBody {
     fn description(&self) -> &str {
         "Replace if body with empty block"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
-        if !IF_STMT_KINDS.contains(&node.kind()) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
+        if node.kind() != lang.if_statement_node() {
             return vec![];
         }
         // Look for "consequence" or "body" field
@@ -35,8 +40,13 @@ impl MutationOperator for RemoveElse {
     fn description(&self) -> &str {
         "Remove else clause"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
-        if !IF_STMT_KINDS.contains(&node.kind()) {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
+        if node.kind() != lang.if_statement_node() {
             return vec![];
         }
         // Look for "alternative" or "else" field
@@ -87,7 +97,12 @@ impl MutationOperator for RemoveCallStatement {
     fn description(&self) -> &str {
         "Remove void method/function call"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !EXPR_STMT_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -120,7 +135,12 @@ impl MutationOperator for RemoveAssignment {
     fn description(&self) -> &str {
         "Remove assignment statement"
     }
-    fn apply(&self, node: &tree_sitter::Node, _source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        _source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !ASSIGNMENT_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -151,7 +171,7 @@ mod tests {
 func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = RemoveIfBody.apply(&if_node, src.as_bytes());
+        let candidates = RemoveIfBody.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "{}", r#"{ println("yes") }"#);
     }
 
@@ -160,7 +180,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let src = "package main\nfunc f(x int) int { if x > 0 { return 1 } else { return 0 } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = RemoveElse.apply(&if_node, src.as_bytes());
+        let candidates = RemoveElse.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "", "else { return 0 }");
     }
 
@@ -170,7 +190,8 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let stmt = find_node_by_kind(tree.root_node(), "expression_statement")
             .expect("should find expression_statement node");
-        let candidates = RemoveCallStatement.apply(&stmt, src.as_bytes());
+        let candidates =
+            RemoveCallStatement.apply(&stmt, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "", r#"println("hi")"#);
     }
 
@@ -180,7 +201,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let bin = find_node_by_kind(tree.root_node(), "binary_expression")
             .expect("should find binary_expression node");
-        let candidates = RemoveCallStatement.apply(&bin, src.as_bytes());
+        let candidates = RemoveCallStatement.apply(&bin, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -190,7 +211,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let tree = parse_go(src);
         let stmt = find_node_by_kind(tree.root_node(), "assignment_statement")
             .expect("should find assignment_statement node");
-        let candidates = RemoveAssignment.apply(&stmt, src.as_bytes());
+        let candidates = RemoveAssignment.apply(&stmt, src.as_bytes(), &crate::languages::go::Go);
         assert_single_candidate(&candidates, src, "", "x = 1");
     }
 
@@ -199,7 +220,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let src = "package main\nfunc f() { for i := 0; i < 10; i++ { println(i) } }";
         let tree = parse_go(src);
         let for_node = find_node_by_kind(tree.root_node(), "for_statement").unwrap();
-        let candidates = RemoveIfBody.apply(&for_node, src.as_bytes());
+        let candidates = RemoveIfBody.apply(&for_node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 
@@ -208,7 +229,7 @@ func f(x int) { if x > 0 { println("yes") } }"#;
         let src = "package main\nfunc f(x int) { if x > 0 { println(x) } }";
         let tree = parse_go(src);
         let if_node = find_node_by_kind(tree.root_node(), "if_statement").unwrap();
-        let candidates = RemoveElse.apply(&if_node, src.as_bytes());
+        let candidates = RemoveElse.apply(&if_node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 }

--- a/src/operators/unary.rs
+++ b/src/operators/unary.rs
@@ -12,7 +12,12 @@ impl MutationOperator for RemoveUnaryNot {
     fn description(&self) -> &str {
         "Remove ! operator: !x → x"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !UNARY_EXPR_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -39,7 +44,12 @@ impl MutationOperator for RemoveUnaryNeg {
     fn description(&self) -> &str {
         "Remove unary -: -x → x"
     }
-    fn apply(&self, node: &tree_sitter::Node, source: &[u8]) -> Vec<MutationCandidate> {
+    fn apply(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        _lang: &dyn crate::languages::LanguageSupport,
+    ) -> Vec<MutationCandidate> {
         if !UNARY_EXPR_KINDS.contains(&node.kind()) {
             return vec![];
         }
@@ -69,7 +79,7 @@ mod tests {
         let src = "package main\nfunc f(x bool) bool { return !x }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
-        let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
+        let candidates = RemoveUnaryNot.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "x");
     }
@@ -79,7 +89,7 @@ mod tests {
         let src = "package main\nfunc f(x int) int { return -x }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
-        let candidates = RemoveUnaryNeg.apply(&node, src.as_bytes());
+        let candidates = RemoveUnaryNeg.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "x");
     }
@@ -92,7 +102,8 @@ mod tests {
         parser.set_language(&lang.into()).unwrap();
         let tree = parser.parse(src, None).unwrap();
         let node = find_node_by_kind(tree.root_node(), "not_operator").unwrap();
-        let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
+        let candidates =
+            RemoveUnaryNot.apply(&node, src.as_bytes(), &crate::languages::python::Python);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].replacement, "y");
     }
@@ -102,7 +113,7 @@ mod tests {
         let src = "package main\nfunc f(x int) int { return -x }";
         let tree = parse_go(src);
         let node = find_node_by_kind(tree.root_node(), "unary_expression").unwrap();
-        let candidates = RemoveUnaryNot.apply(&node, src.as_bytes());
+        let candidates = RemoveUnaryNot.apply(&node, src.as_bytes(), &crate::languages::go::Go);
         assert!(candidates.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- pass LanguageSupport into MutationOperator::apply from mutation generation
- remove operator-local binary/if/return kind tables in favor of LanguageSupport methods
- use LanguageSupport::operator_field when locating binary operator tokens

Refs #322. This is the second operator-layer slice; literal/unary/loop/removal-specific kind tables remain unchanged unless we decide to tackle those separately.

## Tests
- cargo fmt --check
- cargo test operators:: --no-run
- cargo test operators::
- cargo test mutator::
- cargo test
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced mutation operators to be language-aware, enabling more accurate code transformations across different programming languages. The system now recognizes language-specific syntax patterns and expression structures for improved mutation accuracy and coverage across Go, Rust, Python, and other supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->