### PR TITLE
refactor: centralize remaining operator node kinds

### DIFF
--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -142,7 +142,6 @@ const STRING_LITERAL_NODE_KINDS: &[&str] = &[
     "raw_string_literal",
     "string",
     "string_literal",
-    "string_content",
     "template_string",
 ];
 
@@ -362,10 +361,6 @@ pub trait LanguageSupport: Send + Sync {
             None
         } else if self.is_integer_literal_node(kind) || matches!(kind, "float_literal" | "float") {
             Some("0".to_string())
-        } else if self.boolean_true_literals().contains(&text)
-            || self.boolean_false_literals().contains(&text)
-        {
-            Some("false".to_string())
         } else if text.starts_with('"') || text.starts_with('\'') || text.starts_with('`') {
             Some("\"\"".to_string())
         } else {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -15,8 +15,8 @@ pub mod typescript;
 ///   binary_expression: "binary_expression"
 ///   if_statement: "if_statement"
 ///   return_statement: "return_statement"
-///   bool_true: ["true"]
-///   bool_false: ["false"]
+///   bool_true: ["true", "True", "TRUE"]
+///   bool_false: ["false", "False", "FALSE"]
 ///   operator_field: "operator"
 ///   skip_subtree_kinds: []
 ///   filter_candidate: function path
@@ -55,10 +55,10 @@ macro_rules! define_language {
                 $crate::languages::define_language!(@first $($ret)? ; "return_statement")
             }
             fn boolean_true_literals(&self) -> &[&str] {
-                $crate::languages::define_language!(@arr [$($($bt),*)?] ; ["true"])
+                $crate::languages::define_language!(@arr [$($($bt),*)?] ; ["true", "True", "TRUE"])
             }
             fn boolean_false_literals(&self) -> &[&str] {
-                $crate::languages::define_language!(@arr [$($($bf),*)?] ; ["false"])
+                $crate::languages::define_language!(@arr [$($($bf),*)?] ; ["false", "False", "FALSE"])
             }
             fn operator_field(&self) -> &str {
                 $crate::languages::define_language!(@first $($op)? ; "operator")
@@ -129,42 +129,40 @@ const SIMPLE_RETURN_TYPE_KINDS: &[&str] = &[
     "floating_point_type",
 ];
 
-// Shared operator-family node kinds. Primary binary/if/return kinds come from
-// each LanguageSupport implementation.
-const SHARED_MUTABLE_NODE_KINDS: &[&str] = &[
-    "binary_expr",
-    "comparison_expression",
-    "if_expr",
-    "true",
-    "false",
-    "boolean_literal",
+const INTEGER_LITERAL_NODE_KINDS: &[&str] = &[
     "integer_literal",
     "int_literal",
     "integer",
     "number",
     "number_literal",
-    "unary_expression",
-    "unary_expr",
-    "not_operator",
+];
+
+const STRING_LITERAL_NODE_KINDS: &[&str] = &[
     "interpreted_string_literal",
     "raw_string_literal",
     "string",
     "string_literal",
     "string_content",
     "template_string",
-    "expression_statement",
-    "expression_stmt",
+];
+
+const UNARY_EXPRESSION_NODE_KINDS: &[&str] = &["unary_expression", "unary_expr", "not_operator"];
+
+const EXPRESSION_STATEMENT_NODE_KINDS: &[&str] = &["expression_statement", "expression_stmt"];
+
+const CALL_EXPRESSION_NODE_KINDS: &[&str] = &[
+    "call_expression",
+    "call",
+    "method_invocation",
+    "invocation_expression",
+];
+
+const ASSIGNMENT_NODE_KINDS: &[&str] = &[
     "assignment_statement",
     "assignment_expression",
     "assignment",
     "augmented_assignment",
     "augmented_assignment_expression",
-    "break_statement",
-    "break_expression",
-    "break",
-    "continue_statement",
-    "continue_expression",
-    "next",
 ];
 
 pub(crate) fn is_default_mutable_node_kind<L: LanguageSupport + ?Sized>(
@@ -174,7 +172,18 @@ pub(crate) fn is_default_mutable_node_kind<L: LanguageSupport + ?Sized>(
     kind == lang.binary_expression_node()
         || kind == lang.if_statement_node()
         || kind == lang.return_statement_node()
-        || SHARED_MUTABLE_NODE_KINDS.contains(&kind)
+        || kind == "binary_expr"
+        || kind == "comparison_expression"
+        || kind == "if_expr"
+        || lang.is_boolean_true_literal_node(kind)
+        || lang.is_boolean_false_literal_node(kind)
+        || lang.is_integer_literal_node(kind)
+        || lang.is_string_literal_node(kind)
+        || lang.is_unary_expression_node(kind)
+        || lang.is_expression_statement_node(kind)
+        || lang.is_assignment_node(kind)
+        || lang.is_break_node(kind)
+        || lang.is_continue_node(kind)
 }
 
 pub(crate) fn should_skip_return_empty_for_type(
@@ -285,6 +294,84 @@ pub trait LanguageSupport: Send + Sync {
 
     /// Primary return-statement or return-expression node kind.
     fn return_statement_node(&self) -> &str;
+
+    /// Return true when `kind` can hold a boolean true literal for this grammar.
+    fn is_boolean_true_literal_node(&self, kind: &str) -> bool {
+        matches!(kind, "true" | "True" | "TRUE" | "boolean_literal")
+            || self.boolean_true_literals().contains(&kind)
+    }
+
+    /// Return true when `kind` can hold a boolean false literal for this grammar.
+    fn is_boolean_false_literal_node(&self, kind: &str) -> bool {
+        matches!(kind, "false" | "False" | "FALSE" | "boolean_literal")
+            || self.boolean_false_literals().contains(&kind)
+    }
+
+    /// Return true when `kind` can hold an integer-style numeric literal.
+    fn is_integer_literal_node(&self, kind: &str) -> bool {
+        INTEGER_LITERAL_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return true when `kind` can hold a string literal.
+    fn is_string_literal_node(&self, kind: &str) -> bool {
+        STRING_LITERAL_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return true when `kind` is a unary expression node.
+    fn is_unary_expression_node(&self, kind: &str) -> bool {
+        UNARY_EXPRESSION_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return true when `kind` is a loop break node.
+    fn is_break_node(&self, kind: &str) -> bool {
+        matches!(kind, "break_statement" | "break_expression" | "break")
+    }
+
+    /// Return true when `kind` is a loop continue node.
+    fn is_continue_node(&self, kind: &str) -> bool {
+        matches!(kind, "continue_statement" | "continue_expression" | "next")
+    }
+
+    /// Return true when `kind` is an expression statement node.
+    fn is_expression_statement_node(&self, kind: &str) -> bool {
+        EXPRESSION_STATEMENT_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return true when `kind` is a call expression node.
+    fn is_call_expression_node(&self, kind: &str) -> bool {
+        CALL_EXPRESSION_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return true when `kind` is an assignment node.
+    fn is_assignment_node(&self, kind: &str) -> bool {
+        ASSIGNMENT_NODE_KINDS.contains(&kind)
+    }
+
+    /// Return the replacement for a return value, or None if it is already empty.
+    fn return_empty_replacement(&self, kind: &str, text: &str) -> Option<String> {
+        if self.is_string_literal_node(kind) {
+            Some("\"\"".to_string())
+        } else if self.is_boolean_true_literal_node(kind)
+            || self.is_boolean_false_literal_node(kind)
+            || kind == "boolean"
+        {
+            Some("false".to_string())
+        } else if matches!(kind, "null" | "nil" | "none" | "None")
+            || matches!(text, "nil" | "null" | "None")
+        {
+            None
+        } else if self.is_integer_literal_node(kind) || matches!(kind, "float_literal" | "float") {
+            Some("0".to_string())
+        } else if self.boolean_true_literals().contains(&text)
+            || self.boolean_false_literals().contains(&text)
+        {
+            Some("false".to_string())
+        } else if text.starts_with('"') || text.starts_with('\'') || text.starts_with('`') {
+            Some("\"\"".to_string())
+        } else {
+            Some("0".to_string())
+        }
+    }
 
     /// Return true when `kind` is a mutation-relevant AST node kind for this language.
     fn is_mutable_node_kind(&self, kind: &str) -> bool {

--- a/src/operators/literal.rs
+++ b/src/operators/literal.rs
@@ -1,24 +1,6 @@
 use super::{MutationOperator, mutation_candidate};
 use crate::MutationCandidate;
 
-const TRUE_KINDS: &[&str] = &["true", "True", "TRUE", "boolean_literal"];
-const FALSE_KINDS: &[&str] = &["false", "False", "FALSE", "boolean_literal"];
-const INT_LITERAL_KINDS: &[&str] = &[
-    "integer_literal",
-    "int_literal",
-    "integer", // Ruby
-    "number",
-    "number_literal",
-];
-const STRING_LITERAL_KINDS: &[&str] = &[
-    "interpreted_string_literal",
-    "raw_string_literal",
-    "string",
-    "string_literal",
-    "string_content",
-    "template_string",
-];
-
 pub struct TrueToFalse;
 
 impl MutationOperator for TrueToFalse {
@@ -32,11 +14,11 @@ impl MutationOperator for TrueToFalse {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if TRUE_KINDS.contains(&node.kind()) {
+        if lang.is_boolean_true_literal_node(node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
-            if text == "true" || text == "True" || text == "TRUE" {
+            if lang.boolean_true_literals().contains(&text) {
                 return vec![mutation_candidate(self, node.byte_range(), "false")];
             }
         }
@@ -57,11 +39,11 @@ impl MutationOperator for FalseToTrue {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if FALSE_KINDS.contains(&node.kind()) {
+        if lang.is_boolean_false_literal_node(node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
-            if text == "false" || text == "False" || text == "FALSE" {
+            if lang.boolean_false_literals().contains(&text) {
                 return vec![mutation_candidate(self, node.byte_range(), "true")];
             }
         }
@@ -82,9 +64,9 @@ impl MutationOperator for ZeroToOne {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if INT_LITERAL_KINDS.contains(&node.kind()) {
+        if lang.is_integer_literal_node(node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "0" {
                 return vec![mutation_candidate(self, node.byte_range(), "1")];
@@ -107,9 +89,9 @@ impl MutationOperator for StringToEmpty {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if STRING_LITERAL_KINDS.contains(&node.kind()) {
+        if lang.is_string_literal_node(node.kind()) {
             let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
             if text == "\"\"" || text == "''" || text == "``" {
                 return vec![];
@@ -140,9 +122,9 @@ impl MutationOperator for IncrementNumeric {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !INT_LITERAL_KINDS.contains(&node.kind()) {
+        if !lang.is_integer_literal_node(node.kind()) {
             return vec![];
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
@@ -171,9 +153,9 @@ impl MutationOperator for DecrementNumeric {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !INT_LITERAL_KINDS.contains(&node.kind()) {
+        if !lang.is_integer_literal_node(node.kind()) {
             return vec![];
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");

--- a/src/operators/loop_control.rs
+++ b/src/operators/loop_control.rs
@@ -1,18 +1,6 @@
 use super::MutationOperator;
 use crate::MutationCandidate;
 
-const BREAK_KINDS: &[&str] = &[
-    "break_statement",
-    "break_expression", // Rust
-    "break",            // Ruby
-];
-
-const CONTINUE_KINDS: &[&str] = &[
-    "continue_statement",
-    "continue_expression", // Rust
-    "next",                // Ruby
-];
-
 pub struct RemoveBreak;
 
 impl MutationOperator for RemoveBreak {
@@ -26,9 +14,9 @@ impl MutationOperator for RemoveBreak {
         &self,
         node: &tree_sitter::Node,
         _source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !BREAK_KINDS.contains(&node.kind()) {
+        if !lang.is_break_node(node.kind()) {
             return vec![];
         }
         vec![MutationCandidate {
@@ -53,9 +41,9 @@ impl MutationOperator for RemoveContinue {
         &self,
         node: &tree_sitter::Node,
         _source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !CONTINUE_KINDS.contains(&node.kind()) {
+        if !lang.is_continue_node(node.kind()) {
             return vec![];
         }
         vec![MutationCandidate {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -132,8 +132,18 @@ impl MutationOperator for ReturnEmpty {
         let last = &children[children.len() - 1];
         let value_range = first.start_byte()..last.end_byte();
         let text = std::str::from_utf8(&source[value_range.clone()]).unwrap_or("");
+        let replacement_kind = if first.kind() == "expression_list" {
+            let mut cursor = first.walk();
+            let mut values = first.named_children(&mut cursor);
+            match (values.next(), values.next()) {
+                (Some(value), None) => value.kind(),
+                _ => first.kind(),
+            }
+        } else {
+            first.kind()
+        };
 
-        let Some(replacement) = lang.return_empty_replacement(first.kind(), text) else {
+        let Some(replacement) = lang.return_empty_replacement(replacement_kind, text) else {
             return vec![];
         };
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -133,34 +133,8 @@ impl MutationOperator for ReturnEmpty {
         let value_range = first.start_byte()..last.end_byte();
         let text = std::str::from_utf8(&source[value_range.clone()]).unwrap_or("");
 
-        // Use tree-sitter node kind of the first child for more accurate replacement
-        let first_kind = first.kind();
-        let replacement = match first_kind {
-            // String literals
-            "interpreted_string_literal"
-            | "raw_string_literal"
-            | "string"
-            | "string_literal"
-            | "template_string" => "\"\"".to_string(),
-            // Boolean literals
-            "true" | "false" | "boolean" => "false".to_string(),
-            // Null/nil/None
-            "null" | "nil" | "none" | "None" => return vec![], // already a zero-value, skip
-            // Numeric literals
-            "integer_literal" | "int_literal" | "float_literal" | "number" | "integer"
-            | "float" => "0".to_string(),
-            // Fallback: use text-based heuristic
-            _ => {
-                if text == "nil" || text == "null" || text == "None" {
-                    return vec![]; // Already a zero-value, mutation not useful
-                } else if text == "true" || text == "false" {
-                    "false".to_string()
-                } else if text.starts_with('"') || text.starts_with('\'') || text.starts_with('`') {
-                    "\"\"".to_string()
-                } else {
-                    "0".to_string()
-                }
-            }
+        let Some(replacement) = lang.return_empty_replacement(first.kind(), text) else {
+            return vec![];
         };
 
         vec![crate::MutationCandidate {

--- a/src/operators/removal.rs
+++ b/src/operators/removal.rs
@@ -80,14 +80,6 @@ impl MutationOperator for RemoveElse {
     }
 }
 
-const EXPR_STMT_KINDS: &[&str] = &["expression_statement", "expression_stmt"];
-const CALL_EXPR_KINDS: &[&str] = &[
-    "call_expression",
-    "call",
-    "method_invocation",
-    "invocation_expression",
-];
-
 pub struct RemoveCallStatement;
 
 impl MutationOperator for RemoveCallStatement {
@@ -101,15 +93,15 @@ impl MutationOperator for RemoveCallStatement {
         &self,
         node: &tree_sitter::Node,
         _source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !EXPR_STMT_KINDS.contains(&node.kind()) {
+        if !lang.is_expression_statement_node(node.kind()) {
             return vec![];
         }
         let mut cursor = node.walk();
         let has_call = node
             .named_children(&mut cursor)
-            .any(|child| CALL_EXPR_KINDS.contains(&child.kind()));
+            .any(|child| lang.is_call_expression_node(child.kind()));
         if has_call {
             vec![mutation_candidate(self, node.byte_range(), String::new())]
         } else {
@@ -117,14 +109,6 @@ impl MutationOperator for RemoveCallStatement {
         }
     }
 }
-
-const ASSIGNMENT_KINDS: &[&str] = &[
-    "assignment_statement",
-    "assignment_expression",
-    "assignment",
-    "augmented_assignment",
-    "augmented_assignment_expression",
-];
 
 pub struct RemoveAssignment;
 
@@ -139,9 +123,9 @@ impl MutationOperator for RemoveAssignment {
         &self,
         node: &tree_sitter::Node,
         _source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !ASSIGNMENT_KINDS.contains(&node.kind()) {
+        if !lang.is_assignment_node(node.kind()) {
             return vec![];
         }
         vec![mutation_candidate(self, node.byte_range(), String::new())]

--- a/src/operators/unary.rs
+++ b/src/operators/unary.rs
@@ -1,8 +1,6 @@
 use super::MutationOperator;
 use crate::MutationCandidate;
 
-const UNARY_EXPR_KINDS: &[&str] = &["unary_expression", "unary_expr", "not_operator"];
-
 pub struct RemoveUnaryNot;
 
 impl MutationOperator for RemoveUnaryNot {
@@ -16,9 +14,9 @@ impl MutationOperator for RemoveUnaryNot {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !UNARY_EXPR_KINDS.contains(&node.kind()) {
+        if !lang.is_unary_expression_node(node.kind()) {
             return vec![];
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");
@@ -48,9 +46,9 @@ impl MutationOperator for RemoveUnaryNeg {
         &self,
         node: &tree_sitter::Node,
         source: &[u8],
-        _lang: &dyn crate::languages::LanguageSupport,
+        lang: &dyn crate::languages::LanguageSupport,
     ) -> Vec<MutationCandidate> {
-        if !UNARY_EXPR_KINDS.contains(&node.kind()) {
+        if !lang.is_unary_expression_node(node.kind()) {
             return vec![];
         }
         let text = std::str::from_utf8(&source[node.byte_range()]).unwrap_or("");


### PR DESCRIPTION
Summary:
- Move remaining literal, unary, loop-control, and removal node-kind role checks behind LanguageSupport.
- Centralize return_empty value replacement classification behind LanguageSupport.
- Remove remaining operator-local node-kind tables.

Tests:
- cargo test operators::
- cargo test mutator::
- cargo test languages::tests::
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Boolean literal mutations now recognize additional case variants (e.g., `True`, `TRUE`, `False`, `FALSE`) in addition to lowercase forms, improving mutation coverage across different programming language conventions.

* **Refactor**
  * Improved mutation operator architecture for greater language flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->