### PR TITLE
Fix unbounded mutation runner memory use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,18 +115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,15 +183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,15 +223,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "diffy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
-dependencies = [
- "hashbrown 0.17.0",
-]
 
 [[package]]
 name = "dispatch2"
@@ -310,12 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +311,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -355,9 +319,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -442,17 +403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,12 +455,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -699,22 +643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,11 +690,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "bytecount",
  "clap",
- "colored",
  "ctrlc",
- "diffy",
  "globset",
  "ignore",
  "libc",
@@ -774,9 +699,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
- "siphasher",
  "tempfile",
- "tokio",
  "toml",
  "tree-sitter",
  "tree-sitter-c",
@@ -789,32 +712,6 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "windows-sys",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "signal-hook-registry",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1002,12 +899,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ categories = ["development-tools::testing", "command-line-utilities"]
 # CLI
 clap = { version = "4", features = ["derive"] }
 
-# Async runtime
-tokio = { version = "1", features = ["rt-multi-thread", "process", "time", "sync", "macros"] }
-
 # Parsing
 tree-sitter = "0.26"
 tree-sitter-go = "0.25"
@@ -29,24 +26,17 @@ tree-sitter-cpp = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-c-sharp = "0.23"
 
-# Diff parsing
-diffy = "0.5"
-
 # Config
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
 
 # Output
-colored = "3"
 serde_json = "1"
 
 # Filesystem
 tempfile = "3"
 globset = "0.4"
 ignore = "0.4"
-
-# Byte counting
-bytecount = "0.6"
 
 # Shell parsing
 shell-words = "1"
@@ -56,9 +46,6 @@ anyhow = "1"
 
 # Signal handling
 ctrlc = "3"
-
-# Hashing
-siphasher = "1"
 
 # Platform
 [target.'cfg(unix)'.dependencies]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,7 +6,9 @@
 //! stored as JSON files in `.togi-cache/`.
 
 use crate::MutationResult;
+use std::collections::hash_map::DefaultHasher;
 use std::fs;
+use std::hash::Hasher;
 use std::path::{Path, PathBuf};
 
 /// Directory where cache entries are stored.
@@ -51,7 +53,7 @@ impl CacheKey {
     }
 
     fn digest_with_versions(&self, cache_schema_version: &str, togi_version: &str) -> String {
-        let mut hash = FNV_OFFSET;
+        let mut hash = 0;
         update_hash_str(&mut hash, cache_schema_version);
         update_hash_str(&mut hash, togi_version);
         update_hash_bytes(&mut hash, &self.file_content_hash.to_le_bytes());
@@ -102,13 +104,10 @@ fn entry_path(project_root: &Path, key: &CacheKey) -> PathBuf {
     cache_dir(project_root).join(key.digest())
 }
 
-const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-const FNV_PRIME: u64 = 0x100000001b3;
-
 fn hash_bytes(data: &[u8]) -> u64 {
-    let mut hash = FNV_OFFSET;
-    update_hash_bytes(&mut hash, data);
-    hash
+    let mut hasher = DefaultHasher::new();
+    hasher.write(data);
+    hasher.finish()
 }
 
 fn hash_str(s: &str) -> u64 {
@@ -121,10 +120,10 @@ fn update_hash_str(hash: &mut u64, value: &str) {
 }
 
 fn update_hash_bytes(hash: &mut u64, bytes: &[u8]) {
-    for byte in bytes {
-        *hash ^= u64::from(*byte);
-        *hash = hash.wrapping_mul(FNV_PRIME);
-    }
+    let mut hasher = DefaultHasher::new();
+    hasher.write(&(*hash).to_le_bytes());
+    hasher.write(bytes);
+    *hash = hasher.finish();
 }
 
 #[cfg(test)]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,10 +7,7 @@
 
 use crate::MutationResult;
 use std::fs;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
-
-use siphasher::sip::SipHasher;
 
 /// Directory where cache entries are stored.
 const CACHE_DIR: &str = ".togi-cache";
@@ -54,14 +51,14 @@ impl CacheKey {
     }
 
     fn digest_with_versions(&self, cache_schema_version: &str, togi_version: &str) -> String {
-        let mut h = SipHasher::new();
-        cache_schema_version.hash(&mut h);
-        togi_version.hash(&mut h);
-        self.file_content_hash.hash(&mut h);
-        self.mutation_identity.hash(&mut h);
-        self.mutation_description.hash(&mut h);
-        self.test_command_hash.hash(&mut h);
-        format!("{:016x}", h.finish())
+        let mut hash = FNV_OFFSET;
+        update_hash_str(&mut hash, cache_schema_version);
+        update_hash_str(&mut hash, togi_version);
+        update_hash_bytes(&mut hash, &self.file_content_hash.to_le_bytes());
+        update_hash_str(&mut hash, &self.mutation_identity);
+        update_hash_str(&mut hash, &self.mutation_description);
+        update_hash_bytes(&mut hash, &self.test_command_hash.to_le_bytes());
+        format!("{hash:016x}")
     }
 }
 
@@ -105,16 +102,29 @@ fn entry_path(project_root: &Path, key: &CacheKey) -> PathBuf {
     cache_dir(project_root).join(key.digest())
 }
 
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
 fn hash_bytes(data: &[u8]) -> u64 {
-    let mut h = SipHasher::new();
-    data.hash(&mut h);
-    h.finish()
+    let mut hash = FNV_OFFSET;
+    update_hash_bytes(&mut hash, data);
+    hash
 }
 
 fn hash_str(s: &str) -> u64 {
-    let mut h = SipHasher::new();
-    s.hash(&mut h);
-    h.finish()
+    hash_bytes(s.as_bytes())
+}
+
+fn update_hash_str(hash: &mut u64, value: &str) {
+    update_hash_bytes(hash, &(value.len() as u64).to_le_bytes());
+    update_hash_bytes(hash, value.as_bytes());
+}
+
+fn update_hash_bytes(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
 }
 
 #[cfg(test)]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,7 +6,6 @@
 //! stored as JSON files in `.togi-cache/`.
 
 use crate::MutationResult;
-use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::Hasher;
 use std::path::{Path, PathBuf};
@@ -53,13 +52,14 @@ impl CacheKey {
     }
 
     fn digest_with_versions(&self, cache_schema_version: &str, togi_version: &str) -> String {
-        let mut hash = 0;
-        update_hash_str(&mut hash, cache_schema_version);
-        update_hash_str(&mut hash, togi_version);
-        update_hash_bytes(&mut hash, &self.file_content_hash.to_le_bytes());
-        update_hash_str(&mut hash, &self.mutation_identity);
-        update_hash_str(&mut hash, &self.mutation_description);
-        update_hash_bytes(&mut hash, &self.test_command_hash.to_le_bytes());
+        let mut hasher = Fnv64Hasher::default();
+        update_hash_str(&mut hasher, cache_schema_version);
+        update_hash_str(&mut hasher, togi_version);
+        update_hash_bytes(&mut hasher, &self.file_content_hash.to_le_bytes());
+        update_hash_str(&mut hasher, &self.mutation_identity);
+        update_hash_str(&mut hasher, &self.mutation_description);
+        update_hash_bytes(&mut hasher, &self.test_command_hash.to_le_bytes());
+        let hash = hasher.finish();
         format!("{hash:016x}")
     }
 }
@@ -104,8 +104,34 @@ fn entry_path(project_root: &Path, key: &CacheKey) -> PathBuf {
     cache_dir(project_root).join(key.digest())
 }
 
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+struct Fnv64Hasher {
+    hash: u64,
+}
+
+impl Default for Fnv64Hasher {
+    fn default() -> Self {
+        Self { hash: FNV_OFFSET }
+    }
+}
+
+impl Hasher for Fnv64Hasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.hash ^= u64::from(*byte);
+            self.hash = self.hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+}
+
 fn hash_bytes(data: &[u8]) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = Fnv64Hasher::default();
     hasher.write(data);
     hasher.finish()
 }
@@ -114,16 +140,13 @@ fn hash_str(s: &str) -> u64 {
     hash_bytes(s.as_bytes())
 }
 
-fn update_hash_str(hash: &mut u64, value: &str) {
-    update_hash_bytes(hash, &(value.len() as u64).to_le_bytes());
-    update_hash_bytes(hash, value.as_bytes());
+fn update_hash_str(hasher: &mut impl Hasher, value: &str) {
+    update_hash_bytes(hasher, &(value.len() as u64).to_le_bytes());
+    update_hash_bytes(hasher, value.as_bytes());
 }
 
-fn update_hash_bytes(hash: &mut u64, bytes: &[u8]) {
-    let mut hasher = DefaultHasher::new();
-    hasher.write(&(*hash).to_le_bytes());
+fn update_hash_bytes(hasher: &mut impl Hasher, bytes: &[u8]) {
     hasher.write(bytes);
-    *hash = hasher.finish();
 }
 
 #[cfg(test)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -63,7 +63,7 @@ pub fn collect_all_supported_files(
                 continue;
             }
         };
-        let newlines = bytecount::count(&bytes, b'\n');
+        let newlines = bytes.iter().filter(|byte| **byte == b'\n').count();
         let line_count = if bytes.is_empty() {
             0
         } else if bytes.last() == Some(&b'\n') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,8 +347,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
 
     if outcome.cancelled {
         eprintln!("Interrupted; skipping baseline and PR comment updates.");
-        drop(_lock);
-        process::exit(130);
+        exit_with(_lock, 130);
     }
 
     let current = togi::baseline::from_report(&report, &project_root_ref);
@@ -386,20 +385,22 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
 
     let score = togi::report::mutation_score(&report);
     if should_fail {
-        drop(_lock);
-        process::exit(1);
+        exit_with(_lock, 1);
     } else if let Some(threshold) = fail_under {
         if score < threshold {
             eprintln!("Mutation score {score:.1}% is below --fail-under threshold {threshold:.1}%");
-            drop(_lock);
-            process::exit(1);
+            exit_with(_lock, 1);
         }
     } else if report.survived > 0 && !check_baseline {
-        drop(_lock);
-        process::exit(1);
+        exit_with(_lock, 1);
     }
 
     Ok(())
+}
+
+fn exit_with(lock: togi::lock::LockGuard, code: i32) -> ! {
+    drop(lock);
+    process::exit(code);
 }
 
 fn resolve_config(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde::Deserialize;
-use togi::{ChangedFile, Mutation, MutationReport};
+use togi::{ChangedFile, Mutation};
 
 struct CheckConfig {
     all: bool,
@@ -328,7 +328,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
     eprintln!("Running {} mutations...", mutations.len());
 
     let project_root_ref = project_root.clone();
-    let report = execute(
+    let outcome = execute(
         mutations,
         config,
         project_root,
@@ -342,7 +342,14 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
         },
     );
 
+    let report = outcome.report;
     togi::report::print_report(&report, output_format)?;
+
+    if outcome.cancelled {
+        eprintln!("Interrupted; skipping baseline and PR comment updates.");
+        drop(_lock);
+        process::exit(130);
+    }
 
     let current = togi::baseline::from_report(&report, &project_root_ref);
     let mut should_fail = false;
@@ -618,7 +625,7 @@ fn execute(
     config: togi::config::Config,
     project_root: PathBuf,
     options: ExecuteOptions,
-) -> MutationReport {
+) -> togi::runner::RunOutcome {
     let mut language_commands: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
     let mut language_timeouts: std::collections::HashMap<String, Duration> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,7 @@ struct ExecuteOptions {
     cancelled: Arc<AtomicBool>,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let cancelled = Arc::new(AtomicBool::new(false));
     let cancelled_handler = cancelled.clone();
 
@@ -111,7 +110,7 @@ async fn main() {
                 check_baseline,
                 pr_comment,
             };
-            if let Err(e) = run_check(cfg, cancelled).await {
+            if let Err(e) = run_check(cfg, cancelled) {
                 eprintln!("Error: {e:#}");
                 process::exit(2);
             }
@@ -265,7 +264,7 @@ fn print_operators() {
     }
 }
 
-async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()> {
+fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()> {
     let all = cfg.all;
     let paths = cfg.paths.clone();
     let dry_run = cfg.dry_run;
@@ -341,8 +340,7 @@ async fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Resu
             force_default_timeout: has_cli_timeout,
             cancelled,
         },
-    )
-    .await;
+    );
 
     togi::report::print_report(&report, output_format)?;
 
@@ -615,7 +613,7 @@ fn print_dry_run(mutations: &[Mutation]) {
     }
 }
 
-async fn execute(
+fn execute(
     mutations: Vec<Mutation>,
     config: togi::config::Config,
     project_root: PathBuf,
@@ -682,7 +680,7 @@ async fn execute(
         cancelled: options.cancelled,
     };
 
-    runner.run(mutations).await
+    runner.run(mutations)
 }
 
 fn load_test_selection(

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -150,6 +150,9 @@ pub fn mutation_diff(mutation: &Mutation) -> Option<String> {
     if !original_line.is_char_boundary(byte_start) || !original_line.is_char_boundary(byte_end) {
         return None;
     }
+    if &original_line[byte_start..byte_end] != mutation.original.as_str() {
+        return None;
+    }
     let mutated_line = format!(
         "{}{}{}",
         &original_line[..byte_start],
@@ -298,6 +301,14 @@ mod tests {
         let content = "日本語\n";
         // column 2 (1-indexed) → byte_start 1, which is mid-character
         let m = make_mutation(tmp.path(), "t.rs", content, 1, 2, "x", "y");
+        assert!(mutation_diff(&m).is_none());
+    }
+
+    #[test]
+    fn mutation_diff_original_mismatch_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let content = "a = true\n";
+        let m = make_mutation(tmp.path(), "t.rs", content, 1, 5, "false", "true");
         assert!(mutation_diff(&m).is_none());
     }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -4,6 +4,7 @@ pub mod json;
 pub mod terminal;
 
 use crate::{Mutation, MutationReport};
+use std::fmt::Write;
 use std::fs;
 
 /// Compute mutation score as a percentage, excluding build errors from the denominator.
@@ -160,32 +161,27 @@ pub fn mutation_diff(mutation: &Mutation) -> Option<String> {
     let start = line_idx.saturating_sub(ctx);
     let end = (line_idx + ctx + 1).min(lines.len());
 
-    let mut original_block = String::new();
-    let mut mutated_block = String::new();
+    let file_display = mutation.file.display().to_string();
+    let hunk_start = start + 1;
+    let hunk_len = end - start;
+    let mut diff = String::new();
+    writeln!(diff, "--- a/{file_display}").ok()?;
+    writeln!(diff, "+++ b/{file_display}").ok()?;
+    writeln!(
+        diff,
+        "@@ -{hunk_start},{hunk_len} +{hunk_start},{hunk_len} @@"
+    )
+    .ok()?;
     for (i, line) in lines.iter().enumerate().take(end).skip(start) {
         if i == line_idx {
-            original_block.push_str(original_line);
-            original_block.push('\n');
-            mutated_block.push_str(&mutated_line);
-            mutated_block.push('\n');
+            writeln!(diff, "-{original_line}").ok()?;
+            writeln!(diff, "+{mutated_line}").ok()?;
         } else {
-            original_block.push_str(line);
-            original_block.push('\n');
-            mutated_block.push_str(line);
-            mutated_block.push('\n');
+            writeln!(diff, " {line}").ok()?;
         }
     }
 
-    let file_display = mutation.file.display().to_string();
-    let original_name = format!("a/{}", file_display);
-    let modified_name = format!("b/{}", file_display);
-    let diff = diffy::DiffOptions::new()
-        .set_context_len(ctx)
-        .set_original_filename(original_name)
-        .set_modified_filename(modified_name)
-        .create_patch(&original_block, &mutated_block);
-
-    Some(diff.to_string())
+    Some(diff)
 }
 
 #[cfg(test)]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -1,5 +1,4 @@
 use crate::{MutationReport, MutationResult};
-use colored::Colorize;
 use std::fmt::Write;
 
 pub fn print_report(report: &MutationReport) {
@@ -28,7 +27,7 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                     detail,
                     "              {}",
                     if color {
-                        "Your tests don't catch this mutation.".red().to_string()
+                        red("Your tests don't catch this mutation.")
                     } else {
                         "Your tests don't catch this mutation.".to_string()
                     }
@@ -38,11 +37,11 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                     for diff_line in diff.lines() {
                         if color {
                             if diff_line.starts_with('-') {
-                                writeln!(detail, "              {}", diff_line.red())
+                                writeln!(detail, "              {}", red(diff_line))
                             } else if diff_line.starts_with('+') {
-                                writeln!(detail, "              {}", diff_line.green())
+                                writeln!(detail, "              {}", green(diff_line))
                             } else {
-                                writeln!(detail, "              {}", diff_line.dimmed())
+                                writeln!(detail, "              {}", dim(diff_line))
                             }
                         } else {
                             writeln!(detail, "              {diff_line}")
@@ -58,9 +57,9 @@ fn format_report(report: &MutationReport, color: bool) -> String {
 
         if color {
             let tag_colored = match result {
-                MutationResult::Killed => tag.green().to_string(),
-                MutationResult::Survived => tag.red().to_string(),
-                MutationResult::Timeout | MutationResult::BuildError => tag.yellow().to_string(),
+                MutationResult::Killed => green(tag),
+                MutationResult::Survived => red(tag),
+                MutationResult::Timeout | MutationResult::BuildError => yellow(tag),
             };
             writeln!(
                 out,
@@ -68,8 +67,8 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                 tag_colored,
                 file,
                 line,
-                "—".dimmed(),
-                operator.dimmed(),
+                dim("—"),
+                dim(operator),
                 desc
             )
         } else {
@@ -110,6 +109,26 @@ fn format_report(report: &MutationReport, color: bool) -> String {
     }
 
     out
+}
+
+fn ansi(code: &str, text: &str) -> String {
+    format!("\x1b[{code}m{text}\x1b[0m")
+}
+
+fn green(text: &str) -> String {
+    ansi("32", text)
+}
+
+fn red(text: &str) -> String {
+    ansi("31", text)
+}
+
+fn yellow(text: &str) -> String {
+    ansi("33", text)
+}
+
+fn dim(text: &str) -> String {
+    ansi("2", text)
 }
 
 /// Guidance text when every mutation is a build error.

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -324,4 +324,13 @@ mod tests {
             _ => None,
         }));
     }
+
+    #[test]
+    fn clicolor_force_overrides_no_color_when_not_terminal() {
+        assert!(color_enabled_from_env(false, |name| match name {
+            "NO_COLOR" => Some("1".to_string()),
+            "CLICOLOR_FORCE" => Some("1".to_string()),
+            _ => None,
+        }));
+    }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -1,8 +1,9 @@
 use crate::{MutationReport, MutationResult};
 use std::fmt::Write;
+use std::io::IsTerminal;
 
 pub fn print_report(report: &MutationReport) {
-    print!("{}", format_report(report, true));
+    print!("{}", format_report(report, should_colorize()));
 }
 
 pub fn format_report_plain(report: &MutationReport) -> String {
@@ -129,6 +130,25 @@ fn yellow(text: &str) -> String {
 
 fn dim(text: &str) -> String {
     ansi("2", text)
+}
+
+fn should_colorize() -> bool {
+    color_enabled_from_env(std::io::stdout().is_terminal(), |name| {
+        std::env::var(name).ok()
+    })
+}
+
+fn color_enabled_from_env(is_terminal: bool, env: impl Fn(&str) -> Option<String>) -> bool {
+    if env("CLICOLOR_FORCE").is_some_and(|value| value != "0") {
+        return true;
+    }
+    if env("NO_COLOR").is_some() {
+        return false;
+    }
+    if env("CLICOLOR").is_some_and(|value| value == "0") {
+        return false;
+    }
+    is_terminal
 }
 
 /// Guidance text when every mutation is a build error.
@@ -275,5 +295,33 @@ mod tests {
         ]);
         let output = format_report_plain(&report);
         assert!(!output.contains("All mutations caused build errors"));
+    }
+
+    #[test]
+    fn color_is_disabled_when_stdout_is_not_terminal() {
+        assert!(!color_enabled_from_env(false, |_| None));
+    }
+
+    #[test]
+    fn no_color_disables_color() {
+        assert!(!color_enabled_from_env(true, |name| {
+            (name == "NO_COLOR").then(|| "1".to_string())
+        }));
+    }
+
+    #[test]
+    fn clicolor_zero_disables_color() {
+        assert!(!color_enabled_from_env(true, |name| {
+            (name == "CLICOLOR").then(|| "0".to_string())
+        }));
+    }
+
+    #[test]
+    fn clicolor_force_overrides_no_color() {
+        assert!(color_enabled_from_env(true, |name| match name {
+            "NO_COLOR" => Some("1".to_string()),
+            "CLICOLOR_FORCE" => Some("1".to_string()),
+            _ => None,
+        }));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,14 +5,14 @@ use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::{IsTerminal, Read, Write};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex, mpsc};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
 const CAPTURED_OUTPUT_LIMIT: usize = 1024 * 1024;
-const OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Write mutation workspace content. Workspaces are disposable temp copies, so
 /// durable temp-file + fsync writes would only add hot-loop I/O overhead.
@@ -698,38 +698,50 @@ impl TestRunner {
                             break;
                         }
 
-                        let Some((index, mutation)) = queue
-                            .lock()
-                            .expect("mutation queue mutex poisoned")
-                            .pop_front()
-                        else {
+                        let next = match queue.lock() {
+                            Ok(mut queue) => queue.pop_front(),
+                            Err(_) => {
+                                eprintln!("warning: mutation queue mutex poisoned");
+                                break;
+                            }
+                        };
+                        let Some((index, mutation)) = next else {
                             break;
                         };
 
-                        if let Some(result) = run_queued_mutation(
-                            QueuedMutation { index, mutation },
-                            RunShared {
-                                workspace_pool: workspace_pool.as_ref(),
-                                project_root: project_root.as_ref().as_path(),
-                                commands,
-                                build_command: build_command.as_ref().as_slice(),
-                                build_command_explicit,
-                                env,
-                                total,
-                                verbose,
-                                is_tty,
-                                show_output,
-                                max_tested,
-                                counter: &counter,
-                                scheduled_counter: &scheduled_counter,
-                                tested_counter: &tested_counter,
-                                cancelled: &cancelled,
+                        let outcome = catch_unwind(AssertUnwindSafe(|| {
+                            run_queued_mutation(
+                                QueuedMutation { index, mutation },
+                                RunShared {
+                                    workspace_pool: workspace_pool.as_ref(),
+                                    project_root: project_root.as_ref().as_path(),
+                                    commands,
+                                    build_command: build_command.as_ref().as_slice(),
+                                    build_command_explicit,
+                                    env,
+                                    total,
+                                    verbose,
+                                    is_tty,
+                                    show_output,
+                                    max_tested,
+                                    counter: &counter,
+                                    scheduled_counter: &scheduled_counter,
+                                    tested_counter: &tested_counter,
+                                    cancelled: &cancelled,
+                                },
+                            )
+                        }));
+
+                        match outcome {
+                            Ok(Some(result)) => match results.lock() {
+                                Ok(mut results) => results.push(result),
+                                Err(_) => {
+                                    eprintln!("warning: mutation results mutex poisoned");
+                                    break;
+                                }
                             },
-                        ) {
-                            results
-                                .lock()
-                                .expect("mutation results mutex poisoned")
-                                .push(result);
+                            Ok(None) => {}
+                            Err(_) => eprintln!("warning: mutation task panicked"),
                         }
                     }
                 });
@@ -1025,9 +1037,53 @@ fn run_command(
     let mut cmd = std::process::Command::new(&command[0]);
     cmd.args(&command[1..]).current_dir(cwd).envs(env);
 
+    let mut stdout_capture = None;
+    let mut stderr_capture = None;
     if capture_output {
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
+        let stdout_file = match tempfile::NamedTempFile::new() {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("warning: could not create stdout capture file: {e}");
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
+            }
+        };
+        let stderr_file = match tempfile::NamedTempFile::new() {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("warning: could not create stderr capture file: {e}");
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
+            }
+        };
+        let stdout_handle = match stdout_file.reopen() {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("warning: could not open stdout capture file: {e}");
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
+            }
+        };
+        let stderr_handle = match stderr_file.reopen() {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("warning: could not open stderr capture file: {e}");
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
+            }
+        };
+        cmd.stdout(std::process::Stdio::from(stdout_handle));
+        cmd.stderr(std::process::Stdio::from(stderr_handle));
+        stdout_capture = Some(stdout_file);
+        stderr_capture = Some(stderr_file);
     } else {
         cmd.stdout(std::process::Stdio::null());
         cmd.stderr(std::process::Stdio::null());
@@ -1042,17 +1098,6 @@ fn run_command(
                 test_output: None,
             };
         }
-    };
-
-    let stdout_reader = if capture_output {
-        child.stdout.take().map(spawn_output_reader)
-    } else {
-        None
-    };
-    let stderr_reader = if capture_output {
-        child.stderr.take().map(spawn_output_reader)
-    } else {
-        None
     };
 
     let started = Instant::now();
@@ -1082,22 +1127,26 @@ fn run_command(
         }
     };
 
-    let drain_duration = OUTPUT_DRAIN_TIMEOUT;
-    let stdout = match recv_output_reader(stdout_reader, drain_duration) {
-        Ok(bytes) => bytes,
-        Err(result) => return result,
-    };
-    let stderr = match recv_output_reader(stderr_reader, drain_duration) {
-        Ok(bytes) => bytes,
-        Err(result) => return result,
-    };
-
     let result = if status.success() {
         MutationResult::Survived
     } else {
         MutationResult::Killed
     };
     let test_output = if capture_output {
+        let stdout = read_captured_output(
+            stdout_capture
+                .as_ref()
+                .expect("stdout capture file should exist")
+                .path(),
+            "stdout",
+        );
+        let stderr = read_captured_output(
+            stderr_capture
+                .as_ref()
+                .expect("stderr capture file should exist")
+                .path(),
+            "stderr",
+        );
         let mut combined = String::from_utf8_lossy(&stdout.bytes).into_owned();
         append_truncation_notice(&mut combined, stdout.truncated, "stdout");
 
@@ -1125,55 +1174,31 @@ struct CapturedOutput {
     truncated: bool,
 }
 
-fn spawn_output_reader<R>(mut reader: R) -> mpsc::Receiver<CapturedOutput>
-where
-    R: Read + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let mut bytes = Vec::new();
-        let mut truncated = false;
-        let mut buffer = [0; 8192];
-
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let available = CAPTURED_OUTPUT_LIMIT.saturating_sub(bytes.len());
-                    let keep = n.min(available);
-                    if keep > 0 {
-                        bytes.extend_from_slice(&buffer[..keep]);
-                    }
-                    if keep < n {
-                        truncated = true;
-                    }
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(_) => break,
-            }
+fn read_captured_output(path: &Path, stream: &str) -> CapturedOutput {
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("warning: could not read {stream} capture file: {e}");
+            return CapturedOutput {
+                bytes: Vec::new(),
+                truncated: false,
+            };
         }
-
-        let _ = tx.send(CapturedOutput { bytes, truncated });
-    });
-    rx
-}
-
-fn recv_output_reader(
-    reader: Option<mpsc::Receiver<CapturedOutput>>,
-    drain_duration: Duration,
-) -> Result<CapturedOutput, MutationOutcome> {
-    let Some(reader) = reader else {
-        return Ok(CapturedOutput {
+    };
+    let mut bytes = Vec::new();
+    let mut limited = std::io::Read::by_ref(&mut file).take((CAPTURED_OUTPUT_LIMIT + 1) as u64);
+    if let Err(e) = limited.read_to_end(&mut bytes) {
+        eprintln!("warning: could not read {stream} capture output: {e}");
+        return CapturedOutput {
             bytes: Vec::new(),
             truncated: false,
-        });
-    };
-    reader
-        .recv_timeout(drain_duration)
-        .map_err(|_| MutationOutcome {
-            result: MutationResult::Timeout,
-            test_output: None,
-        })
+        };
+    }
+    let truncated = bytes.len() > CAPTURED_OUTPUT_LIMIT;
+    if truncated {
+        bytes.truncate(CAPTURED_OUTPUT_LIMIT);
+    }
+    CapturedOutput { bytes, truncated }
 }
 
 fn append_truncation_notice(output: &mut String, truncated: bool, stream: &str) {
@@ -2085,6 +2110,56 @@ mod tests {
         assert!(
             output.len() < CAPTURED_OUTPUT_LIMIT + 128,
             "captured output should stay close to the configured cap"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_output_does_not_timeout_when_background_writer_holds_stdout() {
+        let started = Instant::now();
+        let outcome = run_command(
+            &[
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf out; (sleep 1; printf late) &".to_string(),
+            ],
+            &PathBuf::from("."),
+            Duration::from_secs(5),
+            true,
+            &HashMap::new(),
+        );
+
+        assert_eq!(outcome.result, MutationResult::Survived);
+        assert!(
+            started.elapsed() < Duration::from_millis(900),
+            "finished child should not wait for background writer EOF"
+        );
+        assert!(
+            outcome.test_output.unwrap().contains("out"),
+            "captured output should include immediate stdout"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_output_timeout_returns_promptly_with_background_writer() {
+        let started = Instant::now();
+        let outcome = run_command(
+            &[
+                "sh".to_string(),
+                "-c".to_string(),
+                "(sleep 1; printf late) & sleep 10".to_string(),
+            ],
+            &PathBuf::from("."),
+            Duration::from_millis(100),
+            true,
+            &HashMap::new(),
+        );
+
+        assert_eq!(outcome.result, MutationResult::Timeout);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "timeout path should not wait for descendant-held stdout"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -118,6 +118,16 @@ pub struct TestRunner {
     pub cancelled: Arc<AtomicBool>,
 }
 
+/// Result of a runner invocation.
+///
+/// `report` contains the completed mutation results. `cancelled` is true when
+/// the runner observed cancellation before or during execution.
+#[derive(Debug)]
+pub struct RunOutcome {
+    pub report: MutationReport,
+    pub cancelled: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SelectedTestCommand {
     argv: Vec<String>,
@@ -478,33 +488,20 @@ struct RunShared<'a> {
     verbose: bool,
     is_tty: bool,
     show_output: bool,
-    max_tested: Option<usize>,
     counter: &'a AtomicUsize,
-    scheduled_counter: &'a AtomicUsize,
-    tested_counter: &'a AtomicUsize,
     cancelled: &'a AtomicBool,
 }
 
 fn run_queued_mutation(
     queued: QueuedMutation,
+    reservation: TestSlotReservation,
     shared: RunShared<'_>,
 ) -> Option<(usize, Mutation, MutationResult)> {
     let QueuedMutation { index, mutation } = queued;
 
-    // Stop if cancelled (Ctrl+C) or enough mutations have been tested.
+    // Stop if cancelled (Ctrl+C).
     if shared.cancelled.load(Ordering::Relaxed) {
         return None;
-    }
-    if let Some(max) = shared.max_tested {
-        let reserved = shared
-            .scheduled_counter
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                (current < max).then_some(current + 1)
-            })
-            .is_ok();
-        if !reserved {
-            return None;
-        }
     }
 
     let selected_test = select_test_command(shared.project_root, shared.commands, &mutation);
@@ -533,6 +530,7 @@ fn run_queued_mutation(
     if let Some(ref key) = cache_key
         && let Some(result) = cache::lookup(shared.project_root, key)
     {
+        reservation.release();
         record_progress(&shared, &mutation, result, None, true);
         return Some((index, mutation, result));
     }
@@ -553,8 +551,18 @@ fn run_queued_mutation(
             workspace_target,
             shared.show_output,
             shared.env,
+            shared.cancelled,
         )
     };
+
+    if outcome.cancelled {
+        return None;
+    }
+    if outcome.result == MutationResult::BuildError {
+        reservation.release();
+    } else {
+        reservation.commit();
+    }
 
     if let Some(ref key) = cache_key {
         cache::store(shared.project_root, key, outcome.result);
@@ -571,6 +579,47 @@ fn run_queued_mutation(
     Some((index, mutation, result))
 }
 
+struct TestSlotReservation {
+    counter: Option<Arc<AtomicUsize>>,
+}
+
+impl TestSlotReservation {
+    fn try_reserve(max_tested: Option<usize>, counter: &Arc<AtomicUsize>) -> Option<Self> {
+        let Some(max) = max_tested else {
+            return Some(Self { counter: None });
+        };
+
+        counter
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < max).then_some(current + 1)
+            })
+            .ok()
+            .map(|_| Self {
+                counter: Some(counter.clone()),
+            })
+    }
+
+    fn commit(mut self) {
+        self.counter = None;
+    }
+
+    fn release(mut self) {
+        self.release_inner();
+    }
+
+    fn release_inner(&mut self) {
+        if let Some(counter) = self.counter.take() {
+            counter.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
+
+impl Drop for TestSlotReservation {
+    fn drop(&mut self) {
+        self.release_inner();
+    }
+}
+
 #[allow(clippy::manual_is_multiple_of)]
 fn record_progress(
     shared: &RunShared<'_>,
@@ -579,10 +628,6 @@ fn record_progress(
     test_output: Option<&str>,
     cached: bool,
 ) {
-    if result != MutationResult::BuildError {
-        shared.tested_counter.fetch_add(1, Ordering::Release);
-    }
-
     let n = shared.counter.fetch_add(1, Ordering::Relaxed) + 1;
     if shared.verbose {
         if cached {
@@ -637,23 +682,26 @@ fn record_progress(
 
 impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
-    pub fn run(&self, mutations: Vec<Mutation>) -> MutationReport {
+    pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
         let start = Instant::now();
         let total = mutations.len();
         if total == 0 {
-            return self.report_from_results(Vec::new(), start.elapsed());
+            return self.outcome_from_results(Vec::new(), start.elapsed());
+        }
+        if self.cancelled.load(Ordering::Acquire) {
+            return self.outcome_from_results(Vec::new(), start.elapsed());
         }
 
         let counter = Arc::new(AtomicUsize::new(0));
-        let scheduled_counter = Arc::new(AtomicUsize::new(0));
         let tested_counter = Arc::new(AtomicUsize::new(0));
         let verbose = self.verbose;
         let is_tty = std::io::stderr().is_terminal();
+        let workspace_slots = workspace_pool_slot_count(self.parallelism, total);
 
         let workspace_pool_result = if self.respect_workspace_ignores {
-            WorkspacePool::new(&self.project_root, self.parallelism)
+            WorkspacePool::new(&self.project_root, workspace_slots)
         } else {
-            WorkspacePool::new_with_options(&self.project_root, self.parallelism, false)
+            WorkspacePool::new_with_options(&self.project_root, workspace_slots, false)
         };
         let workspace_pool = match workspace_pool_result {
             Ok(pool) => Arc::new(pool),
@@ -663,7 +711,7 @@ impl TestRunner {
                     .into_iter()
                     .map(|mutation| (mutation, MutationResult::BuildError))
                     .collect();
-                return self.report_from_results(results, start.elapsed());
+                return self.outcome_from_results(results, start.elapsed());
             }
         };
 
@@ -684,7 +732,6 @@ impl TestRunner {
                 let project_root = project_root.clone();
                 let build_command = build_command.clone();
                 let counter = counter.clone();
-                let scheduled_counter = scheduled_counter.clone();
                 let tested_counter = tested_counter.clone();
                 let cancelled = self.cancelled.clone();
                 let commands = &self.commands;
@@ -698,6 +745,11 @@ impl TestRunner {
                             break;
                         }
 
+                        let Some(reservation) =
+                            TestSlotReservation::try_reserve(max_tested, &tested_counter)
+                        else {
+                            break;
+                        };
                         let next = match queue.lock() {
                             Ok(mut queue) => queue.pop_front(),
                             Err(_) => {
@@ -712,6 +764,7 @@ impl TestRunner {
                         let outcome = catch_unwind(AssertUnwindSafe(|| {
                             run_queued_mutation(
                                 QueuedMutation { index, mutation },
+                                reservation,
                                 RunShared {
                                     workspace_pool: workspace_pool.as_ref(),
                                     project_root: project_root.as_ref().as_path(),
@@ -723,10 +776,7 @@ impl TestRunner {
                                     verbose,
                                     is_tty,
                                     show_output,
-                                    max_tested,
                                     counter: &counter,
-                                    scheduled_counter: &scheduled_counter,
-                                    tested_counter: &tested_counter,
                                     cancelled: &cancelled,
                                 },
                             )
@@ -764,7 +814,18 @@ impl TestRunner {
             let _ = std::io::stderr().flush();
         }
 
-        self.report_from_results(all_results, start.elapsed())
+        self.outcome_from_results(all_results, start.elapsed())
+    }
+
+    fn outcome_from_results(
+        &self,
+        all_results: Vec<(Mutation, MutationResult)>,
+        duration: Duration,
+    ) -> RunOutcome {
+        RunOutcome {
+            report: self.report_from_results(all_results, duration),
+            cancelled: self.cancelled.load(Ordering::Acquire),
+        }
     }
 
     fn report_from_results(
@@ -814,9 +875,37 @@ impl TestRunner {
     }
 }
 
+fn workspace_pool_slot_count(parallelism: usize, total: usize) -> usize {
+    debug_assert!(total > 0);
+    parallelism.max(1).min(total)
+}
+
 struct MutationOutcome {
     result: MutationResult,
     test_output: Option<String>,
+    cancelled: bool,
+}
+
+impl MutationOutcome {
+    fn new(result: MutationResult, test_output: Option<String>) -> Self {
+        Self {
+            result,
+            test_output,
+            cancelled: false,
+        }
+    }
+
+    fn build_error() -> Self {
+        Self::new(MutationResult::BuildError, None)
+    }
+
+    fn cancelled() -> Self {
+        Self {
+            result: MutationResult::BuildError,
+            test_output: None,
+            cancelled: true,
+        }
+    }
 }
 
 struct BuildCommand<'a> {
@@ -948,6 +1037,7 @@ impl<'a> ResolvedMutation<'a> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_single_mutation(
     command: &[String],
     build_command: BuildCommand<'_>,
@@ -956,15 +1046,17 @@ fn run_single_mutation(
     target: ResolvedMutation<'_>,
     capture_output: bool,
     env: &HashMap<String, String>,
+    cancelled: &AtomicBool,
 ) -> MutationOutcome {
+    if cancelled.load(Ordering::Acquire) {
+        return MutationOutcome::cancelled();
+    }
+
     let mutation = target.mutation;
     let file_path = match target.file_path {
         Ok(path) => path,
         Err(()) => {
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         }
     };
 
@@ -973,10 +1065,7 @@ fn run_single_mutation(
         Ok(content) => content,
         Err(e) => {
             eprintln!("warning: could not read {}: {e}", file_path.display());
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         }
     };
 
@@ -990,34 +1079,46 @@ fn run_single_mutation(
     let mut mutated = original.clone();
     let range = mutation.byte_range.clone();
     if range.start > range.end || range.end > mutated.len() {
-        return MutationOutcome {
-            result: MutationResult::BuildError,
-            test_output: None,
-        };
+        return MutationOutcome::build_error();
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
     if let Err(e) = write_workspace_file(&file_path, &mutated) {
         eprintln!("warning: could not write {}: {e}", file_path.display());
-        return MutationOutcome {
-            result: MutationResult::BuildError,
-            test_output: None,
-        };
+        return MutationOutcome::build_error();
     }
 
     // Explicit build check: skip expensive test if mutation doesn't compile.
     if build_command.explicit && !build_command.argv.is_empty() {
-        let build_outcome = run_command(build_command.argv, project_root, timeout, false, env);
+        let build_outcome = run_command(
+            build_command.argv,
+            project_root,
+            timeout,
+            false,
+            env,
+            cancelled,
+        );
+        if build_outcome.cancelled {
+            return build_outcome;
+        }
         if build_outcome.result != MutationResult::Survived {
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         }
     }
 
+    if cancelled.load(Ordering::Acquire) {
+        return MutationOutcome::cancelled();
+    }
+
     // Run test command; guard will restore the file on drop
-    run_command(command, project_root, timeout, capture_output, env)
+    run_command(
+        command,
+        project_root,
+        timeout,
+        capture_output,
+        env,
+        cancelled,
+    )
 }
 
 fn run_command(
@@ -1026,12 +1127,14 @@ fn run_command(
     timeout_dur: Duration,
     capture_output: bool,
     env: &HashMap<String, String>,
+    cancelled: &AtomicBool,
 ) -> MutationOutcome {
+    if cancelled.load(Ordering::Acquire) {
+        return MutationOutcome::cancelled();
+    }
+
     if command.is_empty() {
-        return MutationOutcome {
-            result: MutationResult::BuildError,
-            test_output: None,
-        };
+        return MutationOutcome::build_error();
     }
 
     let mut cmd = std::process::Command::new(&command[0]);
@@ -1045,20 +1148,14 @@ fn run_command(
             Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stdout capture file: {e}");
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
+                return MutationOutcome::build_error();
             }
         };
         stderr_capture = match OutputCapture::new("stderr") {
             Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stderr capture file: {e}");
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
+                return MutationOutcome::build_error();
             }
         };
         cmd.stdout(std::process::Stdio::piped());
@@ -1068,58 +1165,44 @@ fn run_command(
         cmd.stderr(std::process::Stdio::null());
     }
 
+    if cancelled.load(Ordering::Acquire) {
+        return MutationOutcome::cancelled();
+    }
+
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("warning: could not spawn command {:?}: {e}", &command[0]);
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         }
     };
+    let mut process_tree = ProcessTreeGuard::attach(&child);
 
     if capture_output {
         let Some(stdout) = child.stdout.take() else {
-            terminate_process_tree(child.id());
-            let _ = child.wait();
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            terminate_and_wait(&mut child, &mut process_tree);
+            return MutationOutcome::build_error();
         };
         if let Some(capture) = stdout_capture.as_mut()
             && let Err(e) = capture.start(stdout)
         {
             eprintln!("warning: could not open stdout capture file: {e}");
-            terminate_process_tree(child.id());
-            let _ = child.wait();
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            terminate_and_wait(&mut child, &mut process_tree);
+            return MutationOutcome::build_error();
         }
 
         let Some(stderr) = child.stderr.take() else {
-            terminate_process_tree(child.id());
-            let _ = child.wait();
+            terminate_and_wait(&mut child, &mut process_tree);
             finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         };
         if let Some(capture) = stderr_capture.as_mut()
             && let Err(e) = capture.start(stderr)
         {
             eprintln!("warning: could not open stderr capture file: {e}");
-            terminate_process_tree(child.id());
-            let _ = child.wait();
+            terminate_and_wait(&mut child, &mut process_tree);
             finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-            return MutationOutcome {
-                result: MutationResult::BuildError,
-                test_output: None,
-            };
+            return MutationOutcome::build_error();
         }
     }
 
@@ -1128,33 +1211,28 @@ fn run_command(
         match child.try_wait() {
             Ok(Some(status)) => break status,
             Ok(None) => {
-                if started.elapsed() >= timeout_dur {
-                    terminate_process_tree(child.id());
-                    let _ = child.wait();
+                if cancelled.load(Ordering::Acquire) {
+                    terminate_and_wait(&mut child, &mut process_tree);
                     finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-                    return MutationOutcome {
-                        result: MutationResult::Timeout,
-                        test_output: None,
-                    };
+                    return MutationOutcome::cancelled();
+                }
+                if started.elapsed() >= timeout_dur {
+                    terminate_and_wait(&mut child, &mut process_tree);
+                    finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
+                    return MutationOutcome::new(MutationResult::Timeout, None);
                 }
                 let remaining = timeout_dur.saturating_sub(started.elapsed());
                 thread::sleep(remaining.min(Duration::from_millis(10)));
             }
             Err(_) => {
-                terminate_process_tree(child.id());
-                let _ = child.wait();
+                terminate_and_wait(&mut child, &mut process_tree);
                 finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
+                return MutationOutcome::build_error();
             }
         }
     };
 
-    if capture_output {
-        terminate_process_tree(child.id());
-    }
+    process_tree.terminate(child.id());
 
     let result = if status.success() {
         MutationResult::Survived
@@ -1186,10 +1264,162 @@ fn run_command(
         None
     };
 
-    MutationOutcome {
-        result,
-        test_output,
+    MutationOutcome::new(result, test_output)
+}
+
+fn terminate_and_wait(child: &mut std::process::Child, process_tree: &mut ProcessTreeGuard) {
+    process_tree.terminate(child.id());
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+struct ProcessTreeGuard;
+
+#[cfg(unix)]
+impl ProcessTreeGuard {
+    fn attach(_child: &std::process::Child) -> Self {
+        Self
     }
+
+    fn terminate(&mut self, pid: u32) {
+        terminate_process_tree(pid);
+    }
+}
+
+#[cfg(windows)]
+struct ProcessTreeGuard {
+    job: Option<WindowsJobHandle>,
+}
+
+#[cfg(windows)]
+impl ProcessTreeGuard {
+    fn attach(child: &std::process::Child) -> Self {
+        match WindowsJobHandle::new_kill_on_close().and_then(|job| {
+            job.assign(child)?;
+            Ok(job)
+        }) {
+            Ok(job) => Self { job: Some(job) },
+            Err(e) => {
+                eprintln!("warning: could not attach command to Windows job object: {e}");
+                Self { job: None }
+            }
+        }
+    }
+
+    fn terminate(&mut self, pid: u32) {
+        if self.job.take().is_none() {
+            terminate_process_tree(pid);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct WindowsJobHandle {
+    handle: WindowsHandle,
+}
+
+#[cfg(windows)]
+impl WindowsJobHandle {
+    fn new_kill_on_close() -> std::io::Result<Self> {
+        use std::mem::size_of;
+        use std::ptr::null;
+
+        let handle = unsafe { CreateJobObjectW(null(), null()) };
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let job = Self { handle };
+        let mut info = WindowsJobBasicLimitInformation::default();
+        info.limit_flags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job.handle,
+                JOB_OBJECT_BASIC_LIMIT_INFORMATION_CLASS,
+                &info as *const _ as *const std::ffi::c_void,
+                size_of::<WindowsJobBasicLimitInformation>() as u32,
+            )
+        };
+        if configured == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(job)
+    }
+
+    fn assign(&self, child: &std::process::Child) -> std::io::Result<()> {
+        use std::os::windows::io::AsRawHandle;
+
+        let assigned = unsafe {
+            AssignProcessToJobObject(self.handle, child.as_raw_handle() as WindowsHandle)
+        };
+        if assigned == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJobHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+type WindowsHandle = *mut std::ffi::c_void;
+
+#[cfg(windows)]
+const INVALID_HANDLE_VALUE: WindowsHandle = -1isize as WindowsHandle;
+#[cfg(windows)]
+const JOB_OBJECT_BASIC_LIMIT_INFORMATION_CLASS: i32 = 2;
+#[cfg(windows)]
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: u32 = 0x0000_2000;
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct WindowsJobBasicLimitInformation {
+    per_process_user_time_limit: i64,
+    per_job_user_time_limit: i64,
+    limit_flags: u32,
+    minimum_working_set_size: usize,
+    maximum_working_set_size: usize,
+    active_process_limit: u32,
+    affinity: usize,
+    priority_class: u32,
+    scheduling_class: u32,
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn CreateJobObjectW(job_attributes: *const std::ffi::c_void, name: *const u16)
+    -> WindowsHandle;
+    fn SetInformationJobObject(
+        job: WindowsHandle,
+        information_class: i32,
+        information: *const std::ffi::c_void,
+        information_length: u32,
+    ) -> i32;
+    fn AssignProcessToJobObject(job: WindowsHandle, process: WindowsHandle) -> i32;
+    fn CloseHandle(handle: WindowsHandle) -> i32;
+}
+
+#[cfg(not(any(unix, windows)))]
+struct ProcessTreeGuard;
+
+#[cfg(not(any(unix, windows)))]
+impl ProcessTreeGuard {
+    fn attach(_child: &std::process::Child) -> Self {
+        Self
+    }
+
+    fn terminate(&mut self, _pid: u32) {}
 }
 
 #[cfg(unix)]
@@ -1948,6 +2178,14 @@ mod tests {
     }
 
     #[test]
+    fn workspace_pool_slot_count_is_bounded_by_total_mutations() {
+        assert_eq!(workspace_pool_slot_count(0, 3), 1);
+        assert_eq!(workspace_pool_slot_count(1, 3), 1);
+        assert_eq!(workspace_pool_slot_count(2, 5), 2);
+        assert_eq!(workspace_pool_slot_count(8, 3), 3);
+    }
+
+    #[test]
     fn command_succeeds_returns_survived() {
         let (dir, file, mutation) = make_relative_test_setup();
 
@@ -1962,6 +2200,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -1983,6 +2222,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Killed);
@@ -2020,6 +2260,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -2042,6 +2283,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
@@ -2064,6 +2306,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Timeout);
@@ -2092,6 +2335,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
@@ -2115,6 +2359,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Killed);
@@ -2147,6 +2392,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -2177,6 +2423,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
@@ -2198,6 +2445,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
@@ -2211,6 +2459,7 @@ mod tests {
             Duration::from_secs(5),
             false,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
@@ -2229,6 +2478,7 @@ mod tests {
             Duration::from_secs(5),
             true,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -2251,6 +2501,7 @@ mod tests {
             Duration::from_secs(5),
             true,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -2279,6 +2530,7 @@ mod tests {
             Duration::from_secs(5),
             true,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Survived);
@@ -2306,6 +2558,7 @@ mod tests {
             Duration::from_millis(100),
             true,
             &HashMap::new(),
+            &AtomicBool::new(false),
         );
 
         assert_eq!(outcome.result, MutationResult::Timeout);
@@ -2313,6 +2566,83 @@ mod tests {
             started.elapsed() < Duration::from_secs(1),
             "timeout path should not wait for descendant-held stdout"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn no_capture_normal_completion_terminates_background_descendants() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("descendant.marker");
+        let mut env = HashMap::new();
+        env.insert("MARKER".to_string(), marker.display().to_string());
+
+        let outcome = run_command(
+            &[
+                "sh".to_string(),
+                "-c".to_string(),
+                "(sleep 0.5; touch \"$MARKER\") &".to_string(),
+            ],
+            dir.path(),
+            Duration::from_secs(5),
+            false,
+            &env,
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(outcome.result, MutationResult::Survived);
+        thread::sleep(Duration::from_millis(800));
+        assert!(
+            !marker.exists(),
+            "background descendant should be killed even when output is not captured"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runner_cancellation_stops_promptly_and_returns_cancelled() {
+        let (dir, file, mutation) = make_test_setup();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancel_from_thread = cancelled.clone();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["sleep".into(), "10".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(30),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled,
+        };
+
+        let canceller = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            cancel_from_thread.store(true, Ordering::Release);
+        });
+
+        let started = Instant::now();
+        let outcome = runner.run(vec![mutation]);
+        canceller.join().unwrap();
+
+        assert!(outcome.cancelled);
+        assert_eq!(outcome.report.total, 0);
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "runner should not wait for the command timeout after cancellation"
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
     #[test]
@@ -2323,6 +2653,7 @@ mod tests {
             .map(|i| {
                 let mut m = make_test_mutation(&file);
                 m.id = i;
+                m.description = format!("max tested limit {i}");
                 m
             })
             .collect();
@@ -2350,8 +2681,305 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations);
+        let report = runner.run(mutations).report;
         assert_eq!(report.total, 2, "should stop after max_tested");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn max_tested_reservation_caps_execution_before_commands_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+
+        let mutations: Vec<Mutation> = (0..4)
+            .map(|i| {
+                let file = dir.path().join(format!("test{i}.txt"));
+                std::fs::write(&file, b"hello world").unwrap();
+                let mut mutation = make_test_mutation(&file);
+                mutation.id = i;
+                mutation.description = format!("max reservation {i}");
+                mutation
+            })
+            .collect();
+
+        let script = r#"
+lock="$STATE_DIR/lock"
+while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+runs=0
+if [ -f "$STATE_DIR/runs" ]; then runs=$(cat "$STATE_DIR/runs"); fi
+runs=$((runs + 1))
+printf '%s\n' "$runs" > "$STATE_DIR/runs"
+rmdir "$lock"
+sleep 0.2
+"#;
+        let mut env = HashMap::new();
+        env.insert("STATE_DIR".to_string(), state.path().display().to_string());
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["sh".into(), "-c".into(), script.into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 4,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: Some(1),
+            respect_workspace_ignores: true,
+            env,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run(mutations).report;
+        let runs: usize = std::fs::read_to_string(state.path().join("runs"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.survived, 1);
+        assert_eq!(
+            runs, 1,
+            "max_tested should reserve before execution, not after commands finish"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn max_tested_cache_hits_release_reservation_for_uncached_execution() {
+        fn run_case(cached_result: MutationResult) {
+            let dir = tempfile::tempdir().unwrap();
+            let state = tempfile::tempdir().unwrap();
+            let cached_file = dir.path().join("cached.txt");
+            let uncached_file = dir.path().join("uncached.txt");
+            std::fs::write(&cached_file, b"hello world").unwrap();
+            std::fs::write(&uncached_file, b"hello world").unwrap();
+
+            let mut cached_mutation = make_test_mutation(&cached_file);
+            cached_mutation.id = 1;
+            cached_mutation.description = format!("cached {cached_result}");
+            let mut uncached_mutation = make_test_mutation(&uncached_file);
+            uncached_mutation.id = 2;
+            uncached_mutation.description = "uncached execution".into();
+
+            let script = r#"
+lock="$STATE_DIR/lock"
+while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+runs=0
+if [ -f "$STATE_DIR/runs" ]; then runs=$(cat "$STATE_DIR/runs"); fi
+runs=$((runs + 1))
+printf '%s\n' "$runs" > "$STATE_DIR/runs"
+rmdir "$lock"
+"#;
+            let mut env = HashMap::new();
+            env.insert("STATE_DIR".to_string(), state.path().display().to_string());
+            let commands = CommandConfig {
+                command: vec!["sh".into(), "-c".into(), script.into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            };
+
+            let selected = select_test_command(dir.path(), &commands, &cached_mutation);
+            let cache_ctx = selected.cache_context(
+                &commands.build_command,
+                commands.build_command_explicit,
+                &env,
+            );
+            let cached_content = std::fs::read(&cached_file).unwrap();
+            let key = CacheKey::new(
+                &cached_content,
+                &cache_identity(dir.path(), &cached_mutation),
+                &cached_mutation.description,
+                &cache_ctx,
+            );
+            cache::store(dir.path(), &key, cached_result);
+
+            let runner = TestRunner {
+                commands,
+                parallelism: 2,
+                project_root: dir.path().to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: Some(1),
+                respect_workspace_ignores: true,
+                env,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+
+            let report = runner.run(vec![cached_mutation, uncached_mutation]).report;
+            let runs: usize = std::fs::read_to_string(state.path().join("runs"))
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap();
+
+            assert_eq!(report.total, 2);
+            assert_eq!(report.results[0].1, cached_result);
+            assert_eq!(report.results[1].1, MutationResult::Survived);
+            assert_eq!(
+                runs, 1,
+                "cache hits should not consume the max_tested execution budget"
+            );
+        }
+
+        run_case(MutationResult::Survived);
+        run_case(MutationResult::Killed);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn max_tested_does_not_count_build_errors() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mutations: Vec<Mutation> = ["first.txt", "second.txt", "third.txt"]
+            .into_iter()
+            .enumerate()
+            .map(|(i, file_name)| {
+                let file = dir.path().join(file_name);
+                std::fs::write(&file, b"hello world").unwrap();
+                let mut mutation = make_test_mutation(&file);
+                mutation.id = i as u32;
+                mutation.description = format!("build classification {i}");
+                if i < 2 {
+                    mutation.replacement = "build_error".into();
+                } else {
+                    mutation.replacement = "ok".into();
+                }
+                mutation
+            })
+            .collect();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "grep -q build_error *.txt && exit 1; exit 0".into(),
+                ],
+                build_command_explicit: true,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 4,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: Some(1),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run(mutations).report;
+
+        assert_eq!(report.total, 3);
+        assert_eq!(report.build_errors, 2);
+        assert_eq!(report.survived, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_queue_preserves_report_order_and_caps_concurrency() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+
+        let mutations: Vec<Mutation> = (0..5)
+            .map(|i| {
+                let file = dir.path().join(format!("test{i}.txt"));
+                std::fs::write(&file, b"hello world").unwrap();
+                let mut mutation = make_test_mutation(&file);
+                mutation.id = (100 - i) as u32;
+                mutation.description = format!("queue mutation {i}");
+                mutation
+            })
+            .collect();
+        let expected_ids: Vec<u32> = mutations.iter().map(|mutation| mutation.id).collect();
+
+        let script = r#"
+lock="$STATE_DIR/lock"
+while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+active=0
+if [ -f "$STATE_DIR/active" ]; then active=$(cat "$STATE_DIR/active"); fi
+active=$((active + 1))
+printf '%s\n' "$active" > "$STATE_DIR/active"
+max=0
+if [ -f "$STATE_DIR/max" ]; then max=$(cat "$STATE_DIR/max"); fi
+if [ "$active" -gt "$max" ]; then printf '%s\n' "$active" > "$STATE_DIR/max"; fi
+rmdir "$lock"
+sleep 0.15
+while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+active=$(cat "$STATE_DIR/active")
+active=$((active - 1))
+printf '%s\n' "$active" > "$STATE_DIR/active"
+rmdir "$lock"
+"#;
+        let mut env = HashMap::new();
+        env.insert("STATE_DIR".to_string(), state.path().display().to_string());
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["sh".into(), "-c".into(), script.into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 2,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            respect_workspace_ignores: true,
+            env,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run(mutations).report;
+        let actual_ids: Vec<u32> = report
+            .results
+            .iter()
+            .map(|(mutation, _)| mutation.id)
+            .collect();
+        let max_active: usize = std::fs::read_to_string(state.path().join("max"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+
+        assert_eq!(report.total, 5);
+        assert_eq!(report.survived, 5);
+        assert_eq!(actual_ids, expected_ids);
+        assert!(
+            max_active <= 2,
+            "runner should not execute more commands concurrently than parallelism"
+        );
     }
 
     #[test]
@@ -2396,7 +3024,7 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![m_survived, m_killed]);
+        let report = runner.run(vec![m_survived, m_killed]).report;
         assert_eq!(report.total, 2);
         assert_eq!(report.killed, 1);
         assert_eq!(report.survived, 1);
@@ -2439,7 +3067,7 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![mutation]);
+        let report = runner.run(vec![mutation]).report;
         assert_eq!(report.killed, 1, "should use language-specific command");
         assert_eq!(
             report.test_command, None,
@@ -2507,7 +3135,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations);
+        let report = runner.run(mutations).report;
         assert_eq!(report.total, 4);
         assert_eq!(report.survived, 4);
         assert_eq!(report.killed, 0);
@@ -2583,7 +3211,7 @@ exit 1"#
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations);
+        let report = runner.run(mutations).report;
         assert_eq!(report.total, 2);
         assert_eq!(
             report.killed, 0,
@@ -2638,7 +3266,7 @@ exit 1"#
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![m_slow, m_fast]);
+        let report = runner.run(vec![m_slow, m_fast]).report;
         let slow_result = report
             .results
             .iter()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1330,14 +1330,14 @@ impl WindowsJobHandle {
         }
 
         let job = Self { handle };
-        let mut info = WindowsJobBasicLimitInformation::default();
-        info.limit_flags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let mut info = WindowsJobExtendedLimitInformation::default();
+        info.basic_limit_information.limit_flags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         let configured = unsafe {
             SetInformationJobObject(
                 job.handle,
-                JOB_OBJECT_BASIC_LIMIT_INFORMATION_CLASS,
+                JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
                 &info as *const _ as *const std::ffi::c_void,
-                size_of::<WindowsJobBasicLimitInformation>() as u32,
+                size_of::<WindowsJobExtendedLimitInformation>() as u32,
             )
         };
         if configured == 0 {
@@ -1376,7 +1376,7 @@ type WindowsHandle = *mut std::ffi::c_void;
 #[cfg(windows)]
 const INVALID_HANDLE_VALUE: WindowsHandle = -1isize as WindowsHandle;
 #[cfg(windows)]
-const JOB_OBJECT_BASIC_LIMIT_INFORMATION_CLASS: i32 = 2;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS: i32 = 9;
 #[cfg(windows)]
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: u32 = 0x0000_2000;
 
@@ -1393,6 +1393,30 @@ struct WindowsJobBasicLimitInformation {
     affinity: usize,
     priority_class: u32,
     scheduling_class: u32,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct WindowsIoCounters {
+    read_operation_count: u64,
+    write_operation_count: u64,
+    other_operation_count: u64,
+    read_transfer_count: u64,
+    write_transfer_count: u64,
+    other_transfer_count: u64,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct WindowsJobExtendedLimitInformation {
+    basic_limit_information: WindowsJobBasicLimitInformation,
+    io_info: WindowsIoCounters,
+    process_memory_limit: usize,
+    job_memory_limit: usize,
+    peak_process_memory_used: usize,
+    peak_job_memory_used: usize,
 }
 
 #[cfg(windows)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,22 +4,19 @@ use crate::cache::{self, CacheKey};
 use crate::{Mutation, MutationReport, MutationResult};
 use std::collections::{HashMap, VecDeque};
 use std::fs;
-use std::io::{IsTerminal, Write};
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
+use std::thread;
 use std::time::{Duration, Instant};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// Write `data` to `path` atomically: write to a temp file in the same
-/// directory, fsync, then rename over the target.
-fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let dir = path.parent().unwrap_or(Path::new("."));
-    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
-    tmp.write_all(data)?;
-    tmp.as_file().sync_all()?;
-    tmp.persist(path)?;
-    Ok(())
+const CAPTURED_OUTPUT_LIMIT: usize = 1024 * 1024;
+
+/// Write mutation workspace content. Workspaces are disposable temp copies, so
+/// durable temp-file + fsync writes would only add hot-loop I/O overhead.
+fn write_workspace_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    fs::write(path, data)
 }
 
 /// Commands and timeouts used while evaluating mutations.
@@ -278,7 +275,7 @@ struct FileGuard {
 
 impl Drop for FileGuard {
     fn drop(&mut self) {
-        if let Err(e) = atomic_write(&self.path, &self.original) {
+        if let Err(e) = write_workspace_file(&self.path, &self.original) {
             eprintln!(
                 "error: failed to restore {}: {} — file may be corrupted, check git status",
                 self.path.display(),
@@ -387,8 +384,7 @@ fn copy_workspace_with_options(
 
 pub(crate) struct WorkspacePool {
     slots: Arc<Vec<WorkspaceCopy>>,
-    semaphore: Arc<Semaphore>,
-    free_slots: Arc<Mutex<VecDeque<usize>>>,
+    free_slots: Arc<(Mutex<VecDeque<usize>>, Condvar)>,
 }
 
 impl WorkspacePool {
@@ -416,38 +412,37 @@ impl WorkspacePool {
 
         Ok(Self {
             slots: Arc::new(copies),
-            semaphore: Arc::new(Semaphore::new(slots)),
-            free_slots: Arc::new(Mutex::new(free_slots)),
+            free_slots: Arc::new((Mutex::new(free_slots), Condvar::new())),
         })
     }
 
-    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.slots.len()
     }
 
-    pub(crate) async fn acquire(&self) -> WorkspaceSlot {
-        let permit = self.semaphore.clone().acquire_owned().await.unwrap();
-        let index = self
-            .free_slots
-            .lock()
-            .expect("workspace free-list mutex poisoned")
-            .pop_front()
-            .expect("workspace semaphore permit without a free slot");
+    pub(crate) fn acquire(&self) -> WorkspaceSlot {
+        let (lock, cvar) = &*self.free_slots;
+        let mut free_slots = lock.lock().expect("workspace free-list mutex poisoned");
+        let index = loop {
+            if let Some(index) = free_slots.pop_front() {
+                break index;
+            }
+            free_slots = cvar
+                .wait(free_slots)
+                .expect("workspace free-list mutex poisoned");
+        };
         WorkspaceSlot {
             slots: self.slots.clone(),
             free_slots: self.free_slots.clone(),
             index,
-            _permit: permit,
         }
     }
 }
 
 pub(crate) struct WorkspaceSlot {
     slots: Arc<Vec<WorkspaceCopy>>,
-    free_slots: Arc<Mutex<VecDeque<usize>>>,
+    free_slots: Arc<(Mutex<VecDeque<usize>>, Condvar)>,
     index: usize,
-    _permit: OwnedSemaphorePermit,
 }
 
 impl WorkspaceSlot {
@@ -458,18 +453,196 @@ impl WorkspaceSlot {
 
 impl Drop for WorkspaceSlot {
     fn drop(&mut self) {
-        self.free_slots
-            .lock()
+        let (lock, cvar) = &*self.free_slots;
+        lock.lock()
             .expect("workspace free-list mutex poisoned")
             .push_back(self.index);
+        cvar.notify_one();
+    }
+}
+
+struct QueuedMutation {
+    index: usize,
+    mutation: Mutation,
+}
+
+struct RunShared<'a> {
+    workspace_pool: &'a WorkspacePool,
+    project_root: &'a Path,
+    commands: &'a CommandConfig,
+    build_command: &'a [String],
+    build_command_explicit: bool,
+    env: &'a HashMap<String, String>,
+    total: usize,
+    verbose: bool,
+    is_tty: bool,
+    show_output: bool,
+    max_tested: Option<usize>,
+    counter: &'a AtomicUsize,
+    scheduled_counter: &'a AtomicUsize,
+    tested_counter: &'a AtomicUsize,
+    cancelled: &'a AtomicBool,
+}
+
+fn run_queued_mutation(
+    queued: QueuedMutation,
+    shared: RunShared<'_>,
+) -> Option<(usize, Mutation, MutationResult)> {
+    let QueuedMutation { index, mutation } = queued;
+
+    // Stop if cancelled (Ctrl+C) or enough mutations have been tested.
+    if shared.cancelled.load(Ordering::Relaxed) {
+        return None;
+    }
+    if let Some(max) = shared.max_tested {
+        let reserved = shared
+            .scheduled_counter
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < max).then_some(current + 1)
+            })
+            .is_ok();
+        if !reserved {
+            return None;
+        }
+    }
+
+    let selected_test = select_test_command(shared.project_root, shared.commands, &mutation);
+    let cache_ctx = selected_test.cache_context(
+        shared.build_command,
+        shared.build_command_explicit,
+        shared.env,
+    );
+
+    let original_target = ResolvedMutation::new(shared.project_root, &mutation);
+
+    // Check cache before acquiring a workspace slot.
+    let file_content = original_target
+        .file_path
+        .as_ref()
+        .ok()
+        .and_then(|file_path| fs::read(file_path).ok());
+    let cache_key = file_content.as_ref().map(|content| {
+        CacheKey::new(
+            content,
+            &cache_identity(shared.project_root, &mutation),
+            &mutation.description,
+            &cache_ctx,
+        )
+    });
+    if let Some(ref key) = cache_key
+        && let Some(result) = cache::lookup(shared.project_root, key)
+    {
+        record_progress(&shared, &mutation, result, None, true);
+        return Some((index, mutation, result));
+    }
+
+    let outcome = {
+        let workspace_slot = shared.workspace_pool.acquire();
+        let workspace_root = workspace_slot.root().to_path_buf();
+        let workspace_target =
+            ResolvedMutation::new_for_execution(shared.project_root, &workspace_root, &mutation);
+        run_single_mutation(
+            &selected_test.argv,
+            BuildCommand {
+                argv: shared.build_command,
+                explicit: shared.build_command_explicit,
+            },
+            selected_test.timeout,
+            &workspace_root,
+            workspace_target,
+            shared.show_output,
+            shared.env,
+        )
+    };
+
+    if let Some(ref key) = cache_key {
+        cache::store(shared.project_root, key, outcome.result);
+    }
+
+    let result = outcome.result;
+    record_progress(
+        &shared,
+        &mutation,
+        result,
+        outcome.test_output.as_deref(),
+        false,
+    );
+    Some((index, mutation, result))
+}
+
+#[allow(clippy::manual_is_multiple_of)]
+fn record_progress(
+    shared: &RunShared<'_>,
+    mutation: &Mutation,
+    result: MutationResult,
+    test_output: Option<&str>,
+    cached: bool,
+) {
+    if result != MutationResult::BuildError {
+        shared.tested_counter.fetch_add(1, Ordering::Release);
+    }
+
+    let n = shared.counter.fetch_add(1, Ordering::Relaxed) + 1;
+    if shared.verbose {
+        if cached {
+            eprintln!(
+                "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
+                n,
+                shared.total,
+                mutation.file.display(),
+                mutation.line,
+                mutation.operator
+            );
+        } else {
+            let symbol = match result {
+                MutationResult::Killed => "\u{2713} killed",
+                MutationResult::Survived => "\u{2717} survived",
+                MutationResult::Timeout => "⧖ timeout",
+                MutationResult::BuildError => "⚠ build error",
+            };
+            eprintln!(
+                "  [{}/{}] {}  {}:{} \u{2014} {}",
+                n,
+                shared.total,
+                symbol,
+                mutation.file.display(),
+                mutation.line,
+                mutation.operator
+            );
+        }
+    } else if shared.is_tty {
+        eprint!("\r  [{}/{}] testing mutations...", n, shared.total);
+        let _ = std::io::stderr().flush();
+    } else if n == shared.total || (shared.total >= 4 && n % (shared.total / 4) == 0) {
+        eprintln!("  [{}/{}] testing mutations...", n, shared.total);
+    }
+
+    if shared.show_output
+        && result == MutationResult::Survived
+        && let Some(output) = test_output
+    {
+        eprintln!(
+            "  ┌─ test output for {}:{} ({})",
+            mutation.file.display(),
+            mutation.line,
+            mutation.operator
+        );
+        for line in output.lines() {
+            eprintln!("  │ {}", line);
+        }
+        eprintln!("  └─");
     }
 }
 
 impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
-    pub async fn run(&self, mutations: Vec<Mutation>) -> MutationReport {
+    pub fn run(&self, mutations: Vec<Mutation>) -> MutationReport {
         let start = Instant::now();
         let total = mutations.len();
+        if total == 0 {
+            return self.report_from_results(Vec::new(), start.elapsed());
+        }
+
         let counter = Arc::new(AtomicUsize::new(0));
         let scheduled_counter = Arc::new(AtomicUsize::new(0));
         let tested_counter = Arc::new(AtomicUsize::new(0));
@@ -496,168 +669,82 @@ impl TestRunner {
         let project_root = Arc::new(self.project_root.clone());
         let build_command = Arc::new(self.commands.build_command.clone());
         let build_command_explicit = self.commands.build_command_explicit;
-        let mut handles = Vec::new();
+        let queue = Arc::new(Mutex::new(
+            mutations.into_iter().enumerate().collect::<VecDeque<_>>(),
+        ));
+        let results = Arc::new(Mutex::new(Vec::new()));
+        let worker_count = workspace_pool.len().min(total).max(1);
 
-        for mutation in mutations {
-            let workspace_pool = workspace_pool.clone();
-            let selected_test = select_test_command(&project_root, &self.commands, &mutation);
-            let command = selected_test.argv.clone();
-            let timeout = selected_test.timeout;
-            let project_root = project_root.clone();
-            let build_command = build_command.clone();
-            let counter = counter.clone();
-            let scheduled_counter = scheduled_counter.clone();
-            let tested_counter = tested_counter.clone();
-            let max_tested = self.max_tested;
-            let show_output = self.show_output;
-            let env = self.env.clone();
-            let cancelled = self.cancelled.clone();
+        thread::scope(|scope| {
+            for _ in 0..worker_count {
+                let queue = queue.clone();
+                let results = results.clone();
+                let workspace_pool = workspace_pool.clone();
+                let project_root = project_root.clone();
+                let build_command = build_command.clone();
+                let counter = counter.clone();
+                let scheduled_counter = scheduled_counter.clone();
+                let tested_counter = tested_counter.clone();
+                let cancelled = self.cancelled.clone();
+                let commands = &self.commands;
+                let env = &self.env;
+                let max_tested = self.max_tested;
+                let show_output = self.show_output;
 
-            let cache_ctx =
-                selected_test.cache_context(&build_command, build_command_explicit, &env);
+                scope.spawn(move || {
+                    loop {
+                        if cancelled.load(Ordering::Relaxed) {
+                            break;
+                        }
 
-            let handle = tokio::spawn(async move {
-                // Stop if cancelled (Ctrl+C) or enough mutations have been tested
-                if cancelled.load(Ordering::Relaxed) {
-                    return None;
-                }
-                if let Some(max) = max_tested {
-                    let reserved = scheduled_counter
-                        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                            (current < max).then_some(current + 1)
-                        })
-                        .is_ok();
-                    if !reserved {
-                        return None;
+                        let Some((index, mutation)) = queue
+                            .lock()
+                            .expect("mutation queue mutex poisoned")
+                            .pop_front()
+                        else {
+                            break;
+                        };
+
+                        if let Some(result) = run_queued_mutation(
+                            QueuedMutation { index, mutation },
+                            RunShared {
+                                workspace_pool: workspace_pool.as_ref(),
+                                project_root: project_root.as_ref().as_path(),
+                                commands,
+                                build_command: build_command.as_ref().as_slice(),
+                                build_command_explicit,
+                                env,
+                                total,
+                                verbose,
+                                is_tty,
+                                show_output,
+                                max_tested,
+                                counter: &counter,
+                                scheduled_counter: &scheduled_counter,
+                                tested_counter: &tested_counter,
+                                cancelled: &cancelled,
+                            },
+                        ) {
+                            results
+                                .lock()
+                                .expect("mutation results mutex poisoned")
+                                .push(result);
+                        }
                     }
-                }
-
-                let original_target = ResolvedMutation::new(&project_root, &mutation);
-
-                // Check cache before running
-                let file_content = original_target
-                    .file_path
-                    .as_ref()
-                    .ok()
-                    .and_then(|file_path| std::fs::read(file_path).ok());
-                let cache_key = file_content.as_ref().map(|content| {
-                    CacheKey::new(
-                        content,
-                        &cache_identity(&project_root, &mutation),
-                        &mutation.description,
-                        &cache_ctx,
-                    )
                 });
-                if let Some(ref key) = cache_key
-                    && let Some(cached) = cache::lookup(&project_root, key)
-                {
-                    let result = cached;
-                    if result != MutationResult::BuildError {
-                        tested_counter.fetch_add(1, Ordering::Release);
-                    }
-                    let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                    if verbose {
-                        eprintln!(
-                            "  [{}/{}] \u{21bb} cached  {}:{} \u{2014} {}",
-                            n,
-                            total,
-                            mutation.file.display(),
-                            mutation.line,
-                            mutation.operator
-                        );
-                    } else if is_tty {
-                        eprint!("\r  [{}/{}] testing mutations...", n, total);
-                        let _ = std::io::stderr().flush();
-                    } else if n == total || (total >= 4 && n % (total / 4) == 0) {
-                        eprintln!("  [{}/{}] testing mutations...", n, total);
-                    }
-                    return Some((mutation, result));
-                }
-
-                let outcome = {
-                    let workspace_slot = workspace_pool.acquire().await;
-                    let workspace_root = workspace_slot.root().to_path_buf();
-                    let workspace_target = ResolvedMutation::new_for_execution(
-                        &project_root,
-                        &workspace_root,
-                        &mutation,
-                    );
-                    run_single_mutation(
-                        &command,
-                        BuildCommand {
-                            argv: &build_command,
-                            explicit: build_command_explicit,
-                        },
-                        timeout,
-                        &workspace_root,
-                        workspace_target,
-                        show_output,
-                        &env,
-                    )
-                    .await
-                };
-
-                // Store result in cache
-                if let Some(ref key) = cache_key {
-                    cache::store(&project_root, key, outcome.result);
-                }
-
-                if outcome.result != MutationResult::BuildError {
-                    tested_counter.fetch_add(1, Ordering::Release);
-                }
-                let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
-                if verbose {
-                    let symbol = match outcome.result {
-                        MutationResult::Killed => "\u{2713} killed",
-                        MutationResult::Survived => "\u{2717} survived",
-                        MutationResult::Timeout => "⧖ timeout",
-                        MutationResult::BuildError => "⚠ build error",
-                    };
-                    eprintln!(
-                        "  [{}/{}] {}  {}:{} \u{2014} {}",
-                        n,
-                        total,
-                        symbol,
-                        mutation.file.display(),
-                        mutation.line,
-                        mutation.operator
-                    );
-                } else {
-                    if is_tty {
-                        eprint!("\r  [{}/{}] testing mutations...", n, total);
-                        let _ = std::io::stderr().flush();
-                    } else if n == total || (total >= 4 && n % (total / 4) == 0) {
-                        eprintln!("  [{}/{}] testing mutations...", n, total);
-                    }
-                }
-                if show_output
-                    && outcome.result == MutationResult::Survived
-                    && let Some(output) = &outcome.test_output
-                {
-                    eprintln!(
-                        "  ┌─ test output for {}:{} ({})",
-                        mutation.file.display(),
-                        mutation.line,
-                        mutation.operator
-                    );
-                    for line in output.lines() {
-                        eprintln!("  │ {}", line);
-                    }
-                    eprintln!("  └─");
-                }
-                Some((mutation, outcome.result))
-            });
-            handles.push(handle);
-        }
-
-        let mut all_results = Vec::new();
-        for handle in handles {
-            match handle.await {
-                Ok(Some(result)) => all_results.push(result),
-                Ok(None) => {}
-                Err(e) => eprintln!("warning: mutation task panicked: {e}"),
             }
-        }
+        });
+
+        let mut indexed_results = Arc::try_unwrap(results)
+            .expect("all result handles should be dropped")
+            .into_inner()
+            .expect("mutation results mutex poisoned");
+        indexed_results.sort_by_key(|(index, _, _)| *index);
+        let all_results = indexed_results
+            .into_iter()
+            .map(|(_, mutation, result)| (mutation, result))
+            .collect();
+
         // Clear progress line on TTY
         if !verbose && is_tty {
             eprint!("\r                                        \r");
@@ -848,7 +935,7 @@ impl<'a> ResolvedMutation<'a> {
     }
 }
 
-async fn run_single_mutation(
+fn run_single_mutation(
     command: &[String],
     build_command: BuildCommand<'_>,
     timeout: Duration,
@@ -897,7 +984,7 @@ async fn run_single_mutation(
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
-    if let Err(e) = atomic_write(&file_path, &mutated) {
+    if let Err(e) = write_workspace_file(&file_path, &mutated) {
         eprintln!("warning: could not write {}: {e}", file_path.display());
         return MutationOutcome {
             result: MutationResult::BuildError,
@@ -907,8 +994,7 @@ async fn run_single_mutation(
 
     // Explicit build check: skip expensive test if mutation doesn't compile.
     if build_command.explicit && !build_command.argv.is_empty() {
-        let build_outcome =
-            run_command(build_command.argv, project_root, timeout, false, env).await;
+        let build_outcome = run_command(build_command.argv, project_root, timeout, false, env);
         if build_outcome.result != MutationResult::Survived {
             return MutationOutcome {
                 result: MutationResult::BuildError,
@@ -918,10 +1004,10 @@ async fn run_single_mutation(
     }
 
     // Run test command; guard will restore the file on drop
-    run_command(command, project_root, timeout, capture_output, env).await
+    run_command(command, project_root, timeout, capture_output, env)
 }
 
-async fn run_command(
+fn run_command(
     command: &[String],
     cwd: &Path,
     timeout_dur: Duration,
@@ -935,7 +1021,7 @@ async fn run_command(
         };
     }
 
-    let mut cmd = tokio::process::Command::new(&command[0]);
+    let mut cmd = std::process::Command::new(&command[0]);
     cmd.args(&command[1..]).current_dir(cwd).envs(env);
 
     if capture_output {
@@ -946,8 +1032,7 @@ async fn run_command(
         cmd.stderr(std::process::Stdio::null());
     }
 
-    cmd.kill_on_drop(true);
-    let child = match cmd.spawn() {
+    let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("warning: could not spawn command {:?}: {e}", &command[0]);
@@ -958,40 +1043,152 @@ async fn run_command(
         }
     };
 
-    match tokio::time::timeout(timeout_dur, child.wait_with_output()).await {
-        Ok(Ok(output)) => {
-            let result = if output.status.success() {
-                MutationResult::Survived
-            } else {
-                MutationResult::Killed
-            };
-            let test_output = if capture_output {
-                let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                if !stderr.is_empty() {
-                    if !combined.is_empty() {
-                        combined.push('\n');
-                    }
-                    combined.push_str(&stderr);
+    let stdout_reader = if capture_output {
+        child.stdout.take().map(spawn_output_reader)
+    } else {
+        None
+    };
+    let stderr_reader = if capture_output {
+        child.stderr.take().map(spawn_output_reader)
+    } else {
+        None
+    };
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if started.elapsed() >= timeout_dur {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return MutationOutcome {
+                        result: MutationResult::Timeout,
+                        test_output: None,
+                    };
                 }
-                Some(combined)
-            } else {
-                None
-            };
-            MutationOutcome {
-                result,
-                test_output,
+                let remaining = timeout_dur.saturating_sub(started.elapsed());
+                thread::sleep(remaining.min(Duration::from_millis(10)));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return MutationOutcome {
+                    result: MutationResult::BuildError,
+                    test_output: None,
+                };
             }
         }
-        Ok(Err(_)) => MutationOutcome {
-            result: MutationResult::BuildError,
-            test_output: None,
-        },
-        Err(_) => MutationOutcome {
+    };
+
+    let stdout = match recv_output_reader(stdout_reader, started, timeout_dur) {
+        Ok(bytes) => bytes,
+        Err(result) => return result,
+    };
+    let stderr = match recv_output_reader(stderr_reader, started, timeout_dur) {
+        Ok(bytes) => bytes,
+        Err(result) => return result,
+    };
+
+    let result = if status.success() {
+        MutationResult::Survived
+    } else {
+        MutationResult::Killed
+    };
+    let test_output = if capture_output {
+        let mut combined = String::from_utf8_lossy(&stdout.bytes).into_owned();
+        append_truncation_notice(&mut combined, stdout.truncated, "stdout");
+
+        let stderr_text = String::from_utf8_lossy(&stderr.bytes);
+        if !stderr_text.is_empty() {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(&stderr_text);
+        }
+        append_truncation_notice(&mut combined, stderr.truncated, "stderr");
+        Some(combined)
+    } else {
+        None
+    };
+
+    MutationOutcome {
+        result,
+        test_output,
+    }
+}
+
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+fn spawn_output_reader<R>(mut reader: R) -> mpsc::Receiver<CapturedOutput>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut truncated = false;
+        let mut buffer = [0; 8192];
+
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let available = CAPTURED_OUTPUT_LIMIT.saturating_sub(bytes.len());
+                    let keep = n.min(available);
+                    if keep > 0 {
+                        bytes.extend_from_slice(&buffer[..keep]);
+                    }
+                    if keep < n {
+                        truncated = true;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+
+        let _ = tx.send(CapturedOutput { bytes, truncated });
+    });
+    rx
+}
+
+fn recv_output_reader(
+    reader: Option<mpsc::Receiver<CapturedOutput>>,
+    started: Instant,
+    timeout_dur: Duration,
+) -> Result<CapturedOutput, MutationOutcome> {
+    let Some(reader) = reader else {
+        return Ok(CapturedOutput {
+            bytes: Vec::new(),
+            truncated: false,
+        });
+    };
+    let Some(remaining) = timeout_dur.checked_sub(started.elapsed()) else {
+        return Err(MutationOutcome {
             result: MutationResult::Timeout,
             test_output: None,
-        },
+        });
+    };
+    reader.recv_timeout(remaining).map_err(|_| MutationOutcome {
+        result: MutationResult::Timeout,
+        test_output: None,
+    })
+}
+
+fn append_truncation_notice(output: &mut String, truncated: bool, stream: &str) {
+    if !truncated {
+        return;
     }
+    if !output.is_empty() && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output.push_str(&format!(
+        "[{stream} truncated after {CAPTURED_OUTPUT_LIMIT} bytes]"
+    ));
 }
 
 #[cfg(test)]
@@ -1541,8 +1738,8 @@ mod tests {
         assert!(!copy.root().join("target").exists());
     }
 
-    #[tokio::test]
-    async fn workspace_pool_creates_slots_and_reuses_after_drop() {
+    #[test]
+    fn workspace_pool_creates_slots_and_reuses_after_drop() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -1551,8 +1748,8 @@ mod tests {
         let pool = WorkspacePool::new(root, 2).unwrap();
         assert_eq!(pool.len(), 2);
 
-        let first = pool.acquire().await;
-        let second = pool.acquire().await;
+        let first = pool.acquire();
+        let second = pool.acquire();
         assert_ne!(first.root(), second.root());
         assert!(first.root().join("src/lib.rs").exists());
         assert!(second.root().join("src/lib.rs").exists());
@@ -1561,7 +1758,7 @@ mod tests {
         let second_root = second.root().to_path_buf();
         drop(second);
 
-        let third = pool.acquire().await;
+        let third = pool.acquire();
         assert_eq!(third.root(), second_root.as_path());
         assert_ne!(third.root(), first_root.as_path());
     }
@@ -1576,8 +1773,8 @@ mod tests {
         assert_eq!(pool.len(), 1);
     }
 
-    #[tokio::test]
-    async fn command_succeeds_returns_survived() {
+    #[test]
+    fn command_succeeds_returns_survived() {
         let (dir, file, mutation) = make_relative_test_setup();
 
         let outcome = run_single_mutation(
@@ -1591,15 +1788,14 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Survived);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn command_fails_returns_killed() {
+    #[test]
+    fn command_fails_returns_killed() {
         let (dir, file, mutation) = make_test_setup();
 
         let outcome = run_single_mutation(
@@ -1613,15 +1809,14 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Killed);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn empty_replacement_splices_correctly() {
+    #[test]
+    fn empty_replacement_splices_correctly() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
@@ -1651,16 +1846,15 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Survived);
         // File should be restored to original
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn command_not_found_returns_build_error() {
+    #[test]
+    fn command_not_found_returns_build_error() {
         let (dir, file, mutation) = make_test_setup();
 
         let outcome = run_single_mutation(
@@ -1674,16 +1868,15 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
         // File should be restored
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn command_timeout_returns_timeout() {
+    #[test]
+    fn command_timeout_returns_timeout() {
         let (dir, file, mutation) = make_test_setup();
 
         let outcome = run_single_mutation(
@@ -1697,16 +1890,15 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Timeout);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn build_check_failure_skips_test() {
+    #[test]
+    fn build_check_failure_skips_test() {
         let (dir, file, mutation) = make_test_setup();
 
         let marker = dir.path().join("test_ran.marker");
@@ -1726,16 +1918,15 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
         assert!(!marker.exists(), "test command should not have run");
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn build_check_success_runs_test() {
+    #[test]
+    fn build_check_success_runs_test() {
         let (dir, _file, mutation) = make_test_setup();
 
         // Build succeeds → test runs and fails → Killed
@@ -1750,15 +1941,14 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Killed);
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn non_explicit_build_command_does_not_pre_filter() {
+    #[test]
+    fn non_explicit_build_command_does_not_pre_filter() {
         let (dir, _file, mutation) = make_test_setup();
 
         let build_marker = dir.path().join("build_ran.marker");
@@ -1783,8 +1973,7 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Survived);
         assert!(
@@ -1794,8 +1983,8 @@ mod tests {
         assert!(test_marker.exists(), "test command should still run");
     }
 
-    #[tokio::test]
-    async fn out_of_range_byte_range_returns_build_error() {
+    #[test]
+    fn out_of_range_byte_range_returns_build_error() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hi").unwrap();
@@ -1814,14 +2003,13 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
     }
 
-    #[tokio::test]
-    async fn missing_file_returns_build_error() {
+    #[test]
+    fn missing_file_returns_build_error() {
         let dir = tempfile::tempdir().unwrap();
         let mutation = make_test_mutation(&dir.path().join("nonexistent.txt"));
 
@@ -1836,29 +2024,27 @@ mod tests {
             ResolvedMutation::new(dir.path(), &mutation),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
     }
 
-    #[tokio::test]
-    async fn empty_command_returns_build_error() {
+    #[test]
+    fn empty_command_returns_build_error() {
         let outcome = run_command(
             &[],
             &PathBuf::from("."),
             Duration::from_secs(5),
             false,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn capture_output_collects_stdout_stderr() {
+    #[test]
+    fn capture_output_collects_stdout_stderr() {
         let outcome = run_command(
             &[
                 "sh".to_string(),
@@ -1869,8 +2055,7 @@ mod tests {
             Duration::from_secs(5),
             true,
             &HashMap::new(),
-        )
-        .await;
+        );
 
         assert_eq!(outcome.result, MutationResult::Survived);
         let output = outcome.test_output.unwrap();
@@ -1878,8 +2063,36 @@ mod tests {
         assert!(output.contains("err"), "should capture stderr");
     }
 
-    #[tokio::test]
-    async fn max_tested_limits_mutations() {
+    #[cfg(unix)]
+    #[test]
+    fn capture_output_truncates_and_drains_large_stdout() {
+        let bytes_to_write = CAPTURED_OUTPUT_LIMIT + 256 * 1024;
+        let outcome = run_command(
+            &[
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("yes x | head -c {bytes_to_write}"),
+            ],
+            &PathBuf::from("."),
+            Duration::from_secs(5),
+            true,
+            &HashMap::new(),
+        );
+
+        assert_eq!(outcome.result, MutationResult::Survived);
+        let output = outcome.test_output.unwrap();
+        assert!(
+            output.contains("[stdout truncated after"),
+            "large stdout should be marked as truncated"
+        );
+        assert!(
+            output.len() < CAPTURED_OUTPUT_LIMIT + 128,
+            "captured output should stay close to the configured cap"
+        );
+    }
+
+    #[test]
+    fn max_tested_limits_mutations() {
         let (dir, file, _) = make_test_setup();
 
         let mutations: Vec<Mutation> = (0..5)
@@ -1913,12 +2126,12 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations).await;
+        let report = runner.run(mutations);
         assert_eq!(report.total, 2, "should stop after max_tested");
     }
 
-    #[tokio::test]
-    async fn report_aggregates_results_correctly() {
+    #[test]
+    fn report_aggregates_results_correctly() {
         let dir = tempfile::tempdir().unwrap();
 
         let survived_file = dir.path().join("survived.txt");
@@ -1959,7 +2172,7 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![m_survived, m_killed]).await;
+        let report = runner.run(vec![m_survived, m_killed]);
         assert_eq!(report.total, 2);
         assert_eq!(report.killed, 1);
         assert_eq!(report.survived, 1);
@@ -1967,8 +2180,8 @@ mod tests {
         assert_eq!(report.build_errors, 0);
     }
 
-    #[tokio::test]
-    async fn language_commands_override_default() {
+    #[test]
+    fn language_commands_override_default() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
@@ -2002,7 +2215,7 @@ mod tests {
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![mutation]).await;
+        let report = runner.run(vec![mutation]);
         assert_eq!(report.killed, 1, "should use language-specific command");
         assert_eq!(
             report.test_command, None,
@@ -2011,8 +2224,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn mutations_on_same_file_run_in_isolated_workspaces() {
+    #[test]
+    fn mutations_on_same_file_run_in_isolated_workspaces() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
@@ -2070,7 +2283,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations).await;
+        let report = runner.run(mutations);
         assert_eq!(report.total, 4);
         assert_eq!(report.survived, 4);
         assert_eq!(report.killed, 0);
@@ -2089,8 +2302,8 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn mutations_on_different_files_run_in_isolated_workspaces() {
+    #[test]
+    fn mutations_on_different_files_run_in_isolated_workspaces() {
         let dir = tempfile::tempdir().unwrap();
         let first = dir.path().join("first.txt");
         let second = dir.path().join("second.txt");
@@ -2146,7 +2359,7 @@ exit 1"#
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(mutations).await;
+        let report = runner.run(mutations);
         assert_eq!(report.total, 2);
         assert_eq!(
             report.killed, 0,
@@ -2156,8 +2369,8 @@ exit 1"#
         assert_eq!(std::fs::read_to_string(&second).unwrap(), "hello world");
     }
 
-    #[tokio::test]
-    async fn per_language_timeout_overrides_default() {
+    #[test]
+    fn per_language_timeout_overrides_default() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("test.txt");
         std::fs::write(&file, b"hello world").unwrap();
@@ -2201,7 +2414,7 @@ exit 1"#
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
-        let report = runner.run(vec![m_slow, m_fast]).await;
+        let report = runner.run(vec![m_slow, m_fast]);
         let slow_result = report
             .results
             .iter()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,6 +12,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const CAPTURED_OUTPUT_LIMIT: usize = 1024 * 1024;
+const OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Write mutation workspace content. Workspaces are disposable temp copies, so
 /// durable temp-file + fsync writes would only add hot-loop I/O overhead.
@@ -1081,11 +1082,12 @@ fn run_command(
         }
     };
 
-    let stdout = match recv_output_reader(stdout_reader, started, timeout_dur) {
+    let drain_duration = OUTPUT_DRAIN_TIMEOUT;
+    let stdout = match recv_output_reader(stdout_reader, drain_duration) {
         Ok(bytes) => bytes,
         Err(result) => return result,
     };
-    let stderr = match recv_output_reader(stderr_reader, started, timeout_dur) {
+    let stderr = match recv_output_reader(stderr_reader, drain_duration) {
         Ok(bytes) => bytes,
         Err(result) => return result,
     };
@@ -1158,8 +1160,7 @@ where
 
 fn recv_output_reader(
     reader: Option<mpsc::Receiver<CapturedOutput>>,
-    started: Instant,
-    timeout_dur: Duration,
+    drain_duration: Duration,
 ) -> Result<CapturedOutput, MutationOutcome> {
     let Some(reader) = reader else {
         return Ok(CapturedOutput {
@@ -1167,16 +1168,12 @@ fn recv_output_reader(
             truncated: false,
         });
     };
-    let Some(remaining) = timeout_dur.checked_sub(started.elapsed()) else {
-        return Err(MutationOutcome {
+    reader
+        .recv_timeout(drain_duration)
+        .map_err(|_| MutationOutcome {
             result: MutationResult::Timeout,
             test_output: None,
-        });
-    };
-    reader.recv_timeout(remaining).map_err(|_| MutationOutcome {
-        result: MutationResult::Timeout,
-        test_output: None,
-    })
+        })
 }
 
 fn append_truncation_notice(output: &mut String, truncated: bool, stream: &str) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1036,12 +1036,13 @@ fn run_command(
 
     let mut cmd = std::process::Command::new(&command[0]);
     cmd.args(&command[1..]).current_dir(cwd).envs(env);
+    configure_command_for_process_tree(&mut cmd);
 
     let mut stdout_capture = None;
     let mut stderr_capture = None;
     if capture_output {
-        let stdout_file = match tempfile::NamedTempFile::new() {
-            Ok(file) => file,
+        stdout_capture = match OutputCapture::new("stdout") {
+            Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stdout capture file: {e}");
                 return MutationOutcome {
@@ -1050,8 +1051,8 @@ fn run_command(
                 };
             }
         };
-        let stderr_file = match tempfile::NamedTempFile::new() {
-            Ok(file) => file,
+        stderr_capture = match OutputCapture::new("stderr") {
+            Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stderr capture file: {e}");
                 return MutationOutcome {
@@ -1060,30 +1061,8 @@ fn run_command(
                 };
             }
         };
-        let stdout_handle = match stdout_file.reopen() {
-            Ok(file) => file,
-            Err(e) => {
-                eprintln!("warning: could not open stdout capture file: {e}");
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
-            }
-        };
-        let stderr_handle = match stderr_file.reopen() {
-            Ok(file) => file,
-            Err(e) => {
-                eprintln!("warning: could not open stderr capture file: {e}");
-                return MutationOutcome {
-                    result: MutationResult::BuildError,
-                    test_output: None,
-                };
-            }
-        };
-        cmd.stdout(std::process::Stdio::from(stdout_handle));
-        cmd.stderr(std::process::Stdio::from(stderr_handle));
-        stdout_capture = Some(stdout_file);
-        stderr_capture = Some(stderr_file);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
     } else {
         cmd.stdout(std::process::Stdio::null());
         cmd.stderr(std::process::Stdio::null());
@@ -1100,14 +1079,59 @@ fn run_command(
         }
     };
 
+    if capture_output {
+        let Some(stdout) = child.stdout.take() else {
+            terminate_process_tree(child.id());
+            let _ = child.wait();
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        };
+        if let Some(capture) = stdout_capture.as_mut()
+            && let Err(e) = capture.start(stdout)
+        {
+            eprintln!("warning: could not open stdout capture file: {e}");
+            terminate_process_tree(child.id());
+            let _ = child.wait();
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
+
+        let Some(stderr) = child.stderr.take() else {
+            terminate_process_tree(child.id());
+            let _ = child.wait();
+            finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        };
+        if let Some(capture) = stderr_capture.as_mut()
+            && let Err(e) = capture.start(stderr)
+        {
+            eprintln!("warning: could not open stderr capture file: {e}");
+            terminate_process_tree(child.id());
+            let _ = child.wait();
+            finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
+            return MutationOutcome {
+                result: MutationResult::BuildError,
+                test_output: None,
+            };
+        }
+    }
+
     let started = Instant::now();
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,
             Ok(None) => {
                 if started.elapsed() >= timeout_dur {
-                    let _ = child.kill();
+                    terminate_process_tree(child.id());
                     let _ = child.wait();
+                    finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
                     return MutationOutcome {
                         result: MutationResult::Timeout,
                         test_output: None,
@@ -1117,8 +1141,9 @@ fn run_command(
                 thread::sleep(remaining.min(Duration::from_millis(10)));
             }
             Err(_) => {
-                let _ = child.kill();
+                terminate_process_tree(child.id());
                 let _ = child.wait();
+                finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
                 return MutationOutcome {
                     result: MutationResult::BuildError,
                     test_output: None,
@@ -1127,26 +1152,24 @@ fn run_command(
         }
     };
 
+    if capture_output {
+        terminate_process_tree(child.id());
+    }
+
     let result = if status.success() {
         MutationResult::Survived
     } else {
         MutationResult::Killed
     };
     let test_output = if capture_output {
-        let stdout = read_captured_output(
-            stdout_capture
-                .as_ref()
-                .expect("stdout capture file should exist")
-                .path(),
-            "stdout",
-        );
-        let stderr = read_captured_output(
-            stderr_capture
-                .as_ref()
-                .expect("stderr capture file should exist")
-                .path(),
-            "stderr",
-        );
+        let stdout = stdout_capture
+            .as_mut()
+            .expect("stdout capture file should exist")
+            .finish();
+        let stderr = stderr_capture
+            .as_mut()
+            .expect("stderr capture file should exist")
+            .finish();
         let mut combined = String::from_utf8_lossy(&stdout.bytes).into_owned();
         append_truncation_notice(&mut combined, stdout.truncated, "stdout");
 
@@ -1169,12 +1192,141 @@ fn run_command(
     }
 }
 
+#[cfg(unix)]
+fn configure_command_for_process_tree(cmd: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+}
+
+#[cfg(windows)]
+fn configure_command_for_process_tree(cmd: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn configure_command_for_process_tree(_cmd: &mut std::process::Command) {}
+
+#[cfg(unix)]
+fn terminate_process_tree(pid: u32) {
+    let pgid = pid as libc::pid_t;
+    unsafe {
+        let _ = libc::killpg(pgid, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+fn terminate_process_tree(pid: u32) {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_process_tree(_pid: u32) {}
+
+struct OutputCapture {
+    file: tempfile::NamedTempFile,
+    reader: Option<thread::JoinHandle<bool>>,
+    stream: &'static str,
+}
+
+impl OutputCapture {
+    fn new(stream: &'static str) -> std::io::Result<Self> {
+        Ok(Self {
+            file: tempfile::NamedTempFile::new()?,
+            reader: None,
+            stream,
+        })
+    }
+
+    fn start<R>(&mut self, reader: R) -> std::io::Result<()>
+    where
+        R: Read + Send + 'static,
+    {
+        let writer = self.file.reopen()?;
+        self.reader = Some(spawn_output_capture(reader, writer, self.stream));
+        Ok(())
+    }
+
+    fn finish(&mut self) -> CapturedOutput {
+        let truncated = match self.reader.take() {
+            Some(reader) => match reader.join() {
+                Ok(truncated) => truncated,
+                Err(_) => {
+                    eprintln!("warning: {} capture thread panicked", self.stream);
+                    true
+                }
+            },
+            None => false,
+        };
+        read_captured_output(self.file.path(), self.stream, truncated)
+    }
+}
+
+fn finish_capture_threads(
+    stdout_capture: &mut Option<OutputCapture>,
+    stderr_capture: &mut Option<OutputCapture>,
+) {
+    if let Some(capture) = stdout_capture.as_mut() {
+        let _ = capture.finish();
+    }
+    if let Some(capture) = stderr_capture.as_mut() {
+        let _ = capture.finish();
+    }
+}
+
 struct CapturedOutput {
     bytes: Vec<u8>,
     truncated: bool,
 }
 
-fn read_captured_output(path: &Path, stream: &str) -> CapturedOutput {
+fn spawn_output_capture<R>(
+    mut reader: R,
+    mut writer: fs::File,
+    stream: &'static str,
+) -> thread::JoinHandle<bool>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut written = 0usize;
+        let mut truncated = false;
+        let mut buffer = [0; 8192];
+
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let available = CAPTURED_OUTPUT_LIMIT.saturating_sub(written);
+                    let keep = n.min(available);
+                    if keep > 0 {
+                        if let Err(e) = writer.write_all(&buffer[..keep]) {
+                            eprintln!("warning: could not write {stream} capture output: {e}");
+                            break;
+                        }
+                        written += keep;
+                    }
+                    if keep < n {
+                        truncated = true;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    eprintln!("warning: could not read {stream} capture output: {e}");
+                    break;
+                }
+            }
+        }
+        let _ = writer.flush();
+        truncated
+    })
+}
+
+fn read_captured_output(path: &Path, stream: &str, already_truncated: bool) -> CapturedOutput {
     let mut file = match fs::File::open(path) {
         Ok(file) => file,
         Err(e) => {
@@ -1194,7 +1346,7 @@ fn read_captured_output(path: &Path, stream: &str) -> CapturedOutput {
             truncated: false,
         };
     }
-    let truncated = bytes.len() > CAPTURED_OUTPUT_LIMIT;
+    let truncated = already_truncated || bytes.len() > CAPTURED_OUTPUT_LIMIT;
     if truncated {
         bytes.truncate(CAPTURED_OUTPUT_LIMIT);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,11 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::Path;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 fn togi() -> Command {
@@ -278,6 +282,162 @@ fn check_baseline_still_honors_fail_under() {
         .assert()
         .code(1)
         .stderr(predicate::str::contains("below --fail-under threshold"));
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_check_exits_130_without_writing_side_effects() {
+    let dir = setup_git_repo();
+    let marker = dir.path().join("test-command-started");
+    let release = dir.path().join("test-command-release");
+    let stdout_path = dir.path().join("togi-stdout.log");
+    let stderr_path = dir.path().join("togi-stderr.log");
+    let pr_comment_path = dir.path().join("togi-pr-comment.md");
+    let baseline_path = dir.path().join(".togi-baseline");
+    let slow_test = dir.path().join("slow-test.sh");
+
+    fs::write(
+        &slow_test,
+        format!(
+            "#!/bin/sh\n\
+             marker={}\n\
+             release={}\n\
+             printf started > \"$marker\"\n\
+             while [ ! -f \"$release\" ]; do\n\
+             \tsleep 0.05\n\
+             done\n",
+            shell_quote(&marker),
+            shell_quote(&release)
+        ),
+    )
+    .unwrap();
+
+    let stdout = fs::File::create(&stdout_path).unwrap();
+    let stderr = fs::File::create(&stderr_path).unwrap();
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("togi"))
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--test-cmd",
+            &format!("sh {}", shell_quote(&slow_test)),
+            "--timeout",
+            "5",
+            "--jobs",
+            "1",
+            "--save-baseline",
+            "--pr-comment",
+            pr_comment_path
+                .to_str()
+                .expect("PR comment path should be utf-8"),
+        ])
+        .current_dir(dir.path())
+        .process_group(0)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .unwrap();
+
+    if !wait_for_path(&marker, Duration::from_secs(10)) {
+        send_signal_to_process_group(child.id(), libc::SIGKILL);
+        let _ = child.wait();
+        panic!(
+            "test command did not start\nstdout:\n{}\nstderr:\n{}",
+            read_log(&stdout_path),
+            read_log(&stderr_path)
+        );
+    }
+
+    send_signal_to_process_group(child.id(), libc::SIGINT);
+    let _ = wait_for_file_contains(&stderr_path, "Interrupted", Duration::from_secs(1));
+    fs::write(&release, "").unwrap();
+
+    let status = wait_for_child(&mut child, Duration::from_secs(10)).unwrap_or_else(|message| {
+        send_signal_to_process_group(child.id(), libc::SIGKILL);
+        let _ = child.wait();
+        panic!(
+            "{message}\nstdout:\n{}\nstderr:\n{}",
+            read_log(&stdout_path),
+            read_log(&stderr_path)
+        );
+    });
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "interrupted check should exit 130\nstatus: {status:?}\nstdout:\n{}\nstderr:\n{}",
+        read_log(&stdout_path),
+        read_log(&stderr_path)
+    );
+    assert!(
+        !baseline_path.exists(),
+        "interrupted check wrote {}",
+        baseline_path.display()
+    );
+    assert!(
+        !pr_comment_path.exists(),
+        "interrupted check wrote {}",
+        pr_comment_path.display()
+    );
+}
+
+#[cfg(unix)]
+fn shell_quote(path: &Path) -> String {
+    let value = path.to_str().expect("test path should be utf-8");
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn wait_for_path(path: &Path, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    false
+}
+
+#[cfg(unix)]
+fn wait_for_file_contains(path: &Path, needle: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if fs::read_to_string(path).is_ok_and(|content| content.contains(needle)) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    false
+}
+
+#[cfg(unix)]
+fn wait_for_child(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Result<std::process::ExitStatus, String> {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return Ok(status);
+        }
+        if start.elapsed() >= timeout {
+            return Err(format!("togi did not exit within {timeout:?}"));
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn send_signal_to_process_group(pid: u32, signal: libc::c_int) {
+    unsafe {
+        let _ = libc::killpg(pid as libc::pid_t, signal);
+    }
+}
+
+#[cfg(unix)]
+fn read_log(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_default()
 }
 
 #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,11 +1,11 @@
 mod mutations;
 mod verify;
 
-use std::sync::OnceLock;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
-async fn go_fixture_lock() -> tokio::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+fn go_fixture_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
         .lock()
-        .await
+        .expect("go fixture lock poisoned")
 }

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -68,10 +68,10 @@ fn generates_mutations_for_go_fixture() {
 
 /// End-to-end test: generate mutations and run them against the Go test suite.
 /// Requires `go` to be installed. Run with: cargo test -- --ignored
-#[tokio::test]
+#[test]
 #[ignore]
-async fn end_to_end_go_fixture_all_killed_with_cache_off() {
-    let _fixture_guard = crate::go_fixture_lock().await;
+fn end_to_end_go_fixture_all_killed_with_cache_off() {
+    let _fixture_guard = crate::go_fixture_lock();
     let root = fixture_path();
     togi::cache::clear(&root).expect("failed to clear togi cache");
 
@@ -114,7 +114,7 @@ async fn end_to_end_go_fixture_all_killed_with_cache_off() {
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
-    let report = runner.run(mutations).await;
+    let report = runner.run(mutations);
 
     println!(
         "Results: {} total, {} killed, {} survived, {} timeout, {} build errors",

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::Duration;
 use togi::{ChangedFile, LineRange};
 
@@ -70,7 +71,7 @@ fn generates_mutations_for_go_fixture() {
 /// Requires `go` to be installed. Run with: cargo test -- --ignored
 #[test]
 #[ignore]
-fn end_to_end_go_fixture_all_killed_with_cache_off() {
+fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
     let _fixture_guard = crate::go_fixture_lock();
     let root = fixture_path();
     togi::cache::clear(&root).expect("failed to clear togi cache");
@@ -84,12 +85,28 @@ fn end_to_end_go_fixture_all_killed_with_cache_off() {
     let mutations = togi::mutator::generate_mutations(&changed, &root, 200, 0, &[]).unwrap();
     assert!(!mutations.is_empty());
 
-    // Disable Go caching via runner env (no process-wide set_var)
+    // Force fresh test execution while keeping Go's required build cache enabled.
+    let go_cache = tempfile::tempdir().expect("failed to create temporary Go cache");
     let go_env: std::collections::HashMap<String, String> = [
         ("GOFLAGS".into(), "-count=1".into()),
-        ("GOCACHE".into(), "off".into()),
+        (
+            "GOCACHE".into(),
+            go_cache.path().to_string_lossy().into_owned(),
+        ),
     ]
     .into();
+    let baseline = Command::new("go")
+        .args(["test", "./..."])
+        .envs(&go_env)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run baseline go test");
+    assert!(
+        baseline.status.success(),
+        "baseline go test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&baseline.stdout),
+        String::from_utf8_lossy(&baseline.stderr)
+    );
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
@@ -133,10 +150,13 @@ fn end_to_end_go_fixture_all_killed_with_cache_off() {
         );
     }
 
-    // With GOCACHE=off, all mutations are killed because Go recompiles fresh.
     // Parent-level mutation mapping intentionally adds if-body, condition, and
-    // return mutations alongside expression/literal mutations.
+    // return mutations alongside expression/literal mutations. The fixture's
+    // tests intentionally do not kill every generated mutation; these counts
+    // prove Go actually ran instead of failing before test execution.
     assert_eq!(report.total, 26);
-    assert_eq!(report.killed, report.total);
+    assert_eq!(report.killed, 10);
+    assert_eq!(report.survived, 16);
+    assert_eq!(report.timeout, 0);
     assert_eq!(report.build_errors, 0);
 }

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -131,7 +131,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
-    let report = runner.run(mutations);
+    let report = runner.run(mutations).report;
 
     println!(
         "Results: {} total, {} killed, {} survived, {} timeout, {} build errors",

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -90,7 +90,8 @@ fn verify_mutation_outcomes_match_independent_replay() {
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
-    let report = runner.run(mutations);
+    togi::cache::clear(&root).expect("failed to clear togi cache before verification run");
+    let report = runner.run(mutations).report;
 
     // Verify runner restored the file
     let after_run = std::fs::read(&calc_path).expect("failed to re-read calc.go");

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -1,8 +1,7 @@
 //! Mutation verification: replay each mutation independently and confirm
 //! togi's reported outcome matches the actual test result.
 //!
-//! Sets GOCACHE=off because Go's build cache can return stale binaries
-//! when source files change rapidly via atomic rename.
+//! Sets GOCACHE=off so Go recompiles each mutated workspace.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -25,10 +24,10 @@ fn classify_result(status: std::process::ExitStatus) -> MutationResult {
 /// and assert the outcomes match.
 ///
 /// Requires `go` to be installed. Run with: cargo test -- --ignored
-#[tokio::test]
+#[test]
 #[ignore]
-async fn verify_mutation_outcomes_match_independent_replay() {
-    let _fixture_guard = crate::go_fixture_lock().await;
+fn verify_mutation_outcomes_match_independent_replay() {
+    let _fixture_guard = crate::go_fixture_lock();
     let root = fixture_path();
     let calc_path = root.join("calc.go");
 
@@ -73,7 +72,7 @@ async fn verify_mutation_outcomes_match_independent_replay() {
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
-    let report = runner.run(mutations).await;
+    let report = runner.run(mutations);
 
     // Verify runner restored the file
     let after_run = std::fs::read(&calc_path).expect("failed to re-read calc.go");

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -30,6 +30,7 @@ fn classify_result(status: std::process::ExitStatus) -> MutationResult {
 fn verify_mutation_outcomes_match_independent_replay() {
     let _fixture_guard = crate::go_fixture_lock();
     let root = fixture_path();
+    togi::cache::clear(&root).expect("failed to clear togi cache");
     let calc_path = root.join("calc.go");
 
     let changed = vec![ChangedFile {

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -1,7 +1,8 @@
 //! Mutation verification: replay each mutation independently and confirm
 //! togi's reported outcome matches the actual test result.
 //!
-//! Sets GOCACHE=off so Go recompiles each mutated workspace.
+//! Uses `-count=1` with a temporary GOCACHE so Go reruns tests while keeping
+//! the required build cache enabled.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -42,12 +43,28 @@ fn verify_mutation_outcomes_match_independent_replay() {
     // Capture pristine fixture before runner.run() touches it
     let original = std::fs::read(&calc_path).expect("failed to read calc.go");
 
-    // Disable Go build+test caching via runner env (no process-wide set_var)
+    // Force fresh test execution while keeping Go's required build cache enabled.
+    let go_cache = tempfile::tempdir().expect("failed to create temporary Go cache");
     let go_env: std::collections::HashMap<String, String> = [
         ("GOFLAGS".into(), "-count=1".into()),
-        ("GOCACHE".into(), "off".into()),
+        (
+            "GOCACHE".into(),
+            go_cache.path().to_string_lossy().into_owned(),
+        ),
     ]
     .into();
+    let baseline = Command::new("go")
+        .args(["test", "./..."])
+        .envs(&go_env)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run baseline go test");
+    assert!(
+        baseline.status.success(),
+        "baseline go test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&baseline.stdout),
+        String::from_utf8_lossy(&baseline.stderr)
+    );
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {


### PR DESCRIPTION
## Summary
- replace per-mutation async task scheduling with a bounded worker pool tied to workspace parallelism
- cap captured test output at 1 MiB per stream while still draining stdout/stderr
- remove now-unused runtime/helper dependencies after moving runner/report/cache code to std-backed implementations

## Verification
- cargo test
- cargo clippy -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pruned and reorganized dependencies for a leaner configuration

* **Refactor**
  * Switched CLI and runner to synchronous, multithreaded execution
  * Reworked workspace pooling, command execution, timeouts, and output capture
  * Simplified diff generation and terminal styling (no external color dependency)
  * Changed cache filename hashing for deterministic names

* **Bug Fixes**
  * Skip mismatched mutation diffs to avoid incorrect reporting

* **Tests**
  * Updated and added integration tests to reflect synchronous flow and interruption behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->