### PR TITLE
Preserve workspace target cache between mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ togi check --all
 # Adjust parallelism and timeout
 togi check --jobs 8 --timeout 60
 
+# Cap mutation count for a bounded exploratory run
+togi check --max-per-run 50  # --max-per-run 0 = unlimited
+
 # Scope to a directory
 togi check --all --path src/rules/
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,10 @@ pub enum Commands {
         #[arg(short, long)]
         timeout: Option<u64>,
 
+        /// Maximum mutations to run (0 = unlimited)
+        #[arg(long)]
+        max_per_run: Option<usize>,
+
         /// Show mutations without running tests
         #[arg(long)]
         dry_run: bool,
@@ -181,6 +185,17 @@ mod tests {
                 assert_eq!(output, PathBuf::from("map.json"));
             }
             _ => panic!("expected TestMap command"),
+        }
+    }
+
+    #[test]
+    fn max_per_run_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--max-per-run", "25"]).unwrap();
+        match cli.command {
+            Commands::Check { max_per_run, .. } => {
+                assert_eq!(max_per_run, Some(25));
+            }
+            _ => panic!("expected Check command"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ struct CheckConfig {
     output_format: togi::cli::OutputFormat,
     jobs: Option<usize>,
     timeout: Option<u64>,
+    max_per_run: Option<usize>,
     dry_run: bool,
     verbose: bool,
     show_output: bool,
@@ -70,6 +71,7 @@ fn main() {
             format,
             jobs,
             timeout,
+            max_per_run,
             dry_run,
             verbose,
             show_output,
@@ -94,6 +96,7 @@ fn main() {
                 output_format: format,
                 jobs,
                 timeout,
+                max_per_run,
                 dry_run,
                 verbose,
                 show_output,
@@ -421,6 +424,9 @@ fn resolve_config(
     }
     if let Some(t) = cfg.timeout {
         config.test.timeout = t;
+    }
+    if let Some(max) = cfg.max_per_run {
+        config.mutations.max_per_run = max;
     }
     if let Some(cmd) = cfg.test_cmd {
         config.test.command =

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -336,6 +336,13 @@ fn should_copy_workspace_entry(project_root: &Path, path: &Path) -> bool {
             .is_ok_and(|relative| !should_skip_workspace_entry(relative))
 }
 
+/// Workspace directories kept across resets.
+///
+/// Stashes are created in `workspace_root.parent()` as `.togi-preserved-{name}`
+/// so `fs::rename` stays on the same filesystem and remains metadata-only.
+/// Any stale stash from an interrupted prior reset is reclaimed before rename.
+const PRESERVED_WORKSPACE_DIRS: &[&str] = &["target"];
+
 fn cache_context_fingerprint(project_root: &Path) -> u64 {
     git_cache_context_fingerprint(project_root)
         .unwrap_or_else(|| filesystem_cache_context_fingerprint(project_root))
@@ -620,11 +627,53 @@ fn reset_workspace(
     workspace_root: &Path,
     respect_ignores: bool,
 ) -> std::io::Result<()> {
+    let preserved_dirs = preserve_workspace_dirs(workspace_root)?;
     if workspace_root.exists() {
         fs::remove_dir_all(workspace_root)?;
     }
     fs::create_dir(workspace_root)?;
+    restore_workspace_dirs(workspace_root, preserved_dirs)?;
     populate_workspace(project_root, workspace_root, respect_ignores)
+}
+
+/// Move preserved dirs to sibling stashes before deleting the workspace.
+///
+/// The sibling stash location keeps rename on the same filesystem; removing an
+/// existing stash is intentional recovery from an interrupted previous reset.
+fn preserve_workspace_dirs(workspace_root: &Path) -> std::io::Result<Vec<(PathBuf, PathBuf)>> {
+    let Some(parent) = workspace_root.parent() else {
+        return Ok(Vec::new());
+    };
+
+    let mut preserved = Vec::new();
+    for name in PRESERVED_WORKSPACE_DIRS {
+        let source = workspace_root.join(name);
+        if !source.exists() {
+            continue;
+        }
+
+        let stash = parent.join(format!(".togi-preserved-{name}"));
+        if stash.exists() {
+            fs::remove_dir_all(&stash)?;
+        }
+        fs::rename(&source, &stash)?;
+        preserved.push((PathBuf::from(name), stash));
+    }
+    Ok(preserved)
+}
+
+fn restore_workspace_dirs(
+    workspace_root: &Path,
+    preserved_dirs: Vec<(PathBuf, PathBuf)>,
+) -> std::io::Result<()> {
+    for (relative, stash) in preserved_dirs {
+        let destination = workspace_root.join(relative);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(stash, destination)?;
+    }
+    Ok(())
 }
 
 fn populate_workspace(
@@ -2585,6 +2634,45 @@ mod tests {
         );
         assert!(copy.root().join("src/lib.rs").exists());
         assert!(!copy.root().join("target").exists());
+    }
+
+    #[test]
+    fn reset_workspace_preserves_target_cache_and_removes_other_side_effects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("source");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub fn f() {}\n").unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(workspace.join("target/debug")).unwrap();
+        std::fs::write(workspace.join("target/debug/cache"), b"keep").unwrap();
+        std::fs::write(workspace.join("side-effect"), b"drop").unwrap();
+
+        reset_workspace(&root, &workspace, true).unwrap();
+
+        assert_eq!(
+            std::fs::read(workspace.join("target/debug/cache")).unwrap(),
+            b"keep"
+        );
+        assert!(workspace.join("src/lib.rs").exists());
+        assert!(!workspace.join("side-effect").exists());
+    }
+
+    #[test]
+    fn reset_workspace_handles_missing_workspace_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("source");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub fn f() {}\n").unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("side-effect"), b"drop").unwrap();
+
+        reset_workspace(&root, &workspace, true).unwrap();
+
+        assert!(workspace.join("src/lib.rs").exists());
+        assert!(!workspace.join("side-effect").exists());
+        assert!(!workspace.join("target/debug/cache").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve per-workspace target directories across mutation resets so Cargo can reuse build output
- add a --max-per-run CLI override for bounded exploratory runs
- document the new exploratory cap flag

## Tests
- cargo test
- cargo clippy -- -D warnings
- cargo run -- check --all --path tests/fixtures/go --dry-run --max-per-run 5 --no-skip-defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--max-per-run` CLI option to cap the number of mutations per run for bounded exploratory testing.

* **Documentation**
  * Updated README with usage examples for the new `--max-per-run` option.

* **Improvements**
  * Workspace reset now preserves build cache directories to improve performance across runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->