### PR TITLE
Add opt-in Go schemata execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ togi check --jobs 8 --timeout 60
 # Cap mutation count for a bounded exploratory run
 togi check --max-per-run 50  # --max-per-run 0 = unlimited
 
+# Opt in to Go mutant schemata for compatible mutations
+togi check --schemata
+
 # Scope to a directory
 togi check --all --path src/rules/
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,10 @@ pub enum Commands {
         #[arg(long)]
         max_per_run: Option<usize>,
 
+        /// Use opt-in mutant schemata for supported languages
+        #[arg(long)]
+        schemata: bool,
+
         /// Show mutations without running tests
         #[arg(long)]
         dry_run: bool,
@@ -194,6 +198,17 @@ mod tests {
         match cli.command {
             Commands::Check { max_per_run, .. } => {
                 assert_eq!(max_per_run, Some(25));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn schemata_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--schemata"]).unwrap();
+        match cli.command {
+            Commands::Check { schemata, .. } => {
+                assert!(schemata);
             }
             _ => panic!("expected Check command"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,8 @@ pub struct MutationConfig {
     pub respect_workspace_ignores: bool,
     #[serde(default)]
     pub operators: Vec<String>,
+    #[serde(default)]
+    pub schemata: bool,
 }
 
 fn default_true() -> bool {
@@ -277,6 +279,7 @@ impl Default for MutationConfig {
             skip_noisy_files: true,
             respect_workspace_ignores: true,
             operators: vec![],
+            schemata: false,
         }
     }
 }
@@ -431,6 +434,7 @@ impl Config {
              [mutations]\n\
              max_per_run = 20\n\
              # max_per_file = 20  # cap mutations per source file (0 = unlimited)\n\
+             # schemata = false  # opt in to supported mutant schemata execution\n\
              # respect_workspace_ignores = true  # honor .ignore/.gitignore in mutation workspaces\n",
         );
 
@@ -470,6 +474,7 @@ base = "origin/develop"
 
 [mutations]
 max_per_run = 50
+schemata = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.test.command, vec!["make", "test"]);
@@ -477,6 +482,7 @@ max_per_run = 50
         assert_eq!(config.test.jobs, 8);
         assert_eq!(config.diff.base, "origin/develop");
         assert_eq!(config.mutations.max_per_run, 50);
+        assert!(config.mutations.schemata);
     }
 
     #[test]
@@ -529,6 +535,7 @@ commnad = ["cargo", "test"]
         );
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
+        assert!(!config.mutations.schemata);
         let project = &config.projects["api"];
         assert_eq!(project.path, PathBuf::from("services/api"));
         assert_eq!(project.test.as_ref().unwrap().timeout, Some(60));
@@ -552,6 +559,7 @@ commnad = ["cargo", "test"]
         assert!(config.mutations.exclude_paths.is_empty());
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
+        assert!(!config.mutations.schemata);
         assert!(config.projects.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ struct CheckConfig {
     jobs: Option<usize>,
     timeout: Option<u64>,
     max_per_run: Option<usize>,
+    schemata: bool,
     dry_run: bool,
     verbose: bool,
     show_output: bool,
@@ -72,6 +73,7 @@ fn main() {
             jobs,
             timeout,
             max_per_run,
+            schemata,
             dry_run,
             verbose,
             show_output,
@@ -97,6 +99,7 @@ fn main() {
                 jobs,
                 timeout,
                 max_per_run,
+                schemata,
                 dry_run,
                 verbose,
                 show_output,
@@ -428,6 +431,9 @@ fn resolve_config(
     if let Some(max) = cfg.max_per_run {
         config.mutations.max_per_run = max;
     }
+    if cfg.schemata {
+        config.mutations.schemata = true;
+    }
     if let Some(cmd) = cfg.test_cmd {
         config.test.command =
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --test-cmd: {e}"))?;
@@ -664,6 +670,7 @@ fn execute(
         config.mutations.test_selection_file.as_deref(),
         &project_root,
     );
+    let use_schemata = config.mutations.schemata;
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
@@ -696,7 +703,11 @@ fn execute(
         cancelled: options.cancelled,
     };
 
-    runner.run(mutations)
+    if use_schemata {
+        runner.run_with_schemata(mutations)
+    } else {
+        runner.run(mutations)
+    }
 }
 
 fn load_test_selection(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1028,6 +1028,63 @@ fn record_progress(
 impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
     pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
+        self.run_regular(mutations)
+    }
+
+    pub fn run_with_schemata(&self, mutations: Vec<Mutation>) -> RunOutcome {
+        let start = Instant::now();
+        if mutations.is_empty() {
+            return self.outcome_from_results(Vec::new(), start.elapsed());
+        }
+
+        let index_by_id: HashMap<u32, usize> = mutations
+            .iter()
+            .enumerate()
+            .map(|(index, mutation)| (mutation.id, index))
+            .collect();
+        let plan = crate::schemata::plan(&self.project_root, mutations);
+        let mut schema_mutations = Vec::new();
+        let mut fallback_mutations = Vec::new();
+
+        for schema_mutation in plan.selected {
+            if schema_mutation.mutation.language == "go" {
+                schema_mutations.push(schema_mutation);
+            } else {
+                fallback_mutations.push(schema_mutation.mutation);
+            }
+        }
+        fallback_mutations.extend(plan.fallback.into_iter().map(|fallback| fallback.mutation));
+
+        if schema_mutations.is_empty() {
+            return self.run_regular(fallback_mutations);
+        }
+
+        let mut all_results = Vec::new();
+        match self.run_go_schema_mutations(&schema_mutations) {
+            Ok(results) => all_results.extend(results),
+            Err(err) => {
+                eprintln!("warning: could not run Go schemata: {err} — falling back");
+                fallback_mutations.extend(
+                    schema_mutations
+                        .into_iter()
+                        .map(|schema_mutation| schema_mutation.mutation),
+                );
+            }
+        }
+
+        if !self.cancelled.load(Ordering::Acquire) && !fallback_mutations.is_empty() {
+            let fallback = self.run_regular(fallback_mutations);
+            all_results.extend(fallback.report.results);
+        }
+
+        all_results.sort_by_key(|(mutation, _)| {
+            index_by_id.get(&mutation.id).copied().unwrap_or(usize::MAX)
+        });
+        self.outcome_from_results(all_results, start.elapsed())
+    }
+
+    #[allow(clippy::manual_is_multiple_of)]
+    fn run_regular(&self, mutations: Vec<Mutation>) -> RunOutcome {
         let start = Instant::now();
         let total = mutations.len();
         if total == 0 {
@@ -1168,6 +1225,119 @@ impl TestRunner {
         self.outcome_from_results(all_results, start.elapsed())
     }
 
+    fn run_go_schema_mutations(
+        &self,
+        schema_mutations: &[crate::schemata::SchemaMutation],
+    ) -> Result<Vec<(Mutation, MutationResult)>, crate::schemata::SchemaRewriteError> {
+        let rewrites = crate::schemata::rewrite_go_files(&self.project_root, schema_mutations)?;
+        let workspace =
+            copy_workspace_with_options(&self.project_root, self.respect_workspace_ignores)
+                .map_err(|e| {
+                    crate::schemata::SchemaRewriteError::new(format!(
+                        "could not create schema workspace: {e}"
+                    ))
+                })?;
+
+        for rewrite in rewrites {
+            let relative =
+                project_relative_path(&self.project_root, &rewrite.file).map_err(|_| {
+                    crate::schemata::SchemaRewriteError::new(format!(
+                        "could not resolve rewritten file {}",
+                        rewrite.file.display()
+                    ))
+                })?;
+            let target =
+                validate_and_resolve_mutation_path(workspace.root(), &relative).map_err(|_| {
+                    crate::schemata::SchemaRewriteError::new(format!(
+                        "rewritten file {} is not in schema workspace",
+                        rewrite.file.display()
+                    ))
+                })?;
+            write_workspace_file(&target, &rewrite.content).map_err(|e| {
+                crate::schemata::SchemaRewriteError::new(format!(
+                    "could not write schema file {}: {e}",
+                    target.display()
+                ))
+            })?;
+        }
+
+        if self.commands.build_command_explicit && !self.commands.build_command.is_empty() {
+            let build = run_command(
+                &self.commands.build_command,
+                workspace.root(),
+                self.commands.timeout,
+                false,
+                &self.env,
+                &self.cancelled,
+            );
+            if build.cancelled {
+                return Ok(Vec::new());
+            }
+            if build.result != MutationResult::Survived {
+                return Ok(schema_mutations
+                    .iter()
+                    .map(|schema_mutation| {
+                        (schema_mutation.mutation.clone(), MutationResult::BuildError)
+                    })
+                    .collect());
+            }
+        }
+
+        let mut results = Vec::with_capacity(schema_mutations.len());
+        for schema_mutation in schema_mutations {
+            if self.cancelled.load(Ordering::Acquire) {
+                break;
+            }
+            let mutation = &schema_mutation.mutation;
+            let selected = select_test_command(&self.project_root, &self.commands, mutation);
+            let mut env = self.env.clone();
+            env.insert("TOGI_MUTANT".to_string(), mutation.id.to_string());
+            let outcome = run_command(
+                &force_go_no_test_cache(selected.argv),
+                workspace.root(),
+                selected.timeout,
+                self.show_output,
+                &env,
+                &self.cancelled,
+            );
+            if outcome.cancelled {
+                break;
+            }
+            if self.verbose {
+                let symbol = match outcome.result {
+                    MutationResult::Killed => "✓ killed",
+                    MutationResult::Survived => "✗ survived",
+                    MutationResult::Timeout => "⧖ timeout",
+                    MutationResult::BuildError => "⚠ build error",
+                };
+                eprintln!(
+                    "  [schema] {}  {}:{} — {}",
+                    symbol,
+                    mutation.file.display(),
+                    mutation.line,
+                    mutation.operator
+                );
+            }
+            if self.show_output && outcome.result == MutationResult::Survived {
+                if let Some(output) = outcome.test_output.as_deref() {
+                    eprintln!(
+                        "  ┌─ test output for {}:{} ({})",
+                        mutation.file.display(),
+                        mutation.line,
+                        mutation.operator
+                    );
+                    for line in output.lines() {
+                        eprintln!("  │ {}", line);
+                    }
+                    eprintln!("  └─");
+                }
+            }
+            results.push((mutation.clone(), outcome.result));
+        }
+
+        Ok(results)
+    }
+
     fn outcome_from_results(
         &self,
         all_results: Vec<(Mutation, MutationResult)>,
@@ -1270,6 +1440,34 @@ fn mutation_file_path(project_root: &Path, mutation_file: &Path) -> PathBuf {
     } else {
         project_root.join(mutation_file)
     }
+}
+
+fn project_relative_path(project_root: &Path, file: &Path) -> Result<PathBuf, ()> {
+    if file.is_absolute() {
+        let canonical = file.canonicalize().map_err(|_| ())?;
+        let root = project_root.canonicalize().map_err(|_| ())?;
+        canonical
+            .strip_prefix(root)
+            .map(PathBuf::from)
+            .map_err(|_| ())
+    } else {
+        Ok(file.to_path_buf())
+    }
+}
+
+fn force_go_no_test_cache(mut argv: Vec<String>) -> Vec<String> {
+    if argv.len() < 2 || argv[0] != "go" || argv[1] != "test" {
+        return argv;
+    }
+    if argv
+        .iter()
+        .skip(2)
+        .any(|arg| arg == "-count" || arg.starts_with("-count="))
+    {
+        return argv;
+    }
+    argv.insert(2, "-count=1".to_string());
+    argv
 }
 
 fn cache_identity(project_root: &Path, mutation: &Mutation) -> String {
@@ -2054,6 +2252,32 @@ mod tests {
         (dir, file, mutation)
     }
 
+    fn go_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
+        let mut offset = 0usize;
+        for index in 0..=nth {
+            let next = source[offset..]
+                .find("==")
+                .expect("source should contain ==");
+            offset += next;
+            if index == nth {
+                break;
+            }
+            offset += 2;
+        }
+        Mutation {
+            id,
+            file: PathBuf::from(file),
+            language: "go".into(),
+            line: 1,
+            column: 1,
+            operator: "eq_to_neq".into(),
+            description: "Replace == with !=".into(),
+            original: "==".into(),
+            replacement: "!=".into(),
+            byte_range: offset..offset + 2,
+        }
+    }
+
     #[test]
     fn cache_context_fingerprint_changes_for_tests_and_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -2467,6 +2691,27 @@ mod tests {
         assert_eq!(
             selected.argv,
             vec!["go", "test", "-count=1", "-run=^(TestAdd)$", "./..."]
+        );
+    }
+
+    #[test]
+    fn force_go_no_test_cache_inserts_count_once() {
+        assert_eq!(
+            force_go_no_test_cache(vec!["go".into(), "test".into(), "./...".into()]),
+            vec!["go", "test", "-count=1", "./..."]
+        );
+        assert_eq!(
+            force_go_no_test_cache(vec![
+                "go".into(),
+                "test".into(),
+                "-count=1".into(),
+                "./...".into()
+            ]),
+            vec!["go", "test", "-count=1", "./..."]
+        );
+        assert_eq!(
+            force_go_no_test_cache(vec!["cargo".into(), "test".into()]),
+            vec!["cargo", "test"]
         );
     }
 
@@ -3176,6 +3421,60 @@ mod tests {
             "runner should not wait for the command timeout after cancellation"
         );
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_schemata_executes_go_mutations_with_active_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = "\
+package calc
+func first(a, b int) bool { return a == b }
+func second(c, d int) bool { return c == d }
+";
+        std::fs::write(dir.path().join("calc.go"), source).unwrap();
+        let first = go_operator_mutation(0, "calc.go", source, 0);
+        let second = go_operator_mutation(1, "calc.go", source, 1);
+        let script = r#"
+case "$(cat calc.go)" in
+  *__togi_active*) ;;
+  *) exit 2 ;;
+esac
+case "$TOGI_MUTANT" in
+  0) exit 1 ;;
+  1) exit 0 ;;
+  *) exit 2 ;;
+esac
+"#;
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["sh".into(), "-c".into(), script.into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![first, second]).report;
+
+        assert_eq!(report.total, 2);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert_eq!(report.results[1].1, MutationResult::Survived);
     }
 
     #[test]

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -8,6 +8,7 @@
 use crate::Mutation;
 use crate::operators;
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 /// A schema rewrite shape understood by the generic schemata engine.
@@ -39,6 +40,35 @@ pub struct SchemaPlan {
     pub selected: Vec<SchemaMutation>,
     pub fallback: Vec<SchemaFallback>,
 }
+
+/// Rewritten source for one schema-enabled file.
+#[derive(Debug, Clone)]
+pub struct SchemaFileRewrite {
+    pub file: PathBuf,
+    pub content: Vec<u8>,
+}
+
+/// Why schema source rewriting failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaRewriteError {
+    message: String,
+}
+
+impl SchemaRewriteError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SchemaRewriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SchemaRewriteError {}
 
 /// Why a mutation is not safe for schema execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,12 +320,363 @@ pub fn plan(project_root: &Path, mutations: Vec<Mutation>) -> SchemaPlan {
     }
 }
 
+/// Rewrite Go files once so selected mutations can be activated by `TOGI_MUTANT`.
+pub fn rewrite_go_files(
+    project_root: &Path,
+    selected: &[SchemaMutation],
+) -> Result<Vec<SchemaFileRewrite>, SchemaRewriteError> {
+    let Some(adapter) = adapter_for_language("go") else {
+        return Err(SchemaRewriteError::new(
+            "go schema adapter is not available",
+        ));
+    };
+
+    let mut by_file: BTreeMap<PathBuf, Vec<&SchemaMutation>> = BTreeMap::new();
+    for mutation in selected {
+        if mutation.mutation.language != "go" {
+            return Err(SchemaRewriteError::new(format!(
+                "schema rewrite only supports go, got {}",
+                mutation.mutation.language
+            )));
+        }
+        if mutation.kind != SchemaKind::Expression {
+            return Err(SchemaRewriteError::new(
+                "go schema rewrite currently supports expression mutations only",
+            ));
+        }
+        by_file
+            .entry(source_path(project_root, &mutation.mutation.file))
+            .or_default()
+            .push(mutation);
+    }
+
+    let mut rewritten = BTreeMap::new();
+    let mut helper_file_by_dir = BTreeMap::<PathBuf, PathBuf>::new();
+    for (file, mutations) in by_file {
+        let source = std::fs::read_to_string(&file).map_err(|e| {
+            SchemaRewriteError::new(format!("could not read {}: {e}", file.display()))
+        })?;
+        let rewritten_source = rewrite_go_file(&source, &mutations, adapter)?;
+        let dir = file
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| project_root.to_path_buf());
+        helper_file_by_dir
+            .entry(dir)
+            .or_insert_with(|| file.clone());
+        rewritten.insert(file, rewritten_source);
+    }
+
+    for helper_file in helper_file_by_dir.values() {
+        if let Some(source) = rewritten.get_mut(helper_file) {
+            *source = inject_go_runtime(source, adapter)?;
+        }
+    }
+
+    Ok(rewritten
+        .into_iter()
+        .map(|(file, content)| SchemaFileRewrite {
+            file,
+            content: content.into_bytes(),
+        })
+        .collect())
+}
+
 fn source_path(project_root: &Path, mutation_file: &Path) -> PathBuf {
     if mutation_file.is_absolute() {
         mutation_file.to_path_buf()
     } else {
         project_root.join(mutation_file)
     }
+}
+
+fn rewrite_go_file(
+    source: &str,
+    selected: &[&SchemaMutation],
+    adapter: &dyn SchemaAdapter,
+) -> Result<String, SchemaRewriteError> {
+    let source_bytes = source.as_bytes();
+    let tree = parse_go_source(source)?;
+    let mut edits = Vec::with_capacity(selected.len());
+
+    for schema_mutation in selected {
+        let mutation = &schema_mutation.mutation;
+        validate_source_range(mutation, source_bytes).map_err(|reason| {
+            SchemaRewriteError::new(format!(
+                "mutation {} is not rewriteable: {reason:?}",
+                mutation.id
+            ))
+        })?;
+        let expression_range =
+            go_expression_range_for_mutation(tree.root_node(), source, mutation)?;
+        let original = source_slice(source, expression_range.clone())?;
+        let replacement = mutated_expression(source, expression_range.clone(), mutation)?;
+        let wrapped = adapter.wrap_expression(mutation.id, original, &replacement);
+        edits.push((expression_range, wrapped));
+    }
+
+    edits.sort_by_key(|(range, _)| (range.start, range.end));
+    let mut previous_end = 0usize;
+    for (position, (range, _)) in edits.iter().enumerate() {
+        if position > 0 && range.start < previous_end {
+            return Err(SchemaRewriteError::new(
+                "schema mutations overlap after expression expansion",
+            ));
+        }
+        previous_end = range.end;
+    }
+
+    let mut rewritten = source.as_bytes().to_vec();
+    for (range, replacement) in edits.into_iter().rev() {
+        rewritten.splice(range, replacement.bytes());
+    }
+
+    String::from_utf8(rewritten)
+        .map_err(|e| SchemaRewriteError::new(format!("rewritten Go source is not utf-8: {e}")))
+}
+
+fn mutated_expression(
+    source: &str,
+    expression_range: std::ops::Range<usize>,
+    mutation: &Mutation,
+) -> Result<String, SchemaRewriteError> {
+    if mutation.byte_range.start < expression_range.start
+        || mutation.byte_range.end > expression_range.end
+    {
+        return Err(SchemaRewriteError::new(format!(
+            "mutation {} is outside its containing expression",
+            mutation.id
+        )));
+    }
+
+    let mut expression = source.as_bytes()[expression_range.clone()].to_vec();
+    let start = mutation.byte_range.start - expression_range.start;
+    let end = mutation.byte_range.end - expression_range.start;
+    expression.splice(start..end, mutation.replacement.bytes());
+
+    String::from_utf8(expression)
+        .map_err(|e| SchemaRewriteError::new(format!("mutated expression is not utf-8: {e}")))
+}
+
+fn parse_go_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_go::LANGUAGE.into())
+        .map_err(|e| SchemaRewriteError::new(format!("could not load Go grammar: {e}")))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| SchemaRewriteError::new("could not parse Go source"))?;
+    if tree.root_node().has_error() {
+        return Err(SchemaRewriteError::new("Go source contains parse errors"));
+    }
+    Ok(tree)
+}
+
+fn go_expression_range_for_mutation(
+    root: tree_sitter::Node<'_>,
+    source: &str,
+    mutation: &Mutation,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    match mutation.operator.as_str() {
+        "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" => {
+            smallest_go_node_range(root, mutation.byte_range.clone(), |node| {
+                node.kind() == "binary_expression"
+            })
+        }
+        "true_to_false" | "false_to_true" => exact_go_node_range(root, mutation.byte_range.clone()),
+        "remove_unary_not" => smallest_go_node_range(root, mutation.byte_range.clone(), |node| {
+            node.kind() == "unary_expression"
+        }),
+        "negate_condition" => {
+            source_slice(source, mutation.byte_range.clone())?;
+            Ok(mutation.byte_range.clone())
+        }
+        _ => Err(SchemaRewriteError::new(format!(
+            "unsupported Go schema operator {}",
+            mutation.operator
+        ))),
+    }
+}
+
+fn smallest_go_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+    predicate: impl Fn(tree_sitter::Node<'_>) -> bool + Copy,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut best = None::<std::ops::Range<usize>>;
+    visit_go_nodes(node, &mut |candidate| {
+        let candidate_range = candidate.byte_range();
+        if candidate_range.start <= range.start
+            && range.end <= candidate_range.end
+            && predicate(candidate)
+            && best
+                .as_ref()
+                .is_none_or(|best| candidate_range.len() < best.len())
+        {
+            best = Some(candidate_range);
+        }
+    });
+    best.ok_or_else(|| SchemaRewriteError::new("could not find containing Go expression"))
+}
+
+fn exact_go_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut found = None;
+    visit_go_nodes(node, &mut |candidate| {
+        if candidate.byte_range() == range {
+            found = Some(range.clone());
+        }
+    });
+    found.ok_or_else(|| SchemaRewriteError::new("could not find Go expression node"))
+}
+
+fn visit_go_nodes(node: tree_sitter::Node<'_>, visit: &mut impl FnMut(tree_sitter::Node<'_>)) {
+    visit(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        visit_go_nodes(child, visit);
+    }
+}
+
+fn source_slice(source: &str, range: std::ops::Range<usize>) -> Result<&str, SchemaRewriteError> {
+    std::str::from_utf8(&source.as_bytes()[range])
+        .map_err(|e| SchemaRewriteError::new(format!("source slice is not utf-8: {e}")))
+}
+
+fn inject_go_runtime(
+    source: &str,
+    adapter: &dyn SchemaAdapter,
+) -> Result<String, SchemaRewriteError> {
+    if source.contains("func __togi_active(") {
+        return Ok(source.to_string());
+    }
+    let source = ensure_go_imports(source.to_string(), adapter.required_imports())?;
+    let insert_at = go_runtime_insert_offset(&source)?;
+    let helper = adapter.runtime_helper().trim();
+    let mut rewritten = source;
+    rewritten.insert_str(insert_at, &format!("\n{helper}\n"));
+    Ok(rewritten)
+}
+
+fn ensure_go_imports(mut source: String, imports: &[&str]) -> Result<String, SchemaRewriteError> {
+    let missing: Vec<&str> = imports
+        .iter()
+        .copied()
+        .filter(|import| !go_source_imports(&source, import))
+        .collect();
+    if missing.is_empty() {
+        return Ok(source);
+    }
+
+    let package_end = go_package_decl_end(&source)?;
+    let import_start = skip_ascii_whitespace(&source, package_end);
+    if source[import_start..].starts_with("import (") {
+        let open_end = import_start + "import (".len();
+        let insertion = missing
+            .iter()
+            .map(|import| format!("\n    \"{import}\""))
+            .collect::<String>();
+        source.insert_str(open_end, &insertion);
+        return Ok(source);
+    }
+
+    if source[import_start..].starts_with("import ") {
+        let line_end = source[import_start..]
+            .find('\n')
+            .map(|idx| import_start + idx)
+            .unwrap_or(source.len());
+        let existing_import = source[import_start + "import ".len()..line_end].trim();
+        let mut replacement = String::from("import (\n");
+        for import in missing {
+            replacement.push_str(&format!("    \"{import}\"\n"));
+        }
+        replacement.push_str("    ");
+        replacement.push_str(existing_import);
+        replacement.push_str("\n)");
+        source.replace_range(import_start..line_end, &replacement);
+        return Ok(source);
+    }
+
+    let import_block = missing
+        .iter()
+        .map(|import| format!("    \"{import}\"\n"))
+        .collect::<String>();
+    source.insert_str(package_end, &format!("\nimport (\n{import_block})\n"));
+    Ok(source)
+}
+
+fn go_source_imports(source: &str, import: &str) -> bool {
+    let Ok(package_end) = go_package_decl_end(source) else {
+        return false;
+    };
+    let import_start = skip_ascii_whitespace(source, package_end);
+    let needle = format!("\"{import}\"");
+    if source[import_start..].starts_with("import (") {
+        let rest = &source[import_start..];
+        return rest
+            .find("\n)")
+            .is_some_and(|close| rest[..close + 2].contains(&needle));
+    }
+    if source[import_start..].starts_with("import ") {
+        let line_end = source[import_start..]
+            .find('\n')
+            .map(|idx| import_start + idx)
+            .unwrap_or(source.len());
+        return source[import_start..line_end].contains(&needle);
+    }
+    false
+}
+
+fn go_runtime_insert_offset(source: &str) -> Result<usize, SchemaRewriteError> {
+    let package_end = go_package_decl_end(source)?;
+    let import_start = skip_ascii_whitespace(source, package_end);
+    if source[import_start..].starts_with("import (") {
+        let rest = &source[import_start..];
+        let close = rest
+            .find("\n)")
+            .ok_or_else(|| SchemaRewriteError::new("could not find end of Go import block"))?;
+        let mut offset = import_start + close + 2;
+        if source.as_bytes().get(offset) == Some(&b'\n') {
+            offset += 1;
+        }
+        return Ok(offset);
+    }
+    if source[import_start..].starts_with("import ") {
+        return Ok(source[import_start..]
+            .find('\n')
+            .map(|idx| import_start + idx + 1)
+            .unwrap_or(source.len()));
+    }
+    Ok(package_end)
+}
+
+fn go_package_decl_end(source: &str) -> Result<usize, SchemaRewriteError> {
+    let mut offset = 0usize;
+    for line in source.split_inclusive('\n') {
+        if line.trim_start().starts_with("package ") {
+            return Ok(offset + line.len());
+        }
+        offset += line.len();
+    }
+    if source.trim_start().starts_with("package ") {
+        return Ok(source.len());
+    }
+    Err(SchemaRewriteError::new(
+        "could not find Go package declaration",
+    ))
+}
+
+fn skip_ascii_whitespace(source: &str, mut offset: usize) -> usize {
+    while source
+        .as_bytes()
+        .get(offset)
+        .is_some_and(u8::is_ascii_whitespace)
+    {
+        offset += 1;
+    }
+    offset
 }
 
 fn schema_kind_for_operator(operator: &str) -> Option<SchemaKind> {
@@ -772,5 +1153,91 @@ mod tests {
         assert_eq!(plan.selected.len(), 1);
         assert_eq!(plan.fallback.len(), 1);
         assert_eq!(plan.fallback[0].reason, SchemaSkipReason::OverlappingRange);
+    }
+
+    #[test]
+    fn rewrite_go_files_expands_operator_mutation_to_expression_wrapper() {
+        let dir = TempDir::new().unwrap();
+        let source = "package calc\nfunc packageName() string { return \"os\" }\nfunc f(a, b int) bool { return a == b }\n";
+        write_source(&dir, "calc.go", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "go",
+            "calc.go",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_go_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(rewrites.len(), 1);
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.contains("import (\n    \"os\"\n)"));
+        assert!(rewritten.contains("func __togi_active(id string) bool"));
+        assert!(
+            rewritten.contains(
+                "func() bool { if __togi_active(\"7\") { return a != b } return a == b }()"
+            )
+        );
+    }
+
+    #[test]
+    fn rewrite_go_files_injects_one_helper_per_package_directory() {
+        let dir = TempDir::new().unwrap();
+        let first_source = "package calc\nfunc f(a, b int) bool { return a == b }\n";
+        let second_source = "package calc\nfunc g(c, d int) bool { return c == d }\n";
+        write_source(&dir, "first.go", first_source);
+        write_source(&dir, "second.go", second_source);
+        let first_operator = first_source.find("==").unwrap();
+        let second_operator = second_source.find("==").unwrap();
+        let first = mutation(
+            "go",
+            "first.go",
+            "==",
+            "!=",
+            first_operator..first_operator + 2,
+            "eq_to_neq",
+        );
+        let second = mutation(
+            "go",
+            "second.go",
+            "==",
+            "!=",
+            second_operator..second_operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_go_files(
+            dir.path(),
+            &[
+                SchemaMutation {
+                    mutation: first,
+                    kind: SchemaKind::Expression,
+                },
+                SchemaMutation {
+                    mutation: second,
+                    kind: SchemaKind::Expression,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(rewrites.len(), 2);
+        let helper_count = rewrites
+            .iter()
+            .filter(|rewrite| {
+                String::from_utf8_lossy(&rewrite.content).contains("func __togi_active(")
+            })
+            .count();
+        assert_eq!(helper_count, 1);
     }
 }

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -7,7 +7,7 @@
 
 use crate::Mutation;
 use crate::operators;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -142,7 +142,7 @@ impl SchemaAdapter for GoSchema {
 
     fn wrap_expression(&self, mutant_id: u32, original: &str, replacement: &str) -> String {
         format!(
-            "func() bool {{ if __togi_active(\"{mutant_id}\") {{ return {replacement} }} return {original} }}()"
+            "func() bool {{ if __togi_active(\"{mutant_id}\") {{ return {replacement} }}; return {original} }}()"
         )
     }
 
@@ -351,23 +351,24 @@ pub fn rewrite_go_files(
     }
 
     let mut rewritten = BTreeMap::new();
-    let mut helper_file_by_dir = BTreeMap::<PathBuf, PathBuf>::new();
+    let mut helper_file_by_package = BTreeMap::<(PathBuf, String), PathBuf>::new();
     for (file, mutations) in by_file {
         let source = std::fs::read_to_string(&file).map_err(|e| {
             SchemaRewriteError::new(format!("could not read {}: {e}", file.display()))
         })?;
+        let package_name = go_package_name(&source)?;
         let rewritten_source = rewrite_go_file(&source, &mutations, adapter)?;
         let dir = file
             .parent()
             .map(Path::to_path_buf)
             .unwrap_or_else(|| project_root.to_path_buf());
-        helper_file_by_dir
-            .entry(dir)
+        helper_file_by_package
+            .entry((dir, package_name))
             .or_insert_with(|| file.clone());
         rewritten.insert(file, rewritten_source);
     }
 
-    for helper_file in helper_file_by_dir.values() {
+    for helper_file in helper_file_by_package.values() {
         if let Some(source) = rewritten.get_mut(helper_file) {
             *source = inject_go_runtime(source, adapter)?;
         }
@@ -569,10 +570,36 @@ enum GoImportDeclaration {
         end: usize,
     },
     Single {
-        import_start: usize,
         path_start: usize,
         end: usize,
     },
+}
+
+impl GoImportDeclaration {
+    fn end(self) -> usize {
+        match self {
+            Self::Block { end, .. } | Self::Single { end, .. } => end,
+        }
+    }
+
+    fn import_text(self, source: &str) -> &str {
+        match self {
+            Self::Block {
+                open_end,
+                close_start,
+                ..
+            } => &source[open_end..close_start],
+            Self::Single { path_start, end } => &source[path_start..end],
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GoImportRegion {
+    declarations: Vec<GoImportDeclaration>,
+    imports: BTreeSet<String>,
+    new_import_block_offset: usize,
+    runtime_insert_offset: usize,
 }
 
 fn ensure_go_imports(mut source: String, imports: &[&str]) -> Result<String, SchemaRewriteError> {
@@ -585,98 +612,150 @@ fn ensure_go_imports(mut source: String, imports: &[&str]) -> Result<String, Sch
         return Ok(source);
     }
 
-    let package_end = go_package_decl_end(&source)?;
-    match go_import_declaration(&source, package_end) {
-        Some(GoImportDeclaration::Block {
-            import_start,
-            open_end,
-            close_start,
-            end,
-        }) => {
-            let body = &source[open_end..close_start];
-            if body.contains('\n') {
-                let insertion = missing
-                    .iter()
-                    .map(|import| format!("\n    \"{import}\""))
-                    .collect::<String>();
-                source.insert_str(open_end, &insertion);
-            } else {
-                let existing_imports = body.trim();
-                let mut replacement = String::from("import (\n");
-                for import in missing {
-                    replacement.push_str(&format!("    \"{import}\"\n"));
-                }
-                if !existing_imports.is_empty() {
-                    replacement.push_str("    ");
-                    replacement.push_str(existing_imports);
-                    replacement.push('\n');
-                }
-                replacement.push(')');
-                source.replace_range(import_start..end, &replacement);
-            }
-            return Ok(source);
-        }
-        Some(GoImportDeclaration::Single {
-            import_start,
-            path_start,
-            end,
-        }) => {
-            let existing_import = source[path_start..end].trim();
-            let mut replacement = String::from("import (\n");
-            for import in missing {
-                replacement.push_str(&format!("    \"{import}\"\n"));
-            }
-            replacement.push_str("    ");
-            replacement.push_str(existing_import);
-            replacement.push_str("\n)");
-            source.replace_range(import_start..end, &replacement);
-            return Ok(source);
-        }
-        None => {}
-    }
-
-    let import_block = missing
+    let region = go_import_region(&source)?;
+    if let Some(block) = region
+        .declarations
         .iter()
-        .map(|import| format!("    \"{import}\"\n"))
-        .collect::<String>();
-    source.insert_str(package_end, &format!("\nimport (\n{import_block})\n"));
+        .rev()
+        .copied()
+        .find(|declaration| matches!(declaration, GoImportDeclaration::Block { .. }))
+    {
+        insert_missing_go_imports_into_block(&mut source, block, &missing);
+    } else {
+        let import_block =
+            go_import_block_for_insert(&source, region.new_import_block_offset, &missing);
+        source.insert_str(region.new_import_block_offset, &import_block);
+    }
     Ok(source)
 }
 
 fn go_source_imports(source: &str, import: &str) -> bool {
-    let Ok(package_end) = go_package_decl_end(source) else {
-        return false;
-    };
-    let needle = format!("\"{import}\"");
-    match go_import_declaration(source, package_end) {
-        Some(GoImportDeclaration::Block {
-            open_end,
-            close_start,
-            ..
-        }) => source[open_end..close_start].contains(&needle),
-        Some(GoImportDeclaration::Single {
-            path_start, end, ..
-        }) => source[path_start..end].contains(&needle),
-        None => false,
+    match go_import_region(source) {
+        Ok(region) => region.imports.contains(import),
+        Err(_) => false,
     }
 }
 
 fn go_runtime_insert_offset(source: &str) -> Result<usize, SchemaRewriteError> {
-    let package_end = go_package_decl_end(source)?;
-    match go_import_declaration(source, package_end) {
-        Some(GoImportDeclaration::Block { end, .. } | GoImportDeclaration::Single { end, .. }) => {
-            let mut offset = end;
-            if source.as_bytes().get(offset) == Some(&b'\n') {
-                offset += 1;
-            }
-            Ok(offset)
+    Ok(go_import_region(source)?.runtime_insert_offset)
+}
+
+fn insert_missing_go_imports_into_block(
+    source: &mut String,
+    declaration: GoImportDeclaration,
+    missing: &[&str],
+) {
+    let GoImportDeclaration::Block {
+        import_start,
+        open_end,
+        close_start,
+        end,
+    } = declaration
+    else {
+        return;
+    };
+
+    let body = &source[open_end..close_start];
+    if body.contains('\n') {
+        let insertion_at = go_import_block_append_offset(source, close_start);
+        let mut insertion = String::new();
+        if insertion_at == open_end
+            || !source
+                .as_bytes()
+                .get(insertion_at.saturating_sub(1))
+                .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
+        {
+            insertion.push('\n');
         }
-        None => Ok(package_end),
+        for import in missing {
+            insertion.push_str(&format!("    \"{import}\"\n"));
+        }
+        source.insert_str(insertion_at, &insertion);
+    } else {
+        let existing_imports = body.trim();
+        let mut replacement = String::from("import (\n");
+        if !existing_imports.is_empty() {
+            replacement.push_str("    ");
+            replacement.push_str(existing_imports);
+            replacement.push('\n');
+        }
+        for import in missing {
+            replacement.push_str(&format!("    \"{import}\"\n"));
+        }
+        replacement.push(')');
+        source.replace_range(import_start..end, &replacement);
     }
 }
 
-fn go_import_declaration(source: &str, package_end: usize) -> Option<GoImportDeclaration> {
-    let import_start = skip_ascii_whitespace(source, package_end);
+fn go_import_block_append_offset(source: &str, close_start: usize) -> usize {
+    let mut offset = close_start;
+    while offset > 0
+        && source
+            .as_bytes()
+            .get(offset - 1)
+            .is_some_and(|byte| *byte == b' ' || *byte == b'\t')
+    {
+        offset -= 1;
+    }
+    offset
+}
+
+fn go_import_block_for_insert(source: &str, offset: usize, imports: &[&str]) -> String {
+    let mut block = String::new();
+    if offset > 0
+        && !source
+            .as_bytes()
+            .get(offset - 1)
+            .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
+    {
+        block.push('\n');
+    }
+    block.push_str("import (\n");
+    for import in imports {
+        block.push_str(&format!("    \"{import}\"\n"));
+    }
+    block.push_str(")\n");
+    block
+}
+
+fn go_import_region(source: &str) -> Result<GoImportRegion, SchemaRewriteError> {
+    let package_end = go_package_decl_end(source)?;
+    let mut declarations = Vec::new();
+    let mut imports = BTreeSet::new();
+    let mut offset = package_end;
+    let mut first_declaration_offset = None;
+    let mut runtime_insert_offset = package_end;
+
+    loop {
+        let next = skip_go_import_trivia(source, offset);
+        if first_declaration_offset.is_none() {
+            first_declaration_offset = Some(next);
+        }
+        let Some(declaration) = go_import_declaration(source, next) else {
+            break;
+        };
+
+        collect_go_imports(declaration.import_text(source), &mut imports);
+        runtime_insert_offset = go_import_declaration_end_with_line(source, declaration);
+        offset = runtime_insert_offset;
+        declarations.push(declaration);
+    }
+
+    let new_import_block_offset = if declarations.is_empty() {
+        first_declaration_offset.unwrap_or(package_end)
+    } else {
+        runtime_insert_offset
+    };
+
+    Ok(GoImportRegion {
+        declarations,
+        imports,
+        new_import_block_offset,
+        runtime_insert_offset,
+    })
+}
+
+fn go_import_declaration(source: &str, import_start: usize) -> Option<GoImportDeclaration> {
     let rest = source.get(import_start..)?;
     if !rest.starts_with("import") {
         return None;
@@ -706,10 +785,62 @@ fn go_import_declaration(source: &str, package_end: usize) -> Option<GoImportDec
         .map(|idx| spec_start + idx)
         .unwrap_or(source.len());
     Some(GoImportDeclaration::Single {
-        import_start,
         path_start: spec_start,
         end,
     })
+}
+
+fn go_import_declaration_end_with_line(source: &str, declaration: GoImportDeclaration) -> usize {
+    let mut offset = declaration.end();
+    if source.as_bytes().get(offset) == Some(&b'\r') {
+        offset += 1;
+    }
+    if source.as_bytes().get(offset) == Some(&b'\n') {
+        offset += 1;
+    }
+    offset
+}
+
+fn collect_go_imports(source: &str, imports: &mut BTreeSet<String>) {
+    let bytes = source.as_bytes();
+    let mut offset = 0usize;
+    while let Some(relative_start) = bytes[offset..]
+        .iter()
+        .position(|byte| *byte == b'"' || *byte == b'`')
+    {
+        let start = offset + relative_start;
+        let quote = bytes[start];
+        let Some(relative_end) = bytes[start + 1..].iter().position(|byte| *byte == quote) else {
+            break;
+        };
+        let end = start + 1 + relative_end;
+        imports.insert(source[start + 1..end].to_string());
+        offset = end + 1;
+    }
+}
+
+fn skip_go_import_trivia(source: &str, mut offset: usize) -> usize {
+    loop {
+        offset = skip_ascii_whitespace(source, offset);
+        let Some(rest) = source.get(offset..) else {
+            return offset;
+        };
+        if rest.starts_with("//") {
+            offset = rest
+                .find('\n')
+                .map(|idx| offset + idx + 1)
+                .unwrap_or(source.len());
+            continue;
+        }
+        if rest.starts_with("/*") {
+            offset = rest
+                .find("*/")
+                .map(|idx| offset + idx + 2)
+                .unwrap_or(source.len());
+            continue;
+        }
+        return offset;
+    }
 }
 
 fn go_package_decl_end(source: &str) -> Result<usize, SchemaRewriteError> {
@@ -722,6 +853,29 @@ fn go_package_decl_end(source: &str) -> Result<usize, SchemaRewriteError> {
     }
     if source.trim_start().starts_with("package ") {
         return Ok(source.len());
+    }
+    Err(SchemaRewriteError::new(
+        "could not find Go package declaration",
+    ))
+}
+
+fn go_package_name(source: &str) -> Result<String, SchemaRewriteError> {
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("package") else {
+            continue;
+        };
+        if !rest.as_bytes().first().is_some_and(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let name = rest
+            .trim_start()
+            .split(|character: char| character != '_' && !character.is_ascii_alphanumeric())
+            .next()
+            .unwrap_or_default();
+        if !name.is_empty() {
+            return Ok(name.to_string());
+        }
     }
     Err(SchemaRewriteError::new(
         "could not find Go package declaration",
@@ -954,7 +1108,7 @@ mod tests {
         assert_parsed_node_text(&dir, "calc.go", go, "binary_expression", "a == b");
         assert_eq!(
             go.wrap_expression(42, "a == b", "a != b"),
-            "func() bool { if __togi_active(\"42\") { return a != b } return a == b }()"
+            "func() bool { if __togi_active(\"42\") { return a != b }; return a == b }()"
         );
         assert_eq!(go.required_imports(), &["os"]);
 
@@ -1243,19 +1397,21 @@ mod tests {
         let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
         assert!(rewritten.contains("import (\n    \"os\"\n)"));
         assert!(rewritten.contains("func __togi_active(id string) bool"));
-        assert!(
-            rewritten.contains(
-                "func() bool { if __togi_active(\"7\") { return a != b } return a == b }()"
-            )
-        );
+        assert!(rewritten.contains(
+            "func() bool { if __togi_active(\"7\") { return a != b }; return a == b }()"
+        ));
+        parse_go_source(&rewritten).unwrap();
     }
 
     #[test]
     fn go_import_handling_accepts_spacing_variants() {
         let adapter = adapter_for_language("go").unwrap();
         for (import_decl, expected_imports) in [
-            ("import(\"fmt\")", "import (\n    \"os\"\n    \"fmt\"\n)"),
-            ("import\t\"fmt\"", "import (\n    \"os\"\n    \"fmt\"\n)"),
+            ("import(\"fmt\")", "import (\n    \"fmt\"\n    \"os\"\n)"),
+            (
+                "import\t\"fmt\"",
+                "import\t\"fmt\"\nimport (\n    \"os\"\n)",
+            ),
         ] {
             let source = format!(
                 "package calc\n{import_decl}\nfunc packageName() string {{ return fmt.Sprintf(\"%s\", \"os\") }}\nfunc f(a, b int) bool {{ return a == b }}\n",
@@ -1278,6 +1434,26 @@ mod tests {
                     < rewritten.find("func packageName()").unwrap()
             );
         }
+    }
+
+    #[test]
+    fn go_import_handling_scans_comments_and_multiple_declarations() {
+        let adapter = adapter_for_language("go").unwrap();
+        let source = "package calc\n\n// generated imports\nimport \"fmt\"\n\n// grouped imports\nimport (\n    \"strings\"\n)\n\nfunc packageName() string { return fmt.Sprintf(\"%s\", strings.TrimSpace(\"os\")) }\n";
+        parse_go_source(source).unwrap();
+        assert!(go_source_imports(source, "fmt"));
+        assert!(go_source_imports(source, "strings"));
+        assert!(!go_source_imports(source, "os"));
+
+        let rewritten = inject_go_runtime(source, adapter).unwrap();
+
+        assert!(rewritten.contains("import \"fmt\""));
+        assert!(rewritten.contains("import (\n    \"strings\"\n    \"os\"\n)"));
+        let helper = rewritten.find("func __togi_active(").unwrap();
+        assert!(helper > rewritten.find("\"fmt\"").unwrap());
+        assert!(helper > rewritten.find("\"os\"").unwrap());
+        assert!(helper < rewritten.find("func packageName()").unwrap());
+        parse_go_source(&rewritten).unwrap();
     }
 
     #[test]
@@ -1329,5 +1505,54 @@ mod tests {
             })
             .count();
         assert_eq!(helper_count, 1);
+    }
+
+    #[test]
+    fn rewrite_go_files_injects_helpers_per_directory_and_package() {
+        let dir = TempDir::new().unwrap();
+        let first_source = "package calc\nfunc f(a, b int) bool { return a == b }\n";
+        let second_source = "package calc_test\nfunc g(c, d int) bool { return c == d }\n";
+        write_source(&dir, "calc.go", first_source);
+        write_source(&dir, "calc_test.go", second_source);
+        let first_operator = first_source.find("==").unwrap();
+        let second_operator = second_source.find("==").unwrap();
+        let first = mutation(
+            "go",
+            "calc.go",
+            "==",
+            "!=",
+            first_operator..first_operator + 2,
+            "eq_to_neq",
+        );
+        let second = mutation(
+            "go",
+            "calc_test.go",
+            "==",
+            "!=",
+            second_operator..second_operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_go_files(
+            dir.path(),
+            &[
+                SchemaMutation {
+                    mutation: first,
+                    kind: SchemaKind::Expression,
+                },
+                SchemaMutation {
+                    mutation: second,
+                    kind: SchemaKind::Expression,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(rewrites.len(), 2);
+        for rewrite in rewrites {
+            let rewritten = String::from_utf8(rewrite.content).unwrap();
+            assert!(rewritten.contains("func __togi_active("));
+            parse_go_source(&rewritten).unwrap();
+        }
     }
 }

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -560,6 +560,21 @@ fn inject_go_runtime(
     Ok(rewritten)
 }
 
+#[derive(Debug, Clone, Copy)]
+enum GoImportDeclaration {
+    Block {
+        import_start: usize,
+        open_end: usize,
+        close_start: usize,
+        end: usize,
+    },
+    Single {
+        import_start: usize,
+        path_start: usize,
+        end: usize,
+    },
+}
+
 fn ensure_go_imports(mut source: String, imports: &[&str]) -> Result<String, SchemaRewriteError> {
     let missing: Vec<&str> = imports
         .iter()
@@ -571,32 +586,53 @@ fn ensure_go_imports(mut source: String, imports: &[&str]) -> Result<String, Sch
     }
 
     let package_end = go_package_decl_end(&source)?;
-    let import_start = skip_ascii_whitespace(&source, package_end);
-    if source[import_start..].starts_with("import (") {
-        let open_end = import_start + "import (".len();
-        let insertion = missing
-            .iter()
-            .map(|import| format!("\n    \"{import}\""))
-            .collect::<String>();
-        source.insert_str(open_end, &insertion);
-        return Ok(source);
-    }
-
-    if source[import_start..].starts_with("import ") {
-        let line_end = source[import_start..]
-            .find('\n')
-            .map(|idx| import_start + idx)
-            .unwrap_or(source.len());
-        let existing_import = source[import_start + "import ".len()..line_end].trim();
-        let mut replacement = String::from("import (\n");
-        for import in missing {
-            replacement.push_str(&format!("    \"{import}\"\n"));
+    match go_import_declaration(&source, package_end) {
+        Some(GoImportDeclaration::Block {
+            import_start,
+            open_end,
+            close_start,
+            end,
+        }) => {
+            let body = &source[open_end..close_start];
+            if body.contains('\n') {
+                let insertion = missing
+                    .iter()
+                    .map(|import| format!("\n    \"{import}\""))
+                    .collect::<String>();
+                source.insert_str(open_end, &insertion);
+            } else {
+                let existing_imports = body.trim();
+                let mut replacement = String::from("import (\n");
+                for import in missing {
+                    replacement.push_str(&format!("    \"{import}\"\n"));
+                }
+                if !existing_imports.is_empty() {
+                    replacement.push_str("    ");
+                    replacement.push_str(existing_imports);
+                    replacement.push('\n');
+                }
+                replacement.push(')');
+                source.replace_range(import_start..end, &replacement);
+            }
+            return Ok(source);
         }
-        replacement.push_str("    ");
-        replacement.push_str(existing_import);
-        replacement.push_str("\n)");
-        source.replace_range(import_start..line_end, &replacement);
-        return Ok(source);
+        Some(GoImportDeclaration::Single {
+            import_start,
+            path_start,
+            end,
+        }) => {
+            let existing_import = source[path_start..end].trim();
+            let mut replacement = String::from("import (\n");
+            for import in missing {
+                replacement.push_str(&format!("    \"{import}\"\n"));
+            }
+            replacement.push_str("    ");
+            replacement.push_str(existing_import);
+            replacement.push_str("\n)");
+            source.replace_range(import_start..end, &replacement);
+            return Ok(source);
+        }
+        None => {}
     }
 
     let import_block = missing
@@ -611,45 +647,69 @@ fn go_source_imports(source: &str, import: &str) -> bool {
     let Ok(package_end) = go_package_decl_end(source) else {
         return false;
     };
-    let import_start = skip_ascii_whitespace(source, package_end);
     let needle = format!("\"{import}\"");
-    if source[import_start..].starts_with("import (") {
-        let rest = &source[import_start..];
-        return rest
-            .find("\n)")
-            .is_some_and(|close| rest[..close + 2].contains(&needle));
+    match go_import_declaration(source, package_end) {
+        Some(GoImportDeclaration::Block {
+            open_end,
+            close_start,
+            ..
+        }) => source[open_end..close_start].contains(&needle),
+        Some(GoImportDeclaration::Single {
+            path_start, end, ..
+        }) => source[path_start..end].contains(&needle),
+        None => false,
     }
-    if source[import_start..].starts_with("import ") {
-        let line_end = source[import_start..]
-            .find('\n')
-            .map(|idx| import_start + idx)
-            .unwrap_or(source.len());
-        return source[import_start..line_end].contains(&needle);
-    }
-    false
 }
 
 fn go_runtime_insert_offset(source: &str) -> Result<usize, SchemaRewriteError> {
     let package_end = go_package_decl_end(source)?;
-    let import_start = skip_ascii_whitespace(source, package_end);
-    if source[import_start..].starts_with("import (") {
-        let rest = &source[import_start..];
-        let close = rest
-            .find("\n)")
-            .ok_or_else(|| SchemaRewriteError::new("could not find end of Go import block"))?;
-        let mut offset = import_start + close + 2;
-        if source.as_bytes().get(offset) == Some(&b'\n') {
-            offset += 1;
+    match go_import_declaration(source, package_end) {
+        Some(GoImportDeclaration::Block { end, .. } | GoImportDeclaration::Single { end, .. }) => {
+            let mut offset = end;
+            if source.as_bytes().get(offset) == Some(&b'\n') {
+                offset += 1;
+            }
+            Ok(offset)
         }
-        return Ok(offset);
+        None => Ok(package_end),
     }
-    if source[import_start..].starts_with("import ") {
-        return Ok(source[import_start..]
-            .find('\n')
-            .map(|idx| import_start + idx + 1)
-            .unwrap_or(source.len()));
+}
+
+fn go_import_declaration(source: &str, package_end: usize) -> Option<GoImportDeclaration> {
+    let import_start = skip_ascii_whitespace(source, package_end);
+    let rest = source.get(import_start..)?;
+    if !rest.starts_with("import") {
+        return None;
     }
-    Ok(package_end)
+
+    let keyword_end = import_start + "import".len();
+    match source.as_bytes().get(keyword_end) {
+        Some(byte) if byte.is_ascii_whitespace() || *byte == b'(' => {}
+        _ => return None,
+    }
+
+    let spec_start = skip_ascii_whitespace(source, keyword_end);
+    if source.as_bytes().get(spec_start) == Some(&b'(') {
+        let open_end = spec_start + 1;
+        let close_start = source[open_end..].find(')')? + open_end;
+        return Some(GoImportDeclaration::Block {
+            import_start,
+            open_end,
+            close_start,
+            end: close_start + 1,
+        });
+    }
+
+    source.as_bytes().get(spec_start)?;
+    let end = source[spec_start..]
+        .find('\n')
+        .map(|idx| spec_start + idx)
+        .unwrap_or(source.len());
+    Some(GoImportDeclaration::Single {
+        import_start,
+        path_start: spec_start,
+        end,
+    })
 }
 
 fn go_package_decl_end(source: &str) -> Result<usize, SchemaRewriteError> {
@@ -1188,6 +1248,36 @@ mod tests {
                 "func() bool { if __togi_active(\"7\") { return a != b } return a == b }()"
             )
         );
+    }
+
+    #[test]
+    fn go_import_handling_accepts_spacing_variants() {
+        let adapter = adapter_for_language("go").unwrap();
+        for (import_decl, expected_imports) in [
+            ("import(\"fmt\")", "import (\n    \"os\"\n    \"fmt\"\n)"),
+            ("import\t\"fmt\"", "import (\n    \"os\"\n    \"fmt\"\n)"),
+        ] {
+            let source = format!(
+                "package calc\n{import_decl}\nfunc packageName() string {{ return fmt.Sprintf(\"%s\", \"os\") }}\nfunc f(a, b int) bool {{ return a == b }}\n",
+            );
+            parse_go_source(&source).unwrap();
+            assert!(go_source_imports(&source, "fmt"));
+            assert!(!go_source_imports(&source, "os"));
+
+            let rewritten = inject_go_runtime(&source, adapter).unwrap();
+
+            assert!(
+                rewritten.contains(expected_imports),
+                "rewritten source did not contain {expected_imports:?}:\n{rewritten}"
+            );
+            parse_go_source(&rewritten).unwrap_or_else(|error| {
+                panic!("rewritten source failed to parse: {error:?}\n{rewritten}")
+            });
+            assert!(
+                rewritten.find("func __togi_active(").unwrap()
+                    < rewritten.find("func packageName()").unwrap()
+            );
+        }
     }
 
     #[test]

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -60,6 +60,11 @@ max_per_run = 20
 # 0 means unlimited.
 max_per_file = 20
 
+# Opt in to supported mutant schemata execution.
+# Type: boolean
+# Default: false
+schemata = false
+
 # Optional LCOV file. When set, togi only keeps mutations on covered lines.
 # Type: string path
 # Default: unset


### PR DESCRIPTION
## Summary
- add --schemata / [mutations] schemata opt-in for schema execution
- rewrite compatible Go expression mutations once with TOGI_MUTANT runtime switching
- run Go schema mutants from one rewritten workspace with go test -count=1, while unsupported mutations fall back to the existing runner

## Tests
- cargo test schemata --locked
- cargo test --locked
- cargo clippy --locked -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag and config option to opt into Go mutant schemata, enabling a dedicated execution path for Go mutations that performs isolated source rewrites and enforces deterministic test runs.

* **Documentation**
  * Updated usage docs and example config/template to describe the new schemata option and how to enable it.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/345)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->