### PR TITLE
Add Rust schemata execution

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1093,32 +1093,38 @@ impl TestRunner {
             .map(|(index, mutation)| (mutation.id, index))
             .collect();
         let plan = crate::schemata::plan(&self.project_root, mutations);
-        let mut schema_mutations = Vec::new();
+        let mut schema_by_language = HashMap::<String, Vec<crate::schemata::SchemaMutation>>::new();
         let mut fallback_mutations = Vec::new();
 
         for schema_mutation in plan.selected {
-            if schema_mutation.mutation.language == "go" {
-                schema_mutations.push(schema_mutation);
-            } else {
-                fallback_mutations.push(schema_mutation.mutation);
+            match schema_mutation.mutation.language.as_str() {
+                "go" | "rust" => {
+                    schema_by_language
+                        .entry(schema_mutation.mutation.language.clone())
+                        .or_default()
+                        .push(schema_mutation);
+                }
+                _ => fallback_mutations.push(schema_mutation.mutation),
             }
         }
         fallback_mutations.extend(plan.fallback.into_iter().map(|fallback| fallback.mutation));
 
-        if schema_mutations.is_empty() {
+        if schema_by_language.is_empty() {
             return self.run_regular(fallback_mutations);
         }
 
         let mut all_results = Vec::new();
-        match self.run_go_schema_mutations(&schema_mutations) {
-            Ok(results) => all_results.extend(results),
-            Err(err) => {
-                eprintln!("warning: could not run Go schemata: {err} — falling back");
-                fallback_mutations.extend(
-                    schema_mutations
-                        .into_iter()
-                        .map(|schema_mutation| schema_mutation.mutation),
-                );
+        for (language, schema_mutations) in schema_by_language {
+            match self.run_schema_mutations(&language, &schema_mutations) {
+                Ok(results) => all_results.extend(results),
+                Err(err) => {
+                    eprintln!("warning: could not run {language} schemata: {err} — falling back");
+                    fallback_mutations.extend(
+                        schema_mutations
+                            .into_iter()
+                            .map(|schema_mutation| schema_mutation.mutation),
+                    );
+                }
             }
         }
 
@@ -1275,11 +1281,20 @@ impl TestRunner {
         self.outcome_from_results(all_results, start.elapsed())
     }
 
-    fn run_go_schema_mutations(
+    fn run_schema_mutations(
         &self,
+        language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
     ) -> Result<Vec<(Mutation, MutationResult)>, crate::schemata::SchemaRewriteError> {
-        let rewrites = crate::schemata::rewrite_go_files(&self.project_root, schema_mutations)?;
+        let rewrites = match language {
+            "go" => crate::schemata::rewrite_go_files(&self.project_root, schema_mutations)?,
+            "rust" => crate::schemata::rewrite_rust_files(&self.project_root, schema_mutations)?,
+            _ => {
+                return Err(crate::schemata::SchemaRewriteError::new(format!(
+                    "{language} schemata execution is not available"
+                )));
+            }
+        };
         let workspace =
             copy_workspace_with_options(&self.project_root, self.respect_workspace_ignores)
                 .map_err(|e| {
@@ -1340,10 +1355,15 @@ impl TestRunner {
             }
             let mutation = &schema_mutation.mutation;
             let selected = select_test_command(&self.project_root, &self.commands, mutation);
+            let argv = if language == "go" {
+                force_go_no_test_cache(selected.argv)
+            } else {
+                selected.argv
+            };
             let mut env = self.env.clone();
             env.insert("TOGI_MUTANT".to_string(), mutation.id.to_string());
             let outcome = run_command(
-                &force_go_no_test_cache(selected.argv),
+                &argv,
                 workspace.root(),
                 selected.timeout,
                 self.show_output,
@@ -2326,6 +2346,12 @@ mod tests {
             replacement: "!=".into(),
             byte_range: offset..offset + 2,
         }
+    }
+
+    fn rust_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
+        let mut mutation = go_operator_mutation(id, file, source, nth);
+        mutation.language = "rust".into();
+        mutation
     }
 
     #[test]
@@ -3528,6 +3554,61 @@ esac
         assert_eq!(report.total, 2);
         assert_eq!(report.results[0].1, MutationResult::Killed);
         assert_eq!(report.results[1].1, MutationResult::Survived);
+    }
+
+    #[test]
+    fn run_with_schemata_executes_rust_mutation_with_active_env() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"schemata_fixture\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        let source = "\
+pub fn same(a: i32, b: i32) -> bool { a == b }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_values_match() {
+        assert!(same(1, 1));
+        assert!(!same(1, 2));
+    }
+}
+";
+        std::fs::write(dir.path().join("src/lib.rs"), source).unwrap();
+        let mutation = rust_operator_mutation(0, "src/lib.rs", source, 0);
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["cargo".into(), "test".into(), "--quiet".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(15),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![mutation]).report;
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1349,10 +1349,18 @@ impl TestRunner {
         }
 
         let mut results = Vec::with_capacity(schema_mutations.len());
+        let tested_counter = Arc::new(AtomicUsize::new(0));
+        let source_contents = SourceContentCache::default();
+        let cache_context_hash = cache_context_fingerprint(&self.project_root);
         for schema_mutation in schema_mutations {
             if self.cancelled.load(Ordering::Acquire) {
                 break;
             }
+            let Some(reservation) =
+                TestSlotReservation::try_reserve(self.max_tested, &tested_counter)
+            else {
+                break;
+            };
             let mutation = &schema_mutation.mutation;
             let selected = select_test_command(&self.project_root, &self.commands, mutation);
             let argv = if language == "go" {
@@ -1362,6 +1370,42 @@ impl TestRunner {
             };
             let mut env = self.env.clone();
             env.insert("TOGI_MUTANT".to_string(), mutation.id.to_string());
+            let cache_selected = SelectedTestCommand {
+                argv: argv.clone(),
+                timeout: selected.timeout,
+            };
+            let cache_ctx = cache_selected.cache_context(
+                &self.commands.build_command,
+                self.commands.build_command_explicit,
+                &env,
+            );
+            let cache_ctx = format!("{cache_ctx};context={cache_context_hash:016x}");
+            let cache_key = source_contents
+                .content_for(&self.project_root, &mutation.file)
+                .map(|content| {
+                    CacheKey::new(
+                        &content,
+                        &cache_identity(&self.project_root, mutation),
+                        &mutation.description,
+                        &cache_ctx,
+                    )
+                });
+            if let Some(ref key) = cache_key {
+                if let Some(result) = cache::lookup(&self.project_root, key) {
+                    reservation.release();
+                    if self.verbose {
+                        eprintln!(
+                            "  [schema] ↻ cached  {}:{} — {}",
+                            mutation.file.display(),
+                            mutation.line,
+                            mutation.operator
+                        );
+                    }
+                    results.push((mutation.clone(), result));
+                    continue;
+                }
+            }
+
             let outcome = run_command(
                 &argv,
                 workspace.root(),
@@ -1372,6 +1416,14 @@ impl TestRunner {
             );
             if outcome.cancelled {
                 break;
+            }
+            if outcome.result == MutationResult::BuildError {
+                reservation.release();
+            } else {
+                reservation.commit();
+            }
+            if let Some(ref key) = cache_key {
+                cache::store(&self.project_root, key, outcome.result);
             }
             if self.verbose {
                 let symbol = match outcome.result {
@@ -3556,6 +3608,92 @@ esac
         assert_eq!(report.results[1].1, MutationResult::Survived);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn run_with_schemata_uses_cache_and_releases_max_reservation() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let source = "\
+package calc
+func first(a, b int) bool { return a == b }
+func second(c, d int) bool { return c == d }
+";
+        std::fs::write(dir.path().join("calc.go"), source).unwrap();
+        let first = go_operator_mutation(0, "calc.go", source, 0);
+        let second = go_operator_mutation(1, "calc.go", source, 1);
+        let script = r#"
+runs=0
+if [ -f "$STATE_DIR/runs" ]; then runs=$(cat "$STATE_DIR/runs"); fi
+runs=$((runs + 1))
+printf '%s\n' "$runs" > "$STATE_DIR/runs"
+case "$TOGI_MUTANT" in
+  1) exit 0 ;;
+  *) exit 2 ;;
+esac
+"#;
+        let mut env = HashMap::new();
+        env.insert("STATE_DIR".to_string(), state.path().display().to_string());
+        let commands = CommandConfig {
+            command: vec!["sh".into(), "-c".into(), script.into()],
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let mut cache_env = env.clone();
+        cache_env.insert("TOGI_MUTANT".to_string(), first.id.to_string());
+        let selected = select_test_command(dir.path(), &commands, &first);
+        let cache_selected = SelectedTestCommand {
+            argv: selected.argv,
+            timeout: selected.timeout,
+        };
+        let cache_ctx = cache_selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &cache_env,
+        );
+        let cache_ctx = format!(
+            "{cache_ctx};context={:016x}",
+            cache_context_fingerprint(dir.path())
+        );
+        let key = CacheKey::new(
+            source.as_bytes(),
+            &cache_identity(dir.path(), &first),
+            &first.description,
+            &cache_ctx,
+        );
+        cache::store(dir.path(), &key, MutationResult::Survived);
+
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: Some(1),
+            respect_workspace_ignores: true,
+            env,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![first, second]).report;
+        let runs: usize = std::fs::read_to_string(state.path().join("runs"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+
+        assert_eq!(report.total, 2);
+        assert_eq!(report.results[0].1, MutationResult::Survived);
+        assert_eq!(report.results[1].1, MutationResult::Survived);
+        assert_eq!(runs, 1);
+    }
+
     #[test]
     fn run_with_schemata_executes_rust_mutation_with_active_env() {
         let dir = tempfile::tempdir().unwrap();
@@ -3591,7 +3729,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 build_command_explicit: false,
-                timeout: Duration::from_secs(15),
+                timeout: Duration::from_secs(60),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
             },
@@ -3601,7 +3739,14 @@ mod tests {
             show_output: false,
             max_tested: None,
             respect_workspace_ignores: true,
-            env: HashMap::new(),
+            env: {
+                let mut env = HashMap::new();
+                env.insert(
+                    "CARGO_TARGET_DIR".to_string(),
+                    dir.path().join("target").display().to_string(),
+                );
+                env
+            },
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -124,6 +124,28 @@ struct RustSchema;
 struct PythonSchema;
 struct TypeScriptSchema;
 
+const RUST_OPERATOR_ALLOWLIST: &[&str] = &[
+    "eq_to_neq",
+    "lt_to_lte",
+    "gt_to_gte",
+    "and_to_or",
+    "or_to_and",
+    "mul_to_div",
+    "div_to_mul",
+    "mod_to_mul",
+    "plus_to_minus",
+    "minus_to_plus",
+    "true_to_false",
+    "false_to_true",
+    "zero_to_one",
+    "string_to_empty",
+    "increment_numeric",
+    "decrement_numeric",
+    "remove_unary_not",
+    "remove_unary_neg",
+    "negate_condition",
+];
+
 impl SchemaAdapter for GoSchema {
     fn language(&self) -> &str {
         "go"
@@ -200,13 +222,10 @@ where
         if rust_line_looks_compile_time(mutation, source) {
             return Err(SchemaSkipReason::CompileTimeContext);
         }
-        match mutation.operator.as_str() {
-            "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
-            | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" | "true_to_false"
-            | "false_to_true" | "zero_to_one" | "string_to_empty" | "increment_numeric"
-            | "decrement_numeric" | "remove_unary_not" | "remove_unary_neg"
-            | "negate_condition" => Ok(SchemaKind::Expression),
-            _ => Err(SchemaSkipReason::UnsupportedOperator),
+        if RUST_OPERATOR_ALLOWLIST.contains(&mutation.operator.as_str()) {
+            Ok(SchemaKind::Expression)
+        } else {
+            Err(SchemaSkipReason::UnsupportedOperator)
         }
     }
 
@@ -624,6 +643,13 @@ fn rust_expression_range_for_mutation(
     source: &str,
     mutation: &Mutation,
 ) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    if !RUST_OPERATOR_ALLOWLIST.contains(&mutation.operator.as_str()) {
+        return Err(SchemaRewriteError::new(format!(
+            "unsupported Rust schema operator {}",
+            mutation.operator
+        )));
+    }
+
     match mutation.operator.as_str() {
         "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
         | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" => {
@@ -645,7 +671,7 @@ fn rust_expression_range_for_mutation(
             Ok(mutation.byte_range.clone())
         }
         _ => Err(SchemaRewriteError::new(format!(
-            "unsupported Rust schema operator {}",
+            "accepted Rust schema operator has no rewrite strategy: {}",
             mutation.operator
         ))),
     }
@@ -764,15 +790,35 @@ fn inject_rust_runtime(source: &str, adapter: &dyn SchemaAdapter) -> String {
 
 fn rust_runtime_insert_offset(source: &str) -> usize {
     let mut offset = 0usize;
-    for line in source.split_inclusive('\n') {
+    let mut lines = source.split_inclusive('\n');
+
+    while let Some(line) = lines.next() {
         let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with("#![") {
+        if trimmed.is_empty() || trimmed.starts_with("//") {
             offset += line.len();
+        } else if trimmed.starts_with("#![") {
+            let mut balance = square_bracket_balance(line);
+            offset += line.len();
+            while balance > 0 {
+                let Some(line) = lines.next() else {
+                    break;
+                };
+                balance += square_bracket_balance(line);
+                offset += line.len();
+            }
         } else {
             break;
         }
     }
     offset
+}
+
+fn square_bracket_balance(line: &str) -> i32 {
+    line.chars().fold(0, |balance, character| match character {
+        '[' => balance + 1,
+        ']' => balance - 1,
+        _ => balance,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1647,6 +1693,40 @@ mod tests {
         assert!(rewritten.contains("fn __togi_active(id: u32) -> bool"));
         assert!(
             rewritten.contains("__togi_select(7, || { a == b }, || { a != b })"),
+            "{rewritten}"
+        );
+        parse_rust_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_rust_files_inserts_helper_after_multiline_inner_attribute() {
+        let dir = TempDir::new().unwrap();
+        let source = "#![doc(\n    html_logo_url = \"https://example.com/logo.png\"\n)]\npub fn f(a: i32, b: i32) -> bool { a == b }\n";
+        write_source(&dir, "src/lib.rs", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "rust",
+            "src/lib.rs",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_rust_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(
+            rewritten.starts_with(
+                "#![doc(\n    html_logo_url = \"https://example.com/logo.png\"\n)]\n#[allow(dead_code)]\n"
+            ),
             "{rewritten}"
         );
         parse_rust_source(&rewritten).unwrap();

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -195,6 +195,21 @@ where
         format!("if __togi_active({mutant_id}) {{ {replacement} }} else {{ {original} }}")
     }
 
+    fn classify(&self, mutation: &Mutation, source: &[u8]) -> Result<SchemaKind, SchemaSkipReason> {
+        validate_source_range(mutation, source)?;
+        if rust_line_looks_compile_time(mutation, source) {
+            return Err(SchemaSkipReason::CompileTimeContext);
+        }
+        match mutation.operator.as_str() {
+            "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
+            | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" | "true_to_false"
+            | "false_to_true" | "zero_to_one" | "string_to_empty" | "increment_numeric"
+            | "decrement_numeric" | "remove_unary_not" | "remove_unary_neg"
+            | "negate_condition" => Ok(SchemaKind::Expression),
+            _ => Err(SchemaSkipReason::UnsupportedOperator),
+        }
+    }
+
     fn is_compile_time_context(&self, mutation: &Mutation, source: &[u8]) -> bool {
         rust_line_looks_compile_time(mutation, source)
     }
@@ -383,6 +398,52 @@ pub fn rewrite_go_files(
         .collect())
 }
 
+/// Rewrite Rust files once so selected mutations can be activated by `TOGI_MUTANT`.
+pub fn rewrite_rust_files(
+    project_root: &Path,
+    selected: &[SchemaMutation],
+) -> Result<Vec<SchemaFileRewrite>, SchemaRewriteError> {
+    let Some(adapter) = adapter_for_language("rust") else {
+        return Err(SchemaRewriteError::new(
+            "rust schema adapter is not available",
+        ));
+    };
+
+    let mut by_file: BTreeMap<PathBuf, Vec<&SchemaMutation>> = BTreeMap::new();
+    for mutation in selected {
+        if mutation.mutation.language != "rust" {
+            return Err(SchemaRewriteError::new(format!(
+                "schema rewrite only supports rust, got {}",
+                mutation.mutation.language
+            )));
+        }
+        if mutation.kind != SchemaKind::Expression {
+            return Err(SchemaRewriteError::new(
+                "rust schema rewrite currently supports expression mutations only",
+            ));
+        }
+        by_file
+            .entry(source_path(project_root, &mutation.mutation.file))
+            .or_default()
+            .push(mutation);
+    }
+
+    let mut rewritten = Vec::new();
+    for (file, mutations) in by_file {
+        let source = std::fs::read_to_string(&file).map_err(|e| {
+            SchemaRewriteError::new(format!("could not read {}: {e}", file.display()))
+        })?;
+        let rewritten_source = rewrite_rust_file(&source, &mutations, adapter)?;
+        let rewritten_source = inject_rust_runtime(&rewritten_source, adapter);
+        rewritten.push(SchemaFileRewrite {
+            file,
+            content: rewritten_source.into_bytes(),
+        });
+    }
+
+    Ok(rewritten)
+}
+
 fn source_path(project_root: &Path, mutation_file: &Path) -> PathBuf {
     if mutation_file.is_absolute() {
         mutation_file.to_path_buf()
@@ -436,6 +497,51 @@ fn rewrite_go_file(
         .map_err(|e| SchemaRewriteError::new(format!("rewritten Go source is not utf-8: {e}")))
 }
 
+fn rewrite_rust_file(
+    source: &str,
+    selected: &[&SchemaMutation],
+    adapter: &dyn SchemaAdapter,
+) -> Result<String, SchemaRewriteError> {
+    let source_bytes = source.as_bytes();
+    let tree = parse_rust_source(source)?;
+    let mut edits = Vec::with_capacity(selected.len());
+
+    for schema_mutation in selected {
+        let mutation = &schema_mutation.mutation;
+        validate_source_range(mutation, source_bytes).map_err(|reason| {
+            SchemaRewriteError::new(format!(
+                "mutation {} is not rewriteable: {reason:?}",
+                mutation.id
+            ))
+        })?;
+        let expression_range =
+            rust_expression_range_for_mutation(tree.root_node(), source, mutation)?;
+        let original = source_slice(source, expression_range.clone())?;
+        let replacement = mutated_expression(source, expression_range.clone(), mutation)?;
+        let wrapped = adapter.wrap_expression(mutation.id, original, &replacement);
+        edits.push((expression_range, wrapped));
+    }
+
+    edits.sort_by_key(|(range, _)| (range.start, range.end));
+    let mut previous_end = 0usize;
+    for (position, (range, _)) in edits.iter().enumerate() {
+        if position > 0 && range.start < previous_end {
+            return Err(SchemaRewriteError::new(
+                "schema mutations overlap after expression expansion",
+            ));
+        }
+        previous_end = range.end;
+    }
+
+    let mut rewritten = source.as_bytes().to_vec();
+    for (range, replacement) in edits.into_iter().rev() {
+        rewritten.splice(range, replacement.bytes());
+    }
+
+    String::from_utf8(rewritten)
+        .map_err(|e| SchemaRewriteError::new(format!("rewritten Rust source is not utf-8: {e}")))
+}
+
 fn mutated_expression(
     source: &str,
     expression_range: std::ops::Range<usize>,
@@ -473,6 +579,20 @@ fn parse_go_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError
     Ok(tree)
 }
 
+fn parse_rust_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .map_err(|e| SchemaRewriteError::new(format!("could not load Rust grammar: {e}")))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| SchemaRewriteError::new("could not parse Rust source"))?;
+    if tree.root_node().has_error() {
+        return Err(SchemaRewriteError::new("Rust source contains parse errors"));
+    }
+    Ok(tree)
+}
+
 fn go_expression_range_for_mutation(
     root: tree_sitter::Node<'_>,
     source: &str,
@@ -499,6 +619,38 @@ fn go_expression_range_for_mutation(
     }
 }
 
+fn rust_expression_range_for_mutation(
+    root: tree_sitter::Node<'_>,
+    source: &str,
+    mutation: &Mutation,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    match mutation.operator.as_str() {
+        "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
+        | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" => {
+            smallest_rust_node_range(root, mutation.byte_range.clone(), |node| {
+                node.kind() == "binary_expression"
+            })
+        }
+        "true_to_false" | "false_to_true" | "zero_to_one" | "string_to_empty"
+        | "increment_numeric" | "decrement_numeric" => {
+            exact_rust_node_range(root, mutation.byte_range.clone())
+        }
+        "remove_unary_not" | "remove_unary_neg" => {
+            smallest_rust_node_range(root, mutation.byte_range.clone(), |node| {
+                node.kind() == "unary_expression"
+            })
+        }
+        "negate_condition" => {
+            source_slice(source, mutation.byte_range.clone())?;
+            Ok(mutation.byte_range.clone())
+        }
+        _ => Err(SchemaRewriteError::new(format!(
+            "unsupported Rust schema operator {}",
+            mutation.operator
+        ))),
+    }
+}
+
 fn smallest_go_node_range(
     node: tree_sitter::Node<'_>,
     range: std::ops::Range<usize>,
@@ -520,6 +672,27 @@ fn smallest_go_node_range(
     best.ok_or_else(|| SchemaRewriteError::new("could not find containing Go expression"))
 }
 
+fn smallest_rust_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+    predicate: impl Fn(tree_sitter::Node<'_>) -> bool + Copy,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut best = None::<std::ops::Range<usize>>;
+    visit_nodes(node, &mut |candidate| {
+        let candidate_range = candidate.byte_range();
+        if candidate_range.start <= range.start
+            && range.end <= candidate_range.end
+            && predicate(candidate)
+            && best
+                .as_ref()
+                .is_none_or(|best| candidate_range.len() < best.len())
+        {
+            best = Some(candidate_range);
+        }
+    });
+    best.ok_or_else(|| SchemaRewriteError::new("could not find containing Rust expression"))
+}
+
 fn exact_go_node_range(
     node: tree_sitter::Node<'_>,
     range: std::ops::Range<usize>,
@@ -533,11 +706,28 @@ fn exact_go_node_range(
     found.ok_or_else(|| SchemaRewriteError::new("could not find Go expression node"))
 }
 
+fn exact_rust_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut found = None;
+    visit_nodes(node, &mut |candidate| {
+        if candidate.byte_range() == range {
+            found = Some(range.clone());
+        }
+    });
+    found.ok_or_else(|| SchemaRewriteError::new("could not find Rust expression node"))
+}
+
 fn visit_go_nodes(node: tree_sitter::Node<'_>, visit: &mut impl FnMut(tree_sitter::Node<'_>)) {
+    visit_nodes(node, visit);
+}
+
+fn visit_nodes(node: tree_sitter::Node<'_>, visit: &mut impl FnMut(tree_sitter::Node<'_>)) {
     visit(node);
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        visit_go_nodes(child, visit);
+        visit_nodes(child, visit);
     }
 }
 
@@ -559,6 +749,30 @@ fn inject_go_runtime(
     let mut rewritten = source;
     rewritten.insert_str(insert_at, &format!("\n{helper}\n"));
     Ok(rewritten)
+}
+
+fn inject_rust_runtime(source: &str, adapter: &dyn SchemaAdapter) -> String {
+    if source.contains("fn __togi_active(") {
+        return source.to_string();
+    }
+    let insert_at = rust_runtime_insert_offset(source);
+    let helper = adapter.runtime_helper().trim();
+    let mut rewritten = source.to_string();
+    rewritten.insert_str(insert_at, &format!("{helper}\n\n"));
+    rewritten
+}
+
+fn rust_runtime_insert_offset(source: &str) -> usize {
+    let mut offset = 0usize;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with("#![") {
+            offset += line.len();
+        } else {
+            break;
+        }
+    }
+    offset
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1401,6 +1615,41 @@ mod tests {
             "func() bool { if __togi_active(\"7\") { return a != b }; return a == b }()"
         ));
         parse_go_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_rust_files_expands_operator_mutation_to_expression_wrapper() {
+        let dir = TempDir::new().unwrap();
+        let source = "#![allow(dead_code)]\npub fn f(a: i32, b: i32) -> bool { a == b }\n";
+        write_source(&dir, "src/lib.rs", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "rust",
+            "src/lib.rs",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_rust_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(rewrites.len(), 1);
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.starts_with("#![allow(dead_code)]\n#[allow(dead_code)]\n"));
+        assert!(rewritten.contains("fn __togi_active(id: u32) -> bool"));
+        assert!(
+            rewritten.contains("__togi_select(7, || { a == b }, || { a != b })"),
+            "{rewritten}"
+        );
+        parse_rust_source(&rewritten).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Refs #156

Summary:
- add Rust schemata rewriting with runtime TOGI_MUTANT selection for expression mutations
- route schemata execution by language so Go and Rust can share the runner path
- cover rewritten Rust parsing and an end-to-end Cargo test runner path

Validation:
- cargo test --locked
- cargo clippy --locked -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execute mutations in Rust projects alongside Go with language-aware grouping and per-language execution.
  * Fallback mechanism retries mutations when a language-specific run fails, preserving original ordering.

* **Bug Fixes**
  * Improved caching so cached test runs don’t consume test-budget reservations and release resources properly.

* **Tests**
  * Added Rust-specific tests covering schemata execution, caching behavior, and mutation instrumentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/349)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->