### PR TITLE
Add C++ schemata execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Build
         run: cargo build --locked
       - name: Test
@@ -32,6 +34,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.87
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Test
         run: cargo test --locked
 
@@ -44,6 +48,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - name: Format
@@ -56,6 +62,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: actions/setup-go@v6
         with:
           go-version: stable
@@ -71,6 +79,8 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Build togi
         run: cargo build --locked --release
       - name: Run togi on last commit

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1098,7 +1098,7 @@ impl TestRunner {
 
         for schema_mutation in plan.selected {
             match schema_mutation.mutation.language.as_str() {
-                "c" | "go" | "java" | "rust" => {
+                "c" | "cpp" | "go" | "java" | "rust" => {
                     schema_by_language
                         .entry(schema_mutation.mutation.language.clone())
                         .or_default()
@@ -1288,6 +1288,7 @@ impl TestRunner {
     ) -> Result<Vec<(Mutation, MutationResult)>, crate::schemata::SchemaRewriteError> {
         let rewrites = match language {
             "c" => crate::schemata::rewrite_c_files(&self.project_root, schema_mutations)?,
+            "cpp" => crate::schemata::rewrite_cpp_files(&self.project_root, schema_mutations)?,
             "go" => crate::schemata::rewrite_go_files(&self.project_root, schema_mutations)?,
             "java" => crate::schemata::rewrite_java_files(&self.project_root, schema_mutations)?,
             "rust" => crate::schemata::rewrite_rust_files(&self.project_root, schema_mutations)?,
@@ -2405,6 +2406,12 @@ mod tests {
     fn c_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
         let mut mutation = go_operator_mutation(id, file, source, nth);
         mutation.language = "c".into();
+        mutation
+    }
+
+    fn cpp_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
+        let mut mutation = go_operator_mutation(id, file, source, nth);
+        mutation.language = "cpp".into();
         mutation
     }
 
@@ -3607,6 +3614,72 @@ int main(void) {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec!["cc".into(), "calc.c".into(), "-o".into(), "calc".into()],
+                build_command_explicit: true,
+                timeout: Duration::from_secs(30),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![mutation]).report;
+
+        assert_eq!(report.total, 1);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_schemata_executes_cpp_mutation_with_active_env() {
+        if std::process::Command::new("c++")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping C++ schemata runner test because c++ is unavailable");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = "\
+bool same(int a, int b) {
+    return a == b;
+}
+
+int main() {
+    if (!same(1, 1)) {
+        return 1;
+    }
+    if (same(1, 2)) {
+        return 2;
+    }
+    return 0;
+}
+";
+        std::fs::write(dir.path().join("calc.cpp"), source).unwrap();
+        let mutation = cpp_operator_mutation(0, "calc.cpp", source, 0);
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["./calc".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![
+                    "c++".into(),
+                    "calc.cpp".into(),
+                    "-std=c++11".into(),
+                    "-o".into(),
+                    "calc".into(),
+                ],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -120,6 +120,7 @@ pub trait SchemaAdapter: Send + Sync {
 }
 
 struct CSchema;
+struct CppSchema;
 struct GoSchema;
 struct JavaSchema;
 struct RustSchema;
@@ -127,6 +128,28 @@ struct PythonSchema;
 struct TypeScriptSchema;
 
 const C_OPERATOR_ALLOWLIST: &[&str] = &[
+    "eq_to_neq",
+    "lt_to_lte",
+    "gt_to_gte",
+    "and_to_or",
+    "or_to_and",
+    "mul_to_div",
+    "div_to_mul",
+    "mod_to_mul",
+    "plus_to_minus",
+    "minus_to_plus",
+    "true_to_false",
+    "false_to_true",
+    "zero_to_one",
+    "string_to_empty",
+    "increment_numeric",
+    "decrement_numeric",
+    "remove_unary_not",
+    "remove_unary_neg",
+    "negate_condition",
+];
+
+const CPP_OPERATOR_ALLOWLIST: &[&str] = &[
     "eq_to_neq",
     "lt_to_lte",
     "gt_to_gte",
@@ -235,6 +258,55 @@ impl SchemaAdapter for CSchema {
 
     fn is_compile_time_context(&self, mutation: &Mutation, source: &[u8]) -> bool {
         !c_range_is_runtime_context(source, mutation.byte_range.clone())
+    }
+}
+
+impl SchemaAdapter for CppSchema {
+    fn language(&self) -> &str {
+        "cpp"
+    }
+
+    fn runtime_helper(&self) -> &'static str {
+        r#"static bool __togi_active(unsigned int id) {
+    const char *value = std::getenv("TOGI_MUTANT");
+    unsigned int parsed = 0u;
+    if (value == nullptr || *value == '\0') {
+        return false;
+    }
+    while (*value >= '0' && *value <= '9') {
+        parsed = parsed * 10u + static_cast<unsigned int>(*value - '0');
+        value++;
+    }
+    return *value == '\0' && parsed == id;
+}
+"#
+    }
+
+    fn required_imports(&self) -> &'static [&'static str] {
+        &["cstdlib"]
+    }
+
+    fn wrap_expression(&self, mutant_id: u32, original: &str, replacement: &str) -> String {
+        format!("(::__togi_active({mutant_id}u) ? ({replacement}) : ({original}))")
+    }
+
+    fn wrap_statement(&self, mutant_id: u32, original: &str, replacement: &str) -> String {
+        format!("if (::__togi_active({mutant_id}u)) {{ {replacement} }} else {{ {original} }}")
+    }
+
+    fn classify(&self, mutation: &Mutation, source: &[u8]) -> Result<SchemaKind, SchemaSkipReason> {
+        validate_source_range(mutation, source)?;
+        if !CPP_OPERATOR_ALLOWLIST.contains(&mutation.operator.as_str()) {
+            return Err(SchemaSkipReason::UnsupportedOperator);
+        }
+        if !cpp_range_is_runtime_context(source, mutation.byte_range.clone()) {
+            return Err(SchemaSkipReason::CompileTimeContext);
+        }
+        Ok(SchemaKind::Expression)
+    }
+
+    fn is_compile_time_context(&self, mutation: &Mutation, source: &[u8]) -> bool {
+        !cpp_range_is_runtime_context(source, mutation.byte_range.clone())
     }
 }
 
@@ -413,6 +485,7 @@ function __togi_select<T>(id: number, original: () => T, mutated: () => T): T {
 }
 
 static C_SCHEMA: CSchema = CSchema;
+static CPP_SCHEMA: CppSchema = CppSchema;
 static GO_SCHEMA: GoSchema = GoSchema;
 static JAVA_SCHEMA: JavaSchema = JavaSchema;
 static RUST_SCHEMA: RustSchema = RustSchema;
@@ -423,6 +496,7 @@ static TYPESCRIPT_SCHEMA: TypeScriptSchema = TypeScriptSchema;
 pub fn adapter_for_language(language: &str) -> Option<&'static dyn SchemaAdapter> {
     match language {
         "c" => Some(&C_SCHEMA),
+        "cpp" => Some(&CPP_SCHEMA),
         "go" => Some(&GO_SCHEMA),
         "java" => Some(&JAVA_SCHEMA),
         "rust" => Some(&RUST_SCHEMA),
@@ -521,6 +595,51 @@ pub fn rewrite_c_files(
             SchemaRewriteError::new(format!("could not read {}: {e}", file.display()))
         })?;
         let rewritten_source = rewrite_c_file(&source, &mutations, adapter)?;
+        rewritten.push(SchemaFileRewrite {
+            file,
+            content: rewritten_source.into_bytes(),
+        });
+    }
+
+    Ok(rewritten)
+}
+
+/// Rewrite C++ files once so selected mutations can be activated by `TOGI_MUTANT`.
+pub fn rewrite_cpp_files(
+    project_root: &Path,
+    selected: &[SchemaMutation],
+) -> Result<Vec<SchemaFileRewrite>, SchemaRewriteError> {
+    let Some(adapter) = adapter_for_language("cpp") else {
+        return Err(SchemaRewriteError::new(
+            "cpp schema adapter is not available",
+        ));
+    };
+
+    let mut by_file: BTreeMap<PathBuf, Vec<&SchemaMutation>> = BTreeMap::new();
+    for mutation in selected {
+        if mutation.mutation.language != "cpp" {
+            return Err(SchemaRewriteError::new(format!(
+                "schema rewrite only supports cpp, got {}",
+                mutation.mutation.language
+            )));
+        }
+        if mutation.kind != SchemaKind::Expression {
+            return Err(SchemaRewriteError::new(
+                "cpp schema rewrite currently supports expression mutations only",
+            ));
+        }
+        by_file
+            .entry(source_path(project_root, &mutation.mutation.file))
+            .or_default()
+            .push(mutation);
+    }
+
+    let mut rewritten = Vec::new();
+    for (file, mutations) in by_file {
+        let source = std::fs::read_to_string(&file).map_err(|e| {
+            SchemaRewriteError::new(format!("could not read {}: {e}", file.display()))
+        })?;
+        let rewritten_source = rewrite_cpp_file(&source, &mutations, adapter)?;
         rewritten.push(SchemaFileRewrite {
             file,
             content: rewritten_source.into_bytes(),
@@ -737,6 +856,52 @@ fn rewrite_c_file(
     inject_c_runtime(&rewritten, adapter)
 }
 
+fn rewrite_cpp_file(
+    source: &str,
+    selected: &[&SchemaMutation],
+    adapter: &dyn SchemaAdapter,
+) -> Result<String, SchemaRewriteError> {
+    let source_bytes = source.as_bytes();
+    let tree = parse_cpp_source(source)?;
+    let mut edits = Vec::with_capacity(selected.len());
+
+    for schema_mutation in selected {
+        let mutation = &schema_mutation.mutation;
+        validate_source_range(mutation, source_bytes).map_err(|reason| {
+            SchemaRewriteError::new(format!(
+                "mutation {} is not rewriteable: {reason:?}",
+                mutation.id
+            ))
+        })?;
+        let expression_range =
+            cpp_expression_range_for_mutation(tree.root_node(), source, mutation)?;
+        let original = source_slice(source, expression_range.clone())?;
+        let replacement = mutated_expression(source, expression_range.clone(), mutation)?;
+        let wrapped = adapter.wrap_expression(mutation.id, original, &replacement);
+        edits.push((expression_range, wrapped));
+    }
+
+    edits.sort_by_key(|(range, _)| (range.start, range.end));
+    let mut previous_end = 0usize;
+    for (position, (range, _)) in edits.iter().enumerate() {
+        if position > 0 && range.start < previous_end {
+            return Err(SchemaRewriteError::new(
+                "schema mutations overlap after expression expansion",
+            ));
+        }
+        previous_end = range.end;
+    }
+
+    let mut rewritten = source.as_bytes().to_vec();
+    for (range, replacement) in edits.into_iter().rev() {
+        rewritten.splice(range, replacement.bytes());
+    }
+
+    let rewritten = String::from_utf8(rewritten)
+        .map_err(|e| SchemaRewriteError::new(format!("rewritten C++ source is not utf-8: {e}")))?;
+    inject_cpp_runtime(&rewritten, adapter)
+}
+
 fn rewrite_go_file(
     source: &str,
     selected: &[&SchemaMutation],
@@ -927,6 +1092,20 @@ fn parse_c_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError>
     Ok(tree)
 }
 
+fn parse_cpp_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_cpp::LANGUAGE.into())
+        .map_err(|e| SchemaRewriteError::new(format!("could not load C++ grammar: {e}")))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| SchemaRewriteError::new("could not parse C++ source"))?;
+    if tree.root_node().has_error() {
+        return Err(SchemaRewriteError::new("C++ source contains parse errors"));
+    }
+    Ok(tree)
+}
+
 fn parse_go_source(source: &str) -> Result<tree_sitter::Tree, SchemaRewriteError> {
     let mut parser = tree_sitter::Parser::new();
     parser
@@ -1003,6 +1182,45 @@ fn c_expression_range_for_mutation(
         }
         _ => Err(SchemaRewriteError::new(format!(
             "accepted C schema operator has no rewrite strategy: {}",
+            mutation.operator
+        ))),
+    }
+}
+
+fn cpp_expression_range_for_mutation(
+    root: tree_sitter::Node<'_>,
+    source: &str,
+    mutation: &Mutation,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    if !CPP_OPERATOR_ALLOWLIST.contains(&mutation.operator.as_str()) {
+        return Err(SchemaRewriteError::new(format!(
+            "unsupported C++ schema operator {}",
+            mutation.operator
+        )));
+    }
+
+    match mutation.operator.as_str() {
+        "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
+        | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" => {
+            smallest_cpp_node_range(root, mutation.byte_range.clone(), |node| {
+                node.kind() == "binary_expression"
+            })
+        }
+        "true_to_false" | "false_to_true" | "zero_to_one" | "string_to_empty"
+        | "increment_numeric" | "decrement_numeric" => {
+            exact_cpp_node_range(root, mutation.byte_range.clone())
+        }
+        "remove_unary_not" | "remove_unary_neg" => {
+            smallest_cpp_node_range(root, mutation.byte_range.clone(), |node| {
+                node.kind() == "unary_expression"
+            })
+        }
+        "negate_condition" => {
+            source_slice(source, mutation.byte_range.clone())?;
+            Ok(mutation.byte_range.clone())
+        }
+        _ => Err(SchemaRewriteError::new(format!(
+            "accepted C++ schema operator has no rewrite strategy: {}",
             mutation.operator
         ))),
     }
@@ -1133,6 +1351,27 @@ fn smallest_c_node_range(
     best.ok_or_else(|| SchemaRewriteError::new("could not find containing C expression"))
 }
 
+fn smallest_cpp_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+    predicate: impl Fn(tree_sitter::Node<'_>) -> bool + Copy,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut best = None::<std::ops::Range<usize>>;
+    visit_nodes(node, &mut |candidate| {
+        let candidate_range = candidate.byte_range();
+        if candidate_range.start <= range.start
+            && range.end <= candidate_range.end
+            && predicate(candidate)
+            && best
+                .as_ref()
+                .is_none_or(|best| candidate_range.len() < best.len())
+        {
+            best = Some(candidate_range);
+        }
+    });
+    best.ok_or_else(|| SchemaRewriteError::new("could not find containing C++ expression"))
+}
+
 fn smallest_go_node_range(
     node: tree_sitter::Node<'_>,
     range: std::ops::Range<usize>,
@@ -1220,6 +1459,19 @@ fn exact_c_node_range(
         }
     });
     found.ok_or_else(|| SchemaRewriteError::new("could not find C expression node"))
+}
+
+fn exact_cpp_node_range(
+    node: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+) -> Result<std::ops::Range<usize>, SchemaRewriteError> {
+    let mut found = None;
+    visit_nodes(node, &mut |candidate| {
+        if candidate.byte_range() == range {
+            found = Some(range.clone());
+        }
+    });
+    found.ok_or_else(|| SchemaRewriteError::new("could not find C++ expression node"))
 }
 
 fn exact_java_node_range(
@@ -1341,6 +1593,43 @@ fn c_range_is_runtime_context(source: &[u8], range: std::ops::Range<usize>) -> b
     inside_function_body
 }
 
+fn cpp_range_is_runtime_context(source: &[u8], range: std::ops::Range<usize>) -> bool {
+    let Ok(source_text) = std::str::from_utf8(source) else {
+        return false;
+    };
+    let Ok(tree) = parse_cpp_source(source_text) else {
+        return false;
+    };
+    let Some(mut current) = smallest_containing_node(tree.root_node(), range) else {
+        return false;
+    };
+
+    let mut inside_function_body = false;
+    loop {
+        let kind = current.kind();
+        if kind.starts_with("preproc") || kind == "case_statement" || kind == "enumerator" {
+            return false;
+        }
+        if kind == "declaration" && c_declaration_has_static_storage(current, source) {
+            return false;
+        }
+        if kind == "compound_statement"
+            && current
+                .parent()
+                .is_some_and(|parent| parent.kind() == "function_definition")
+        {
+            inside_function_body = true;
+        }
+
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
+
+    inside_function_body
+}
+
 fn smallest_containing_node<'tree>(
     node: tree_sitter::Node<'tree>,
     range: std::ops::Range<usize>,
@@ -1411,6 +1700,144 @@ fn inject_c_runtime(
     let mut rewritten = source.to_string();
     rewritten.insert_str(insert_at, &insertion);
     Ok(rewritten)
+}
+
+fn inject_cpp_runtime(
+    source: &str,
+    adapter: &dyn SchemaAdapter,
+) -> Result<String, SchemaRewriteError> {
+    let tree = parse_cpp_source(source)?;
+    if cpp_source_declares_togi_active(tree.root_node(), source.as_bytes()) {
+        return Ok(source.to_string());
+    }
+
+    let source = ensure_cpp_imports(source.to_string(), adapter.required_imports());
+    let tree = parse_cpp_source(&source)?;
+    let insert_at = cpp_runtime_insert_offset(tree.root_node());
+    let helper = adapter.runtime_helper().trim_end();
+    let mut insertion = String::new();
+    if insert_at > 0 && !source[..insert_at].ends_with('\n') {
+        insertion.push('\n');
+    }
+    insertion.push_str(helper);
+    insertion.push_str("\n\n");
+
+    let mut rewritten = source;
+    rewritten.insert_str(insert_at, &insertion);
+    Ok(rewritten)
+}
+
+fn ensure_cpp_imports(mut source: String, imports: &[&str]) -> String {
+    for import in imports {
+        if cpp_source_includes(&source, import) {
+            continue;
+        }
+        let offset = cpp_include_insert_offset(&source);
+        let mut include = String::new();
+        if offset > 0 && !source[..offset].ends_with('\n') {
+            include.push('\n');
+        }
+        include.push_str(&format!("#include <{import}>\n"));
+        source.insert_str(offset, &include);
+    }
+    source
+}
+
+fn cpp_source_includes(source: &str, import: &str) -> bool {
+    let needle = format!("<{import}>");
+    source
+        .lines()
+        .map(str::trim_start)
+        .any(|line| line.starts_with("#include") && line.contains(&needle))
+}
+
+fn cpp_include_insert_offset(source: &str) -> usize {
+    let mut offset = 0usize;
+    let mut insertion = 0usize;
+    let mut in_block_comment = false;
+
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if in_block_comment {
+            offset += line.len();
+            insertion = offset;
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            offset += line.len();
+            insertion = offset;
+            continue;
+        }
+        if trimmed.starts_with("/*") {
+            offset += line.len();
+            insertion = offset;
+            if !trimmed.contains("*/") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+        if trimmed.starts_with("#include") || trimmed.starts_with("#pragma once") {
+            offset += line.len();
+            insertion = offset;
+            continue;
+        }
+        break;
+    }
+
+    insertion
+}
+
+fn cpp_runtime_insert_offset(root: tree_sitter::Node<'_>) -> usize {
+    let mut cursor = root.walk();
+    root.children(&mut cursor)
+        .find(|child| {
+            !matches!(child.kind(), "comment" | "preproc_include" | "preproc_def")
+                && !child.kind().starts_with("preproc")
+        })
+        .map(|child| child.byte_range().start)
+        .unwrap_or(root.byte_range().end)
+}
+
+fn cpp_source_declares_togi_active(root: tree_sitter::Node<'_>, source: &[u8]) -> bool {
+    let mut found = false;
+    visit_nodes(root, &mut |candidate| {
+        if candidate.kind() == "function_definition"
+            && !cpp_function_is_member_definition(candidate)
+            && c_function_definition_name_is(candidate, source, "__togi_active")
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+fn cpp_function_is_member_definition(function: tree_sitter::Node<'_>) -> bool {
+    let mut current = function;
+    while let Some(parent) = current.parent() {
+        if matches!(
+            parent.kind(),
+            "class_specifier" | "struct_specifier" | "union_specifier"
+        ) {
+            return true;
+        }
+        current = parent;
+    }
+    function
+        .child_by_field_name("declarator")
+        .is_some_and(cpp_declarator_is_qualified)
+}
+
+fn cpp_declarator_is_qualified(declarator: tree_sitter::Node<'_>) -> bool {
+    if declarator.kind() == "qualified_identifier" {
+        return true;
+    }
+    let mut cursor = declarator.walk();
+    declarator
+        .children(&mut cursor)
+        .any(cpp_declarator_is_qualified)
 }
 
 fn c_runtime_insert_offset(root: tree_sitter::Node<'_>) -> Result<usize, SchemaRewriteError> {
@@ -2117,6 +2544,19 @@ mod tests {
             "(__togi_active(42u) ? (a != b) : (a == b))"
         );
 
+        let cpp = adapter_for_language("cpp").unwrap();
+        write_source(
+            &dir,
+            "calc.cpp",
+            "bool f(int a, int b) { return a == b; }\n",
+        );
+        assert_parsed_node_text(&dir, "calc.cpp", cpp, "binary_expression", "a == b");
+        assert_eq!(
+            cpp.wrap_expression(42, "a == b", "a != b"),
+            "(::__togi_active(42u) ? (a != b) : (a == b))"
+        );
+        assert_eq!(cpp.required_imports(), &["cstdlib"]);
+
         let go = adapter_for_language("go").unwrap();
         write_source(
             &dir,
@@ -2226,6 +2666,33 @@ mod tests {
     }
 
     #[test]
+    fn plan_selects_cpp_expression_mutations_inside_function_body() {
+        let dir = TempDir::new().unwrap();
+        let adapter = adapter_for_language("cpp").unwrap();
+        write_source(
+            &dir,
+            "calc.cpp",
+            "bool f(int a, int b) { return a == b; }\n",
+        );
+        assert_parsed_node_text(&dir, "calc.cpp", adapter, "binary_expression", "a == b");
+        let start = "bool f(int a, int b) { return ".len();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "a == b",
+            "a != b",
+            start..start + 6,
+            "eq_to_neq",
+        );
+
+        let plan = plan(dir.path(), vec![mutation]);
+
+        assert_eq!(plan.selected.len(), 1);
+        assert_eq!(plan.selected[0].kind, SchemaKind::Expression);
+        assert!(plan.fallback.is_empty());
+    }
+
+    #[test]
     fn plan_falls_back_for_go_non_boolean_expression_mutations() {
         let dir = TempDir::new().unwrap();
         let adapter = adapter_for_language("go").unwrap();
@@ -2298,6 +2765,34 @@ mod tests {
         let mutation = mutation(
             "c",
             "calc.c",
+            "2",
+            "3",
+            start..start + 1,
+            "increment_numeric",
+        );
+
+        let plan = plan(dir.path(), vec![mutation]);
+
+        assert!(plan.selected.is_empty());
+        assert_eq!(plan.fallback.len(), 1);
+        assert_eq!(
+            plan.fallback[0].reason,
+            SchemaSkipReason::CompileTimeContext
+        );
+    }
+
+    #[test]
+    fn plan_falls_back_for_cpp_global_context() {
+        let dir = TempDir::new().unwrap();
+        let adapter = adapter_for_language("cpp").unwrap();
+        let source = "static constexpr int VERSION = 2;\nbool f() { return VERSION > 0; }\n";
+        write_source(&dir, "calc.cpp", source);
+        assert_parsed_node_kind(&dir, "calc.cpp", adapter, "declaration");
+        assert_parsed_node_text(&dir, "calc.cpp", adapter, "number_literal", "2");
+        let start = source.find('2').unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
             "2",
             "3",
             start..start + 1,
@@ -2579,6 +3074,154 @@ mod tests {
             "{rewritten}"
         );
         parse_c_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_cpp_files_expands_operator_mutation_to_expression_wrapper() {
+        let dir = TempDir::new().unwrap();
+        let source = "#include <iostream>\nbool f(int a, int b) { return a == b; }\n";
+        write_source(&dir, "calc.cpp", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_cpp_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(rewrites.len(), 1);
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.contains("#include <cstdlib>"));
+        assert!(rewritten.contains("static bool __togi_active(unsigned int id)"));
+        assert!(rewritten.contains("return (::__togi_active(7u) ? (a != b) : (a == b));"));
+        assert!(
+            rewritten.find("#include <cstdlib>").unwrap()
+                < rewritten.find("static bool __togi_active").unwrap(),
+            "{rewritten}"
+        );
+        assert!(
+            rewritten.find("static bool __togi_active").unwrap()
+                < rewritten.find("bool f").unwrap(),
+            "{rewritten}"
+        );
+        parse_cpp_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_cpp_files_does_not_reuse_member_togi_active_function() {
+        let dir = TempDir::new().unwrap();
+        let source = "class Calc { static bool __togi_active (unsigned int id) { return false; } static bool f(int a, int b) { return a == b; } };\n";
+        write_source(&dir, "calc.cpp", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_cpp_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.contains("#include <cstdlib>"), "{rewritten}");
+        assert!(
+            rewritten.contains("static bool __togi_active(unsigned int id)"),
+            "{rewritten}"
+        );
+        assert!(
+            rewritten.contains("return (::__togi_active(7u) ? (a != b) : (a == b));"),
+            "{rewritten}"
+        );
+        parse_cpp_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_cpp_files_ignores_togi_active_mentions_in_text() {
+        let dir = TempDir::new().unwrap();
+        let source = "const char *marker() { return \"__togi_active(\"; }\nbool f(int a, int b) { return a == b; }\n";
+        write_source(&dir, "calc.cpp", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_cpp_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert_eq!(
+            rewritten
+                .matches("static bool __togi_active(unsigned int id)")
+                .count(),
+            1,
+            "{rewritten}"
+        );
+        parse_cpp_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_cpp_files_reuses_existing_togi_active_function_with_spacing() {
+        let dir = TempDir::new().unwrap();
+        let source = "static bool __togi_active (unsigned int id) { return false; }\nbool f(int a, int b) { return a == b; }\n";
+        write_source(&dir, "calc.cpp", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_cpp_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert_eq!(
+            rewritten.matches("static bool __togi_active").count(),
+            1,
+            "{rewritten}"
+        );
+        assert!(!rewritten.contains("#include <cstdlib>"), "{rewritten}");
+        parse_cpp_source(&rewritten).unwrap();
     }
 
     #[test]

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -1610,7 +1610,13 @@ fn cpp_range_is_runtime_context(source: &[u8], range: std::ops::Range<usize>) ->
         if kind.starts_with("preproc") || kind == "case_statement" || kind == "enumerator" {
             return false;
         }
+        if kind.contains("static_assert") {
+            return false;
+        }
         if kind == "declaration" && c_declaration_has_static_storage(current, source) {
+            return false;
+        }
+        if kind == "function_definition" && cpp_function_is_constant_evaluated(current, source) {
             return false;
         }
         if kind == "compound_statement"
@@ -1819,7 +1825,7 @@ fn cpp_function_is_member_definition(function: tree_sitter::Node<'_>) -> bool {
     while let Some(parent) = current.parent() {
         if matches!(
             parent.kind(),
-            "class_specifier" | "struct_specifier" | "union_specifier"
+            "class_specifier" | "struct_specifier" | "union_specifier" | "namespace_definition"
         ) {
             return true;
         }
@@ -1838,6 +1844,33 @@ fn cpp_declarator_is_qualified(declarator: tree_sitter::Node<'_>) -> bool {
     declarator
         .children(&mut cursor)
         .any(cpp_declarator_is_qualified)
+}
+
+fn cpp_function_is_constant_evaluated(function: tree_sitter::Node<'_>, source: &[u8]) -> bool {
+    let prefix_end = function
+        .child_by_field_name("declarator")
+        .map(|declarator| declarator.byte_range().start)
+        .unwrap_or_else(|| function.byte_range().end);
+    source
+        .get(function.byte_range().start..prefix_end)
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .is_some_and(|prefix| {
+            contains_ascii_keyword(prefix, "constexpr")
+                || contains_ascii_keyword(prefix, "consteval")
+        })
+}
+
+fn contains_ascii_keyword(text: &str, keyword: &str) -> bool {
+    text.match_indices(keyword).any(|(start, _)| {
+        let before = text[..start].chars().next_back();
+        let after = text[start + keyword.len()..].chars().next();
+        before.is_none_or(|character| !is_ascii_identifier_character(character))
+            && after.is_none_or(|character| !is_ascii_identifier_character(character))
+    })
+}
+
+fn is_ascii_identifier_character(character: char) -> bool {
+    character == '_' || character.is_ascii_alphanumeric()
 }
 
 fn c_runtime_insert_offset(root: tree_sitter::Node<'_>) -> Result<usize, SchemaRewriteError> {
@@ -2810,6 +2843,54 @@ mod tests {
     }
 
     #[test]
+    fn plan_falls_back_for_cpp_constant_evaluated_contexts() {
+        let dir = TempDir::new().unwrap();
+        let adapter = adapter_for_language("cpp").unwrap();
+        for (file, source, original, replacement) in [
+            (
+                "constexpr.cpp",
+                "constexpr bool f(int a, int b) { return a == b; }\n",
+                "a == b",
+                "a != b",
+            ),
+            (
+                "consteval.cpp",
+                "consteval bool f(int a, int b) { return a == b; }\n",
+                "a == b",
+                "a != b",
+            ),
+            (
+                "static_assert.cpp",
+                "bool f() { static_assert(1 == 1, \"ok\"); return true; }\n",
+                "1 == 1",
+                "1 != 1",
+            ),
+        ] {
+            write_source(&dir, file, source);
+            assert_parsed_node_text(&dir, file, adapter, "binary_expression", original);
+            let start = source.find(original).unwrap();
+            let mutation = mutation(
+                "cpp",
+                file,
+                original,
+                replacement,
+                start..start + original.len(),
+                "eq_to_neq",
+            );
+
+            let plan = plan(dir.path(), vec![mutation]);
+
+            assert!(plan.selected.is_empty(), "{file}");
+            assert_eq!(plan.fallback.len(), 1, "{file}");
+            assert_eq!(
+                plan.fallback[0].reason,
+                SchemaSkipReason::CompileTimeContext,
+                "{file}"
+            );
+        }
+    }
+
+    #[test]
     fn plan_falls_back_for_java_static_final_context() {
         let dir = TempDir::new().unwrap();
         let adapter = adapter_for_language("java").unwrap();
@@ -3150,6 +3231,44 @@ mod tests {
         );
         assert!(
             rewritten.contains("return (::__togi_active(7u) ? (a != b) : (a == b));"),
+            "{rewritten}"
+        );
+        parse_cpp_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_cpp_files_does_not_reuse_namespace_togi_active_function() {
+        let dir = TempDir::new().unwrap();
+        let source = "namespace hidden { static bool __togi_active (unsigned int id) { return false; } }\nbool f(int a, int b) { return a == b; }\n";
+        write_source(&dir, "calc.cpp", source);
+        let operator = source.find("==").unwrap();
+        let mutation = mutation(
+            "cpp",
+            "calc.cpp",
+            "==",
+            "!=",
+            operator..operator + 2,
+            "eq_to_neq",
+        );
+
+        let rewrites = rewrite_cpp_files(
+            dir.path(),
+            &[SchemaMutation {
+                mutation,
+                kind: SchemaKind::Expression,
+            }],
+        )
+        .unwrap();
+
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.contains("#include <cstdlib>"), "{rewritten}");
+        assert!(
+            rewritten.contains("static bool __togi_active(unsigned int id)"),
+            "{rewritten}"
+        );
+        assert_eq!(
+            rewritten.matches("static bool __togi_active").count(),
+            2,
             "{rewritten}"
         );
         parse_cpp_source(&rewritten).unwrap();


### PR DESCRIPTION
## Summary
- add a C++ schema adapter for expression-safe mutations inside function bodies
- inject a global C++ runtime helper and required <cstdlib> include for TOGI_MUTANT activation
- route cpp through schema execution and cover parser, rewrite, name-lookup, and c++ runner behavior

## Validation
- cargo test schemata --locked
- cargo test run_with_schemata_executes_cpp_mutation_with_active_env --locked
- cargo test --locked (first run hit unrelated lock::tests::acquire_and_release temp-lock flake; rerun passed)
- cargo clippy --locked -- -D warnings
- git diff --check

Part of #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class C++ support for schema-based mutation planning and rewrites.
  * Expression-level C++ mutations with improved compile-time/context detection and operator allowlist.
  * Runtime helper injection for C++ that avoids duplicate helpers and manages required includes.
  * C++ mutations now follow the unified schema execution path alongside C/Go/Java/Rust.

* **Tests**
  * Added end-to-end C++ tests covering planning, rewriting, helper reuse, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/352)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->