### PR TITLE
Report actionable build error diagnostics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,53 @@ impl fmt::Display for MutationResult {
     }
 }
 
+/// Diagnostic details captured when a mutation is classified as a build error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildErrorDiagnostic {
+    pub mutation_id: u32,
+    pub runner: String,
+    pub phase: String,
+    pub command: Vec<String>,
+    pub message: String,
+    pub fingerprint: String,
+}
+
+impl BuildErrorDiagnostic {
+    pub fn new(
+        mutation_id: u32,
+        runner: impl Into<String>,
+        phase: impl Into<String>,
+        command: Vec<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        let message = build_error_message_snippet(&message.into());
+        let fingerprint = Self::fingerprint_for(&message);
+        Self {
+            mutation_id,
+            runner: runner.into(),
+            phase: phase.into(),
+            command,
+            message,
+            fingerprint,
+        }
+    }
+
+    pub fn fingerprint_for(message: &str) -> String {
+        let normalized = normalize_build_error_message(message);
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in normalized.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        format!("{hash:016x}")
+    }
+}
+
 /// Aggregated results from a mutation testing run
 #[derive(Debug)]
 pub struct MutationReport {
     pub results: Vec<(Mutation, MutationResult)>,
+    pub build_error_diagnostics: Vec<BuildErrorDiagnostic>,
     pub duration: Duration,
     pub test_command: Option<Vec<String>>,
     pub build_command: Vec<String>,
@@ -106,6 +149,198 @@ pub struct MutationReport {
     pub survived: usize,
     pub timeout: usize,
     pub build_errors: usize,
+}
+
+fn build_error_message_snippet(message: &str) -> String {
+    const LIMIT: usize = 1_200;
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        return "build error diagnostic unavailable".to_string();
+    }
+
+    let mut snippet = String::new();
+    for ch in trimmed.chars().take(LIMIT) {
+        snippet.push(ch);
+    }
+    if trimmed.chars().count() > LIMIT {
+        snippet.push_str("\n[diagnostic truncated]");
+    }
+    snippet
+}
+
+fn normalize_build_error_message(message: &str) -> String {
+    let stripped = strip_ansi(message);
+    let tokens = tokenize_for_fingerprint(&stripped);
+    let mut normalized = String::new();
+    let mut pending_space = false;
+
+    for (index, token) in tokens.iter().enumerate() {
+        match token.kind {
+            FingerprintTokenKind::Word => {
+                if pending_space && !normalized.is_empty() {
+                    normalized.push(' ');
+                }
+                pending_space = false;
+                if should_collapse_numeric_token(&tokens, index) {
+                    normalized.push('#');
+                } else {
+                    normalized.push_str(&token.text);
+                }
+            }
+            FingerprintTokenKind::Other => {
+                for ch in token.text.chars() {
+                    if ch.is_whitespace() {
+                        pending_space = true;
+                        continue;
+                    }
+                    if pending_space && !normalized.is_empty() {
+                        normalized.push(' ');
+                    }
+                    pending_space = false;
+                    normalized.push(ch);
+                }
+            }
+        }
+    }
+
+    normalized
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FingerprintTokenKind {
+    Word,
+    Other,
+}
+
+#[derive(Debug)]
+struct FingerprintToken {
+    kind: FingerprintTokenKind,
+    text: String,
+}
+
+fn tokenize_for_fingerprint(value: &str) -> Vec<FingerprintToken> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut current_kind = None;
+
+    for ch in value.chars() {
+        let kind = if ch.is_alphanumeric() || ch == '_' {
+            FingerprintTokenKind::Word
+        } else {
+            FingerprintTokenKind::Other
+        };
+        if current_kind == Some(kind) {
+            current.push(ch);
+            continue;
+        }
+        if let Some(previous_kind) = current_kind {
+            tokens.push(FingerprintToken {
+                kind: previous_kind,
+                text: std::mem::take(&mut current),
+            });
+        }
+        current_kind = Some(kind);
+        current.push(ch);
+    }
+
+    if let Some(kind) = current_kind {
+        tokens.push(FingerprintToken {
+            kind,
+            text: current,
+        });
+    }
+
+    tokens
+}
+
+fn should_collapse_numeric_token(tokens: &[FingerprintToken], index: usize) -> bool {
+    let token = &tokens[index];
+    if token.kind != FingerprintTokenKind::Word || !token.text.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return false;
+    }
+
+    previous_non_whitespace_char(tokens, index).is_some_and(|ch| ch == ':')
+        || previous_word(tokens, index).is_some_and(|word| {
+            matches!(
+                word.to_ascii_lowercase().as_str(),
+                "line" | "lines" | "column" | "columns" | "col" | "row"
+            )
+        })
+        || (previous_non_whitespace_char(tokens, index).is_some_and(|ch| ch == '[')
+            && previous_word(tokens, index).is_some_and(|word| word.eq_ignore_ascii_case("error")))
+        || is_standalone_numeric_token(tokens, index)
+}
+
+fn is_standalone_numeric_token(tokens: &[FingerprintToken], index: usize) -> bool {
+    let previous_is_word = index
+        .checked_sub(1)
+        .and_then(|previous| tokens.get(previous))
+        .is_some_and(|token| token.kind == FingerprintTokenKind::Word);
+    let next_is_word = tokens
+        .get(index + 1)
+        .is_some_and(|token| token.kind == FingerprintTokenKind::Word);
+    !previous_is_word && !next_is_word
+}
+
+fn previous_word(tokens: &[FingerprintToken], index: usize) -> Option<&str> {
+    tokens[..index]
+        .iter()
+        .rev()
+        .find(|token| token.kind == FingerprintTokenKind::Word)
+        .map(|token| token.text.as_str())
+}
+
+fn previous_non_whitespace_char(tokens: &[FingerprintToken], index: usize) -> Option<char> {
+    tokens[..index]
+        .iter()
+        .rev()
+        .flat_map(|token| token.text.chars().rev())
+        .find(|ch| !ch.is_whitespace())
+}
+
+fn strip_ansi(message: &str) -> String {
+    let mut stripped = String::new();
+    let mut chars = message.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\x1b' => match chars.next() {
+                Some('[') => consume_csi(&mut chars),
+                Some(']') => consume_osc(&mut chars),
+                Some(_) | None => {}
+            },
+            '\u{009b}' => consume_csi(&mut chars),
+            _ => stripped.push(ch),
+        }
+    }
+    stripped
+}
+
+fn consume_csi<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    for ch in chars.by_ref() {
+        if ('@'..='~').contains(&ch) {
+            break;
+        }
+    }
+}
+
+fn consume_osc<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\x07' => break,
+            '\x1b' if chars.peek() == Some(&'\\') => {
+                chars.next();
+                break;
+            }
+            _ => {}
+        }
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +360,39 @@ mod tests {
         assert_eq!(MutationResult::Survived.to_string(), "survived");
         assert_eq!(MutationResult::Timeout.to_string(), "timeout");
         assert_eq!(MutationResult::BuildError.to_string(), "build error");
+    }
+
+    #[test]
+    fn build_error_fingerprint_normalizes_unstable_text() {
+        let first = BuildErrorDiagnostic::fingerprint_for(
+            "\x1b[31merror[E0308]\x1b[0m: mismatched types at line 12",
+        );
+        let second =
+            BuildErrorDiagnostic::fingerprint_for("error[E0308]:   mismatched types at line 99");
+        assert_eq!(first, second);
+
+        let distinct_code =
+            BuildErrorDiagnostic::fingerprint_for("error[E0277]: mismatched types at line 99");
+        assert_ne!(first, distinct_code);
+    }
+
+    #[test]
+    fn build_error_normalization_preserves_identifier_digits() {
+        let normalized = normalize_build_error_message(
+            "error[E0308]: i32 func2 src/lib.rs:12:34 line 99 column 8",
+        );
+        assert_eq!(
+            normalized,
+            "error[E0308]: i32 func2 src/lib.rs:#:# line # column #"
+        );
+    }
+
+    #[test]
+    fn strip_ansi_handles_csi_osc_and_single_character_escapes() {
+        let stripped = strip_ansi(
+            "a\x1b[31mred\x1b[0m b\x1b]0;title\x07c\x1bc d\u{009b}31me\x1b]1;title\x1b\\f",
+        );
+        assert_eq!(stripped, "ared bc def");
     }
 
     #[test]

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -99,6 +99,7 @@ mod tests {
             test_command: None,
             build_command: vec![],
             results,
+            build_error_diagnostics: vec![],
         }
     }
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -125,6 +125,51 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
 
     write!(html, "</ul></nav><main>")?;
 
+    let build_error_groups = super::build_error_groups(report);
+    if !build_error_groups.is_empty() {
+        write!(
+            html,
+            "<section class=\"build-error-diagnostics\"><h3>Build error diagnostics</h3>\
+             <table><thead><tr>\
+             <th>Count</th><th>Language</th><th>Operator</th><th>Runner</th>\
+             <th>Phase</th><th>Files</th><th>Fingerprint</th><th>Message</th>\
+             </tr></thead><tbody>"
+        )?;
+        for group in build_error_groups.iter().take(10) {
+            let files = group
+                .files
+                .iter()
+                .take(3)
+                .map(|file| format!("{} ({})", file.file, file.count))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let message = group.message.lines().next().unwrap_or("").trim();
+            write!(
+                html,
+                "<tr><td>{}</td><td>{}</td><td><code>{}</code></td><td>{}</td>\
+                 <td>{}</td><td>{}</td><td><code>{}</code></td><td>{}</td></tr>",
+                group.count,
+                html_escape(&group.language),
+                html_escape(&group.operator),
+                html_escape(&group.runner),
+                html_escape(&group.phase),
+                html_escape(&files),
+                html_escape(&group.fingerprint),
+                html_escape(message)
+            )?;
+        }
+        if build_error_groups.len() > 10 {
+            let remaining = build_error_groups.len() - 10;
+            write!(
+                html,
+                "<tr><td colspan=\"8\">... {} more group{}</td></tr>",
+                remaining,
+                if remaining == 1 { "" } else { "s" }
+            )?;
+        }
+        write!(html, "</tbody></table></section>")?;
+    }
+
     // Per-file sections
     for (path, stats) in &files {
         write!(
@@ -233,6 +278,7 @@ code{font-family:'SF Mono',Menlo,monospace;font-size:.82rem}
 .result-survived{background:rgba(233,69,96,.08)}
 .result-timeout{background:rgba(255,200,50,.06)}
 .result-build-error{background:rgba(255,200,50,.06)}
+.build-error-diagnostics{background:rgba(255,200,50,.05);padding:1rem;border:1px solid rgba(255,200,50,.18)}
 .score-good,.score-good .badge{color:#53d769}
 .score-ok,.score-ok .badge{color:#f5a623}
 .score-bad,.score-bad .badge{color:#e94560}
@@ -242,8 +288,8 @@ a.score-good,a.score-ok,a.score-bad{color:inherit}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Mutation;
     use crate::test_helpers::sample_report;
+    use crate::{BuildErrorDiagnostic, Mutation};
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -277,6 +323,94 @@ mod tests {
     }
 
     #[test]
+    fn html_contains_build_error_diagnostics() {
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 1,
+                    file: PathBuf::from("src/test.rs"),
+                    language: "rust".to_string(),
+                    line: 1,
+                    column: 1,
+                    operator: "eq_to_neq".to_string(),
+                    description: "d".to_string(),
+                    original: "==".to_string(),
+                    replacement: "!=".to_string(),
+                    byte_range: 0..2,
+                },
+                MutationResult::BuildError,
+            )],
+            build_error_diagnostics: vec![BuildErrorDiagnostic::new(
+                1,
+                "regular",
+                "build_command",
+                vec!["cargo".into(), "check".into()],
+                "error[E0308]: mismatched types",
+            )],
+            duration: Duration::from_millis(100),
+            test_command: None,
+            build_command: vec![],
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 1,
+        };
+
+        let html = generate_report(&report).unwrap();
+        assert!(html.contains("Build error diagnostics"));
+        assert!(html.contains("eq_to_neq"));
+        assert!(html.contains("build_command"));
+        assert!(html.contains("error[E0308]: mismatched types"));
+    }
+
+    #[test]
+    fn html_build_error_diagnostics_show_truncation_notice() {
+        let mut results = Vec::new();
+        let mut build_error_diagnostics = Vec::new();
+        for id in 0..11 {
+            let operator = format!("op{id}");
+            results.push((
+                Mutation {
+                    id,
+                    file: PathBuf::from(format!("src/test{id}.rs")),
+                    language: "rust".to_string(),
+                    line: 1,
+                    column: 1,
+                    operator,
+                    description: "d".to_string(),
+                    original: "==".to_string(),
+                    replacement: "!=".to_string(),
+                    byte_range: 0..2,
+                },
+                MutationResult::BuildError,
+            ));
+            build_error_diagnostics.push(BuildErrorDiagnostic::new(
+                id,
+                "regular",
+                "build_command",
+                vec!["cargo".into(), "check".into()],
+                format!("error {id}"),
+            ));
+        }
+        let report = MutationReport {
+            results,
+            build_error_diagnostics,
+            duration: Duration::from_millis(100),
+            test_command: None,
+            build_command: vec![],
+            total: 11,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 11,
+        };
+
+        let html = generate_report(&report).unwrap();
+        assert!(html.contains("... 1 more group"));
+    }
+
+    #[test]
     fn html_escapes_special_chars() {
         let report = MutationReport {
             results: vec![(
@@ -294,6 +428,7 @@ mod tests {
                 },
                 MutationResult::Killed,
             )],
+            build_error_diagnostics: vec![],
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,6 +1,7 @@
 use crate::{MutationReport, MutationResult};
 use anyhow::Result;
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 #[derive(Serialize)]
 struct JsonReport {
@@ -14,7 +15,36 @@ struct JsonReport {
     duration_ms: u128,
     test_command: Option<Vec<String>>,
     build_command: Vec<String>,
+    build_error_groups: Vec<JsonBuildErrorGroup>,
     mutations: Vec<JsonMutation>,
+}
+
+#[derive(Serialize)]
+struct JsonBuildErrorGroup {
+    count: usize,
+    language: String,
+    operator: String,
+    runner: String,
+    phase: String,
+    fingerprint: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    command: Vec<String>,
+    message: String,
+    files: Vec<JsonBuildErrorFileCount>,
+    examples: Vec<JsonBuildErrorExample>,
+}
+
+#[derive(Serialize)]
+struct JsonBuildErrorFileCount {
+    file: String,
+    count: usize,
+}
+
+#[derive(Serialize)]
+struct JsonBuildErrorExample {
+    mutation_id: u32,
+    file: String,
+    line: usize,
 }
 
 #[derive(Serialize)]
@@ -33,6 +63,8 @@ struct JsonMutation {
     replacement: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    build_error_fingerprint: Option<String>,
 }
 
 pub fn print_report(report: &MutationReport) -> Result<()> {
@@ -43,6 +75,11 @@ pub fn print_report(report: &MutationReport) -> Result<()> {
 
 /// Serialize report to a JSON string (for testing and programmatic use).
 pub fn to_json_string(report: &MutationReport) -> Result<String> {
+    let diagnostic_by_id: BTreeMap<_, _> = report
+        .build_error_diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.mutation_id, diagnostic))
+        .collect();
     let mutations: Vec<JsonMutation> = report
         .results
         .iter()
@@ -62,6 +99,39 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
             original: Some(m.original.clone()),
             replacement: Some(m.replacement.clone()),
             diff: super::mutation_diff(m),
+            build_error_fingerprint: diagnostic_by_id
+                .get(&m.id)
+                .map(|diagnostic| diagnostic.fingerprint.clone()),
+        })
+        .collect();
+    let build_error_groups = super::build_error_groups(report)
+        .into_iter()
+        .map(|group| JsonBuildErrorGroup {
+            count: group.count,
+            language: group.language,
+            operator: group.operator,
+            runner: group.runner,
+            phase: group.phase,
+            fingerprint: group.fingerprint,
+            command: group.command,
+            message: group.message,
+            files: group
+                .files
+                .into_iter()
+                .map(|file| JsonBuildErrorFileCount {
+                    file: file.file,
+                    count: file.count,
+                })
+                .collect(),
+            examples: group
+                .examples
+                .into_iter()
+                .map(|example| JsonBuildErrorExample {
+                    mutation_id: example.mutation_id,
+                    file: example.file,
+                    line: example.line,
+                })
+                .collect(),
         })
         .collect();
 
@@ -77,6 +147,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         duration_ms: report.duration.as_millis(),
         test_command: report.test_command.clone(),
         build_command: report.build_command.clone(),
+        build_error_groups,
         mutations,
     };
 
@@ -86,8 +157,8 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Mutation;
     use crate::test_helpers::sample_report;
+    use crate::{BuildErrorDiagnostic, Mutation};
     use serde_json::Value;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -124,6 +195,7 @@ mod tests {
         assert_eq!(value["duration_ms"], 1234);
         assert_eq!(value["test_command"], serde_json::json!(["cargo", "test"]));
         assert_eq!(value["build_command"], serde_json::json!([]));
+        assert_eq!(value["build_error_groups"], serde_json::json!([]));
 
         let mutations = value["mutations"].as_array().unwrap();
         assert_eq!(mutations.len(), 2);
@@ -154,6 +226,7 @@ mod tests {
                 "duration_ms",
                 "test_command",
                 "build_command",
+                "build_error_groups",
                 "mutations",
             ],
         );
@@ -207,6 +280,7 @@ mod tests {
                 },
                 MutationResult::BuildError,
             )],
+            build_error_diagnostics: vec![],
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
@@ -223,9 +297,64 @@ mod tests {
     }
 
     #[test]
+    fn json_output_includes_build_error_groups() {
+        let diagnostic = BuildErrorDiagnostic::new(
+            1,
+            "regular",
+            "build_command",
+            vec!["cargo".into(), "check".into()],
+            "error[E0308]: mismatched types",
+        );
+        let fingerprint = diagnostic.fingerprint.clone();
+        let report = MutationReport {
+            results: vec![(
+                Mutation {
+                    id: 1,
+                    file: PathBuf::from("src/a.rs"),
+                    language: "rust".to_string(),
+                    line: 1,
+                    column: 1,
+                    operator: "eq_to_neq".to_string(),
+                    description: "d".to_string(),
+                    original: "==".to_string(),
+                    replacement: "!=".to_string(),
+                    byte_range: 0..2,
+                },
+                MutationResult::BuildError,
+            )],
+            build_error_diagnostics: vec![diagnostic],
+            duration: Duration::from_millis(100),
+            test_command: None,
+            build_command: vec![],
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: 0,
+            build_errors: 1,
+        };
+
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(value["build_error_groups"][0]["count"], 1);
+        assert_eq!(value["build_error_groups"][0]["language"], "rust");
+        assert_eq!(value["build_error_groups"][0]["operator"], "eq_to_neq");
+        assert_eq!(value["build_error_groups"][0]["runner"], "regular");
+        assert_eq!(value["build_error_groups"][0]["phase"], "build_command");
+        assert_eq!(
+            value["build_error_groups"][0]["command"],
+            serde_json::json!(["cargo", "check"])
+        );
+        assert_eq!(
+            value["mutations"][0]["build_error_fingerprint"],
+            serde_json::json!(fingerprint)
+        );
+    }
+
+    #[test]
     fn json_score_100_when_empty_report() {
         let report = MutationReport {
             results: vec![],
+            build_error_diagnostics: vec![],
             duration: Duration::from_millis(0),
             test_command: None,
             build_command: vec![],

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -3,7 +3,8 @@ pub mod html;
 pub mod json;
 pub mod terminal;
 
-use crate::{Mutation, MutationReport};
+use crate::{BuildErrorDiagnostic, Mutation, MutationReport, MutationResult};
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
 
@@ -16,6 +17,148 @@ pub fn mutation_score(report: &MutationReport) -> f64 {
         100.0
     } else {
         0.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildErrorGroup {
+    pub count: usize,
+    pub language: String,
+    pub operator: String,
+    pub runner: String,
+    pub phase: String,
+    pub fingerprint: String,
+    pub command: Vec<String>,
+    pub message: String,
+    pub files: Vec<BuildErrorFileCount>,
+    pub examples: Vec<BuildErrorExample>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildErrorFileCount {
+    pub file: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildErrorExample {
+    pub mutation_id: u32,
+    pub file: String,
+    pub line: usize,
+}
+
+struct BuildErrorGroupAccumulator {
+    count: usize,
+    command: Vec<String>,
+    message: String,
+    files: BTreeMap<String, usize>,
+    examples: Vec<BuildErrorExample>,
+}
+
+/// Group build errors into actionable buckets for report output.
+pub fn build_error_groups(report: &MutationReport) -> Vec<BuildErrorGroup> {
+    let diagnostics: BTreeMap<u32, &BuildErrorDiagnostic> = report
+        .build_error_diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.mutation_id, diagnostic))
+        .collect();
+    let mut groups =
+        BTreeMap::<(String, String, String, String, String), BuildErrorGroupAccumulator>::new();
+
+    for (mutation, result) in &report.results {
+        if *result != MutationResult::BuildError {
+            continue;
+        }
+
+        let diagnostic = diagnostics.get(&mutation.id).copied();
+        let language = label_or_unknown(&mutation.language);
+        let operator = label_or_unknown(&mutation.operator);
+        let runner = diagnostic
+            .map(|diagnostic| diagnostic.runner.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        let phase = diagnostic
+            .map(|diagnostic| diagnostic.phase.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        let message = diagnostic
+            .map(|diagnostic| diagnostic.message.clone())
+            .unwrap_or_else(|| "build error diagnostic unavailable".to_string());
+        let fingerprint = diagnostic
+            .map(|diagnostic| diagnostic.fingerprint.clone())
+            .unwrap_or_else(|| BuildErrorDiagnostic::fingerprint_for(&message));
+        let command = diagnostic
+            .map(|diagnostic| diagnostic.command.clone())
+            .unwrap_or_default();
+        let key = (
+            language.clone(),
+            operator.clone(),
+            runner.clone(),
+            phase.clone(),
+            fingerprint.clone(),
+        );
+        let accumulator = groups
+            .entry(key)
+            .or_insert_with(|| BuildErrorGroupAccumulator {
+                count: 0,
+                command,
+                message,
+                files: BTreeMap::new(),
+                examples: Vec::new(),
+            });
+
+        accumulator.count += 1;
+        *accumulator
+            .files
+            .entry(mutation.file.display().to_string())
+            .or_default() += 1;
+        if accumulator.examples.len() < 3 {
+            accumulator.examples.push(BuildErrorExample {
+                mutation_id: mutation.id + 1,
+                file: mutation.file.display().to_string(),
+                line: mutation.line,
+            });
+        }
+    }
+
+    let mut groups: Vec<_> = groups
+        .into_iter()
+        .map(
+            |((language, operator, runner, phase, fingerprint), accumulator)| BuildErrorGroup {
+                count: accumulator.count,
+                language,
+                operator,
+                runner,
+                phase,
+                fingerprint,
+                command: accumulator.command,
+                message: accumulator.message,
+                files: accumulator
+                    .files
+                    .into_iter()
+                    .map(|(file, count)| BuildErrorFileCount { file, count })
+                    .collect(),
+                examples: accumulator.examples,
+            },
+        )
+        .collect();
+    groups.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.language.cmp(&right.language))
+            .then_with(|| left.operator.cmp(&right.operator))
+            .then_with(|| left.runner.cmp(&right.runner))
+            .then_with(|| left.phase.cmp(&right.phase))
+            .then_with(|| left.fingerprint.cmp(&right.fingerprint))
+    });
+    groups
+}
+
+fn label_or_unknown(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        "unknown".to_string()
+    } else {
+        trimmed.to_string()
     }
 }
 
@@ -217,6 +360,69 @@ mod tests {
         }
     }
 
+    fn report_mutation(id: u32, file: &str, result: MutationResult) -> (Mutation, MutationResult) {
+        (
+            Mutation {
+                id,
+                file: std::path::PathBuf::from(file),
+                language: "rust".into(),
+                line: usize::try_from(id + 1).unwrap(),
+                column: 1,
+                operator: "eq_to_neq".into(),
+                description: "Replace == with !=".into(),
+                original: "==".into(),
+                replacement: "!=".into(),
+                byte_range: 0..2,
+            },
+            result,
+        )
+    }
+
+    #[test]
+    fn build_error_groups_deduplicate_by_diagnostic_fingerprint() {
+        let report = MutationReport {
+            results: vec![
+                report_mutation(0, "src/a.rs", MutationResult::BuildError),
+                report_mutation(1, "src/b.rs", MutationResult::BuildError),
+                report_mutation(2, "src/c.rs", MutationResult::Killed),
+            ],
+            build_error_diagnostics: vec![
+                BuildErrorDiagnostic::new(
+                    0,
+                    "regular",
+                    "build_command",
+                    vec!["cargo".into(), "check".into()],
+                    "error[E0308]: mismatched types at line 10",
+                ),
+                BuildErrorDiagnostic::new(
+                    1,
+                    "regular",
+                    "build_command",
+                    vec!["cargo".into(), "check".into()],
+                    "error[E0308]: mismatched types at line 20",
+                ),
+            ],
+            duration: std::time::Duration::from_millis(10),
+            test_command: None,
+            build_command: vec![],
+            total: 3,
+            killed: 1,
+            survived: 0,
+            timeout: 0,
+            build_errors: 2,
+        };
+
+        let groups = build_error_groups(&report);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].count, 2);
+        assert_eq!(groups[0].language, "rust");
+        assert_eq!(groups[0].operator, "eq_to_neq");
+        assert_eq!(groups[0].runner, "regular");
+        assert_eq!(groups[0].phase, "build_command");
+        assert_eq!(groups[0].files.len(), 2);
+        assert_eq!(groups[0].examples.len(), 2);
+    }
+
     #[test]
     fn mutation_diff_basic() {
         let tmp = TempDir::new().unwrap();
@@ -349,6 +555,7 @@ mod tests {
                 },
                 MutationResult::Killed,
             )],
+            build_error_diagnostics: vec![],
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],
@@ -383,6 +590,7 @@ mod tests {
                 },
                 MutationResult::Timeout,
             )],
+            build_error_diagnostics: vec![],
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -104,11 +104,68 @@ fn format_report(report: &MutationReport, color: bool) -> String {
     writeln!(out, "Duration: {:.2}s", report.duration.as_secs_f64()).unwrap();
     writeln!(out, "{separator}").unwrap();
 
+    let build_error_summary = format_build_error_groups(report);
+    if !build_error_summary.is_empty() {
+        writeln!(out).unwrap();
+        write!(out, "{build_error_summary}").unwrap();
+    }
+
     if let Some(guidance) = all_build_error_guidance(report) {
         writeln!(out).unwrap();
         write!(out, "{guidance}").unwrap();
     }
 
+    out
+}
+
+fn format_build_error_groups(report: &MutationReport) -> String {
+    let groups = super::build_error_groups(report);
+    if groups.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    writeln!(out, "Build error diagnostics:").unwrap();
+    for group in groups.iter().take(5) {
+        writeln!(
+            out,
+            "  {} build error{} — {} / {} / {} / {} [{}]",
+            group.count,
+            if group.count == 1 { "" } else { "s" },
+            group.language,
+            group.operator,
+            group.runner,
+            group.phase,
+            group.fingerprint
+        )
+        .unwrap();
+        if !group.command.is_empty() {
+            writeln!(out, "      command: {}", group.command.join(" ")).unwrap();
+        }
+        if !group.files.is_empty() {
+            let files = group
+                .files
+                .iter()
+                .take(3)
+                .map(|file| format!("{} ({})", file.file, file.count))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(out, "      files: {files}").unwrap();
+        }
+        let first_line = group.message.lines().next().unwrap_or("").trim();
+        if !first_line.is_empty() {
+            writeln!(out, "      {first_line}").unwrap();
+        }
+    }
+    if groups.len() > 5 {
+        writeln!(
+            out,
+            "  ... {} more build-error group{}",
+            groups.len() - 5,
+            if groups.len() - 5 == 1 { "" } else { "s" }
+        )
+        .unwrap();
+    }
     out
 }
 
@@ -170,7 +227,7 @@ fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Mutation;
+    use crate::{BuildErrorDiagnostic, Mutation};
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -210,6 +267,7 @@ mod tests {
 
         MutationReport {
             results,
+            build_error_diagnostics: vec![],
             duration: Duration::from_millis(500),
             test_command: None,
             build_command: vec![],
@@ -254,14 +312,27 @@ mod tests {
 
     #[test]
     fn terminal_output_summary_with_timeout_and_build_errors() {
-        let report = report(vec![
+        let mut report = report(vec![
             (mutation(1, "src/a.rs", 1), MutationResult::Killed),
             (mutation(2, "src/b.rs", 2), MutationResult::Timeout),
             (mutation(3, "src/c.rs", 3), MutationResult::BuildError),
         ]);
+        report
+            .build_error_diagnostics
+            .push(BuildErrorDiagnostic::new(
+                3,
+                "regular",
+                "build_command",
+                vec!["cargo".into(), "check".into()],
+                "error[E0308]: mismatched types",
+            ));
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 0 survived, 1 timeout, 1 build errors"));
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
+        assert!(output.contains("Build error diagnostics:"));
+        assert!(output.contains("unknown / op / regular / build_command"));
+        assert!(output.contains("command: cargo check"));
+        assert!(output.contains("error[E0308]: mismatched types"));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,7 +1,7 @@
 // Parallel test execution with timeouts
 
 use crate::cache::{self, CacheKey};
-use crate::{Mutation, MutationReport, MutationResult};
+use crate::{BuildErrorDiagnostic, Mutation, MutationReport, MutationResult};
 use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::hash::Hasher;
@@ -857,6 +857,27 @@ struct QueuedMutation {
     mutation: Mutation,
 }
 
+#[derive(Debug)]
+struct MutationRunRecord {
+    mutation: Mutation,
+    result: MutationResult,
+    build_error_diagnostic: Option<BuildErrorDiagnostic>,
+}
+
+impl MutationRunRecord {
+    fn new(
+        mutation: Mutation,
+        result: MutationResult,
+        build_error_diagnostic: Option<BuildErrorDiagnostic>,
+    ) -> Self {
+        Self {
+            mutation,
+            result,
+            build_error_diagnostic,
+        }
+    }
+}
+
 struct RunShared<'a> {
     workspace_pool: &'a WorkspacePool,
     project_root: &'a Path,
@@ -879,7 +900,7 @@ fn run_queued_mutation(
     queued: QueuedMutation,
     reservation: TestSlotReservation,
     shared: RunShared<'_>,
-) -> Option<(usize, Mutation, MutationResult)> {
+) -> Option<(usize, MutationRunRecord)> {
     let QueuedMutation { index, mutation } = queued;
 
     // Stop if cancelled (Ctrl+C).
@@ -914,7 +935,8 @@ fn run_queued_mutation(
         if let Some(result) = cache::lookup(shared.project_root, key) {
             reservation.release();
             record_progress(&shared, &mutation, result, None, true);
-            return Some((index, mutation, result));
+            let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
+            return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
         }
     }
 
@@ -932,7 +954,20 @@ fn run_queued_mutation(
             );
             reservation.release();
             record_progress(&shared, &mutation, MutationResult::BuildError, None, false);
-            return Some((index, mutation, MutationResult::BuildError));
+            let diagnostic = BuildErrorDiagnostic::new(
+                mutation.id,
+                "regular",
+                "workspace_reset",
+                vec![],
+                format!(
+                    "could not reset isolated mutation workspace {}: {e}",
+                    workspace_root.display()
+                ),
+            );
+            return Some((
+                index,
+                MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic)),
+            ));
         }
         let workspace_target =
             ResolvedMutation::new_for_execution(shared.project_root, &workspace_root, &mutation);
@@ -972,7 +1007,8 @@ fn run_queued_mutation(
         outcome.test_output.as_deref(),
         false,
     );
-    Some((index, mutation, result))
+    let diagnostic = build_error_diagnostic_from_outcome(&mutation, "regular", &outcome);
+    Some((index, MutationRunRecord::new(mutation, result, diagnostic)))
 }
 
 struct TestSlotReservation {
@@ -1084,7 +1120,7 @@ impl TestRunner {
     pub fn run_with_schemata(&self, mutations: Vec<Mutation>) -> RunOutcome {
         let start = Instant::now();
         if mutations.is_empty() {
-            return self.outcome_from_results(Vec::new(), start.elapsed());
+            return self.outcome_from_records(Vec::new(), start.elapsed());
         }
 
         let index_by_id: HashMap<u32, usize> = mutations
@@ -1113,10 +1149,10 @@ impl TestRunner {
             return self.run_regular(fallback_mutations);
         }
 
-        let mut all_results = Vec::new();
+        let mut all_records = Vec::new();
         for (language, schema_mutations) in schema_by_language {
             match self.run_schema_mutations(&language, &schema_mutations) {
-                Ok(results) => all_results.extend(results),
+                Ok(records) => all_records.extend(records),
                 Err(err) => {
                     eprintln!("warning: could not run {language} schemata: {err} — falling back");
                     fallback_mutations.extend(
@@ -1130,13 +1166,16 @@ impl TestRunner {
 
         if !self.cancelled.load(Ordering::Acquire) && !fallback_mutations.is_empty() {
             let fallback = self.run_regular(fallback_mutations);
-            all_results.extend(fallback.report.results);
+            all_records.extend(records_from_report(fallback.report));
         }
 
-        all_results.sort_by_key(|(mutation, _)| {
-            index_by_id.get(&mutation.id).copied().unwrap_or(usize::MAX)
+        all_records.sort_by_key(|record| {
+            index_by_id
+                .get(&record.mutation.id)
+                .copied()
+                .unwrap_or(usize::MAX)
         });
-        self.outcome_from_results(all_results, start.elapsed())
+        self.outcome_from_records(all_records, start.elapsed())
     }
 
     #[allow(clippy::manual_is_multiple_of)]
@@ -1144,10 +1183,10 @@ impl TestRunner {
         let start = Instant::now();
         let total = mutations.len();
         if total == 0 {
-            return self.outcome_from_results(Vec::new(), start.elapsed());
+            return self.outcome_from_records(Vec::new(), start.elapsed());
         }
         if self.cancelled.load(Ordering::Acquire) {
-            return self.outcome_from_results(Vec::new(), start.elapsed());
+            return self.outcome_from_records(Vec::new(), start.elapsed());
         }
 
         let counter = Arc::new(AtomicUsize::new(0));
@@ -1167,9 +1206,22 @@ impl TestRunner {
                 eprintln!("warning: could not create isolated mutation workspaces: {e}");
                 let results = mutations
                     .into_iter()
-                    .map(|mutation| (mutation, MutationResult::BuildError))
+                    .map(|mutation| {
+                        let diagnostic = BuildErrorDiagnostic::new(
+                            mutation.id,
+                            "regular",
+                            "workspace_pool",
+                            vec![],
+                            format!("could not create isolated mutation workspaces: {e}"),
+                        );
+                        MutationRunRecord::new(
+                            mutation,
+                            MutationResult::BuildError,
+                            Some(diagnostic),
+                        )
+                    })
                     .collect();
-                return self.outcome_from_results(results, start.elapsed());
+                return self.outcome_from_records(results, start.elapsed());
             }
         };
 
@@ -1266,10 +1318,10 @@ impl TestRunner {
             .expect("all result handles should be dropped")
             .into_inner()
             .expect("mutation results mutex poisoned");
-        indexed_results.sort_by_key(|(index, _, _)| *index);
-        let all_results = indexed_results
+        indexed_results.sort_by_key(|(index, _)| *index);
+        let all_records = indexed_results
             .into_iter()
-            .map(|(_, mutation, result)| (mutation, result))
+            .map(|(_, record)| record)
             .collect();
 
         // Clear progress line on TTY
@@ -1278,14 +1330,14 @@ impl TestRunner {
             let _ = std::io::stderr().flush();
         }
 
-        self.outcome_from_results(all_results, start.elapsed())
+        self.outcome_from_records(all_records, start.elapsed())
     }
 
     fn run_schema_mutations(
         &self,
         language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
-    ) -> Result<Vec<(Mutation, MutationResult)>, crate::schemata::SchemaRewriteError> {
+    ) -> Result<Vec<MutationRunRecord>, crate::schemata::SchemaRewriteError> {
         let rewrites = match language {
             "c" => crate::schemata::rewrite_c_files(&self.project_root, schema_mutations)?,
             "cpp" => crate::schemata::rewrite_cpp_files(&self.project_root, schema_mutations)?,
@@ -1334,7 +1386,7 @@ impl TestRunner {
                 &self.commands.build_command,
                 workspace.root(),
                 self.commands.timeout,
-                false,
+                true,
                 &self.env,
                 &self.cancelled,
             );
@@ -1345,7 +1397,23 @@ impl TestRunner {
                 return Ok(schema_mutations
                     .iter()
                     .map(|schema_mutation| {
-                        (schema_mutation.mutation.clone(), MutationResult::BuildError)
+                        let diagnostic = BuildErrorDiagnostic::new(
+                            schema_mutation.mutation.id,
+                            "schemata",
+                            "schema_build",
+                            self.commands.build_command.clone(),
+                            build_error_message_from_outcome(
+                                "schema build command",
+                                &self.commands.build_command,
+                                workspace.root(),
+                                &build,
+                            ),
+                        );
+                        MutationRunRecord::new(
+                            schema_mutation.mutation.clone(),
+                            MutationResult::BuildError,
+                            Some(diagnostic),
+                        )
                     })
                     .collect());
             }
@@ -1404,7 +1472,8 @@ impl TestRunner {
                             mutation.operator
                         );
                     }
-                    results.push((mutation.clone(), result));
+                    let diagnostic = cached_build_error_diagnostic(mutation, "schemata", result);
+                    results.push(MutationRunRecord::new(mutation.clone(), result, diagnostic));
                     continue;
                 }
             }
@@ -1457,48 +1526,58 @@ impl TestRunner {
                     eprintln!("  └─");
                 }
             }
-            results.push((mutation.clone(), outcome.result));
+            let diagnostic = build_error_diagnostic_from_outcome(mutation, "schemata", &outcome);
+            results.push(MutationRunRecord::new(
+                mutation.clone(),
+                outcome.result,
+                diagnostic,
+            ));
         }
 
         Ok(results)
     }
 
-    fn outcome_from_results(
+    fn outcome_from_records(
         &self,
-        all_results: Vec<(Mutation, MutationResult)>,
+        all_records: Vec<MutationRunRecord>,
         duration: Duration,
     ) -> RunOutcome {
         RunOutcome {
-            report: self.report_from_results(all_results, duration),
+            report: self.report_from_records(all_records, duration),
             cancelled: self.cancelled.load(Ordering::Acquire),
         }
     }
 
-    fn report_from_results(
+    fn report_from_records(
         &self,
-        all_results: Vec<(Mutation, MutationResult)>,
+        all_records: Vec<MutationRunRecord>,
         duration: Duration,
     ) -> MutationReport {
-        let total = all_results.len();
-        let killed = all_results
-            .iter()
-            .filter(|(_, r)| *r == MutationResult::Killed)
-            .count();
-        let survived = all_results
-            .iter()
-            .filter(|(_, r)| *r == MutationResult::Survived)
-            .count();
-        let timeout_count = all_results
-            .iter()
-            .filter(|(_, r)| *r == MutationResult::Timeout)
-            .count();
-        let build_errors = all_results
-            .iter()
-            .filter(|(_, r)| *r == MutationResult::BuildError)
-            .count();
+        let mut results = Vec::with_capacity(all_records.len());
+        let mut build_error_diagnostics = Vec::new();
+        let mut total = 0;
+        let mut killed = 0;
+        let mut survived = 0;
+        let mut timeout_count = 0;
+        let mut build_errors = 0;
+
+        for record in all_records {
+            total += 1;
+            match record.result {
+                MutationResult::Killed => killed += 1,
+                MutationResult::Survived => survived += 1,
+                MutationResult::Timeout => timeout_count += 1,
+                MutationResult::BuildError => build_errors += 1,
+            }
+            if let Some(diagnostic) = record.build_error_diagnostic {
+                build_error_diagnostics.push(diagnostic);
+            }
+            results.push((record.mutation, record.result));
+        }
 
         MutationReport {
-            results: all_results,
+            results,
+            build_error_diagnostics,
             duration,
             test_command: if self.commands.language_commands.is_empty()
                 && self.commands.project_commands.is_empty()
@@ -1521,6 +1600,22 @@ impl TestRunner {
     }
 }
 
+fn records_from_report(report: MutationReport) -> Vec<MutationRunRecord> {
+    let mut diagnostics: HashMap<u32, BuildErrorDiagnostic> = report
+        .build_error_diagnostics
+        .into_iter()
+        .map(|diagnostic| (diagnostic.mutation_id, diagnostic))
+        .collect();
+    report
+        .results
+        .into_iter()
+        .map(|(mutation, result)| {
+            let diagnostic = diagnostics.remove(&mutation.id);
+            MutationRunRecord::new(mutation, result, diagnostic)
+        })
+        .collect()
+}
+
 fn workspace_pool_slot_count(parallelism: usize, total: usize) -> usize {
     debug_assert!(total > 0);
     parallelism.max(1).min(total)
@@ -1529,7 +1624,24 @@ fn workspace_pool_slot_count(parallelism: usize, total: usize) -> usize {
 struct MutationOutcome {
     result: MutationResult,
     test_output: Option<String>,
+    build_error_detail: Option<BuildErrorDetail>,
     cancelled: bool,
+}
+
+struct BuildErrorDetail {
+    phase: String,
+    command: Vec<String>,
+    message: String,
+}
+
+impl BuildErrorDetail {
+    fn new(phase: impl Into<String>, command: Vec<String>, message: impl Into<String>) -> Self {
+        Self {
+            phase: phase.into(),
+            command,
+            message: message.into(),
+        }
+    }
 }
 
 impl MutationOutcome {
@@ -1537,18 +1649,29 @@ impl MutationOutcome {
         Self {
             result,
             test_output,
+            build_error_detail: None,
             cancelled: false,
         }
     }
 
-    fn build_error() -> Self {
-        Self::new(MutationResult::BuildError, None)
+    fn build_error_with(
+        phase: impl Into<String>,
+        command: Vec<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            result: MutationResult::BuildError,
+            test_output: None,
+            build_error_detail: Some(BuildErrorDetail::new(phase, command, message)),
+            cancelled: false,
+        }
     }
 
     fn cancelled() -> Self {
         Self {
             result: MutationResult::BuildError,
             test_output: None,
+            build_error_detail: None,
             cancelled: true,
         }
     }
@@ -1557,6 +1680,80 @@ impl MutationOutcome {
 struct BuildCommand<'a> {
     argv: &'a [String],
     explicit: bool,
+}
+
+/// Cache entries currently persist only [`MutationResult`], so
+/// `cached_build_error_diagnostic` intentionally groups cached build errors
+/// under one synthetic [`BuildErrorDiagnostic::new`] bucket. Persist the
+/// original phase/fingerprint with cached results to restore full fidelity.
+fn cached_build_error_diagnostic(
+    mutation: &Mutation,
+    runner: &str,
+    result: MutationResult,
+) -> Option<BuildErrorDiagnostic> {
+    (result == MutationResult::BuildError).then(|| {
+        BuildErrorDiagnostic::new(
+            mutation.id,
+            runner,
+            "cache",
+            vec![],
+            "build error result restored from cache; diagnostic output unavailable",
+        )
+    })
+}
+
+fn build_error_diagnostic_from_outcome(
+    mutation: &Mutation,
+    runner: &str,
+    outcome: &MutationOutcome,
+) -> Option<BuildErrorDiagnostic> {
+    if outcome.result != MutationResult::BuildError {
+        return None;
+    }
+    let Some(detail) = outcome.build_error_detail.as_ref() else {
+        return Some(BuildErrorDiagnostic::new(
+            mutation.id,
+            runner,
+            "unknown",
+            vec![],
+            "build error diagnostic unavailable",
+        ));
+    };
+    Some(BuildErrorDiagnostic::new(
+        mutation.id,
+        runner,
+        detail.phase.clone(),
+        detail.command.clone(),
+        detail.message.clone(),
+    ))
+}
+
+fn build_error_message_from_outcome(
+    context: &str,
+    command: &[String],
+    cwd: &Path,
+    outcome: &MutationOutcome,
+) -> String {
+    if let Some(output) = outcome.test_output.as_deref() {
+        if !output.trim().is_empty() {
+            return output.to_string();
+        }
+    }
+    if let Some(detail) = outcome.build_error_detail.as_ref() {
+        if !detail.message.trim().is_empty() {
+            return detail.message.clone();
+        }
+    }
+    let command = if command.is_empty() {
+        "<empty>".to_string()
+    } else {
+        command.join(" ")
+    };
+    format!(
+        "{context} returned {}; command: {command}; cwd: {}",
+        outcome.result,
+        cwd.display()
+    )
 }
 
 fn mutation_file_path(project_root: &Path, mutation_file: &Path) -> PathBuf {
@@ -1731,7 +1928,15 @@ fn run_single_mutation(
     let file_path = match target.file_path {
         Ok(path) => path,
         Err(()) => {
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "resolve_mutation_path",
+                vec![],
+                format!(
+                    "could not resolve mutation path {} in workspace {}",
+                    mutation.file.display(),
+                    project_root.display()
+                ),
+            );
         }
     };
 
@@ -1740,7 +1945,11 @@ fn run_single_mutation(
         Ok(content) => content,
         Err(e) => {
             eprintln!("warning: could not read {}: {e}", file_path.display());
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "read_source",
+                vec![],
+                format!("could not read {}: {e}", file_path.display()),
+            );
         }
     };
 
@@ -1754,13 +1963,27 @@ fn run_single_mutation(
     let mut mutated = original.clone();
     let range = mutation.byte_range.clone();
     if range.start > range.end || range.end > mutated.len() {
-        return MutationOutcome::build_error();
+        return MutationOutcome::build_error_with(
+            "apply_mutation",
+            vec![],
+            format!(
+                "mutation byte range {}..{} is outside {} bytes in {}",
+                range.start,
+                range.end,
+                mutated.len(),
+                file_path.display()
+            ),
+        );
     }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
     if let Err(e) = write_workspace_file(&file_path, &mutated) {
         eprintln!("warning: could not write {}: {e}", file_path.display());
-        return MutationOutcome::build_error();
+        return MutationOutcome::build_error_with(
+            "write_source",
+            vec![],
+            format!("could not write {}: {e}", file_path.display()),
+        );
     }
 
     // Explicit build check: skip expensive test if mutation doesn't compile.
@@ -1769,7 +1992,7 @@ fn run_single_mutation(
             build_command.argv,
             project_root,
             timeout,
-            false,
+            true,
             env,
             cancelled,
         );
@@ -1777,7 +2000,16 @@ fn run_single_mutation(
             return build_outcome;
         }
         if build_outcome.result != MutationResult::Survived {
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "build_command",
+                build_command.argv.to_vec(),
+                build_error_message_from_outcome(
+                    "build command",
+                    build_command.argv,
+                    project_root,
+                    &build_outcome,
+                ),
+            );
         }
     }
 
@@ -1809,7 +2041,7 @@ fn run_command(
     }
 
     if command.is_empty() {
-        return MutationOutcome::build_error();
+        return MutationOutcome::build_error_with("command", vec![], "command is empty");
     }
 
     let mut cmd = std::process::Command::new(&command[0]);
@@ -1823,14 +2055,22 @@ fn run_command(
             Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stdout capture file: {e}");
-                return MutationOutcome::build_error();
+                return MutationOutcome::build_error_with(
+                    "command",
+                    command.to_vec(),
+                    format!("could not create stdout capture file: {e}"),
+                );
             }
         };
         stderr_capture = match OutputCapture::new("stderr") {
             Ok(capture) => Some(capture),
             Err(e) => {
                 eprintln!("warning: could not create stderr capture file: {e}");
-                return MutationOutcome::build_error();
+                return MutationOutcome::build_error_with(
+                    "command",
+                    command.to_vec(),
+                    format!("could not create stderr capture file: {e}"),
+                );
             }
         };
         cmd.stdout(std::process::Stdio::piped());
@@ -1848,7 +2088,11 @@ fn run_command(
         Ok(c) => c,
         Err(e) => {
             eprintln!("warning: could not spawn command {:?}: {e}", &command[0]);
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "command",
+                command.to_vec(),
+                format!("could not spawn command {:?}: {e}", &command[0]),
+            );
         }
     };
     let mut process_tree = ProcessTreeGuard::attach(&child);
@@ -1856,27 +2100,43 @@ fn run_command(
     if capture_output {
         let Some(stdout) = child.stdout.take() else {
             terminate_and_wait(&mut child, &mut process_tree);
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "command",
+                command.to_vec(),
+                "could not capture command stdout",
+            );
         };
         if let Some(capture) = stdout_capture.as_mut() {
             if let Err(e) = capture.start(stdout) {
                 eprintln!("warning: could not open stdout capture file: {e}");
                 terminate_and_wait(&mut child, &mut process_tree);
-                return MutationOutcome::build_error();
+                return MutationOutcome::build_error_with(
+                    "command",
+                    command.to_vec(),
+                    format!("could not open stdout capture file: {e}"),
+                );
             }
         }
 
         let Some(stderr) = child.stderr.take() else {
             terminate_and_wait(&mut child, &mut process_tree);
             finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-            return MutationOutcome::build_error();
+            return MutationOutcome::build_error_with(
+                "command",
+                command.to_vec(),
+                "could not capture command stderr",
+            );
         };
         if let Some(capture) = stderr_capture.as_mut() {
             if let Err(e) = capture.start(stderr) {
                 eprintln!("warning: could not open stderr capture file: {e}");
                 terminate_and_wait(&mut child, &mut process_tree);
                 finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-                return MutationOutcome::build_error();
+                return MutationOutcome::build_error_with(
+                    "command",
+                    command.to_vec(),
+                    format!("could not open stderr capture file: {e}"),
+                );
             }
         }
     }
@@ -1899,10 +2159,14 @@ fn run_command(
                 let remaining = timeout_dur.saturating_sub(started.elapsed());
                 thread::sleep(remaining.min(Duration::from_millis(10)));
             }
-            Err(_) => {
+            Err(e) => {
                 terminate_and_wait(&mut child, &mut process_tree);
                 finish_capture_threads(&mut stdout_capture, &mut stderr_capture);
-                return MutationOutcome::build_error();
+                return MutationOutcome::build_error_with(
+                    "command",
+                    command.to_vec(),
+                    format!("could not wait for command: {e}"),
+                );
             }
         }
     };
@@ -3243,6 +3507,21 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
+    #[test]
+    fn empty_build_error_output_falls_back_to_command_context() {
+        let outcome = MutationOutcome::new(MutationResult::Killed, Some(String::new()));
+        let message = build_error_message_from_outcome(
+            "build command",
+            &["cargo".to_string(), "check".to_string()],
+            Path::new("/tmp/workspace"),
+            &outcome,
+        );
+
+        assert!(message.contains("build command returned killed"));
+        assert!(message.contains("command: cargo check"));
+        assert!(message.contains("cwd: /tmp/workspace"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn build_check_failure_skips_test() {
@@ -3257,7 +3536,11 @@ mod tests {
                 format!("touch {}", marker.display()),
             ],
             BuildCommand {
-                argv: &["false".to_string()], // build fails
+                argv: &[
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "echo compile nope >&2; exit 1".to_string(),
+                ],
                 explicit: true,
             },
             Duration::from_secs(5),
@@ -3269,6 +3552,12 @@ mod tests {
         );
 
         assert_eq!(outcome.result, MutationResult::BuildError);
+        let detail = outcome
+            .build_error_detail
+            .as_ref()
+            .expect("build failure should carry diagnostics");
+        assert_eq!(detail.phase, "build_command");
+        assert!(detail.message.contains("compile nope"));
         assert!(!marker.exists(), "test command should not have run");
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -39,6 +39,7 @@ pub fn sample_report() -> MutationReport {
                 MutationResult::Survived,
             ),
         ],
+        build_error_diagnostics: vec![],
         duration: Duration::from_millis(1234),
         test_command: Some(vec!["cargo".into(), "test".into()]),
         build_command: vec![],


### PR DESCRIPTION
## Summary

- add build-error diagnostics to mutation reports without changing `MutationResult`
- capture explicit build-check stderr/stdout and attach runner/phase/fingerprint metadata
- group build errors in terminal, JSON, and HTML reports by language/operator/runner/phase/fingerprint

Closes #355

## Validation

- `cargo test --locked`
- `cargo clippy --locked -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build error diagnostics now captured and reported with mutation details including ID, runner, phase, command, and normalized error fingerprints.
  * Reports include aggregated build error groups organized by language, operator, runner, and phase for pattern analysis.
  * Build error information available across HTML, JSON, and terminal report formats with key details and example mutations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->