### PR TITLE
Reduce local resource pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ togi check --format html
 togi check --all
 
 # Adjust parallelism and timeout
-togi check --jobs 8 --timeout 60
+togi check --jobs 2 --timeout 60
+
+# Keep laptop CPU/temperature lower
+togi check --jobs 1 --fail-fast
 
 # Cap mutation count for a bounded exploratory run
 togi check --max-per-run 50  # --max-per-run 0 = unlimited
@@ -163,7 +166,7 @@ Create a `togi.toml` for customization:
 [test]
 command = ["go", "test", "./..."]
 timeout = 30
-jobs = 4
+jobs = 2
 build_command = ["go", "build", "./..."]
 
 [test.languages.python]
@@ -196,6 +199,32 @@ Test command precedence is: CLI `--test-cmd` / `--timeout`, matching
 then the global `[test]` command.
 When `--test-cmd` is set, `--fail-fast` does not modify the custom command;
 include runner-specific fail-fast flags in `--test-cmd` instead.
+
+## Resource tuning
+
+The default worker count is conservative for local machines: `1` on 1-2 CPU
+systems, otherwise `2`. Increase `--jobs` or `[test] jobs` in CI when throughput
+matters more than fan noise, temperature, or foreground responsiveness.
+
+Each togi worker runs the configured test command, and that test command may
+parallelize too. For cooler local runs, cap both layers:
+
+```bash
+# Togi only runs one mutation test process at a time
+togi check --jobs 1 --fail-fast
+
+# Rust: cap Cargo build jobs and libtest threads
+togi check --jobs 1 --test-cmd "cargo test -j 2 -- --test-threads=2"
+
+# Go: cap package and test-level parallelism
+togi check --jobs 1 --test-cmd "go test -p 2 -parallel 2 ./..."
+
+# Jest: avoid worker fan-out
+togi check --jobs 1 --test-cmd "npm test -- --runInBand"
+
+# pytest: avoid xdist workers unless you explicitly want them
+togi check --jobs 1 --test-cmd "pytest"
+```
 
 ## CI workflows
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,7 @@ pub enum Commands {
         #[arg(short, long, default_value = "terminal")]
         format: OutputFormat,
 
-        /// Number of parallel jobs
+        /// Number of parallel mutation workers
         #[arg(short, long)]
         jobs: Option<usize>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,8 +222,12 @@ fn default_timeout() -> u64 {
 
 fn default_jobs() -> usize {
     std::thread::available_parallelism()
-        .map(|n| n.get())
+        .map(|n| default_jobs_for_available_parallelism(n.get()))
         .unwrap_or(1)
+}
+
+fn default_jobs_for_available_parallelism(available: usize) -> usize {
+    if available <= 2 { 1 } else { 2 }
 }
 
 fn default_base() -> String {
@@ -368,11 +372,12 @@ impl Config {
             ));
         }
 
-        template.push_str(
+        template.push_str(&format!(
             "timeout = 30\n\
-             # jobs = 4  # defaults to number of CPUs\n\
+             # jobs = {}  # conservative local default; raise in CI for throughput\n\
              \n",
-        );
+            default_jobs()
+        ));
 
         // Detect additional languages for polyglot repos
         let has_python = project_root.join("pyproject.toml").exists()
@@ -522,7 +527,7 @@ commnad = ["cargo", "test"]
         assert_eq!(config.test.command, vec!["go", "test", "./..."]);
         assert!(config.test.build_command.is_empty());
         assert_eq!(config.test.timeout, 30);
-        assert_eq!(config.test.jobs, 4);
+        assert_eq!(config.test.jobs, 2);
         assert_eq!(config.test.languages["python"].command, vec!["pytest"]);
         assert_eq!(config.diff.base, "origin/main");
         assert_eq!(
@@ -561,6 +566,15 @@ commnad = ["cargo", "test"]
         assert!(config.mutations.respect_workspace_ignores);
         assert!(!config.mutations.schemata);
         assert!(config.projects.is_empty());
+    }
+
+    #[test]
+    fn default_jobs_are_conservative_for_local_runs() {
+        assert_eq!(default_jobs_for_available_parallelism(0), 1);
+        assert_eq!(default_jobs_for_available_parallelism(1), 1);
+        assert_eq!(default_jobs_for_available_parallelism(2), 1);
+        assert_eq!(default_jobs_for_available_parallelism(3), 2);
+        assert_eq!(default_jobs_for_available_parallelism(16), 2);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -777,6 +777,7 @@ fn populate_workspace(
 pub(crate) struct WorkspacePool {
     slots: Arc<Vec<WorkspaceCopy>>,
     free_slots: Arc<(Mutex<VecDeque<usize>>, Condvar)>,
+    dirty_slots: Arc<Mutex<Vec<bool>>>,
 }
 
 impl WorkspacePool {
@@ -801,10 +802,12 @@ impl WorkspacePool {
         }
 
         let free_slots = (0..slots).collect();
+        let dirty_slots = vec![false; slots];
 
         Ok(Self {
             slots: Arc::new(copies),
             free_slots: Arc::new((Mutex::new(free_slots), Condvar::new())),
+            dirty_slots: Arc::new(Mutex::new(dirty_slots)),
         })
     }
 
@@ -823,10 +826,21 @@ impl WorkspacePool {
                 .wait(free_slots)
                 .expect("workspace free-list mutex poisoned");
         };
+        let needs_reset = {
+            let mut dirty_slots = self
+                .dirty_slots
+                .lock()
+                .expect("workspace dirty-list mutex poisoned");
+            let needs_reset = dirty_slots[index];
+            dirty_slots[index] = true;
+            needs_reset
+        };
+
         WorkspaceSlot {
             slots: self.slots.clone(),
             free_slots: self.free_slots.clone(),
             index,
+            needs_reset,
         }
     }
 }
@@ -835,11 +849,16 @@ pub(crate) struct WorkspaceSlot {
     slots: Arc<Vec<WorkspaceCopy>>,
     free_slots: Arc<(Mutex<VecDeque<usize>>, Condvar)>,
     index: usize,
+    needs_reset: bool,
 }
 
 impl WorkspaceSlot {
     pub(crate) fn root(&self) -> &Path {
         self.slots[self.index].root()
+    }
+
+    fn needs_reset(&self) -> bool {
+        self.needs_reset
     }
 }
 
@@ -944,31 +963,33 @@ fn run_queued_mutation(
     let outcome = {
         let workspace_slot = shared.workspace_pool.acquire();
         let workspace_root = workspace_slot.root().to_path_buf();
-        if let Err(e) = reset_workspace(
-            shared.project_root,
-            &workspace_root,
-            shared.respect_workspace_ignores,
-        ) {
-            eprintln!(
-                "warning: could not reset isolated mutation workspace {}: {e}",
-                workspace_root.display()
-            );
-            reservation.release();
-            record_progress(&shared, &mutation, MutationResult::BuildError, None, false);
-            let diagnostic = BuildErrorDiagnostic::new(
-                mutation.id,
-                "regular",
-                "workspace_reset",
-                vec![],
-                format!(
-                    "could not reset isolated mutation workspace {}: {e}",
+        if workspace_slot.needs_reset() {
+            if let Err(e) = reset_workspace(
+                shared.project_root,
+                &workspace_root,
+                shared.respect_workspace_ignores,
+            ) {
+                eprintln!(
+                    "warning: could not reset isolated mutation workspace {}: {e}",
                     workspace_root.display()
-                ),
-            );
-            return Some((
-                index,
-                MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic)),
-            ));
+                );
+                reservation.release();
+                record_progress(&shared, &mutation, MutationResult::BuildError, None, false);
+                let diagnostic = BuildErrorDiagnostic::new(
+                    mutation.id,
+                    "regular",
+                    "workspace_reset",
+                    vec![],
+                    format!(
+                        "could not reset isolated mutation workspace {}: {e}",
+                        workspace_root.display()
+                    ),
+                );
+                return Some((
+                    index,
+                    MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic)),
+                ));
+            }
         }
         let workspace_target =
             ResolvedMutation::new_for_execution(shared.project_root, &workspace_root, &mutation);
@@ -1363,6 +1384,7 @@ impl TestRunner {
         let tested_counter = Arc::new(AtomicUsize::new(0));
         let source_contents = SourceContentCache::default();
         let cache_context_hash = cache_context_fingerprint(&self.project_root);
+        let mut workspace_needs_reset = false;
         for schema_mutation in schema_mutations {
             if self.cancelled.load(Ordering::Acquire) {
                 break;
@@ -1419,72 +1441,43 @@ impl TestRunner {
             }
 
             let mut cacheable = true;
-            let outcome = if let Err(e) = reset_workspace(
-                &self.project_root,
-                workspace.root(),
-                self.respect_workspace_ignores,
-            ) {
-                cacheable = false;
-                MutationOutcome::build_error_with(
-                    "schema_workspace_reset",
-                    vec![],
-                    format!(
-                        "could not reset schema workspace {}: {e}",
-                        workspace.root().display()
-                    ),
-                )
-            } else if let Err(e) =
-                apply_schema_rewrites_to_workspace(&self.project_root, workspace.root(), &rewrites)
-            {
-                cacheable = false;
-                MutationOutcome::build_error_with(
-                    "schema_rewrite",
-                    vec![],
-                    format!("could not apply schema rewrites: {e}"),
-                )
-            } else if self.commands.build_command_explicit
-                && !self.commands.build_command.is_empty()
-            {
-                let build = run_command(
-                    &self.commands.build_command,
+            let outcome = if workspace_needs_reset {
+                if let Err(e) = reset_workspace(
+                    &self.project_root,
                     workspace.root(),
-                    self.commands.timeout,
-                    true,
-                    &self.env,
-                    &self.cancelled,
-                );
-                if build.cancelled {
-                    break;
-                }
-                if build.result != MutationResult::Survived {
+                    self.respect_workspace_ignores,
+                ) {
+                    cacheable = false;
                     MutationOutcome::build_error_with(
-                        "schema_build",
-                        self.commands.build_command.clone(),
-                        build_error_message_from_outcome(
-                            "schema build command",
-                            &self.commands.build_command,
-                            workspace.root(),
-                            &build,
+                        "schema_workspace_reset",
+                        vec![],
+                        format!(
+                            "could not reset schema workspace {}: {e}",
+                            workspace.root().display()
                         ),
                     )
                 } else {
-                    run_command(
-                        &argv,
+                    workspace_needs_reset = true;
+                    run_schema_workspace_mutation(
+                        self,
                         workspace.root(),
+                        &rewrites,
+                        &argv,
                         selected.timeout,
-                        self.show_output,
                         &env,
-                        &self.cancelled,
+                        &mut cacheable,
                     )
                 }
             } else {
-                run_command(
-                    &argv,
+                workspace_needs_reset = true;
+                run_schema_workspace_mutation(
+                    self,
                     workspace.root(),
+                    &rewrites,
+                    &argv,
                     selected.timeout,
-                    self.show_output,
                     &env,
-                    &self.cancelled,
+                    &mut cacheable,
                 )
             };
             if outcome.cancelled {
@@ -1631,6 +1624,62 @@ fn apply_schema_rewrites_to_workspace(
     }
 
     Ok(())
+}
+
+fn run_schema_workspace_mutation(
+    runner: &TestRunner,
+    workspace_root: &Path,
+    rewrites: &[crate::schemata::SchemaFileRewrite],
+    argv: &[String],
+    timeout: Duration,
+    env: &HashMap<String, String>,
+    cacheable: &mut bool,
+) -> MutationOutcome {
+    if let Err(e) =
+        apply_schema_rewrites_to_workspace(&runner.project_root, workspace_root, rewrites)
+    {
+        *cacheable = false;
+        return MutationOutcome::build_error_with(
+            "schema_rewrite",
+            vec![],
+            format!("could not apply schema rewrites: {e}"),
+        );
+    }
+
+    if runner.commands.build_command_explicit && !runner.commands.build_command.is_empty() {
+        let build = run_command(
+            &runner.commands.build_command,
+            workspace_root,
+            runner.commands.timeout,
+            true,
+            &runner.env,
+            &runner.cancelled,
+        );
+        if build.cancelled {
+            return build;
+        }
+        if build.result != MutationResult::Survived {
+            return MutationOutcome::build_error_with(
+                "schema_build",
+                runner.commands.build_command.clone(),
+                build_error_message_from_outcome(
+                    "schema build command",
+                    &runner.commands.build_command,
+                    workspace_root,
+                    &build,
+                ),
+            );
+        }
+    }
+
+    run_command(
+        argv,
+        workspace_root,
+        timeout,
+        runner.show_output,
+        env,
+        &runner.cancelled,
+    )
 }
 
 fn records_from_report(report: MutationReport) -> Vec<MutationRunRecord> {
@@ -3427,6 +3476,8 @@ mod tests {
 
         let first = pool.acquire();
         let second = pool.acquire();
+        assert!(!first.needs_reset());
+        assert!(!second.needs_reset());
         assert_ne!(first.root(), second.root());
         assert!(first.root().join("src/lib.rs").exists());
         assert!(second.root().join("src/lib.rs").exists());
@@ -3436,6 +3487,7 @@ mod tests {
         drop(second);
 
         let third = pool.acquire();
+        assert!(third.needs_reset());
         assert_eq!(third.root(), second_root.as_path());
         assert_ne!(third.root(), first_root.as_path());
     }

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -23,11 +23,11 @@ command = ["go", "test", "./..."]
 timeout = 30
 
 # Maximum number of mutation jobs.
-# The shared working tree is protected so only one mutation is active at a time;
-# this still bounds task scheduling and future isolated execution.
+# Each job can launch a full test runner, so higher values can multiply CPU
+# load quickly. Keep this low for laptops and raise it explicitly in CI.
 # Type: integer
-# Default: number of available CPUs
-jobs = 4
+# Default: 1 on 1-2 CPU machines, otherwise 2
+jobs = 2
 
 [test.languages.python]
 # Override the test command for mutations in one language.


### PR DESCRIPTION
## Summary
- make default mutation workers conservative for local machines
- avoid redundant first workspace resets in regular and schemata runners
- document lower-temperature command patterns and update example config

## Tests
- cargo test config::tests
- cargo test cli::tests
- cargo test workspace
- cargo test run_with_schemata_uses_cache_and_releases_max_reservation
- git diff --check