### PR TITLE
Add Foxguard security scans to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,28 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
+  foxguard:
+    name: Foxguard Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run Foxguard
+        uses: 0sec-labs/foxguard/action@v0.8.1
+        with:
+          path: .
+          severity: medium
+          version: v0.8.1
+          fail-on-findings: "false"
+          upload-sarif: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
   check:
     name: Build & Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
       security-events: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Run Foxguard
-        uses: 0sec-labs/foxguard/action@v0.8.1
+        uses: 0sec-labs/foxguard/action@e13233eb0b83a495ff7ad8fe30d62128cb625c14
         with:
           path: .
           severity: medium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,26 @@ permissions:
   id-token: write
 
 jobs:
+  foxguard:
+    name: Foxguard Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run Foxguard
+        uses: 0sec-labs/foxguard/action@v0.8.1
+        with:
+          path: .
+          severity: medium
+          version: v0.8.1
+          fail-on-findings: "false"
+          upload-sarif: "true"
+
   build:
     name: Build ${{ matrix.target }}
+    needs: foxguard
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Run Foxguard
-        uses: 0sec-labs/foxguard/action@v0.8.1
+        uses: 0sec-labs/foxguard/action@e13233eb0b83a495ff7ad8fe30d62128cb625c14
         with:
           path: .
           severity: medium


### PR DESCRIPTION
## Summary
- add a Foxguard security scan job to the main CI workflow
- run Foxguard before release builds on tag pushes
- upload SARIF to GitHub Code Scanning where token permissions allow it

## Rollout notes
- Foxguard is pinned to v0.8.1 for both the action and scanner binary
- findings are report-only for now because a local v0.8.1 scan currently reports existing findings in the tree; this avoids breaking the pipeline on the initial integration
- external fork PRs skip SARIF upload because GitHub does not grant code-scanning write permissions there

## Verification
- ruby YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- git diff --check
- local Foxguard v0.8.1 scan verified current findings behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security vulnerability scanning to continuous integration and release workflows to ensure all code changes are scanned before deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->