### PR TITLE
Add early-exit mutation gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ togi check --jobs 1 --fail-fast
 # Cap mutation count for a bounded exploratory run
 togi check --max-per-run 50  # --max-per-run 0 = unlimited
 
+# Stop once a PR gate has enough signal
+togi check --first-survivor
+togi check --max-survivors 3
+
 # Disable schemata if you need one-mutant-at-a-time execution
 togi check --no-schemata
 
@@ -125,7 +129,7 @@ togi test-map --path . --output coverage/test-selection.json
 togi check --test-selection-file coverage/test-selection.json
 
 # Fail below a mutation score threshold
-togi check --fail-under 80
+togi check --fail-under 80  # stops early once 80% is impossible
 
 # Split mutation work across parallel CI jobs
 togi check --shard 1/4
@@ -234,8 +238,15 @@ Use togi as a PR gate, a non-blocking annotation job, or a scheduled deeper scan
 ### Fast PR gate
 
 ```bash
-togi check --base origin/main --fail-under 80
+togi check --base origin/main --fail-under 80 --first-survivor
 ```
+
+`--first-survivor` is shorthand for `--max-survivors 1`: it stops scheduling
+new mutants after the first survived result. `--max-survivors N` keeps collecting
+up to `N` survivors for triage. `--fail-under` also stops early once even killing
+every remaining scheduled mutation could not reach the threshold. Early-stop
+runs report how many scheduled mutations completed, so use full runs for
+baselines and detailed trend reports.
 
 ### GitHub annotations
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -217,7 +217,8 @@ mod tests {
 
     #[test]
     fn first_survivor_argument_is_accepted() {
-        let cli = Cli::try_parse_from(["togi", "check", "--first-survivor"]).unwrap();
+        let cli = Cli::try_parse_from(["togi", "check", "--first-survivor"])
+            .expect("--first-survivor should parse");
         match cli.command {
             Commands::Check { first_survivor, .. } => {
                 assert!(first_survivor);
@@ -228,7 +229,8 @@ mod tests {
 
     #[test]
     fn max_survivors_argument_is_accepted() {
-        let cli = Cli::try_parse_from(["togi", "check", "--max-survivors", "2"]).unwrap();
+        let cli = Cli::try_parse_from(["togi", "check", "--max-survivors", "2"])
+            .expect("--max-survivors should parse");
         match cli.command {
             Commands::Check { max_survivors, .. } => {
                 assert_eq!(max_survivors, Some(2));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,14 @@ pub enum Commands {
         #[arg(long)]
         max_per_run: Option<usize>,
 
+        /// Stop scheduling new mutations after the first survived mutant
+        #[arg(long, conflicts_with = "max_survivors")]
+        first_survivor: bool,
+
+        /// Stop scheduling new mutations after this many survived mutants
+        #[arg(long)]
+        max_survivors: Option<usize>,
+
         /// Use mutant schemata for supported languages
         #[arg(long)]
         schemata: bool,
@@ -205,6 +213,38 @@ mod tests {
             }
             _ => panic!("expected Check command"),
         }
+    }
+
+    #[test]
+    fn first_survivor_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--first-survivor"]).unwrap();
+        match cli.command {
+            Commands::Check { first_survivor, .. } => {
+                assert!(first_survivor);
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn max_survivors_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--max-survivors", "2"]).unwrap();
+        match cli.command {
+            Commands::Check { max_survivors, .. } => {
+                assert_eq!(max_survivors, Some(2));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn first_survivor_conflicts_with_max_survivors() {
+        let res =
+            Cli::try_parse_from(["togi", "check", "--first-survivor", "--max-survivors", "2"]);
+        assert!(
+            res.is_err(),
+            "--first-survivor and --max-survivors should conflict"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,8 @@ pub struct MutationReport {
     pub duration: Duration,
     pub test_command: Option<Vec<String>>,
     pub build_command: Vec<String>,
+    pub planned_total: usize,
+    pub early_stop_reason: Option<String>,
     pub total: usize,
     pub killed: usize,
     pub survived: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ struct CheckConfig {
     jobs: Option<usize>,
     timeout: Option<u64>,
     max_per_run: Option<usize>,
+    first_survivor: bool,
+    max_survivors: Option<usize>,
     schemata: bool,
     no_schemata: bool,
     dry_run: bool,
@@ -44,6 +46,7 @@ struct ExecuteOptions {
     build_command_explicit: bool,
     force_default_command: bool,
     force_default_timeout: bool,
+    early_stop: togi::runner::EarlyStopConfig,
     cancelled: Arc<AtomicBool>,
 }
 
@@ -74,6 +77,8 @@ fn main() {
             jobs,
             timeout,
             max_per_run,
+            first_survivor,
+            max_survivors,
             schemata,
             no_schemata,
             dry_run,
@@ -101,6 +106,8 @@ fn main() {
                 jobs,
                 timeout,
                 max_per_run,
+                first_survivor,
+                max_survivors,
                 schemata,
                 no_schemata,
                 dry_run,
@@ -281,6 +288,15 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
     let show_output = cfg.show_output;
     let output_format = cfg.output_format;
     let fail_under = cfg.fail_under;
+    let max_survivors = match (cfg.first_survivor, cfg.max_survivors) {
+        (true, _) => Some(1),
+        (false, Some(0)) => anyhow::bail!("--max-survivors must be greater than 0"),
+        (false, value) => value,
+    };
+    let early_stop = togi::runner::EarlyStopConfig {
+        max_survivors,
+        fail_under,
+    };
     let shard = cfg.shard.as_deref().map(parse_shard).transpose()?;
     let save_baseline = cfg.save_baseline;
     let check_baseline = cfg.check_baseline;
@@ -347,6 +363,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
             build_command_explicit: has_explicit_build_cmd,
             force_default_command: has_custom_test_cmd,
             force_default_timeout: has_cli_timeout,
+            early_stop,
             cancelled,
         },
     );
@@ -362,14 +379,18 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
     let current = togi::baseline::from_report(&report, &project_root_ref);
     let mut should_fail = false;
 
-    if save_baseline {
+    let partial_report = report.total < report.planned_total;
+
+    if partial_report && (save_baseline || check_baseline) {
+        eprintln!("Partial early-stop report; skipping baseline save/check.");
+    } else if save_baseline {
         togi::baseline::save_baseline(&current, &project_root_ref)?;
         eprintln!("Baseline saved to .togi-baseline");
     }
 
     let mut baseline_score: Option<f64> = None;
     let mut loaded_baseline = false;
-    if check_baseline {
+    if check_baseline && !partial_report {
         if let Some(baseline) = togi::baseline::load_baseline(&project_root_ref)? {
             loaded_baseline = true;
             baseline_score = Some(baseline.killed as f64 / baseline.total.max(1) as f64 * 100.0);
@@ -704,6 +725,7 @@ fn execute(
         } else {
             Some(config.mutations.max_per_run)
         },
+        early_stop: options.early_stop,
         respect_workspace_ignores: config.mutations.respect_workspace_ignores,
         env: std::collections::HashMap::new(),
         cancelled: options.cancelled,

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -49,6 +49,15 @@ pub fn print_report(report: &MutationReport) {
         "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors)",
         score, report.killed, report.survived, report.timeout, report.build_errors
     );
+    if report.total < report.planned_total {
+        eprintln!(
+            "Partial results: stopped after {}/{} scheduled mutations",
+            report.total, report.planned_total
+        );
+    }
+    if let Some(reason) = &report.early_stop_reason {
+        eprintln!("Early stop: {reason}");
+    }
 
     if report.survived > 0 && tested > 0 {
         let message = format!(
@@ -90,6 +99,8 @@ mod tests {
             .filter(|(_, r)| *r == MutationResult::Survived)
             .count();
         MutationReport {
+            planned_total: results.len(),
+            early_stop_reason: None,
             total: results.len(),
             killed,
             survived,

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -95,7 +95,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         html,
         "<div class=\"summary\"><span class=\"score\">{:.1}%</span> mutation score \
          &mdash; {}/{} killed, {} survived, {} timeout, {} build errors \
-         &mdash; {:.2}s</div></header>",
+         &mdash; {:.2}s</div>",
         score_pct,
         report.killed,
         tested,
@@ -104,6 +104,21 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         report.build_errors,
         report.duration.as_secs_f64()
     )?;
+    if report.total < report.planned_total {
+        write!(
+            html,
+            "<div class=\"partial\">Partial report: stopped after {}/{} scheduled mutations.</div>",
+            report.total, report.planned_total
+        )?;
+    }
+    if let Some(reason) = &report.early_stop_reason {
+        write!(
+            html,
+            "<div class=\"partial\">Early stop: {}</div>",
+            html_escape(reason)
+        )?;
+    }
+    write!(html, "</header>")?;
 
     // Layout
     write!(html, "<div class=\"container\"><nav class=\"file-tree\">")?;
@@ -262,6 +277,7 @@ header{background:#16213e;padding:1.5rem 2rem;border-bottom:2px solid #0f3460}
 h1{font-size:1.4rem;color:#e94560}
 .summary{margin-top:.5rem;font-size:.95rem;color:#a0a0b0}
 .summary .score{font-size:1.3rem;font-weight:700;color:#e94560}
+.partial{margin-top:.35rem;font-size:.85rem;color:#f0b35a}
 .container{display:flex;min-height:calc(100vh - 100px)}
 .file-tree{width:280px;background:#16213e;padding:1rem;overflow-y:auto;border-right:1px solid #0f3460;flex-shrink:0}
 .file-tree h2{font-size:.9rem;text-transform:uppercase;letter-spacing:.1em;color:#888;margin-bottom:.5rem}
@@ -357,6 +373,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 0,
             survived: 0,
@@ -407,6 +425,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 11,
+            early_stop_reason: None,
             total: 11,
             killed: 0,
             survived: 0,
@@ -441,6 +461,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 1,
             survived: 0,
@@ -479,6 +501,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 3,
+            early_stop_reason: None,
             total: 3,
             killed: 3,
             survived: 0,

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -246,8 +246,8 @@ mod tests {
     #[test]
     fn json_output_schema_is_stable() {
         let report = sample_report();
-        let json_str = to_json_string(&report).unwrap();
-        let value: Value = serde_json::from_str(&json_str).unwrap();
+        let json_str = to_json_string(&report).expect("sample report should serialize");
+        let value: Value = serde_json::from_str(&json_str).expect("sample report JSON is valid");
 
         assert_object_keys(
             &value,
@@ -306,8 +306,8 @@ mod tests {
         report.planned_total = 5;
         report.early_stop_reason = Some("--max-survivors 1 reached".into());
 
-        let json_str = to_json_string(&report).unwrap();
-        let value: Value = serde_json::from_str(&json_str).unwrap();
+        let json_str = to_json_string(&report).expect("sample report should serialize");
+        let value: Value = serde_json::from_str(&json_str).expect("sample report JSON is valid");
 
         assert_eq!(value["total"], 2);
         assert_eq!(value["planned_total"], 5);

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -6,11 +6,15 @@ use std::collections::BTreeMap;
 #[derive(Serialize)]
 struct JsonReport {
     total: usize,
+    planned_total: usize,
     tested: usize,
     killed: usize,
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    partial: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    early_stop_reason: Option<String>,
     mutation_score: f64,
     duration_ms: u128,
     test_command: Option<Vec<String>>,
@@ -153,11 +157,14 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
     let tested = report.total.saturating_sub(report.build_errors);
     let json_report = JsonReport {
         total: report.total,
+        planned_total: report.planned_total,
         tested,
         killed: report.killed,
         survived: report.survived,
         timeout: report.timeout,
         build_errors: report.build_errors,
+        partial: report.total < report.planned_total,
+        early_stop_reason: report.early_stop_reason.clone(),
         mutation_score: super::mutation_score(report),
         duration_ms: report.duration.as_millis(),
         test_command: report.test_command.clone(),
@@ -214,6 +221,8 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(value["total"], 2);
+        assert_eq!(value["planned_total"], 2);
+        assert_eq!(value["partial"], false);
         assert_eq!(value["killed"], 1);
         assert_eq!(value["survived"], 1);
         assert_eq!(value["timeout"], 0);
@@ -244,11 +253,13 @@ mod tests {
             &value,
             &[
                 "total",
+                "planned_total",
                 "tested",
                 "killed",
                 "survived",
                 "timeout",
                 "build_errors",
+                "partial",
                 "mutation_score",
                 "duration_ms",
                 "test_command",
@@ -290,6 +301,21 @@ mod tests {
     }
 
     #[test]
+    fn json_output_marks_partial_early_stop_reports() {
+        let mut report = sample_report();
+        report.planned_total = 5;
+        report.early_stop_reason = Some("--max-survivors 1 reached".into());
+
+        let json_str = to_json_string(&report).unwrap();
+        let value: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(value["total"], 2);
+        assert_eq!(value["planned_total"], 5);
+        assert_eq!(value["partial"], true);
+        assert_eq!(value["early_stop_reason"], "--max-survivors 1 reached");
+    }
+
+    #[test]
     fn json_score_zero_when_all_build_errors() {
         let report = MutationReport {
             results: vec![(
@@ -312,6 +338,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 0,
             survived: 0,
@@ -355,6 +383,8 @@ mod tests {
             duration: Duration::from_millis(100),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 0,
             survived: 0,
@@ -388,6 +418,8 @@ mod tests {
             duration: Duration::from_millis(0),
             test_command: None,
             build_command: vec![],
+            planned_total: 0,
+            early_stop_reason: None,
             total: 0,
             killed: 0,
             survived: 0,

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -214,6 +214,17 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
         "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors — {:.2}s",
         report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
     ).unwrap();
+    if report.total < report.planned_total {
+        writeln!(
+            md,
+            "\nPartial report: stopped after {}/{} scheduled mutations.",
+            report.total, report.planned_total
+        )
+        .unwrap();
+    }
+    if let Some(reason) = &report.early_stop_reason {
+        writeln!(md, "\nEarly stop: {reason}").unwrap();
+    }
     writeln!(md).unwrap();
 
     let survived: Vec<_> = report
@@ -406,6 +417,8 @@ mod tests {
             duration: std::time::Duration::from_millis(10),
             test_command: None,
             build_command: vec![],
+            planned_total: 3,
+            early_stop_reason: None,
             total: 3,
             killed: 1,
             survived: 0,
@@ -561,6 +574,8 @@ mod tests {
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 1,
             survived: 0,
@@ -597,6 +612,8 @@ mod tests {
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 0,
             survived: 0,
@@ -634,6 +651,8 @@ mod tests {
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
             total: 1,
             killed: 0,
             survived: 0,
@@ -691,6 +710,8 @@ mod tests {
             duration: Duration::from_secs(1),
             test_command: None,
             build_command: vec![],
+            planned_total: 2,
+            early_stop_reason: None,
             total: 2,
             killed: 1,
             survived: 0,

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -220,10 +220,10 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
             "\nPartial report: stopped after {}/{} scheduled mutations.",
             report.total, report.planned_total
         )
-        .unwrap();
+        .expect("writing to String should not fail");
     }
     if let Some(reason) = &report.early_stop_reason {
-        writeln!(md, "\nEarly stop: {reason}").unwrap();
+        writeln!(md, "\nEarly stop: {reason}").expect("writing to String should not fail");
     }
     writeln!(md).unwrap();
 

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -95,6 +95,17 @@ fn format_report(report: &MutationReport, color: bool) -> String {
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
+    if report.total < report.planned_total {
+        writeln!(
+            out,
+            "Partial: stopped after {}/{} scheduled mutations",
+            report.total, report.planned_total
+        )
+        .unwrap();
+    }
+    if let Some(reason) = &report.early_stop_reason {
+        writeln!(out, "Early stop: {reason}").unwrap();
+    }
     writeln!(
         out,
         "Mutation score (test kills only): {:.1}%",
@@ -289,6 +300,8 @@ mod tests {
             duration: Duration::from_millis(500),
             test_command: None,
             build_command: vec![],
+            planned_total: total,
+            early_stop_reason: None,
             total,
             killed,
             survived,
@@ -362,6 +375,18 @@ mod tests {
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 1 survived, 0 timeout, 0 build errors"));
         assert!(output.contains("Mutation score (test kills only): 50.0%"));
+    }
+
+    #[test]
+    fn terminal_output_marks_partial_early_stop_reports() {
+        let mut report = report(vec![(mutation(1, "src/a.rs", 1), MutationResult::Survived)]);
+        report.planned_total = 3;
+        report.early_stop_reason = Some("--max-survivors 1 reached".into());
+
+        let output = format_report_plain(&report);
+
+        assert!(output.contains("Partial: stopped after 1/3 scheduled mutations"));
+        assert!(output.contains("Early stop: --max-survivors 1 reached"));
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -101,10 +101,10 @@ fn format_report(report: &MutationReport, color: bool) -> String {
             "Partial: stopped after {}/{} scheduled mutations",
             report.total, report.planned_total
         )
-        .unwrap();
+        .expect("writing to String should not fail");
     }
     if let Some(reason) = &report.early_stop_reason {
-        writeln!(out, "Early stop: {reason}").unwrap();
+        writeln!(out, "Early stop: {reason}").expect("writing to String should not fail");
     }
     writeln!(
         out,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5093,11 +5093,11 @@ mod tests {
 
     #[test]
     fn max_survivors_stops_scheduling_new_mutations() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir should be created");
         let mutations: Vec<Mutation> = (0..3)
             .map(|i| {
                 let file = dir.path().join(format!("survivor{i}.txt"));
-                std::fs::write(&file, b"hello world").unwrap();
+                std::fs::write(&file, b"hello world").expect("fixture file should be written");
                 let mut mutation = make_test_mutation(&file);
                 mutation.id = i;
                 mutation.description = format!("survivor limit {i}");
@@ -5147,11 +5147,11 @@ mod tests {
 
     #[test]
     fn fail_under_stops_when_threshold_cannot_be_reached() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir should be created");
         let mutations: Vec<Mutation> = (0..3)
             .map(|i| {
                 let file = dir.path().join(format!("threshold{i}.txt"));
-                std::fs::write(&file, b"hello world").unwrap();
+                std::fs::write(&file, b"hello world").expect("fixture file should be written");
                 let mut mutation = make_test_mutation(&file);
                 mutation.id = i;
                 mutation.description = format!("threshold gate {i}");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -96,6 +96,22 @@ impl TestSelectionConfig {
     }
 }
 
+/// Optional conditions that stop scheduling new mutations once enough signal
+/// has been observed for a PR gate.
+#[derive(Debug, Clone, Default)]
+pub struct EarlyStopConfig {
+    /// Stop after at least this many survived mutants have completed.
+    pub max_survivors: Option<usize>,
+    /// Stop when even killing every remaining mutation could not satisfy this score.
+    pub fail_under: Option<f64>,
+}
+
+impl EarlyStopConfig {
+    fn is_enabled(&self) -> bool {
+        self.max_survivors.is_some() || self.fail_under.is_some()
+    }
+}
+
 /// Applies mutations, runs checks, restores files, and aggregates results.
 ///
 /// The runner evaluates mutations in isolated workspace copies so whole-project
@@ -115,6 +131,8 @@ pub struct TestRunner {
     pub show_output: bool,
     /// Optional cap on how many non-build-error mutations are tested.
     pub max_tested: Option<usize>,
+    /// Optional stop conditions for gate-style partial runs.
+    pub early_stop: EarlyStopConfig,
     /// Whether workspace copies should honor `.ignore`/`.gitignore` rules.
     pub respect_workspace_ignores: bool,
     /// Extra environment variables passed to every spawned command.
@@ -1094,6 +1112,114 @@ impl SchemataRunSummary {
     }
 }
 
+#[derive(Default)]
+struct EarlyStopCounts {
+    completed: usize,
+    killed: usize,
+    survived: usize,
+    build_errors: usize,
+}
+
+struct EarlyStopState {
+    config: EarlyStopConfig,
+    planned_total: usize,
+    stopped: AtomicBool,
+    reason: Mutex<Option<String>>,
+    counts: Mutex<EarlyStopCounts>,
+}
+
+impl EarlyStopState {
+    fn new(config: EarlyStopConfig, planned_total: usize) -> Self {
+        Self {
+            config,
+            planned_total,
+            stopped: AtomicBool::new(false),
+            reason: Mutex::new(None),
+            counts: Mutex::new(EarlyStopCounts::default()),
+        }
+    }
+
+    fn for_config(config: EarlyStopConfig, planned_total: usize) -> Option<Arc<Self>> {
+        config
+            .is_enabled()
+            .then(|| Arc::new(Self::new(config, planned_total)))
+    }
+
+    fn should_stop(&self) -> bool {
+        self.stopped.load(Ordering::Acquire)
+    }
+
+    fn reason(&self) -> Option<String> {
+        self.reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn record(&self, result: MutationResult) {
+        if self.should_stop() {
+            return;
+        }
+
+        let mut counts = self
+            .counts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        counts.completed += 1;
+        match result {
+            MutationResult::Killed => counts.killed += 1,
+            MutationResult::Survived => counts.survived += 1,
+            MutationResult::Timeout => {}
+            MutationResult::BuildError => counts.build_errors += 1,
+        }
+
+        let remaining = self.planned_total.saturating_sub(counts.completed);
+        if remaining == 0 {
+            return;
+        }
+
+        if let Some(max_survivors) = self.config.max_survivors {
+            if counts.survived >= max_survivors {
+                self.stop(format!(
+                    "--max-survivors {max_survivors} reached after {} completed mutation{}",
+                    counts.completed,
+                    if counts.completed == 1 { "" } else { "s" }
+                ));
+                return;
+            }
+        }
+
+        if let Some(threshold) = self.config.fail_under {
+            let tested = counts.completed.saturating_sub(counts.build_errors);
+            let best_tested = tested + remaining;
+            let best_killed = counts.killed + remaining;
+            let best_score = if best_tested > 0 {
+                (best_killed as f64 / best_tested as f64) * 100.0
+            } else if self.planned_total == 0 {
+                100.0
+            } else {
+                0.0
+            };
+            if best_score < threshold {
+                self.stop(format!(
+                    "--fail-under {threshold:.1} cannot be reached; best possible score is {best_score:.1}%"
+                ));
+            }
+        }
+    }
+
+    fn stop(&self, reason: String) {
+        let mut current = self
+            .reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if current.is_none() {
+            *current = Some(reason);
+            self.stopped.store(true, Ordering::Release);
+        }
+    }
+}
+
 struct RunShared<'a> {
     workspace_pool: &'a WorkspacePool,
     project_root: &'a Path,
@@ -1107,9 +1233,20 @@ struct RunShared<'a> {
     show_output: bool,
     counter: &'a AtomicUsize,
     cancelled: &'a AtomicBool,
+    early_stop: Option<&'a Arc<EarlyStopState>>,
     respect_workspace_ignores: bool,
     cache_context_fingerprint: u64,
     source_contents: &'a SourceContentCache,
+}
+
+fn should_stop_early(early_stop: &Option<Arc<EarlyStopState>>) -> bool {
+    early_stop.as_ref().is_some_and(|state| state.should_stop())
+}
+
+fn record_early_stop(shared: &RunShared<'_>, result: MutationResult) {
+    if let Some(early_stop) = shared.early_stop {
+        early_stop.record(result);
+    }
 }
 
 fn run_queued_mutation(
@@ -1151,6 +1288,7 @@ fn run_queued_mutation(
         if let Some(result) = cache::lookup(shared.project_root, key) {
             reservation.release();
             record_progress(&shared, &mutation, result, None, true);
+            record_early_stop(&shared, result);
             let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
             return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
         }
@@ -1169,6 +1307,7 @@ fn run_queued_mutation(
                 );
                 reservation.release();
                 record_progress(&shared, &mutation, MutationResult::BuildError, None, false);
+                record_early_stop(&shared, MutationResult::BuildError);
                 let diagnostic = BuildErrorDiagnostic::new(
                     mutation.id,
                     "regular",
@@ -1223,6 +1362,7 @@ fn run_queued_mutation(
         outcome.test_output.as_deref(),
         false,
     );
+    record_early_stop(&shared, result);
     let diagnostic = build_error_diagnostic_from_outcome(&mutation, "regular", &outcome);
     Some((index, MutationRunRecord::new(mutation, result, diagnostic)))
 }
@@ -1330,7 +1470,9 @@ fn record_progress(
 impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
     pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
-        self.run_regular(mutations)
+        let planned_total = mutations.len();
+        let early_stop = EarlyStopState::for_config(self.early_stop.clone(), planned_total);
+        self.run_regular_with_state(mutations, early_stop, planned_total)
     }
 
     pub fn run_with_schemata(&self, mutations: Vec<Mutation>) -> RunOutcome {
@@ -1338,6 +1480,8 @@ impl TestRunner {
         if mutations.is_empty() {
             return self.outcome_from_records(Vec::new(), start.elapsed());
         }
+        let planned_total = mutations.len();
+        let early_stop = EarlyStopState::for_config(self.early_stop.clone(), planned_total);
 
         let index_by_id: HashMap<u32, usize> = mutations
             .iter()
@@ -1369,15 +1513,19 @@ impl TestRunner {
         }
 
         if schema_by_language.is_empty() {
-            let mut outcome = self.run_regular(fallback_mutations);
+            let mut outcome =
+                self.run_regular_with_state(fallback_mutations, early_stop, planned_total);
             outcome.report.schemata = Some(schemata_summary.into_report());
             return outcome;
         }
 
         let mut all_records = Vec::new();
         for (language, schema_mutations) in schema_by_language {
+            if should_stop_early(&early_stop) {
+                break;
+            }
             let mutation_count = schema_mutations.len();
-            match self.run_schema_mutations(&language, &schema_mutations) {
+            match self.run_schema_mutations(&language, &schema_mutations, early_stop.clone()) {
                 Ok(records) => {
                     schemata_summary.fast_path += records.len();
                     all_records.extend(records);
@@ -1394,8 +1542,12 @@ impl TestRunner {
             }
         }
 
-        if !self.cancelled.load(Ordering::Acquire) && !fallback_mutations.is_empty() {
-            let fallback = self.run_regular(fallback_mutations);
+        if !self.cancelled.load(Ordering::Acquire)
+            && !fallback_mutations.is_empty()
+            && !should_stop_early(&early_stop)
+        {
+            let fallback =
+                self.run_regular_with_state(fallback_mutations, early_stop.clone(), planned_total);
             all_records.extend(records_from_report(fallback.report));
         }
 
@@ -1405,20 +1557,40 @@ impl TestRunner {
                 .copied()
                 .unwrap_or(usize::MAX)
         });
-        let mut outcome = self.outcome_from_records(all_records, start.elapsed());
+        let mut outcome = self.outcome_from_records_with_status(
+            all_records,
+            start.elapsed(),
+            planned_total,
+            early_stop.as_ref().and_then(|state| state.reason()),
+        );
         outcome.report.schemata = Some(schemata_summary.into_report());
         outcome
     }
 
     #[allow(clippy::manual_is_multiple_of)]
-    fn run_regular(&self, mutations: Vec<Mutation>) -> RunOutcome {
+    fn run_regular_with_state(
+        &self,
+        mutations: Vec<Mutation>,
+        early_stop: Option<Arc<EarlyStopState>>,
+        planned_total: usize,
+    ) -> RunOutcome {
         let start = Instant::now();
         let total = mutations.len();
         if total == 0 {
-            return self.outcome_from_records(Vec::new(), start.elapsed());
+            return self.outcome_from_records_with_status(
+                Vec::new(),
+                start.elapsed(),
+                planned_total,
+                early_stop.as_ref().and_then(|state| state.reason()),
+            );
         }
         if self.cancelled.load(Ordering::Acquire) {
-            return self.outcome_from_records(Vec::new(), start.elapsed());
+            return self.outcome_from_records_with_status(
+                Vec::new(),
+                start.elapsed(),
+                planned_total,
+                early_stop.as_ref().and_then(|state| state.reason()),
+            );
         }
 
         let counter = Arc::new(AtomicUsize::new(0));
@@ -1483,10 +1655,11 @@ impl TestRunner {
                 let max_tested = self.max_tested;
                 let show_output = self.show_output;
                 let source_contents = &source_contents;
+                let early_stop = early_stop.clone();
 
                 scope.spawn(move || {
                     loop {
-                        if cancelled.load(Ordering::Relaxed) {
+                        if cancelled.load(Ordering::Relaxed) || should_stop_early(&early_stop) {
                             break;
                         }
 
@@ -1495,6 +1668,10 @@ impl TestRunner {
                         else {
                             break;
                         };
+                        if should_stop_early(&early_stop) {
+                            reservation.release();
+                            break;
+                        }
                         let next = match queue.lock() {
                             Ok(mut queue) => queue.pop_front(),
                             Err(_) => {
@@ -1523,6 +1700,7 @@ impl TestRunner {
                                     show_output,
                                     counter: &counter,
                                     cancelled: &cancelled,
+                                    early_stop: early_stop.as_ref(),
                                     respect_workspace_ignores: self.respect_workspace_ignores,
                                     cache_context_fingerprint: cache_context_hash,
                                     source_contents,
@@ -1562,13 +1740,19 @@ impl TestRunner {
             let _ = std::io::stderr().flush();
         }
 
-        self.outcome_from_records(all_records, start.elapsed())
+        self.outcome_from_records_with_status(
+            all_records,
+            start.elapsed(),
+            planned_total,
+            early_stop.as_ref().and_then(|state| state.reason()),
+        )
     }
 
     fn run_schema_mutations(
         &self,
         language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
+        early_stop: Option<Arc<EarlyStopState>>,
     ) -> Result<Vec<MutationRunRecord>, crate::schemata::SchemaRewriteError> {
         let rewrites = match language {
             "c" => crate::schemata::rewrite_c_files(&self.project_root, schema_mutations)?,
@@ -1596,7 +1780,7 @@ impl TestRunner {
         let cache_context_hash = cache_context_fingerprint(&self.project_root);
         let mut workspace_needs_reset = false;
         for schema_mutation in schema_mutations {
-            if self.cancelled.load(Ordering::Acquire) {
+            if self.cancelled.load(Ordering::Acquire) || should_stop_early(&early_stop) {
                 break;
             }
             let Some(reservation) =
@@ -1604,6 +1788,10 @@ impl TestRunner {
             else {
                 break;
             };
+            if should_stop_early(&early_stop) {
+                reservation.release();
+                break;
+            }
             let mutation = &schema_mutation.mutation;
             let selected = select_test_command(&self.project_root, &self.commands, mutation);
             let argv = if language == "go" {
@@ -1636,6 +1824,9 @@ impl TestRunner {
             if let Some(ref key) = cache_key {
                 if let Some(result) = cache::lookup(&self.project_root, key) {
                     reservation.release();
+                    if let Some(early_stop) = &early_stop {
+                        early_stop.record(result);
+                    }
                     if self.verbose {
                         eprintln!(
                             "  [schema] ↻ cached  {}:{} — {}",
@@ -1695,6 +1886,9 @@ impl TestRunner {
             } else {
                 reservation.commit();
             }
+            if let Some(early_stop) = &early_stop {
+                early_stop.record(outcome.result);
+            }
             if cacheable {
                 if let Some(ref key) = cache_key {
                     cache::store(&self.project_root, key, outcome.result);
@@ -1745,8 +1939,24 @@ impl TestRunner {
         all_records: Vec<MutationRunRecord>,
         duration: Duration,
     ) -> RunOutcome {
+        let planned_total = all_records.len();
+        self.outcome_from_records_with_status(all_records, duration, planned_total, None)
+    }
+
+    fn outcome_from_records_with_status(
+        &self,
+        all_records: Vec<MutationRunRecord>,
+        duration: Duration,
+        planned_total: usize,
+        early_stop_reason: Option<String>,
+    ) -> RunOutcome {
         RunOutcome {
-            report: self.report_from_records(all_records, duration),
+            report: self.report_from_records(
+                all_records,
+                duration,
+                planned_total,
+                early_stop_reason,
+            ),
             cancelled: self.cancelled.load(Ordering::Acquire),
         }
     }
@@ -1755,6 +1965,8 @@ impl TestRunner {
         &self,
         all_records: Vec<MutationRunRecord>,
         duration: Duration,
+        planned_total: usize,
+        early_stop_reason: Option<String>,
     ) -> MutationReport {
         let mut results = Vec::with_capacity(all_records.len());
         let mut build_error_diagnostics = Vec::new();
@@ -1795,6 +2007,8 @@ impl TestRunner {
             } else {
                 vec![]
             },
+            planned_total,
+            early_stop_reason,
             total,
             killed,
             survived,
@@ -4305,6 +4519,7 @@ sleep 10"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled,
@@ -4366,6 +4581,7 @@ sleep 10"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4432,6 +4648,7 @@ int main(void) {
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4498,6 +4715,7 @@ int main() {
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4551,6 +4769,7 @@ esac
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4602,6 +4821,7 @@ touch side_effect
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4682,6 +4902,7 @@ esac
             verbose: false,
             show_output: false,
             max_tested: Some(1),
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4754,6 +4975,7 @@ class Calc {
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4809,6 +5031,7 @@ mod tests {
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: {
                 let mut env = HashMap::new();
@@ -4858,6 +5081,7 @@ mod tests {
             verbose: false,
             show_output: false,
             max_tested: Some(2),
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4865,6 +5089,114 @@ mod tests {
 
         let report = runner.run(mutations).report;
         assert_eq!(report.total, 2, "should stop after max_tested");
+    }
+
+    #[test]
+    fn max_survivors_stops_scheduling_new_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let mutations: Vec<Mutation> = (0..3)
+            .map(|i| {
+                let file = dir.path().join(format!("survivor{i}.txt"));
+                std::fs::write(&file, b"hello world").unwrap();
+                let mut mutation = make_test_mutation(&file);
+                mutation.id = i;
+                mutation.description = format!("survivor limit {i}");
+                mutation
+            })
+            .collect();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: EarlyStopConfig {
+                max_survivors: Some(1),
+                fail_under: None,
+            },
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run(mutations).report;
+
+        assert_eq!(report.planned_total, 3);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.survived, 1);
+        assert!(
+            report
+                .early_stop_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("--max-survivors 1"))
+        );
+    }
+
+    #[test]
+    fn fail_under_stops_when_threshold_cannot_be_reached() {
+        let dir = tempfile::tempdir().unwrap();
+        let mutations: Vec<Mutation> = (0..3)
+            .map(|i| {
+                let file = dir.path().join(format!("threshold{i}.txt"));
+                std::fs::write(&file, b"hello world").unwrap();
+                let mut mutation = make_test_mutation(&file);
+                mutation.id = i;
+                mutation.description = format!("threshold gate {i}");
+                mutation
+            })
+            .collect();
+
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: vec!["true".into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: EarlyStopConfig {
+                max_survivors: None,
+                fail_under: Some(80.0),
+            },
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run(mutations).report;
+
+        assert_eq!(report.planned_total, 3);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.survived, 1);
+        assert!(
+            report
+                .early_stop_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("--fail-under 80.0"))
+        );
     }
 
     #[cfg(unix)]
@@ -4915,6 +5247,7 @@ sleep 0.2
             verbose: false,
             show_output: false,
             max_tested: Some(1),
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -4986,6 +5319,7 @@ sleep 0.2
             verbose: false,
             show_output: false,
             max_tested: Some(1),
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5070,6 +5404,7 @@ rmdir "$lock"
                 verbose: false,
                 show_output: false,
                 max_tested: Some(1),
+                early_stop: Default::default(),
                 respect_workspace_ignores: true,
                 env,
                 cancelled: Arc::new(AtomicBool::new(false)),
@@ -5140,6 +5475,7 @@ rmdir "$lock"
             verbose: false,
             show_output: false,
             max_tested: Some(1),
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5209,6 +5545,7 @@ rmdir "$lock"
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5272,6 +5609,7 @@ rmdir "$lock"
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5315,6 +5653,7 @@ rmdir "$lock"
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5383,6 +5722,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5459,6 +5799,7 @@ exit 1"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5511,6 +5852,7 @@ exit 1"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -5563,6 +5905,7 @@ exit 1"#
             verbose: false,
             show_output: false,
             max_tested: None,
+            early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
             cancelled: Arc::new(AtomicBool::new(false)),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -44,6 +44,8 @@ pub fn sample_report() -> MutationReport {
         duration: Duration::from_millis(1234),
         test_command: Some(vec!["cargo".into(), "test".into()]),
         build_command: vec![],
+        planned_total: 2,
+        early_stop_reason: None,
         total: 2,
         killed: 1,
         survived: 1,

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -126,6 +126,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
         verbose: false,
         show_output: false,
         max_tested: None,
+        early_stop: Default::default(),
         respect_workspace_ignores: true,
         env: go_env,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -85,6 +85,7 @@ fn verify_mutation_outcomes_match_independent_replay() {
         verbose: false,
         show_output: false,
         max_tested: None,
+        early_stop: Default::default(),
         respect_workspace_ignores: true,
         env: go_env.clone(),
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),


### PR DESCRIPTION
## Summary
- add --first-survivor and --max-survivors PR-gate modes
- stop scheduling once --fail-under is no longer reachable
- mark partial reports in terminal, JSON, GitHub, HTML, and PR comments
- skip baseline save/check for partial early-stop reports and document the tradeoff

Fixes #365

## Validation
- cargo test --locked
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--first-survivor` and `--max-survivors` CLI flags to control early stopping during mutation testing.
  * Reports (terminal, HTML, JSON, PR comments) now show partial results and early-stop reasons when runs stop early.
  * When a run is partial, baseline save/check operations are skipped to avoid incomplete baseline updates.

* **Documentation**
  * README updated with examples and explanation of early-stopping and its interaction with `--fail-under`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->