### PR TITLE
Add resource profiles for mutation runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ togi check --all
 togi check --jobs 2 --timeout 60
 
 # Keep laptop CPU/temperature lower
-togi check --jobs 1 --fail-fast
+togi check --profile cool
 
 # Cap mutation count for a bounded exploratory run
 togi check --max-per-run 50  # --max-per-run 0 = unlimited
@@ -168,6 +168,8 @@ Create a `togi.toml` for customization:
 
 ```toml
 [test]
+# Optional: cool, balanced, or ci
+profile = "balanced"
 command = ["go", "test", "./..."]
 timeout = 30
 jobs = 2
@@ -204,19 +206,29 @@ Test command precedence is: CLI `--test-cmd` / `--timeout`, matching
 then the global `[test]` command.
 When `--test-cmd` is set, `--fail-fast` does not modify the custom command;
 include runner-specific fail-fast flags in `--test-cmd` instead.
+Resource profiles provide defaults only: explicit CLI flags and `togi.toml`
+settings such as `jobs` keep taking precedence.
 
 ## Resource tuning
 
 The default worker count is conservative for local machines: `1` on 1-2 CPU
-systems, otherwise `2`. Increase `--jobs` or `[test] jobs` in CI when throughput
-matters more than fan noise, temperature, or foreground responsiveness.
+systems, otherwise `2`. For named presets, use `--profile cool`, `--profile
+balanced`, or `--profile ci`.
+
+`cool` uses one togi worker, enables fail-fast when togi owns the test command,
+and sets safe caps for known nested runners when those environment variables are
+not already set (`CARGO_BUILD_JOBS`, `RUST_TEST_THREADS`, `GOMAXPROCS`, and
+`PYTEST_XDIST_AUTO_NUM_WORKERS`). `balanced` matches the current conservative
+local defaults. `ci` uses the available CPU count for togi jobs. Explicit
+`--jobs`, `[test] jobs`, `--test-cmd`, and existing environment variables still
+win.
 
 Each togi worker runs the configured test command, and that test command may
 parallelize too. For cooler local runs, cap both layers:
 
 ```bash
 # Togi only runs one mutation test process at a time
-togi check --jobs 1 --fail-fast
+togi check --profile cool
 
 # Rust: cap Cargo build jobs and libtest threads
 togi check --jobs 1 --test-cmd "cargo test -j 2 -- --test-threads=2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,10 @@ pub enum Commands {
         #[arg(short, long, default_value = "terminal")]
         format: OutputFormat,
 
+        /// Resource profile for worker count and nested runner limits
+        #[arg(long, value_enum)]
+        profile: Option<crate::config::ResourceProfile>,
+
         /// Number of parallel mutation workers
         #[arg(short, long)]
         jobs: Option<usize>,
@@ -210,6 +214,18 @@ mod tests {
         match cli.command {
             Commands::Check { max_per_run, .. } => {
                 assert_eq!(max_per_run, Some(25));
+            }
+            _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn profile_argument_is_accepted() {
+        let cli = Cli::try_parse_from(["togi", "check", "--profile", "cool"])
+            .expect("--profile cool should parse");
+        match cli.command {
+            Commands::Check { profile, .. } => {
+                assert_eq!(profile, Some(crate::config::ResourceProfile::Cool));
             }
             _ => panic!("expected Check command"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use clap::ValueEnum;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -43,19 +44,79 @@ pub struct LanguageTestConfig {
     pub timeout: Option<u64>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug)]
 pub struct TestConfig {
-    #[serde(default = "default_test_command")]
+    pub profile: Option<ResourceProfile>,
     pub command: Vec<String>,
-    #[serde(default)]
     pub build_command: Vec<String>,
-    #[serde(default = "default_timeout")]
     pub timeout: u64,
-    #[serde(default = "default_jobs")]
     pub jobs: usize,
-    #[serde(default)]
     pub languages: HashMap<String, LanguageTestConfig>,
+    jobs_explicit: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawTestConfig {
+    #[serde(default)]
+    profile: Option<ResourceProfile>,
+    #[serde(default)]
+    command: Vec<String>,
+    #[serde(default)]
+    build_command: Vec<String>,
+    #[serde(default)]
+    timeout: Option<u64>,
+    #[serde(default)]
+    jobs: Option<usize>,
+    #[serde(default)]
+    languages: HashMap<String, LanguageTestConfig>,
+}
+
+impl<'de> Deserialize<'de> for TestConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawTestConfig::deserialize(deserializer)?;
+        Ok(Self {
+            profile: raw.profile,
+            command: raw.command,
+            build_command: raw.build_command,
+            timeout: raw.timeout.unwrap_or_else(default_timeout),
+            jobs: raw.jobs.unwrap_or_else(default_jobs),
+            languages: raw.languages,
+            jobs_explicit: raw.jobs.is_some(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum ResourceProfile {
+    Cool,
+    Balanced,
+    Ci,
+}
+
+impl ResourceProfile {
+    pub fn default_jobs(self) -> usize {
+        std::thread::available_parallelism()
+            .map(|n| self.jobs_for_available_parallelism(n.get()))
+            .unwrap_or(1)
+    }
+
+    pub fn jobs_for_available_parallelism(self, available: usize) -> usize {
+        match self {
+            Self::Cool => 1,
+            Self::Balanced => default_jobs_for_available_parallelism(available),
+            Self::Ci => available.max(1),
+        }
+    }
+
+    pub fn default_fail_fast(self) -> bool {
+        matches!(self, Self::Cool)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -250,16 +311,22 @@ impl TestConfig {
             &self.command
         }
     }
+
+    pub fn jobs_was_explicit(&self) -> bool {
+        self.jobs_explicit
+    }
 }
 
 impl Default for TestConfig {
     fn default() -> Self {
         Self {
+            profile: None,
             command: default_test_command(),
             build_command: vec![],
             timeout: default_timeout(),
             jobs: default_jobs(),
             languages: HashMap::new(),
+            jobs_explicit: false,
         }
     }
 }
@@ -373,7 +440,8 @@ impl Config {
         }
 
         template.push_str(&format!(
-            "timeout = 30\n\
+            "# profile = \"cool\"  # cool, balanced, or ci; explicit jobs still win\n\
+             timeout = 30\n\
              # jobs = {}  # conservative local default; raise in CI for throughput\n\
              \n",
             default_jobs()
@@ -470,6 +538,7 @@ mod tests {
     fn parse_valid_toml() {
         let toml_str = r#"
 [test]
+profile = "ci"
 command = ["make", "test"]
 timeout = 60
 jobs = 8
@@ -482,9 +551,11 @@ max_per_run = 50
 schemata = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.test.profile, Some(ResourceProfile::Ci));
         assert_eq!(config.test.command, vec!["make", "test"]);
         assert_eq!(config.test.timeout, 60);
         assert_eq!(config.test.jobs, 8);
+        assert!(config.test.jobs_was_explicit());
         assert_eq!(config.diff.base, "origin/develop");
         assert_eq!(config.mutations.max_per_run, 50);
         assert!(config.mutations.schemata);
@@ -550,11 +621,13 @@ commnad = ["cargo", "test"]
     fn defaults_when_empty() {
         let config: Config = toml::from_str("").unwrap();
         // Command is empty sentinel when not explicitly configured
+        assert_eq!(config.test.profile, None);
         assert!(config.test.command.is_empty());
         assert!(config.test.build_command.is_empty());
         assert!(config.test.languages.is_empty());
         assert_eq!(config.test.timeout, 30);
         assert!(config.test.jobs >= 1);
+        assert!(!config.test.jobs_was_explicit());
         assert_eq!(config.diff.base, "origin/main");
         assert_eq!(config.mutations.max_per_run, 20);
         assert_eq!(config.mutations.max_per_file, 20);
@@ -575,6 +648,28 @@ commnad = ["cargo", "test"]
         assert_eq!(default_jobs_for_available_parallelism(2), 1);
         assert_eq!(default_jobs_for_available_parallelism(3), 2);
         assert_eq!(default_jobs_for_available_parallelism(16), 2);
+    }
+
+    #[test]
+    fn profile_jobs_are_predictable() {
+        assert_eq!(ResourceProfile::Cool.jobs_for_available_parallelism(16), 1);
+        assert_eq!(
+            ResourceProfile::Balanced.jobs_for_available_parallelism(16),
+            2
+        );
+        assert_eq!(ResourceProfile::Ci.jobs_for_available_parallelism(16), 16);
+        assert_eq!(ResourceProfile::Ci.jobs_for_available_parallelism(0), 1);
+    }
+
+    #[test]
+    fn parse_profile_without_explicit_jobs() {
+        let toml_str = r#"
+[test]
+profile = "cool"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.test.profile, Some(ResourceProfile::Cool));
+        assert!(!config.test.jobs_was_explicit());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -667,7 +667,7 @@ commnad = ["cargo", "test"]
 [test]
 profile = "cool"
 "#;
-        let config: Config = toml::from_str(toml_str).unwrap();
+        let config: Config = toml::from_str(toml_str).expect("profile config should parse");
         assert_eq!(config.test.profile, Some(ResourceProfile::Cool));
         assert!(!config.test.jobs_was_explicit());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1197,6 +1197,8 @@ mod tests {
             jobs: None,
             timeout: None,
             max_per_run: None,
+            first_survivor: false,
+            max_survivors: None,
             schemata: false,
             no_schemata: false,
             dry_run: false,
@@ -1219,14 +1221,14 @@ mod tests {
 
     #[test]
     fn resolve_config_applies_profile_jobs_when_implicit() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir should be created");
         let config_path = dir.path().join("togi.toml");
-        std::fs::write(&config_path, "").unwrap();
+        std::fs::write(&config_path, "").expect("empty config should be written");
         let mut cfg = check_config();
         cfg.config_path = Some(config_path);
         cfg.profile = Some(togi::config::ResourceProfile::Cool);
 
-        let resolved = resolve_config(cfg).unwrap();
+        let resolved = resolve_config(cfg).expect("config should resolve");
 
         assert_eq!(resolved.config.test.jobs, 1);
         assert!(resolved.fail_fast);
@@ -1234,7 +1236,7 @@ mod tests {
 
     #[test]
     fn resolve_config_keeps_explicit_jobs_over_profile() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir should be created");
         let config_path = dir.path().join("togi.toml");
         std::fs::write(
             &config_path,
@@ -1244,11 +1246,11 @@ profile = "cool"
 jobs = 4
 "#,
         )
-        .unwrap();
+        .expect("config should be written");
         let mut cfg = check_config();
         cfg.config_path = Some(config_path);
 
-        let resolved = resolve_config(cfg).unwrap();
+        let resolved = resolve_config(cfg).expect("config should resolve");
 
         assert_eq!(resolved.profile, Some(togi::config::ResourceProfile::Cool));
         assert_eq!(resolved.config.test.jobs, 4);
@@ -1257,15 +1259,15 @@ jobs = 4
 
     #[test]
     fn resolve_config_cli_jobs_override_profile() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir should be created");
         let config_path = dir.path().join("togi.toml");
-        std::fs::write(&config_path, "").unwrap();
+        std::fs::write(&config_path, "").expect("empty config should be written");
         let mut cfg = check_config();
         cfg.config_path = Some(config_path);
         cfg.profile = Some(togi::config::ResourceProfile::Ci);
         cfg.jobs = Some(3);
 
-        let resolved = resolve_config(cfg).unwrap();
+        let resolved = resolve_config(cfg).expect("config should resolve");
 
         assert_eq!(resolved.config.test.jobs, 3);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::Parser;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
@@ -16,6 +16,7 @@ struct CheckConfig {
     base: Option<String>,
     config_path: Option<PathBuf>,
     output_format: togi::cli::OutputFormat,
+    profile: Option<togi::config::ResourceProfile>,
     jobs: Option<usize>,
     timeout: Option<u64>,
     max_per_run: Option<usize>,
@@ -47,7 +48,17 @@ struct ExecuteOptions {
     force_default_command: bool,
     force_default_timeout: bool,
     early_stop: togi::runner::EarlyStopConfig,
+    env: HashMap<String, String>,
     cancelled: Arc<AtomicBool>,
+}
+
+struct ResolvedCheckConfig {
+    config: togi::config::Config,
+    fail_fast: bool,
+    has_explicit_build_cmd: bool,
+    has_custom_test_cmd: bool,
+    has_cli_timeout: bool,
+    profile: Option<togi::config::ResourceProfile>,
 }
 
 fn main() {
@@ -74,6 +85,7 @@ fn main() {
             base,
             config,
             format,
+            profile,
             jobs,
             timeout,
             max_per_run,
@@ -103,6 +115,7 @@ fn main() {
                 base,
                 config_path: config,
                 output_format: format,
+                profile,
                 jobs,
                 timeout,
                 max_per_run,
@@ -302,13 +315,28 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
     let check_baseline = cfg.check_baseline;
     let pr_comment = cfg.pr_comment.clone();
 
-    let (mut config, fail_fast, has_explicit_build_cmd, has_custom_test_cmd, has_cli_timeout) =
-        resolve_config(cfg)?;
+    let resolved = resolve_config(cfg)?;
+    let ResolvedCheckConfig {
+        mut config,
+        fail_fast,
+        has_explicit_build_cmd,
+        has_custom_test_cmd,
+        has_cli_timeout,
+        profile,
+    } = resolved;
     let project_root = get_project_root()?;
     let _lock = togi::lock::acquire(&project_root)?;
 
     config.resolve_test_command(&project_root);
     config.resolve_build_command(&project_root);
+    warn_if_resource_oversubscribed(config.test.jobs);
+    let profile_env = if has_custom_test_cmd {
+        HashMap::new()
+    } else {
+        profile
+            .map(|profile| resource_profile_env(profile, &config))
+            .unwrap_or_default()
+    };
 
     if fail_fast {
         let args = togi::config::failfast_args(&config.test.command);
@@ -364,6 +392,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
             force_default_command: has_custom_test_cmd,
             force_default_timeout: has_cli_timeout,
             early_stop,
+            env: profile_env,
             cancelled,
         },
     );
@@ -435,16 +464,20 @@ fn exit_with(lock: togi::lock::LockGuard, code: i32) -> ! {
     process::exit(code);
 }
 
-fn resolve_config(
-    cfg: CheckConfig,
-) -> anyhow::Result<(togi::config::Config, bool, bool, bool, bool)> {
+fn resolve_config(cfg: CheckConfig) -> anyhow::Result<ResolvedCheckConfig> {
     let mut config = togi::config::Config::load(cfg.config_path.as_deref())?;
     let has_custom_test_cmd = cfg.test_cmd.is_some();
     let has_cli_build_cmd = cfg.build_cmd.is_some();
     let has_cli_timeout = cfg.timeout.is_some();
+    let profile = cfg.profile.or(config.test.profile);
 
     if let Some(b) = cfg.base {
         config.diff.base = b;
+    }
+    if let Some(profile) = profile {
+        if cfg.jobs.is_none() && !config.test.jobs_was_explicit() {
+            config.test.jobs = profile.default_jobs();
+        }
     }
     if let Some(j) = cfg.jobs {
         config.test.jobs = j;
@@ -484,19 +517,95 @@ fn resolve_config(
     }
 
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
-    let fail_fast = cfg.fail_fast && !has_custom_test_cmd;
+    let profile_fail_fast = profile.is_some_and(|profile| profile.default_fail_fast());
+    let requested_fail_fast = cfg.fail_fast || profile_fail_fast;
+    let fail_fast = requested_fail_fast && !has_custom_test_cmd;
     if cfg.fail_fast && has_custom_test_cmd {
         eprintln!(
             "warning: --fail-fast is ignored when --test-cmd is set; include fail-fast flags in the custom command"
         );
+    } else if profile_fail_fast && has_custom_test_cmd {
+        eprintln!(
+            "warning: --profile cool fail-fast default is ignored when --test-cmd is set; include fail-fast flags in the custom command"
+        );
     }
-    Ok((
+    Ok(ResolvedCheckConfig {
         config,
         fail_fast,
         has_explicit_build_cmd,
         has_custom_test_cmd,
         has_cli_timeout,
-    ))
+        profile,
+    })
+}
+
+fn warn_if_resource_oversubscribed(jobs: usize) {
+    if let Ok(available) = std::thread::available_parallelism() {
+        if jobs > available.get() {
+            eprintln!(
+                "warning: {jobs} togi jobs exceed available parallelism ({}); test runners may oversubscribe CPUs",
+                available.get()
+            );
+        }
+    }
+}
+
+fn resource_profile_env(
+    profile: togi::config::ResourceProfile,
+    config: &togi::config::Config,
+) -> HashMap<String, String> {
+    let mut commands: Vec<&[String]> = Vec::new();
+    commands.push(&config.test.command);
+    commands.extend(
+        config
+            .test
+            .languages
+            .values()
+            .map(|lang_config| lang_config.command.as_slice()),
+    );
+    commands.extend(config.projects.values().filter_map(|project| {
+        project
+            .test
+            .as_ref()
+            .and_then(|test| test.command.as_deref())
+    }));
+    resource_profile_env_for_commands(profile, &commands, |name| std::env::var_os(name).is_some())
+}
+
+fn resource_profile_env_for_commands(
+    profile: togi::config::ResourceProfile,
+    commands: &[&[String]],
+    env_exists: impl Fn(&str) -> bool,
+) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    if profile != togi::config::ResourceProfile::Cool {
+        return env;
+    }
+
+    let has_runner = |runner: &str| {
+        commands
+            .iter()
+            .filter_map(|command| command.first())
+            .any(|program| program == runner)
+    };
+    let mut set_if_missing = |key: &str, value: &str| {
+        if !env_exists(key) {
+            env.insert(key.to_string(), value.to_string());
+        }
+    };
+
+    if has_runner("cargo") {
+        set_if_missing("CARGO_BUILD_JOBS", "1");
+        set_if_missing("RUST_TEST_THREADS", "1");
+    }
+    if has_runner("go") {
+        set_if_missing("GOMAXPROCS", "1");
+    }
+    if has_runner("pytest") {
+        set_if_missing("PYTEST_XDIST_AUTO_NUM_WORKERS", "1");
+    }
+
+    env
 }
 
 /// Parse a shard spec like "1/4" into (k, n) where k is 1-indexed.
@@ -727,7 +836,7 @@ fn execute(
         },
         early_stop: options.early_stop,
         respect_workspace_ignores: config.mutations.respect_workspace_ignores,
-        env: std::collections::HashMap::new(),
+        env: options.env,
         cancelled: options.cancelled,
     };
 
@@ -1076,6 +1185,112 @@ fn validate_diff_base(base: &str) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn check_config() -> CheckConfig {
+        CheckConfig {
+            all: false,
+            paths: vec![],
+            base: None,
+            config_path: None,
+            output_format: togi::cli::OutputFormat::Terminal,
+            profile: None,
+            jobs: None,
+            timeout: None,
+            max_per_run: None,
+            schemata: false,
+            no_schemata: false,
+            dry_run: false,
+            verbose: false,
+            show_output: false,
+            test_cmd: None,
+            coverage_file: None,
+            test_selection_file: None,
+            build_cmd: None,
+            fail_fast: false,
+            no_skip_defaults: false,
+            operators: None,
+            fail_under: None,
+            shard: None,
+            save_baseline: false,
+            check_baseline: false,
+            pr_comment: None,
+        }
+    }
+
+    #[test]
+    fn resolve_config_applies_profile_jobs_when_implicit() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(&config_path, "").unwrap();
+        let mut cfg = check_config();
+        cfg.config_path = Some(config_path);
+        cfg.profile = Some(togi::config::ResourceProfile::Cool);
+
+        let resolved = resolve_config(cfg).unwrap();
+
+        assert_eq!(resolved.config.test.jobs, 1);
+        assert!(resolved.fail_fast);
+    }
+
+    #[test]
+    fn resolve_config_keeps_explicit_jobs_over_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[test]
+profile = "cool"
+jobs = 4
+"#,
+        )
+        .unwrap();
+        let mut cfg = check_config();
+        cfg.config_path = Some(config_path);
+
+        let resolved = resolve_config(cfg).unwrap();
+
+        assert_eq!(resolved.profile, Some(togi::config::ResourceProfile::Cool));
+        assert_eq!(resolved.config.test.jobs, 4);
+        assert!(resolved.fail_fast);
+    }
+
+    #[test]
+    fn resolve_config_cli_jobs_override_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(&config_path, "").unwrap();
+        let mut cfg = check_config();
+        cfg.config_path = Some(config_path);
+        cfg.profile = Some(togi::config::ResourceProfile::Ci);
+        cfg.jobs = Some(3);
+
+        let resolved = resolve_config(cfg).unwrap();
+
+        assert_eq!(resolved.config.test.jobs, 3);
+    }
+
+    #[test]
+    fn cool_profile_sets_safe_runner_env_without_overriding_user_env() {
+        let cargo = vec!["cargo".to_string(), "test".to_string()];
+        let go = vec!["go".to_string(), "test".to_string(), "./...".to_string()];
+        let pytest = vec!["pytest".to_string()];
+        let commands: [&[String]; 3] = [&cargo, &go, &pytest];
+
+        let env = resource_profile_env_for_commands(
+            togi::config::ResourceProfile::Cool,
+            &commands,
+            |name| name == "GOMAXPROCS",
+        );
+
+        assert_eq!(env.get("CARGO_BUILD_JOBS").map(String::as_str), Some("1"));
+        assert_eq!(env.get("RUST_TEST_THREADS").map(String::as_str), Some("1"));
+        assert_eq!(
+            env.get("PYTEST_XDIST_AUTO_NUM_WORKERS").map(String::as_str),
+            Some("1")
+        );
+        assert!(!env.contains_key("GOMAXPROCS"));
+    }
 
     #[test]
     fn parse_test_selection_json_accepts_file_line_test_map() {

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -4,6 +4,13 @@
 # string so togi does not need to re-split a shell command.
 
 [test]
+# Optional resource profile. `cool` keeps local runs quiet, `balanced` matches
+# the default local behavior, and `ci` uses more available parallelism.
+# Explicit jobs and existing environment variables still win over profile defaults.
+# Type: "cool", "balanced", or "ci"
+# Default: unset
+# profile = "cool"
+
 # Test command to run for each mutation.
 # Type: array of strings
 # Default: auto-detected from project files, or ["make", "test"] if unknown.


### PR DESCRIPTION
## Summary
- add --profile cool|balanced|ci and [test] profile config
- preserve explicit CLI/config jobs over profile defaults
- apply cool-profile fail-fast and safe nested-runner env caps without overriding existing env
- document profile behavior in README and togi.toml.example

Fixes #367

## Validation
- cargo test --locked
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--profile` option to the `check` command supporting `cool`, `balanced`, and `ci` for resource configuration defaults.
  * Profiles can now be configured in `togi.toml` under the `[test]` section.

* **Documentation**
  * Updated usage examples demonstrating the new `--profile` option.
  * Expanded "Resource tuning" documentation explaining how profiles set defaults while explicit CLI flags and `togi.toml` settings take precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->