### PR TITLE
Add rich incremental mutation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,21 @@ togi list-operators
 # Clear mutation cache
 togi clean
 
+# Re-run even if cache/history has a matching result
+togi check --force-rerun
+
+# Disable structured incremental history for one run
+togi check --no-incremental-history
+
 # Generate a config file
 togi init
 ```
 
 Mutation cache entries include the Togi package version and an internal cache
 schema version, so upgrades and operator behavior changes automatically stop
-matching older `.togi-cache` entries.
+matching older `.togi-cache` entries. Structured incremental history is stored
+under `.togi-cache/history.json`; it can reuse killed/survived results when the
+mutant source, command context, and relevant covering tests are unchanged.
 
 ## Configuration
 
@@ -201,6 +209,7 @@ max_per_file = 20
 schemata = true
 coverage_file = "coverage/lcov.info"
 test_selection_file = "coverage/test-selection.json"
+incremental_history = true
 operators = ["-string_to_empty"]
 exclude_paths = ["vendor/**"]
 skip_noisy_files = true

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,15 +6,20 @@
 //! stored as JSON files in `.togi-cache/`.
 
 use crate::MutationResult;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::hash::Hasher;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// Directory where cache entries are stored.
 const CACHE_DIR: &str = ".togi-cache";
 
 /// Bump when mutation/operator/cache semantics change without a package version bump.
 const CACHE_SCHEMA_VERSION: &str = "2";
+
+const HISTORY_FILE: &str = "history.json";
+const HISTORY_SCHEMA_VERSION: u32 = 1;
 
 const TOGI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -94,9 +99,155 @@ pub fn clear(project_root: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncrementalHistoryQuery {
+    pub mutation_identity: String,
+    pub mutation_description: String,
+    pub source_hash: u64,
+    pub command_hash: u64,
+    pub relevant_test_hash: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IncrementalHistoryEntry {
+    pub mutation_identity: String,
+    pub mutation_description: String,
+    pub result: MutationResult,
+    pub source_hash: u64,
+    pub command_hash: u64,
+    pub relevant_test_hash: u64,
+    #[serde(default)]
+    pub covering_tests: Vec<String>,
+    #[serde(default)]
+    pub killer_test: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct IncrementalHistoryFile {
+    schema_version: u32,
+    entries: Vec<IncrementalHistoryEntry>,
+}
+
+pub struct IncrementalHistoryStore {
+    project_root: PathBuf,
+    state: Mutex<IncrementalHistoryFile>,
+}
+
+impl IncrementalHistoryStore {
+    pub fn load(project_root: &Path) -> Self {
+        Self {
+            project_root: project_root.to_path_buf(),
+            state: Mutex::new(load_history_file(project_root)),
+        }
+    }
+
+    pub fn lookup(&self, query: &IncrementalHistoryQuery) -> Option<MutationResult> {
+        let history = self.state.lock().ok()?;
+        history
+            .entries
+            .iter()
+            .rev()
+            .find(|entry| history_entry_matches(entry, query))
+            .and_then(|entry| reusable_history_result(entry.result))
+    }
+
+    pub fn preferred_killer_test(
+        &self,
+        mutation_identity: &str,
+        mutation_description: &str,
+        tests: &[String],
+    ) -> Option<String> {
+        let history = self.state.lock().ok()?;
+        history
+            .entries
+            .iter()
+            .rev()
+            .filter(|entry| {
+                entry.mutation_identity == mutation_identity
+                    && entry.mutation_description == mutation_description
+            })
+            .filter_map(|entry| entry.killer_test.as_ref())
+            .find(|killer| tests.iter().any(|test| test == *killer))
+            .cloned()
+    }
+
+    pub fn record(&self, entry: IncrementalHistoryEntry) {
+        let Ok(mut history) = self.state.lock() else {
+            eprintln!("warning: incremental history mutex poisoned");
+            return;
+        };
+        history.schema_version = HISTORY_SCHEMA_VERSION;
+        if let Some(existing) = history.entries.iter_mut().find(|existing| {
+            existing.mutation_identity == entry.mutation_identity
+                && existing.mutation_description == entry.mutation_description
+        }) {
+            *existing = entry;
+        } else {
+            history.entries.push(entry);
+        }
+        save_history_file(&self.project_root, &history);
+    }
+}
+
+fn history_entry_matches(entry: &IncrementalHistoryEntry, query: &IncrementalHistoryQuery) -> bool {
+    entry.mutation_identity == query.mutation_identity
+        && entry.mutation_description == query.mutation_description
+        && entry.source_hash == query.source_hash
+        && entry.command_hash == query.command_hash
+        && entry.relevant_test_hash == query.relevant_test_hash
+}
+
+fn reusable_history_result(result: MutationResult) -> Option<MutationResult> {
+    matches!(result, MutationResult::Killed | MutationResult::Survived).then_some(result)
+}
+
+fn load_history_file(project_root: &Path) -> IncrementalHistoryFile {
+    let path = history_path(project_root);
+    let Ok(data) = fs::read_to_string(path) else {
+        return IncrementalHistoryFile {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            entries: Vec::new(),
+        };
+    };
+    let Ok(history) = serde_json::from_str::<IncrementalHistoryFile>(&data) else {
+        return IncrementalHistoryFile {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            entries: Vec::new(),
+        };
+    };
+    if history.schema_version == HISTORY_SCHEMA_VERSION {
+        history
+    } else {
+        IncrementalHistoryFile {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+fn save_history_file(project_root: &Path, history: &IncrementalHistoryFile) {
+    let path = history_path(project_root);
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let Ok(data) = serde_json::to_vec(history) else {
+        return;
+    };
+    let tmp = path.with_extension("json.tmp");
+    if fs::write(&tmp, data).is_ok() {
+        let _ = fs::rename(tmp, path);
+    }
+}
+
 /// Return the cache directory path under the given project root.
 fn cache_dir(project_root: &Path) -> PathBuf {
     project_root.join(CACHE_DIR)
+}
+
+fn history_path(project_root: &Path) -> PathBuf {
+    cache_dir(project_root).join(HISTORY_FILE)
 }
 
 /// Return the file path for a given cache key.
@@ -130,13 +281,13 @@ impl Hasher for Fnv64Hasher {
     }
 }
 
-fn hash_bytes(data: &[u8]) -> u64 {
+pub(crate) fn hash_bytes(data: &[u8]) -> u64 {
     let mut hasher = Fnv64Hasher::default();
     hasher.write(data);
     hasher.finish()
 }
 
-fn hash_str(s: &str) -> u64 {
+pub(crate) fn hash_str(s: &str) -> u64 {
     hash_bytes(s.as_bytes())
 }
 
@@ -263,5 +414,113 @@ mod tests {
             store(tmp.path(), &key, *result);
             assert_eq!(lookup(tmp.path(), &key), Some(*result));
         }
+    }
+
+    #[test]
+    fn incremental_history_reuses_killed_result_when_inputs_match() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        let query = IncrementalHistoryQuery {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            source_hash: hash_bytes(b"source"),
+            command_hash: hash_str("cargo test"),
+            relevant_test_hash: hash_str("tests"),
+        };
+        store.record(IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity.clone(),
+            mutation_description: query.mutation_description.clone(),
+            result: MutationResult::Killed,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: vec!["test_add".into()],
+            killer_test: Some("test_add".into()),
+        });
+
+        let reloaded = IncrementalHistoryStore::load(tmp.path());
+
+        assert_eq!(reloaded.lookup(&query), Some(MutationResult::Killed));
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_history_rejects_changed_relevant_tests() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        store.record(IncrementalHistoryEntry {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            result: MutationResult::Survived,
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+            covering_tests: vec!["test_add".into()],
+            killer_test: None,
+        });
+        let changed_tests = IncrementalHistoryQuery {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 4,
+        };
+
+        assert_eq!(store.lookup(&changed_tests), None);
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_history_does_not_reuse_timeout_or_build_error() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        let query = IncrementalHistoryQuery {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+        };
+        for result in [MutationResult::Timeout, MutationResult::BuildError] {
+            store.record(IncrementalHistoryEntry {
+                mutation_identity: query.mutation_identity.clone(),
+                mutation_description: query.mutation_description.clone(),
+                result,
+                source_hash: query.source_hash,
+                command_hash: query.command_hash,
+                relevant_test_hash: query.relevant_test_hash,
+                covering_tests: vec![],
+                killer_test: None,
+            });
+
+            assert_eq!(store.lookup(&query), None);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_history_prefers_recorded_killer_test() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        store.record(IncrementalHistoryEntry {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            result: MutationResult::Killed,
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+            covering_tests: vec!["test_add".into(), "test_max".into()],
+            killer_test: Some("test_max".into()),
+        });
+
+        assert_eq!(
+            store.preferred_killer_test(
+                "src/lib.rs:0..1:op",
+                "desc",
+                &["test_add".into(), "test_max".into()]
+            ),
+            Some("test_max".into())
+        );
+        Ok(())
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,14 @@ pub enum Commands {
         #[arg(long)]
         test_selection_file: Option<PathBuf>,
 
+        /// Disable structured incremental history reuse
+        #[arg(long)]
+        no_incremental_history: bool,
+
+        /// Re-run mutations even when cache or history has a matching result
+        #[arg(long)]
+        force_rerun: bool,
+
         /// Override build check command (e.g., 'cargo check')
         #[arg(long)]
         build_cmd: Option<String>,
@@ -222,6 +230,24 @@ mod tests {
             }
             _ => panic!("expected TestMap command"),
         }
+    }
+
+    #[test]
+    fn incremental_history_arguments_are_accepted() -> anyhow::Result<()> {
+        let cli =
+            Cli::try_parse_from(["togi", "check", "--no-incremental-history", "--force-rerun"])?;
+        match cli.command {
+            Commands::Check {
+                no_incremental_history,
+                force_rerun,
+                ..
+            } => {
+                assert!(no_incremental_history);
+                assert!(force_rerun);
+            }
+            _ => panic!("expected Check command"),
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,6 +153,8 @@ pub struct MutationConfig {
     pub skip_noisy_files: bool,
     #[serde(default = "default_true")]
     pub respect_workspace_ignores: bool,
+    #[serde(default = "default_true")]
+    pub incremental_history: bool,
     #[serde(default)]
     pub operators: Vec<String>,
     #[serde(default)]
@@ -364,6 +366,7 @@ impl Default for MutationConfig {
             exclude_paths: vec![],
             skip_noisy_files: true,
             respect_workspace_ignores: true,
+            incremental_history: true,
             operators: vec![],
             schemata: true,
         }
@@ -526,6 +529,7 @@ impl Config {
              max_per_run = 20\n\
              # max_per_file = 20  # cap mutations per source file (0 = unlimited)\n\
              # schemata = true  # use supported mutant schemata as the fast path\n\
+             # incremental_history = true  # reuse safe results from previous runs\n\
              # respect_workspace_ignores = true  # honor .ignore/.gitignore in mutation workspaces\n",
         );
 
@@ -635,6 +639,7 @@ commnad = ["cargo", "test"]
         );
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
+        assert!(config.mutations.incremental_history);
         assert!(config.mutations.schemata);
         let project = &config.projects["api"];
         assert_eq!(project.path, PathBuf::from("services/api"));
@@ -664,6 +669,7 @@ commnad = ["cargo", "test"]
         assert!(config.mutations.exclude_paths.is_empty());
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
+        assert!(config.mutations.incremental_history);
         assert!(config.mutations.schemata);
         assert!(config.projects.is_empty());
     }
@@ -1061,6 +1067,7 @@ language = "go"
 exclude_paths = ["vendor/**", "*.generated.ts"]
 skip_noisy_files = false
 respect_workspace_ignores = false
+incremental_history = false
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -1069,6 +1076,7 @@ respect_workspace_ignores = false
         );
         assert!(!config.mutations.skip_noisy_files);
         assert!(!config.mutations.respect_workspace_ignores);
+        assert!(!config.mutations.incremental_history);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ struct CheckConfig {
     test_cmd: Option<String>,
     coverage_file: Option<PathBuf>,
     test_selection_file: Option<PathBuf>,
+    no_incremental_history: bool,
+    force_rerun: bool,
     build_cmd: Option<String>,
     fail_fast: bool,
     no_skip_defaults: bool,
@@ -53,6 +55,7 @@ struct ExecuteOptions {
     force_default_timeout: bool,
     early_stop: togi::runner::EarlyStopConfig,
     env: HashMap<String, String>,
+    force_rerun: bool,
     cancelled: Arc<AtomicBool>,
 }
 
@@ -107,6 +110,8 @@ fn main() {
             test_cmd,
             coverage_file,
             test_selection_file,
+            no_incremental_history,
+            force_rerun,
             build_cmd,
             fail_fast,
             no_skip_defaults,
@@ -141,6 +146,8 @@ fn main() {
                 test_cmd,
                 coverage_file,
                 test_selection_file,
+                no_incremental_history,
+                force_rerun,
                 build_cmd,
                 fail_fast,
                 no_skip_defaults,
@@ -326,6 +333,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
     let save_baseline = cfg.save_baseline;
     let check_baseline = cfg.check_baseline;
     let pr_comment = cfg.pr_comment.clone();
+    let force_rerun = cfg.force_rerun;
 
     let resolved = resolve_config(cfg)?;
     let ResolvedCheckConfig {
@@ -443,6 +451,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
             force_default_timeout: has_cli_timeout,
             early_stop,
             env: profile_env,
+            force_rerun,
             cancelled,
         },
     );
@@ -571,6 +580,9 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<ResolvedCheckConfig> {
     }
     if let Some(path) = cfg.test_selection_file {
         config.mutations.test_selection_file = Some(path);
+    }
+    if cfg.no_incremental_history {
+        config.mutations.incremental_history = false;
     }
     if let Some(cmd) = cfg.build_cmd {
         config.test.build_command =
@@ -941,6 +953,8 @@ fn execute(
         early_stop: options.early_stop,
         respect_workspace_ignores: config.mutations.respect_workspace_ignores,
         env: options.env,
+        incremental_history: config.mutations.incremental_history,
+        force_rerun: options.force_rerun,
         cancelled: options.cancelled,
     };
 
@@ -1352,6 +1366,8 @@ mod tests {
             test_cmd: None,
             coverage_file: None,
             test_selection_file: None,
+            no_incremental_history: false,
+            force_rerun: false,
             build_cmd: None,
             fail_fast: false,
             no_skip_defaults: false,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -175,6 +175,10 @@ pub struct TestRunner {
     pub respect_workspace_ignores: bool,
     /// Extra environment variables passed to every spawned command.
     pub env: HashMap<String, String>,
+    /// Use structured incremental history in addition to exact cache entries.
+    pub incremental_history: bool,
+    /// Re-run mutations instead of trusting cache or incremental history hits.
+    pub force_rerun: bool,
     /// Set to true externally (e.g. Ctrl+C handler) to stop spawning new mutations.
     pub cancelled: Arc<AtomicBool>,
 }
@@ -209,6 +213,7 @@ pub struct BaselineTimingConfig<'a> {
 struct SelectedTestCommand {
     argv: Vec<String>,
     timeout: Duration,
+    selected_tests: Vec<String>,
 }
 
 impl SelectedTestCommand {
@@ -235,10 +240,20 @@ impl SelectedTestCommand {
     }
 }
 
+#[cfg(test)]
 fn select_test_command(
     project_root: &Path,
     commands: &CommandConfig,
     mutation: &Mutation,
+) -> SelectedTestCommand {
+    select_test_command_with_history(project_root, commands, mutation, None)
+}
+
+fn select_test_command_with_history(
+    project_root: &Path,
+    commands: &CommandConfig,
+    mutation: &Mutation,
+    history: Option<&cache::IncrementalHistoryStore>,
 ) -> SelectedTestCommand {
     let project_info = matching_project_command(project_root, commands, mutation);
 
@@ -252,10 +267,21 @@ fn select_test_command(
         })
         .unwrap_or(&commands.command)
         .clone();
+    let mut selected_tests = Vec::new();
 
     if let Some(test_selection) = &commands.test_selection {
-        if let Some(tests) = test_selection.tests_for(project_root, mutation) {
+        if let Some(mut tests) = test_selection.tests_for(project_root, mutation) {
+            if let Some(preferred) = history.and_then(|history| {
+                history.preferred_killer_test(
+                    &cache_identity(project_root, mutation),
+                    &mutation.description,
+                    &tests,
+                )
+            }) {
+                tests.sort_by_key(|test| if *test == preferred { 0 } else { 1 });
+            }
             argv = narrow_test_command(argv, &tests);
+            selected_tests = tests;
         }
     }
 
@@ -274,6 +300,7 @@ fn select_test_command(
                 })
                 .unwrap_or(commands.timeout)
         },
+        selected_tests,
     }
 }
 
@@ -884,6 +911,130 @@ impl SourceContentCache {
             .expect("source content cache mutex poisoned")
             .len()
     }
+}
+
+#[derive(Default)]
+struct TestContextIndex {
+    files: Vec<TestContextFile>,
+}
+
+struct TestContextFile {
+    key: String,
+    content: Vec<u8>,
+    text: Option<String>,
+}
+
+impl TestContextIndex {
+    fn build(project_root: &Path) -> Self {
+        let mut files = Vec::new();
+        collect_cache_context_files(project_root, project_root, &mut files);
+        files.sort_by_key(|path| normalized_cache_path(project_root, path));
+
+        let files = files
+            .into_iter()
+            .filter_map(|relative| {
+                let content = fs::read(project_root.join(&relative)).ok()?;
+                let key = normalized_cache_path(project_root, &relative);
+                let text = String::from_utf8(content.clone()).ok();
+                Some(TestContextFile { key, content, text })
+            })
+            .collect();
+
+        Self { files }
+    }
+
+    fn fingerprint_for_tests(&self, tests: &[String], fallback: u64) -> u64 {
+        if tests.is_empty() || self.files.is_empty() {
+            return fallback;
+        }
+
+        let mut matched = BTreeSet::new();
+        for test in tests {
+            let matches = self.files_for_test(test);
+            if matches.is_empty() {
+                return fallback;
+            }
+            matched.extend(matches);
+        }
+
+        let mut hasher = StableCacheHasher::default();
+        update_cache_hash(&mut hasher, b"selected-test-context-v1");
+        for test in tests {
+            update_cache_hash(&mut hasher, test.as_bytes());
+        }
+        for index in matched {
+            if let Some(file) = self.files.get(index) {
+                update_cache_hash(&mut hasher, file.key.as_bytes());
+                update_cache_hash(&mut hasher, &file.content);
+            }
+        }
+        hasher.finish()
+    }
+
+    fn files_for_test(&self, test: &str) -> Vec<usize> {
+        if let Some(path_key) = direct_test_path_key(test) {
+            return self
+                .files
+                .iter()
+                .enumerate()
+                .filter_map(|(index, file)| (file.key == path_key).then_some(index))
+                .collect();
+        }
+
+        let tokens = test_name_tokens(test);
+        if tokens.is_empty() {
+            return Vec::new();
+        }
+
+        self.files
+            .iter()
+            .enumerate()
+            .filter_map(|(index, file)| {
+                let text = file.text.as_ref()?;
+                tokens
+                    .iter()
+                    .all(|token| text.contains(token))
+                    .then_some(index)
+            })
+            .collect()
+    }
+}
+
+fn direct_test_path_key(test: &str) -> Option<String> {
+    let path_part = test.split("::").next().unwrap_or(test);
+    if !looks_like_test_path(path_part) {
+        return None;
+    }
+    Some(normalized_cache_path(Path::new(""), Path::new(path_part)))
+}
+
+fn looks_like_test_path(value: &str) -> bool {
+    (value.contains('/') || value.contains('\\'))
+        && matches!(
+            Path::new(value)
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or(""),
+            "go" | "rs" | "py" | "ts" | "tsx" | "js" | "jsx" | "java" | "cs" | "rb"
+        )
+}
+
+fn test_name_tokens(test: &str) -> Vec<String> {
+    if test.chars().any(char::is_whitespace) {
+        return (test.len() >= 3)
+            .then(|| test.to_string())
+            .into_iter()
+            .collect();
+    }
+
+    let mut tokens = BTreeSet::new();
+    for token in test.split([':', '#', '.']) {
+        let token = token.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_');
+        if token.len() >= 3 {
+            tokens.insert(token.to_string());
+        }
+    }
+    tokens.into_iter().collect()
 }
 
 fn read_source_content(project_root: &Path, mutation_file: &Path) -> Option<Vec<u8>> {
@@ -1685,7 +1836,10 @@ struct RunShared<'a> {
     early_stop: Option<&'a Arc<EarlyStopState>>,
     respect_workspace_ignores: bool,
     cache_context_fingerprint: u64,
+    test_context_index: &'a TestContextIndex,
     source_contents: &'a SourceContentCache,
+    history: Option<&'a cache::IncrementalHistoryStore>,
+    force_rerun: bool,
 }
 
 fn should_stop_early(early_stop: &Option<Arc<EarlyStopState>>) -> bool {
@@ -1696,6 +1850,51 @@ fn record_early_stop(shared: &RunShared<'_>, result: MutationResult) {
     if let Some(early_stop) = shared.early_stop {
         early_stop.record(result);
     }
+}
+
+fn incremental_history_query(
+    project_root: &Path,
+    mutation: &Mutation,
+    source_content: &[u8],
+    command_context: &str,
+    relevant_test_hash: u64,
+) -> cache::IncrementalHistoryQuery {
+    cache::IncrementalHistoryQuery {
+        mutation_identity: cache_identity(project_root, mutation),
+        mutation_description: mutation.description.clone(),
+        source_hash: cache::hash_bytes(source_content),
+        command_hash: cache::hash_str(command_context),
+        relevant_test_hash,
+    }
+}
+
+fn record_incremental_history(
+    history: Option<&cache::IncrementalHistoryStore>,
+    query: Option<&cache::IncrementalHistoryQuery>,
+    selected_tests: &[String],
+    result: MutationResult,
+    previous_killer: Option<String>,
+) {
+    let (Some(history), Some(query)) = (history, query) else {
+        return;
+    };
+    let killer_test = if result == MutationResult::Killed {
+        previous_killer
+            .filter(|killer| selected_tests.iter().any(|test| test == killer))
+            .or_else(|| (selected_tests.len() == 1).then(|| selected_tests[0].clone()))
+    } else {
+        None
+    };
+    history.record(cache::IncrementalHistoryEntry {
+        mutation_identity: query.mutation_identity.clone(),
+        mutation_description: query.mutation_description.clone(),
+        result,
+        source_hash: query.source_hash,
+        command_hash: query.command_hash,
+        relevant_test_hash: query.relevant_test_hash,
+        covering_tests: selected_tests.to_vec(),
+        killer_test,
+    });
 }
 
 fn run_queued_mutation(
@@ -1710,36 +1909,83 @@ fn run_queued_mutation(
         return None;
     }
 
-    let selected_test = select_test_command(shared.project_root, shared.commands, &mutation);
-    let cache_ctx = selected_test.cache_context(
+    let selected_test = select_test_command_with_history(
+        shared.project_root,
+        shared.commands,
+        &mutation,
+        shared.history,
+    );
+    let command_ctx = selected_test.cache_context(
         shared.build_command,
         shared.build_command_explicit,
         shared.env,
     );
+    let relevant_test_hash = shared.test_context_index.fingerprint_for_tests(
+        &selected_test.selected_tests,
+        shared.cache_context_fingerprint,
+    );
+    let previous_killer = shared.history.and_then(|history| {
+        history.preferred_killer_test(
+            &cache_identity(shared.project_root, &mutation),
+            &mutation.description,
+            &selected_test.selected_tests,
+        )
+    });
     let cache_ctx = format!(
-        "{cache_ctx};context={:016x}",
+        "{command_ctx};context={:016x}",
         shared.cache_context_fingerprint
     );
 
-    // Check cache before acquiring a workspace slot.
-    let cache_key = shared
+    let source_content = shared
         .source_contents
-        .content_for(shared.project_root, &mutation.file)
-        .map(|content| {
-            CacheKey::new(
-                &content,
-                &cache_identity(shared.project_root, &mutation),
-                &mutation.description,
-                &cache_ctx,
-            )
-        });
-    if let Some(ref key) = cache_key {
-        if let Some(result) = cache::lookup(shared.project_root, key) {
-            reservation.release();
-            record_progress(&shared, &mutation, result, None, true);
-            record_early_stop(&shared, result);
-            let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
-            return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
+        .content_for(shared.project_root, &mutation.file);
+    let history_query = source_content.as_deref().map(|content| {
+        incremental_history_query(
+            shared.project_root,
+            &mutation,
+            content,
+            &command_ctx,
+            relevant_test_hash,
+        )
+    });
+    let cache_key = source_content.as_ref().map(|content| {
+        CacheKey::new(
+            content,
+            &cache_identity(shared.project_root, &mutation),
+            &mutation.description,
+            &cache_ctx,
+        )
+    });
+
+    // Check exact cache and then structured history before acquiring a workspace slot.
+    if !shared.force_rerun {
+        if let Some(ref key) = cache_key {
+            if let Some(result) = cache::lookup(shared.project_root, key) {
+                record_incremental_history(
+                    shared.history,
+                    history_query.as_ref(),
+                    &selected_test.selected_tests,
+                    result,
+                    previous_killer.clone(),
+                );
+                reservation.release();
+                record_progress(&shared, &mutation, result, None, true);
+                record_early_stop(&shared, result);
+                let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
+                return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
+            }
+        }
+        if let (Some(history), Some(query)) = (shared.history, history_query.as_ref()) {
+            if let Some(result) = history.lookup(query) {
+                if let Some(ref key) = cache_key {
+                    cache::store(shared.project_root, key, result);
+                }
+                reservation.release();
+                record_progress(&shared, &mutation, result, None, true);
+                record_early_stop(&shared, result);
+                let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
+                return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
+            }
         }
     }
 
@@ -1802,6 +2048,13 @@ fn run_queued_mutation(
     if let Some(ref key) = cache_key {
         cache::store(shared.project_root, key, outcome.result);
     }
+    record_incremental_history(
+        shared.history,
+        history_query.as_ref(),
+        &selected_test.selected_tests,
+        outcome.result,
+        previous_killer,
+    );
 
     let result = outcome.result;
     record_progress(
@@ -2088,6 +2341,10 @@ impl TestRunner {
         let results = Arc::new(Mutex::new(Vec::new()));
         let worker_count = workspace_pool.len().min(total).max(1);
         let cache_context_hash = cache_context_fingerprint(&self.project_root);
+        let test_context_index = TestContextIndex::build(&self.project_root);
+        let history = self
+            .incremental_history
+            .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
 
         thread::scope(|scope| {
             for _ in 0..worker_count {
@@ -2104,6 +2361,9 @@ impl TestRunner {
                 let max_tested = self.max_tested;
                 let show_output = self.show_output;
                 let source_contents = &source_contents;
+                let test_context_index = &test_context_index;
+                let history = history.as_ref();
+                let force_rerun = self.force_rerun;
                 let early_stop = early_stop.clone();
 
                 scope.spawn(move || {
@@ -2152,7 +2412,10 @@ impl TestRunner {
                                     early_stop: early_stop.as_ref(),
                                     respect_workspace_ignores: self.respect_workspace_ignores,
                                     cache_context_fingerprint: cache_context_hash,
+                                    test_context_index,
                                     source_contents,
+                                    history,
+                                    force_rerun,
                                 },
                             )
                         }));
@@ -2227,6 +2490,10 @@ impl TestRunner {
         let tested_counter = Arc::new(AtomicUsize::new(0));
         let source_contents = SourceContentCache::default();
         let cache_context_hash = cache_context_fingerprint(&self.project_root);
+        let test_context_index = TestContextIndex::build(&self.project_root);
+        let history = self
+            .incremental_history
+            .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
         let mut workspace_needs_reset = false;
         for schema_mutation in schema_mutations {
             if self.cancelled.load(Ordering::Acquire) || should_stop_early(&early_stop) {
@@ -2242,51 +2509,107 @@ impl TestRunner {
                 break;
             }
             let mutation = &schema_mutation.mutation;
-            let selected = select_test_command(&self.project_root, &self.commands, mutation);
+            let selected = select_test_command_with_history(
+                &self.project_root,
+                &self.commands,
+                mutation,
+                history.as_ref(),
+            );
             let argv = if language == "go" {
-                force_go_no_test_cache(selected.argv)
+                force_go_no_test_cache(selected.argv.clone())
             } else {
-                selected.argv
+                selected.argv.clone()
             };
             let mut env = self.env.clone();
             env.insert("TOGI_MUTANT".to_string(), mutation.id.to_string());
             let cache_selected = SelectedTestCommand {
                 argv: argv.clone(),
                 timeout: selected.timeout,
+                selected_tests: selected.selected_tests.clone(),
             };
-            let cache_ctx = cache_selected.cache_context(
+            let command_ctx = cache_selected.cache_context(
                 &self.commands.build_command,
                 self.commands.build_command_explicit,
                 &env,
             );
-            let cache_ctx = format!("{cache_ctx};context={cache_context_hash:016x}");
-            let cache_key = source_contents
-                .content_for(&self.project_root, &mutation.file)
-                .map(|content| {
-                    CacheKey::new(
-                        &content,
-                        &cache_identity(&self.project_root, mutation),
-                        &mutation.description,
-                        &cache_ctx,
-                    )
-                });
-            if let Some(ref key) = cache_key {
-                if let Some(result) = cache::lookup(&self.project_root, key) {
-                    reservation.release();
-                    if let Some(early_stop) = &early_stop {
-                        early_stop.record(result);
-                    }
-                    if self.verbose {
-                        eprintln!(
-                            "  [schema] ↻ cached  {}:{} — {}",
-                            mutation.file.display(),
-                            mutation.line,
-                            mutation.operator
+            let relevant_test_hash = test_context_index
+                .fingerprint_for_tests(&selected.selected_tests, cache_context_hash);
+            let previous_killer = history.as_ref().and_then(|history| {
+                history.preferred_killer_test(
+                    &cache_identity(&self.project_root, mutation),
+                    &mutation.description,
+                    &selected.selected_tests,
+                )
+            });
+            let cache_ctx = format!("{command_ctx};context={cache_context_hash:016x}");
+            let source_content = source_contents.content_for(&self.project_root, &mutation.file);
+            let history_query = source_content.as_deref().map(|content| {
+                incremental_history_query(
+                    &self.project_root,
+                    mutation,
+                    content,
+                    &command_ctx,
+                    relevant_test_hash,
+                )
+            });
+            let cache_key = source_content.as_ref().map(|content| {
+                CacheKey::new(
+                    content,
+                    &cache_identity(&self.project_root, mutation),
+                    &mutation.description,
+                    &cache_ctx,
+                )
+            });
+            if !self.force_rerun {
+                if let Some(ref key) = cache_key {
+                    if let Some(result) = cache::lookup(&self.project_root, key) {
+                        record_incremental_history(
+                            history.as_ref(),
+                            history_query.as_ref(),
+                            &selected.selected_tests,
+                            result,
+                            previous_killer.clone(),
                         );
+                        reservation.release();
+                        if let Some(early_stop) = &early_stop {
+                            early_stop.record(result);
+                        }
+                        if self.verbose {
+                            eprintln!(
+                                "  [schema] ↻ cached  {}:{} — {}",
+                                mutation.file.display(),
+                                mutation.line,
+                                mutation.operator
+                            );
+                        }
+                        let diagnostic =
+                            cached_build_error_diagnostic(mutation, "schemata", result);
+                        results.push(MutationRunRecord::new(mutation.clone(), result, diagnostic));
+                        continue;
                     }
-                    let diagnostic = cached_build_error_diagnostic(mutation, "schemata", result);
-                    results.push(MutationRunRecord::new(mutation.clone(), result, diagnostic));
-                    continue;
+                }
+                if let (Some(history), Some(query)) = (history.as_ref(), history_query.as_ref()) {
+                    if let Some(result) = history.lookup(query) {
+                        if let Some(ref key) = cache_key {
+                            cache::store(&self.project_root, key, result);
+                        }
+                        reservation.release();
+                        if let Some(early_stop) = &early_stop {
+                            early_stop.record(result);
+                        }
+                        if self.verbose {
+                            eprintln!(
+                                "  [schema] ↻ cached  {}:{} — {}",
+                                mutation.file.display(),
+                                mutation.line,
+                                mutation.operator
+                            );
+                        }
+                        let diagnostic =
+                            cached_build_error_diagnostic(mutation, "schemata", result);
+                        results.push(MutationRunRecord::new(mutation.clone(), result, diagnostic));
+                        continue;
+                    }
                 }
             }
 
@@ -2343,6 +2666,13 @@ impl TestRunner {
                     cache::store(&self.project_root, key, outcome.result);
                 }
             }
+            record_incremental_history(
+                history.as_ref(),
+                history_query.as_ref(),
+                &selected.selected_tests,
+                outcome.result,
+                previous_killer,
+            );
             if self.verbose {
                 let symbol = match outcome.result {
                     MutationResult::Killed => "✓ killed",
@@ -3574,6 +3904,17 @@ mod tests {
         }
     }
 
+    fn failing_command() -> Vec<String> {
+        #[cfg(windows)]
+        {
+            vec!["cmd".into(), "/C".into(), "exit 1".into()]
+        }
+        #[cfg(not(windows))]
+        {
+            vec!["sh".into(), "-c".into(), "false".into()]
+        }
+    }
+
     #[test]
     fn file_guard_restores_content_on_drop() {
         let dir = tempfile::tempdir().unwrap();
@@ -4035,10 +4376,12 @@ mod tests {
         let selected = SelectedTestCommand {
             argv: vec!["cargo test".into()],
             timeout: Duration::from_secs(2),
+            selected_tests: Vec::new(),
         };
         let ambiguous = SelectedTestCommand {
             argv: vec!["cargo".into(), "test".into()],
             timeout: Duration::from_secs(2),
+            selected_tests: Vec::new(),
         };
 
         assert_ne!(
@@ -4436,6 +4779,133 @@ mod tests {
         let selected = select_test_command(tmp.path(), &commands, &mutation);
 
         assert_eq!(selected.argv, vec!["make", "test"]);
+        Ok(())
+    }
+
+    #[test]
+    fn select_test_command_prioritizes_history_killer() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            tmp.path(),
+            Path::new("src/calc.py"),
+            3,
+            vec!["test_slow".into(), "test_fast".into()],
+        );
+
+        let mut commands = test_command_config();
+        commands.command = vec!["pytest".into()];
+        commands.test_selection = Some(selection);
+
+        let mut mutation = make_test_mutation(Path::new("src/calc.py"));
+        mutation.line = 3;
+        let history = cache::IncrementalHistoryStore::load(tmp.path());
+        history.record(cache::IncrementalHistoryEntry {
+            mutation_identity: cache_identity(tmp.path(), &mutation),
+            mutation_description: mutation.description.clone(),
+            result: MutationResult::Killed,
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+            covering_tests: vec!["test_slow".into(), "test_fast".into()],
+            killer_test: Some("test_fast".into()),
+        });
+
+        let selected =
+            select_test_command_with_history(tmp.path(), &commands, &mutation, Some(&history));
+
+        assert_eq!(
+            selected.argv,
+            vec!["pytest", "-k", "test_fast or test_slow"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_history_reuses_result_and_force_rerun_bypasses_it() -> anyhow::Result<()> {
+        let (dir, file, mutation) = make_test_setup();
+        std::fs::create_dir_all(dir.path().join("tests"))?;
+        std::fs::write(
+            dir.path().join("tests/test_calc.rs"),
+            "fn test_add() { assert!(true); }\n",
+        )?;
+
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(dir.path(), &file, mutation.line, vec!["test_add".into()]);
+        let commands = || CommandConfig {
+            command: failing_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: Some(selection.clone()),
+        };
+
+        let command_config = commands();
+        let selected =
+            select_test_command_with_history(dir.path(), &command_config, &mutation, None);
+        let command_ctx =
+            selected.cache_context(&command_config.build_command, false, &HashMap::new());
+        let context_hash = cache_context_fingerprint(dir.path());
+        let test_context_index = TestContextIndex::build(dir.path());
+        let relevant_test_hash =
+            test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
+        let source = std::fs::read(&file)?;
+        let query = incremental_history_query(
+            dir.path(),
+            &mutation,
+            &source,
+            &command_ctx,
+            relevant_test_hash,
+        );
+        cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity.clone(),
+            mutation_description: query.mutation_description.clone(),
+            result: MutationResult::Survived,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: selected.selected_tests.clone(),
+            killer_test: None,
+        });
+
+        let cached_runner = TestRunner {
+            commands: commands(),
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let cached = cached_runner.run(vec![mutation.clone()]).report;
+        assert_eq!(cached.results[0].1, MutationResult::Survived);
+
+        let forced_runner = TestRunner {
+            commands: commands(),
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: true,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let forced = forced_runner.run(vec![mutation]).report;
+        assert_eq!(forced.results[0].1, MutationResult::Killed);
         Ok(())
     }
 
@@ -5301,6 +5771,8 @@ sleep 10"#
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled,
         };
 
@@ -5363,6 +5835,8 @@ sleep 10"#
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5430,6 +5904,8 @@ int main(void) {
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5497,6 +5973,8 @@ int main() {
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5551,6 +6029,8 @@ esac
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5603,6 +6083,8 @@ touch side_effect
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5656,6 +6138,7 @@ esac
         let cache_selected = SelectedTestCommand {
             argv: selected.argv,
             timeout: selected.timeout,
+            selected_tests: selected.selected_tests,
         };
         let cache_ctx = cache_selected.cache_context(
             &commands.build_command,
@@ -5684,6 +6167,8 @@ esac
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5757,6 +6242,8 @@ class Calc {
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5820,6 +6307,8 @@ mod tests {
                 );
                 env
             },
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5863,6 +6352,8 @@ mod tests {
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5908,6 +6399,8 @@ mod tests {
             },
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -5962,6 +6455,8 @@ mod tests {
             },
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6029,6 +6524,8 @@ sleep 0.2
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6101,6 +6598,8 @@ sleep 0.2
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6186,6 +6685,8 @@ rmdir "$lock"
                 early_stop: Default::default(),
                 respect_workspace_ignores: true,
                 env,
+                incremental_history: true,
+                force_rerun: false,
                 cancelled: Arc::new(AtomicBool::new(false)),
             };
 
@@ -6257,6 +6758,8 @@ rmdir "$lock"
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6327,6 +6830,8 @@ rmdir "$lock"
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env,
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6391,6 +6896,8 @@ rmdir "$lock"
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6435,6 +6942,8 @@ rmdir "$lock"
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6504,6 +7013,8 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6581,6 +7092,8 @@ exit 1"#
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6634,6 +7147,8 @@ exit 1"#
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6687,6 +7202,8 @@ exit 1"#
             early_stop: Default::default(),
             respect_workspace_ignores: true,
             env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -129,6 +129,8 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
         early_stop: Default::default(),
         respect_workspace_ignores: true,
         env: go_env,
+        incremental_history: true,
+        force_rerun: false,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -88,6 +88,8 @@ fn verify_mutation_outcomes_match_independent_replay() {
         early_stop: Default::default(),
         respect_workspace_ignores: true,
         env: go_env.clone(),
+        incremental_history: true,
+        force_rerun: false,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -93,6 +93,12 @@ coverage_file = "coverage/lcov.info"
 # Default: unset
 test_selection_file = "coverage/test-selection.json"
 
+# Reuse structured incremental history when the mutant source, command context,
+# and relevant covering tests have not changed.
+# Type: boolean
+# Default: true
+incremental_history = true
+
 # Glob patterns excluded from mutation collection.
 # Type: array of strings
 # Default: []


### PR DESCRIPTION
## Summary
- persist structured incremental history under .togi-cache/history.json
- reuse safe killed/survived results when mutant source, command context, and relevant covering tests are unchanged
- prioritize recorded killer tests in selected test ordering and add --force-rerun / --no-incremental-history controls

## Validation
- cargo test --locked
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check

Closes #361.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental history tracking reuses mutation test results when source code, test command, and test suite match previous runs.
  * Added `--force-rerun` flag to force re-execution of mutations, bypassing cached results.
  * Added `--no-incremental-history` flag to disable history reuse for a specific run.
  * New `incremental_history` configuration option in `togi.toml` (enabled by default).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darkroom4364/togi/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->