### PR TITLE
Document togi's security policy and execution model

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+If you believe you found a security vulnerability, do not open a public bug
+report. Follow the instructions in `SECURITY.md` instead.
+
 **Describe the bug**
   A clear and concise description of what the bug is.
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,22 @@ dependency/build directories such as `node_modules`, `.venv`, `dist`, `build`,
 and `target`. Set `[mutations] respect_workspace_ignores = false` only when a
 test command genuinely needs ignored files copied into the mutation workspace.
 
+## Security model
+
+togi executes repository-defined build and test commands with the permissions of
+the current user or CI runner.
+
+Workspace copies, timeouts, and descendant-process cleanup improve correctness
+and cleanup, but they are not a security sandbox. togi does not currently block
+network access or confine filesystem access beyond the restrictions already
+provided by your OS, container, or CI environment.
+
+Run togi only against repositories you trust, or place it inside a separate
+container or VM when evaluating less-trusted code. Running less-trusted
+repositories directly on the host is out of scope for the current security
+model. See [SECURITY.md](SECURITY.md) for the supported-version policy and
+vulnerability reporting instructions.
+
 ## How it works
 
 1. Parse `git diff` to find changed lines

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+togi is still pre-1.0. Security fixes are applied on a best-effort basis to the
+latest tagged release and the current `main` branch.
+
+| Version | Supported |
+| --- | --- |
+| Latest tagged release | Yes |
+| Current `main` branch | Yes |
+| Older tags and maintenance branches | No |
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for an unpatched security vulnerability.
+
+Prefer GitHub's private vulnerability reporting flow for this repository. If
+private reporting is unavailable, contact the maintainer privately through
+GitHub before disclosing details publicly.
+
+Include the affected togi version or commit, operating system, reproduction
+steps, expected impact, and whether the issue depends on a particular target
+language, test command, or CI environment.
+
+The maintainer will triage the report, work on a fix, and coordinate public
+disclosure after a patch or mitigation is available when possible.
+
+## Security Model
+
+togi is a local and CI command runner. It parses repository files, creates
+isolated mutation workspaces, and executes repository-defined build and test
+commands.
+
+Those workspace copies, timeouts, and descendant-process cleanup are operational
+guardrails for correctness and cleanup. They are not a security sandbox.
+
+togi does not currently restrict filesystem or network access for spawned
+commands beyond whatever the host operating system, container, or CI runner
+already enforces. Treat the target repository and its configured test commands
+as trusted code. Running less-trusted repositories directly on the host is out
+of scope for the current security model.
+
+If you need to evaluate less-trusted repositories, run togi inside a separate
+container, VM, or similarly restricted environment with least-privilege
+credentials and explicit filesystem/network boundaries.


### PR DESCRIPTION
## Summary
- add a root SECURITY.md with supported-version and vulnerability-reporting guidance
- document that workspace isolation is not a security sandbox
- redirect public bug reports away from unpatched security disclosures

## Testing
- not run (documentation-only change)

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced security vulnerability reporting policy with private disclosure guidance
  * Clarified security model: workspace isolation without additional security sandbox; respects host OS/container/CI restrictions
  * Updated issue templates with security vulnerability guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->