### PR TITLE
Add opt-in sandbox command wrapper

### DIFF
--- a/.github/scripts/run-dogfood-smoke.sh
+++ b/.github/scripts/run-dogfood-smoke.sh
@@ -14,6 +14,9 @@ set +e
   --all \
   --path src/report/json.rs \
   --test-cmd "cargo test --locked" \
+  --calibrate-timeout \
+  --timeout-multiplier 4 \
+  --timeout-slack 2 \
   --format json \
   >"$raw_report_path"
 status=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: 0sec-labs/foxguard/action@e13233eb0b83a495ff7ad8fe30d62128cb625c14
         with:
           path: .
-          severity: medium
+          severity: high
           version: v0.8.1
           fail-on-findings: "true"
           upload-sarif: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: 0sec-labs/foxguard/action@e13233eb0b83a495ff7ad8fe30d62128cb625c14
         with:
           path: .
-          severity: medium
+          severity: high
           version: v0.8.1
           fail-on-findings: "true"
           upload-sarif: "true"

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ timeout_multiplier = 4.0
 timeout_slack = 2
 jobs = 2
 build_command = ["go", "build", "./..."]
+sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--"]
 
 [test.languages.python]
 command = ["pytest"]
@@ -223,6 +224,10 @@ When `--test-cmd` is set, `--fail-fast` does not modify the custom command;
 include runner-specific fail-fast flags in `--test-cmd` instead.
 Resource profiles provide defaults only: explicit CLI flags and `togi.toml`
 settings such as `jobs` keep taking precedence.
+
+`[test] sandbox_command` is an optional wrapper that runs every build and test
+command inside your own sandbox tool. togi appends the selected command after
+the wrapper argv, so tools that expect `--` as a separator can use it directly.
 
 `--calibrate-timeout` (or `[test] calibrate_timeout = true`) runs the
 unmutated build/test command once in a disposable workspace, then sets the
@@ -453,16 +458,20 @@ test command genuinely needs ignored files copied into the mutation workspace.
 togi executes repository-defined build and test commands with the permissions of
 the current user or CI runner.
 
-Workspace copies, timeouts, and descendant-process cleanup improve correctness
-and cleanup, but they are not a security sandbox. togi does not currently block
-network access or confine filesystem access beyond the restrictions already
-provided by your OS, container, or CI environment.
+Workspace copies, timeouts, descendant-process cleanup, and the optional
+`[test] sandbox_command` wrapper improve correctness and reduce exposure, but
+they are not a complete security sandbox. togi does not itself block network
+access or confine filesystem access beyond what the host OS, container, or CI
+environment already enforces.
 
 Run togi only against repositories you trust, or place it inside a separate
 container or VM when evaluating less-trusted code. Running less-trusted
 repositories directly on the host is out of scope for the current security
-model. See [SECURITY.md](SECURITY.md) for the supported-version policy and
-vulnerability reporting instructions.
+model. On Linux, a wrapper such as `bwrap` or `firejail` is a practical opt-in
+strategy; on macOS, use a platform sandbox or container boundary; on Windows,
+use a container, VM, or equivalent host-managed isolation. See
+[SECURITY.md](SECURITY.md) for the supported-version policy and vulnerability
+reporting instructions.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ togi check --build-cmd "cargo check"
 # Only mutate lines covered by an LCOV file
 togi check --coverage-file coverage/lcov.info
 
+# Gate on line and diff coverage thresholds
+togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90
+togi check --coverage-file coverage/lcov.info --fail-on-uncovered-diff
+
 # Generate and use a source-line to test-name map (Go helper shown)
 togi test-map --path . --output coverage/test-selection.json
 togi check --test-selection-file coverage/test-selection.json
@@ -209,6 +213,9 @@ max_per_run = 20
 max_per_file = 20
 schemata = true
 coverage_file = "coverage/lcov.info"
+min_line_coverage = 80.0
+min_diff_coverage = 90.0
+fail_on_uncovered_diff = false
 test_selection_file = "coverage/test-selection.json"
 incremental_history = true
 operators = ["-string_to_empty"]
@@ -324,15 +331,20 @@ Schemata are enabled by default. They batch compatible mutations into one build 
 
 ## Coverage and test selection
 
-For large repos, togi can avoid work before the runner starts:
+For large repos, togi can avoid work before the runner starts and can also
+fail the run when LCOV coverage is below a threshold:
 
 - `--coverage-file coverage/lcov.info` keeps only mutations on covered lines
+- `--min-line-coverage 80` fails when overall LCOV line coverage is below 80%
+- `--min-diff-coverage 90` fails when changed-line coverage is below 90%
+- `--fail-on-uncovered-diff` fails when any changed line is uncovered
 - `togi test-map` generates a Go line-to-test map from per-test coverage
 - `--test-selection-file coverage/test-selection.json` narrows each mutant to tests that cover that line when the configured runner supports test selection
 
 ```bash
 togi test-map --path . --output coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --test-selection-file coverage/test-selection.json
+togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90
 ```
 
 The selection file is a JSON map of source file to line number to test names.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,16 +30,18 @@ disclosure after a patch or mitigation is available when possible.
 
 togi is a local and CI command runner. It parses repository files, creates
 isolated mutation workspaces, and executes repository-defined build and test
-commands.
+commands. An optional `[test] sandbox_command` wrapper can prefix those
+commands with an external sandbox tool, but the actual isolation boundary is
+still provided by that tool and the host environment.
 
 Those workspace copies, timeouts, and descendant-process cleanup are operational
 guardrails for correctness and cleanup. They are not a security sandbox.
 
 togi does not currently restrict filesystem or network access for spawned
-commands beyond whatever the host operating system, container, or CI runner
-already enforces. Treat the target repository and its configured test commands
-as trusted code. Running less-trusted repositories directly on the host is out
-of scope for the current security model.
+commands beyond whatever the host operating system, container, CI runner, or
+configured sandbox wrapper already enforces. Treat the target repository and
+its configured test commands as trusted code. Running less-trusted repositories
+directly on the host is out of scope for the current security model.
 
 If you need to evaluate less-trusted repositories, run togi inside a separate
 container, VM, or similarly restricted environment with least-privilege

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,18 @@ pub enum Commands {
         #[arg(long)]
         coverage_file: Option<PathBuf>,
 
+        /// Fail if overall LCOV line coverage is below this percentage
+        #[arg(long)]
+        min_line_coverage: Option<f64>,
+
+        /// Fail if changed-line coverage is below this percentage
+        #[arg(long)]
+        min_diff_coverage: Option<f64>,
+
+        /// Fail if any changed line is uncovered in LCOV
+        #[arg(long)]
+        fail_on_uncovered_diff: bool,
+
         /// JSON source-line to test-name map for targeted test runs
         #[arg(long)]
         test_selection_file: Option<PathBuf>,
@@ -244,6 +256,37 @@ mod tests {
             } => {
                 assert!(no_incremental_history);
                 assert!(force_rerun);
+            }
+            _ => panic!("expected Check command"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn coverage_gate_arguments_are_accepted() -> anyhow::Result<()> {
+        let cli = Cli::try_parse_from([
+            "togi",
+            "check",
+            "--coverage-file",
+            "coverage.lcov",
+            "--min-line-coverage",
+            "80",
+            "--min-diff-coverage",
+            "90",
+            "--fail-on-uncovered-diff",
+        ])?;
+        match cli.command {
+            Commands::Check {
+                coverage_file,
+                min_line_coverage,
+                min_diff_coverage,
+                fail_on_uncovered_diff,
+                ..
+            } => {
+                assert_eq!(coverage_file, Some(PathBuf::from("coverage.lcov")));
+                assert_eq!(min_line_coverage, Some(80.0));
+                assert_eq!(min_diff_coverage, Some(90.0));
+                assert!(fail_on_uncovered_diff);
             }
             _ => panic!("expected Check command"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ pub struct TestConfig {
     pub profile: Option<ResourceProfile>,
     pub command: Vec<String>,
     pub build_command: Vec<String>,
+    pub sandbox_command: Vec<String>,
     pub timeout: u64,
     pub calibrate_timeout: bool,
     pub timeout_multiplier: f64,
@@ -67,6 +68,8 @@ struct RawTestConfig {
     command: Vec<String>,
     #[serde(default)]
     build_command: Vec<String>,
+    #[serde(default)]
+    sandbox_command: Vec<String>,
     #[serde(default)]
     timeout: Option<u64>,
     #[serde(default)]
@@ -91,6 +94,7 @@ impl<'de> Deserialize<'de> for TestConfig {
             profile: raw.profile,
             command: raw.command,
             build_command: raw.build_command,
+            sandbox_command: raw.sandbox_command,
             timeout: raw.timeout.unwrap_or_else(default_timeout),
             calibrate_timeout: raw.calibrate_timeout.unwrap_or(false),
             timeout_multiplier: raw.timeout_multiplier.unwrap_or(4.0),
@@ -337,6 +341,7 @@ impl Default for TestConfig {
             profile: None,
             command: default_test_command(),
             build_command: vec![],
+            sandbox_command: vec![],
             timeout: default_timeout(),
             calibrate_timeout: false,
             timeout_multiplier: 4.0,
@@ -456,6 +461,12 @@ impl Config {
                 build_cmd_toml.join(", ")
             ));
         }
+
+        template.push_str(
+            "# sandbox_command = [\"bwrap\", \"--ro-bind\", \"/\", \"/\", \"--dev\", \"/dev\", \"--proc\", \"/proc\", \"--\"]\n\
+             # Optional wrapper that runs every build and test command inside your own sandbox tool.\n\
+             # Leave unset to run directly on the host or CI runner.\n",
+        );
 
         template.push_str(&format!(
             "# profile = \"cool\"  # cool, balanced, or ci; explicit jobs still win\n\
@@ -584,6 +595,7 @@ schemata = true
         assert_eq!(config.test.timeout_slack, 4);
         assert_eq!(config.test.jobs, 8);
         assert!(config.test.jobs_was_explicit());
+        assert!(config.test.sandbox_command.is_empty());
         assert_eq!(config.diff.base, "origin/develop");
         assert_eq!(config.mutations.max_per_run, 50);
         assert!(config.mutations.schemata);
@@ -625,6 +637,7 @@ commnad = ["cargo", "test"]
         let config: Config = toml::from_str(content).unwrap();
         assert_eq!(config.test.command, vec!["go", "test", "./..."]);
         assert!(config.test.build_command.is_empty());
+        assert!(config.test.sandbox_command.is_empty());
         assert_eq!(config.test.timeout, 30);
         assert_eq!(config.test.jobs, 2);
         assert_eq!(config.test.languages["python"].command, vec!["pytest"]);
@@ -653,6 +666,7 @@ commnad = ["cargo", "test"]
         assert_eq!(config.test.profile, None);
         assert!(config.test.command.is_empty());
         assert!(config.test.build_command.is_empty());
+        assert!(config.test.sandbox_command.is_empty());
         assert!(config.test.languages.is_empty());
         assert_eq!(config.test.timeout, 30);
         assert!(!config.test.calibrate_timeout);
@@ -719,6 +733,20 @@ timeout = 120
     }
 
     #[test]
+    fn parse_sandbox_command() {
+        let toml_str = r#"
+[test]
+command = ["cargo", "test"]
+sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--"]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.test.sandbox_command,
+            vec!["bwrap", "--ro-bind", "/", "/", "--"]
+        );
+    }
+
+    #[test]
     fn write_template_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("togi.toml");
@@ -726,6 +754,7 @@ timeout = 120
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("[test]"));
         assert!(content.contains("command = "));
+        assert!(content.contains("sandbox_command = "));
         assert!(content.contains("[diff]"));
         assert!(content.contains("[mutations]"));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,12 @@ pub struct MutationConfig {
     pub max_per_run: usize,
     pub coverage_file: Option<PathBuf>,
     pub test_selection_file: Option<PathBuf>,
+    #[serde(default)]
+    pub min_line_coverage: Option<f64>,
+    #[serde(default)]
+    pub min_diff_coverage: Option<f64>,
+    #[serde(default)]
+    pub fail_on_uncovered_diff: bool,
     #[serde(default = "default_max_per_file")]
     pub max_per_file: usize,
     #[serde(default)]
@@ -368,6 +374,9 @@ impl Default for MutationConfig {
             max_per_file: default_max_per_file(),
             coverage_file: None,
             test_selection_file: None,
+            min_line_coverage: None,
+            min_diff_coverage: None,
+            fail_on_uncovered_diff: false,
             exclude_paths: vec![],
             skip_noisy_files: true,
             respect_workspace_ignores: true,
@@ -466,6 +475,13 @@ impl Config {
             "# sandbox_command = [\"bwrap\", \"--ro-bind\", \"/\", \"/\", \"--dev\", \"/dev\", \"--proc\", \"/proc\", \"--\"]\n\
              # Optional wrapper that runs every build and test command inside your own sandbox tool.\n\
              # Leave unset to run directly on the host or CI runner.\n",
+        );
+
+        template.push_str(
+            "# coverage_file = \"coverage/lcov.info\"  # enable LCOV filtering and coverage gates\n\
+             # min_line_coverage = 80.0  # fail if overall LCOV line coverage drops below this\n\
+             # min_diff_coverage = 90.0  # fail if changed-line coverage drops below this\n\
+             # fail_on_uncovered_diff = false  # fail if any changed line is uncovered\n",
         );
 
         template.push_str(&format!(
@@ -650,6 +666,9 @@ commnad = ["cargo", "test"]
             config.mutations.test_selection_file,
             Some("coverage/test-selection.json".into())
         );
+        assert!(config.mutations.min_line_coverage.is_none());
+        assert!(config.mutations.min_diff_coverage.is_none());
+        assert!(!config.mutations.fail_on_uncovered_diff);
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
         assert!(config.mutations.incremental_history);
@@ -680,6 +699,9 @@ commnad = ["cargo", "test"]
         assert!(config.mutations.operators.is_empty());
         assert!(config.mutations.coverage_file.is_none());
         assert!(config.mutations.test_selection_file.is_none());
+        assert!(config.mutations.min_line_coverage.is_none());
+        assert!(config.mutations.min_diff_coverage.is_none());
+        assert!(!config.mutations.fail_on_uncovered_diff);
         assert!(config.mutations.exclude_paths.is_empty());
         assert!(config.mutations.skip_noisy_files);
         assert!(config.mutations.respect_workspace_ignores);
@@ -854,6 +876,20 @@ coverage_file = "coverage.lcov"
             config.mutations.coverage_file,
             Some(PathBuf::from("coverage.lcov"))
         );
+    }
+
+    #[test]
+    fn parse_coverage_gate_options() {
+        let toml_str = r#"
+[mutations]
+min_line_coverage = 80.0
+min_diff_coverage = 90.0
+fail_on_uncovered_diff = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mutations.min_line_coverage, Some(80.0));
+        assert_eq!(config.mutations.min_diff_coverage, Some(90.0));
+        assert!(config.mutations.fail_on_uncovered_diff);
     }
 
     #[test]

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -1,10 +1,63 @@
 // Parse LCOV coverage data into a map of file -> covered lines.
 
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
 /// Map from file path (relative to project root) to set of covered line numbers.
 pub type CoverageMap = HashMap<PathBuf, HashSet<usize>>;
+
+#[derive(Debug, Clone)]
+pub struct CoverageStats {
+    pub covered_lines: CoverageMap,
+    pub total_lines: CoverageMap,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoverageMetric {
+    pub covered: usize,
+    pub total: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threshold: Option<f64>,
+}
+
+impl CoverageMetric {
+    pub fn percent(&self) -> f64 {
+        if self.total == 0 {
+            100.0
+        } else {
+            (self.covered as f64 / self.total as f64) * 100.0
+        }
+    }
+
+    pub fn meets_threshold(&self) -> bool {
+        self.threshold
+            .is_none_or(|threshold| self.percent() >= threshold)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoverageUncoveredFile {
+    pub file: PathBuf,
+    pub lines: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoverageGateReport {
+    pub line_coverage: CoverageMetric,
+    pub diff_coverage: CoverageMetric,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uncovered_changed_lines: Vec<CoverageUncoveredFile>,
+    pub fail_on_uncovered_diff: bool,
+}
+
+impl CoverageGateReport {
+    pub fn passes(&self) -> bool {
+        self.line_coverage.meets_threshold()
+            && self.diff_coverage.meets_threshold()
+            && (!self.fail_on_uncovered_diff || self.uncovered_changed_lines.is_empty())
+    }
+}
 
 fn normalize_path_components(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
@@ -56,7 +109,13 @@ fn normalize_repo_relative_path(path: &Path, project_root: &Path) -> PathBuf {
 /// Parses both `DA:` (line coverage) and `BRDA:` (branch coverage) records.
 /// Malformed records are logged as warnings and skipped.
 pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
+    parse_lcov_stats(content, project_root).covered_lines
+}
+
+/// Parse an LCOV file and return both total and covered line sets.
+pub fn parse_lcov_stats(content: &str, project_root: &Path) -> CoverageStats {
     let mut map = CoverageMap::new();
+    let mut totals = CoverageMap::new();
     let mut current_file: Option<PathBuf> = None;
 
     for (line_num, line) in content.lines().enumerate() {
@@ -72,6 +131,7 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
                 if let (Some(line_str), Some(count_str)) = (parts.next(), parts.next()) {
                     match (line_str.parse::<usize>(), count_str.parse::<u64>()) {
                         (Ok(line_no), Ok(count)) => {
+                            totals.entry(file.clone()).or_default().insert(line_no);
                             if count > 0 {
                                 map.entry(file.clone()).or_default().insert(line_no);
                             }
@@ -102,6 +162,7 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
                         );
                         continue;
                     };
+                    totals.entry(file.clone()).or_default().insert(line_no);
                     let taken = parts[3].trim();
                     if taken == "-" || taken == "0" {
                         // Never executed or zero count — not covered
@@ -127,7 +188,10 @@ pub fn parse_lcov(content: &str, project_root: &Path) -> CoverageMap {
         }
     }
 
-    map
+    CoverageStats {
+        covered_lines: map,
+        total_lines: totals,
+    }
 }
 
 /// Filter mutations to only those on lines present in the coverage map.
@@ -158,6 +222,71 @@ pub fn filter_by_coverage(
             }
         })
         .collect()
+}
+
+pub fn line_coverage_metric(coverage: &CoverageStats) -> CoverageMetric {
+    let covered = coverage
+        .covered_lines
+        .values()
+        .map(HashSet::len)
+        .sum::<usize>();
+    let total = coverage
+        .total_lines
+        .values()
+        .map(HashSet::len)
+        .sum::<usize>();
+    CoverageMetric {
+        covered,
+        total,
+        threshold: None,
+    }
+}
+
+pub fn diff_coverage_report(
+    coverage: &CoverageStats,
+    changed_files: &[crate::ChangedFile],
+    project_root: &Path,
+) -> CoverageGateReport {
+    let mut covered = 0usize;
+    let mut total = 0usize;
+    let mut uncovered_changed_lines: Vec<CoverageUncoveredFile> = Vec::new();
+
+    for changed in changed_files {
+        let rel = normalize_repo_relative_path(&changed.path, project_root);
+        let covered_lines = coverage.covered_lines.get(&rel);
+
+        let mut missing = Vec::new();
+        for hunk in &changed.hunks {
+            for line in hunk.start..=hunk.end {
+                total += 1;
+                let is_covered = covered_lines.is_some_and(|lines| lines.contains(&line));
+                if is_covered {
+                    covered += 1;
+                } else {
+                    missing.push(line);
+                }
+            }
+        }
+        if !missing.is_empty() {
+            missing.sort_unstable();
+            missing.dedup();
+            uncovered_changed_lines.push(CoverageUncoveredFile {
+                file: rel,
+                lines: missing,
+            });
+        }
+    }
+
+    CoverageGateReport {
+        line_coverage: line_coverage_metric(coverage),
+        diff_coverage: CoverageMetric {
+            covered,
+            total,
+            threshold: None,
+        },
+        uncovered_changed_lines,
+        fail_on_uncovered_diff: false,
+    }
 }
 
 #[cfg(test)]
@@ -199,6 +328,29 @@ end_of_record
         let lcov = "SF:src/lib.rs\nDA:5,1\nend_of_record\n";
         let map = parse_lcov(lcov, Path::new("/project"));
         assert!(map.contains_key(Path::new("src/lib.rs")));
+    }
+
+    #[test]
+    fn parse_lcov_stats_tracks_totals_and_coverage() {
+        let lcov = "\
+SF:/project/src/main.go
+DA:1,1
+DA:2,0
+BRDA:3,0,0,4
+end_of_record
+";
+        let root = Path::new("/project");
+        let stats = parse_lcov_stats(lcov, root);
+        let covered = stats.covered_lines.get(Path::new("src/main.go")).unwrap();
+        let total = stats.total_lines.get(Path::new("src/main.go")).unwrap();
+        assert!(covered.contains(&1));
+        assert!(covered.contains(&3));
+        assert!(total.contains(&1));
+        assert!(total.contains(&2));
+        assert!(total.contains(&3));
+        let metric = line_coverage_metric(&stats);
+        assert_eq!(metric.covered, 2);
+        assert_eq!(metric.total, 3);
     }
 
     #[test]
@@ -298,5 +450,40 @@ end_of_record
         let filtered = filter_by_coverage(mutations, &coverage, root);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].line, 10);
+    }
+
+    #[test]
+    fn diff_coverage_report_lists_uncovered_changed_lines() {
+        let root = Path::new("/project");
+        let mut coverage = CoverageStats {
+            covered_lines: CoverageMap::new(),
+            total_lines: CoverageMap::new(),
+        };
+        coverage
+            .covered_lines
+            .entry(PathBuf::from("src/main.go"))
+            .or_default()
+            .insert(10);
+        coverage
+            .total_lines
+            .entry(PathBuf::from("src/main.go"))
+            .or_default()
+            .extend([10, 11]);
+
+        let changed_files = vec![crate::ChangedFile {
+            path: root.join("src/main.go"),
+            hunks: vec![crate::LineRange { start: 10, end: 11 }],
+        }];
+
+        let report = diff_coverage_report(&coverage, &changed_files, root);
+        assert_eq!(report.diff_coverage.covered, 1);
+        assert_eq!(report.diff_coverage.total, 2);
+        assert_eq!(report.uncovered_changed_lines.len(), 1);
+        assert_eq!(
+            report.uncovered_changed_lines[0].file,
+            PathBuf::from("src/main.go")
+        );
+        assert_eq!(report.uncovered_changed_lines[0].lines, vec![11]);
+        assert!(!report.fail_on_uncovered_diff);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ struct CheckConfig {
     show_output: bool,
     test_cmd: Option<String>,
     coverage_file: Option<PathBuf>,
+    min_line_coverage: Option<f64>,
+    min_diff_coverage: Option<f64>,
+    fail_on_uncovered_diff: bool,
     test_selection_file: Option<PathBuf>,
     no_incremental_history: bool,
     force_rerun: bool,
@@ -109,6 +112,9 @@ fn main() {
             show_output,
             test_cmd,
             coverage_file,
+            min_line_coverage,
+            min_diff_coverage,
+            fail_on_uncovered_diff,
             test_selection_file,
             no_incremental_history,
             force_rerun,
@@ -145,6 +151,9 @@ fn main() {
                 show_output,
                 test_cmd,
                 coverage_file,
+                min_line_coverage,
+                min_diff_coverage,
+                fail_on_uncovered_diff,
                 test_selection_file,
                 no_incremental_history,
                 force_rerun,
@@ -376,8 +385,56 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
         return Ok(());
     }
 
+    let coverage_gate_active = config.mutations.min_line_coverage.is_some()
+        || config.mutations.min_diff_coverage.is_some()
+        || config.mutations.fail_on_uncovered_diff;
+    let coverage_stats = if let Some(ref cov_path) = config.mutations.coverage_file {
+        let resolved_cov_path = if cov_path.is_relative() {
+            project_root.join(cov_path)
+        } else {
+            cov_path.to_path_buf()
+        };
+        match std::fs::read_to_string(&resolved_cov_path) {
+            Ok(cov_content) => Some(togi::coverage::parse_lcov_stats(
+                &cov_content,
+                &project_root,
+            )),
+            Err(e) => {
+                if coverage_gate_active {
+                    return Err(anyhow::anyhow!(
+                        "could not read coverage file {}: {e}",
+                        resolved_cov_path.display()
+                    ));
+                }
+                eprintln!(
+                    "warning: could not read coverage file {}: {e} — running all mutations",
+                    resolved_cov_path.display()
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    if coverage_gate_active {
+        let stats = coverage_stats
+            .as_ref()
+            .expect("coverage stats should exist when coverage gates are enabled");
+        let mut coverage_report =
+            togi::coverage::diff_coverage_report(stats, &changed_files, &project_root);
+        coverage_report.line_coverage.threshold = config.mutations.min_line_coverage;
+        coverage_report.diff_coverage.threshold = config.mutations.min_diff_coverage;
+        coverage_report.fail_on_uncovered_diff = config.mutations.fail_on_uncovered_diff;
+        if !coverage_report.passes() {
+            togi::report::print_coverage_gate_report(&coverage_report, output_format)?;
+            exit_with(_lock, 1);
+        }
+    }
+
     let mutations = generate_mutations(&changed_files, &config, &project_root)?;
-    let mut mutations = filter_mutations(mutations, &config, &project_root)?;
+    let mut mutations =
+        filter_mutations(mutations, &config, &project_root, coverage_stats.as_ref())?;
 
     if let Some((k, n)) = shard {
         let total = mutations.len();
@@ -579,6 +636,17 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<ResolvedCheckConfig> {
     if let Some(path) = cfg.coverage_file {
         config.mutations.coverage_file = Some(path);
     }
+    if let Some(value) = cfg.min_line_coverage {
+        validate_coverage_percentage(value, "--min-line-coverage")?;
+        config.mutations.min_line_coverage = Some(value);
+    }
+    if let Some(value) = cfg.min_diff_coverage {
+        validate_coverage_percentage(value, "--min-diff-coverage")?;
+        config.mutations.min_diff_coverage = Some(value);
+    }
+    if cfg.fail_on_uncovered_diff {
+        config.mutations.fail_on_uncovered_diff = true;
+    }
     if let Some(path) = cfg.test_selection_file {
         config.mutations.test_selection_file = Some(path);
     }
@@ -595,6 +663,16 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<ResolvedCheckConfig> {
     }
     if let Some(ops) = cfg.operators {
         config.mutations.operators = ops;
+    }
+
+    if (config.mutations.min_line_coverage.is_some()
+        || config.mutations.min_diff_coverage.is_some()
+        || config.mutations.fail_on_uncovered_diff)
+        && config.mutations.coverage_file.is_none()
+    {
+        anyhow::bail!(
+            "coverage gates require an LCOV file; set [mutations] coverage_file or --coverage-file"
+        );
     }
 
     let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
@@ -618,6 +696,13 @@ fn resolve_config(cfg: CheckConfig) -> anyhow::Result<ResolvedCheckConfig> {
         has_cli_timeout,
         profile,
     })
+}
+
+fn validate_coverage_percentage(value: f64, flag: &str) -> anyhow::Result<()> {
+    if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+        anyhow::bail!("{flag} must be a finite percentage between 0 and 100");
+    }
+    Ok(())
 }
 
 fn warn_if_resource_oversubscribed(jobs: usize) {
@@ -826,8 +911,21 @@ fn filter_mutations(
     mutations: Vec<Mutation>,
     config: &togi::config::Config,
     project_root: &Path,
+    coverage_stats: Option<&togi::coverage::CoverageStats>,
 ) -> anyhow::Result<Vec<Mutation>> {
-    let mut mutations = if let Some(ref cov_path) = config.mutations.coverage_file {
+    let mut mutations = if let Some(coverage) = coverage_stats {
+        let before = mutations.len();
+        let filtered =
+            togi::coverage::filter_by_coverage(mutations, &coverage.covered_lines, project_root);
+        if before > filtered.len() {
+            eprintln!(
+                "Coverage filter: {} of {} mutations on covered lines",
+                filtered.len(),
+                before
+            );
+        }
+        filtered
+    } else if let Some(ref cov_path) = config.mutations.coverage_file {
         let resolved_cov_path = if std::path::Path::new(cov_path).is_relative() {
             project_root.join(cov_path)
         } else {
@@ -1367,6 +1465,9 @@ mod tests {
             show_output: false,
             test_cmd: None,
             coverage_file: None,
+            min_line_coverage: None,
+            min_diff_coverage: None,
+            fail_on_uncovered_diff: false,
             test_selection_file: None,
             no_incremental_history: false,
             force_rerun: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,6 +405,7 @@ fn run_check(cfg: CheckConfig, cancelled: Arc<AtomicBool>) -> anyhow::Result<()>
             togi::runner::BaselineTimingConfig {
                 test_command: &config.test.command,
                 build_command: &config.test.build_command,
+                sandbox_command: &config.test.sandbox_command,
                 build_command_explicit: has_explicit_build_cmd,
                 timeout: baseline_measurement_timeout(config.test.timeout),
                 env: &profile_env,
@@ -927,6 +928,7 @@ fn execute(
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
             command: config.test.command,
+            sandbox_command: config.test.sandbox_command,
             force_default_command: options.force_default_command,
             force_default_timeout: options.force_default_timeout,
             project_commands,

--- a/src/report/coverage.rs
+++ b/src/report/coverage.rs
@@ -1,0 +1,184 @@
+use crate::cli::OutputFormat;
+use crate::coverage::CoverageGateReport;
+use anyhow::Result;
+use std::fmt::Write;
+use std::path::Path;
+
+pub fn print_terminal(report: &CoverageGateReport) {
+    print!("{}", format_terminal(report));
+}
+
+pub fn print_github(report: &CoverageGateReport) {
+    print!("{}", format_github(report));
+}
+
+pub fn print_json(report: &CoverageGateReport) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(report)?);
+    Ok(())
+}
+
+pub fn write_html(report: &CoverageGateReport, path: &Path) -> Result<()> {
+    std::fs::write(path, format_html(report))?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn print(report: &CoverageGateReport, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => print_json(report)?,
+        OutputFormat::Github => print_github(report),
+        OutputFormat::Html => write_html(report, Path::new("togi-coverage-report.html"))?,
+        OutputFormat::Terminal => print_terminal(report),
+    }
+    Ok(())
+}
+
+fn format_terminal(report: &CoverageGateReport) -> String {
+    let mut out = String::new();
+    writeln!(out, "Coverage gate failed").unwrap();
+    write_metric(&mut out, "Overall line coverage", &report.line_coverage).unwrap();
+    write_metric(&mut out, "Changed-line coverage", &report.diff_coverage).unwrap();
+    if report.fail_on_uncovered_diff || !report.uncovered_changed_lines.is_empty() {
+        writeln!(out, "Uncovered changed lines:").unwrap();
+        for file in &report.uncovered_changed_lines {
+            writeln!(
+                out,
+                "  {}: {}",
+                file.file.display(),
+                join_lines(&file.lines)
+            )
+            .unwrap();
+        }
+    }
+    out
+}
+
+fn format_github(report: &CoverageGateReport) -> String {
+    let mut out = String::new();
+    writeln!(out, "## Coverage gate failed").unwrap();
+    write_metric_md(&mut out, "Overall line coverage", &report.line_coverage).unwrap();
+    write_metric_md(&mut out, "Changed-line coverage", &report.diff_coverage).unwrap();
+    if report.fail_on_uncovered_diff || !report.uncovered_changed_lines.is_empty() {
+        writeln!(out, "\n### Uncovered changed lines").unwrap();
+        for file in &report.uncovered_changed_lines {
+            writeln!(
+                out,
+                "- `{}`: {}",
+                file.file.display(),
+                join_lines(&file.lines)
+            )
+            .unwrap();
+        }
+    }
+    out
+}
+
+fn format_html(report: &CoverageGateReport) -> String {
+    let mut out = String::new();
+    write!(
+        out,
+        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\">"
+    )
+    .unwrap();
+    write!(out, "<title>togi coverage gate</title>").unwrap();
+    write!(
+        out,
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+    )
+    .unwrap();
+    write!(
+        out,
+        "<style>body{{font-family:system-ui,sans-serif;margin:2rem;line-height:1.5}}\
+         h1{{margin-bottom:1rem}}.metric{{margin:.5rem 0}}\
+         table{{border-collapse:collapse;margin-top:1rem}}td,th{{padding:.4rem .6rem;border-bottom:1px solid #ccc;text-align:left}}\
+         code{{font-family:SFMono-Regular,Menlo,monospace}}</style></head><body>"
+    )
+    .unwrap();
+    write!(out, "<h1>Coverage gate failed</h1>").unwrap();
+    write_metric_html(&mut out, "Overall line coverage", &report.line_coverage).unwrap();
+    write_metric_html(&mut out, "Changed-line coverage", &report.diff_coverage).unwrap();
+    if report.fail_on_uncovered_diff || !report.uncovered_changed_lines.is_empty() {
+        write!(out, "<h2>Uncovered changed lines</h2><table><thead><tr><th>File</th><th>Lines</th></tr></thead><tbody>").unwrap();
+        for file in &report.uncovered_changed_lines {
+            write!(
+                out,
+                "<tr><td><code>{}</code></td><td>{}</td></tr>",
+                html_escape(&file.file.display().to_string()),
+                html_escape(&join_lines(&file.lines))
+            )
+            .unwrap();
+        }
+        write!(out, "</tbody></table>").unwrap();
+    }
+    write!(out, "</body></html>").unwrap();
+    out
+}
+
+fn write_metric(
+    out: &mut String,
+    label: &str,
+    metric: &crate::coverage::CoverageMetric,
+) -> std::fmt::Result {
+    let threshold = metric
+        .threshold
+        .map(|value| format!(" (threshold {value:.1}%)"))
+        .unwrap_or_default();
+    writeln!(
+        out,
+        "{label}: {:.1}% ({}/{}){threshold}",
+        metric.percent(),
+        metric.covered,
+        metric.total
+    )
+}
+
+fn write_metric_md(
+    out: &mut String,
+    label: &str,
+    metric: &crate::coverage::CoverageMetric,
+) -> std::fmt::Result {
+    let threshold = metric
+        .threshold
+        .map(|value| format!(" threshold {value:.1}%"))
+        .unwrap_or_default();
+    writeln!(
+        out,
+        "- **{label}**: {:.1}% ({}/{}){threshold}",
+        metric.percent(),
+        metric.covered,
+        metric.total
+    )
+}
+
+fn write_metric_html(
+    out: &mut String,
+    label: &str,
+    metric: &crate::coverage::CoverageMetric,
+) -> std::fmt::Result {
+    let threshold = metric
+        .threshold
+        .map(|value| format!(" (threshold {value:.1}%)"))
+        .unwrap_or_default();
+    writeln!(
+        out,
+        "<div class=\"metric\"><strong>{label}</strong>: {:.1}% ({}/{}){threshold}</div>",
+        metric.percent(),
+        metric.covered,
+        metric.total
+    )
+}
+
+fn join_lines(lines: &[usize]) -> String {
+    lines
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,3 +1,4 @@
+pub mod coverage;
 pub mod github;
 pub mod html;
 pub mod json;
@@ -176,6 +177,24 @@ pub fn print_report(
             eprintln!("HTML report written to {}", path.display());
         }
         OutputFormat::Terminal => terminal::print_report(report),
+    }
+    Ok(())
+}
+
+pub fn print_coverage_gate_report(
+    report: &crate::coverage::CoverageGateReport,
+    format: crate::cli::OutputFormat,
+) -> anyhow::Result<()> {
+    use crate::cli::OutputFormat;
+    match format {
+        OutputFormat::Json => coverage::print_json(report)?,
+        OutputFormat::Github => coverage::print_github(report),
+        OutputFormat::Html => {
+            let path = std::path::Path::new("togi-coverage-report.html");
+            coverage::write_html(report, path)?;
+            eprintln!("HTML coverage report written to {}", path.display());
+        }
+        OutputFormat::Terminal => coverage::print_terminal(report),
     }
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -36,6 +36,8 @@ fn write_workspace_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
 pub struct CommandConfig {
     /// Default test command, stored as argv.
     pub command: Vec<String>,
+    /// Optional wrapper prefixed to every build and test command.
+    pub sandbox_command: Vec<String>,
     /// True when the default command came from a CLI override and must win.
     pub force_default_command: bool,
     /// True when the default timeout came from a CLI override and must win.
@@ -202,6 +204,7 @@ pub struct BaselineMeasurement {
 pub struct BaselineTimingConfig<'a> {
     pub test_command: &'a [String],
     pub build_command: &'a [String],
+    pub sandbox_command: &'a [String],
     pub build_command_explicit: bool,
     pub timeout: Duration,
     pub env: &'a HashMap<String, String>,
@@ -221,6 +224,7 @@ impl SelectedTestCommand {
         &self,
         build_command: &[String],
         build_command_explicit: bool,
+        sandbox_command: &[String],
         env: &HashMap<String, String>,
     ) -> String {
         let build_str = if build_command_explicit {
@@ -228,12 +232,18 @@ impl SelectedTestCommand {
         } else {
             String::new()
         };
+        let sandbox_str = if sandbox_command.is_empty() {
+            String::new()
+        } else {
+            format!("{sandbox_command:?}")
+        };
         let mut env_parts: Vec<String> = env.iter().map(|(k, v)| format!("{k}={v}")).collect();
         env_parts.sort();
         format!(
-            "test={:?};build={};timeout={};env={}",
+            "test={:?};build={};sandbox={};timeout={};env={}",
             self.argv,
             build_str,
+            sandbox_str,
             self.timeout.as_millis(),
             env_parts.join(",")
         )
@@ -1129,6 +1139,7 @@ pub fn measure_baseline_timing(
         Some(measure_baseline_command(
             "baseline build command",
             config.build_command,
+            config.sandbox_command,
             root,
             config.timeout,
             config.env,
@@ -1140,6 +1151,7 @@ pub fn measure_baseline_timing(
     let test_duration = measure_baseline_command(
         "baseline test command",
         config.test_command,
+        config.sandbox_command,
         root,
         config.timeout,
         config.env,
@@ -1155,13 +1167,14 @@ pub fn measure_baseline_timing(
 fn measure_baseline_command(
     label: &str,
     command: &[String],
+    sandbox_command: &[String],
     cwd: &Path,
     timeout: Duration,
     env: &HashMap<String, String>,
     cancelled: &AtomicBool,
 ) -> anyhow::Result<Duration> {
     let started = Instant::now();
-    let outcome = run_command(command, cwd, timeout, true, env, cancelled);
+    let outcome = run_command(command, sandbox_command, cwd, timeout, true, env, cancelled);
     let duration = started.elapsed();
     if outcome.cancelled {
         bail!("baseline timing cancelled");
@@ -1201,6 +1214,15 @@ fn command_for_message(command: &[String]) -> String {
     } else {
         command.join(" ")
     }
+}
+
+fn sandboxed_command(sandbox_command: &[String], command: &[String]) -> Vec<String> {
+    if sandbox_command.is_empty() {
+        return command.to_vec();
+    }
+    let mut argv = sandbox_command.to_vec();
+    argv.extend_from_slice(command);
+    argv
 }
 
 fn baseline_failure_output(output: Option<&str>) -> String {
@@ -1918,6 +1940,7 @@ fn run_queued_mutation(
     let command_ctx = selected_test.cache_context(
         shared.build_command,
         shared.build_command_explicit,
+        shared.commands.sandbox_command.as_slice(),
         shared.env,
     );
     let relevant_test_hash = shared.test_context_index.fingerprint_for_tests(
@@ -2023,6 +2046,7 @@ fn run_queued_mutation(
             ResolvedMutation::new_for_execution(shared.project_root, &workspace_root, &mutation);
         run_single_mutation(
             &selected_test.argv,
+            shared.commands.sandbox_command.as_slice(),
             BuildCommand {
                 argv: shared.build_command,
                 explicit: shared.build_command_explicit,
@@ -2530,6 +2554,7 @@ impl TestRunner {
             let command_ctx = cache_selected.cache_context(
                 &self.commands.build_command,
                 self.commands.build_command_explicit,
+                self.commands.sandbox_command.as_slice(),
                 &env,
             );
             let relevant_test_hash = test_context_index
@@ -2778,12 +2803,15 @@ impl TestRunner {
             test_command: if self.commands.language_commands.is_empty()
                 && self.commands.project_commands.is_empty()
             {
-                Some(self.commands.command.clone())
+                Some(sandboxed_command(
+                    &self.commands.sandbox_command,
+                    &self.commands.command,
+                ))
             } else {
                 None
             },
             build_command: if self.commands.build_command_explicit {
-                self.commands.build_command.clone()
+                sandboxed_command(&self.commands.sandbox_command, &self.commands.build_command)
             } else {
                 vec![]
             },
@@ -2851,6 +2879,7 @@ fn run_schema_workspace_mutation(
     if runner.commands.build_command_explicit && !runner.commands.build_command.is_empty() {
         let build = run_command(
             &runner.commands.build_command,
+            &runner.commands.sandbox_command,
             workspace_root,
             runner.commands.timeout,
             true,
@@ -2876,6 +2905,7 @@ fn run_schema_workspace_mutation(
 
     run_command(
         argv,
+        &runner.commands.sandbox_command,
         workspace_root,
         timeout,
         runner.show_output,
@@ -3196,6 +3226,7 @@ impl<'a> ResolvedMutation<'a> {
 #[allow(clippy::too_many_arguments)]
 fn run_single_mutation(
     command: &[String],
+    sandbox_command: &[String],
     build_command: BuildCommand<'_>,
     timeout: Duration,
     project_root: &Path,
@@ -3274,6 +3305,7 @@ fn run_single_mutation(
     if build_command.explicit && !build_command.argv.is_empty() {
         let build_outcome = run_command(
             build_command.argv,
+            sandbox_command,
             project_root,
             timeout,
             true,
@@ -3304,6 +3336,7 @@ fn run_single_mutation(
     // Run test command; guard will restore the file on drop
     run_command(
         command,
+        sandbox_command,
         project_root,
         timeout,
         capture_output,
@@ -3314,6 +3347,7 @@ fn run_single_mutation(
 
 fn run_command(
     command: &[String],
+    sandbox_command: &[String],
     cwd: &Path,
     timeout_dur: Duration,
     capture_output: bool,
@@ -3328,6 +3362,7 @@ fn run_command(
         return MutationOutcome::build_error_with("command", vec![], "command is empty");
     }
 
+    let command = sandboxed_command(sandbox_command, command);
     let mut cmd = std::process::Command::new(&command[0]);
     cmd.args(&command[1..]).current_dir(cwd).envs(env);
     configure_command_for_process_tree(&mut cmd);
@@ -4183,6 +4218,7 @@ mod tests {
             project_commands: vec![],
             language_commands: HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
             language_timeouts: HashMap::new(),
@@ -4385,9 +4421,21 @@ mod tests {
         };
 
         assert_ne!(
-            selected.cache_context(&[], false, &HashMap::new()),
-            ambiguous.cache_context(&[], false, &HashMap::new())
+            selected.cache_context(&[], false, &[], &HashMap::new()),
+            ambiguous.cache_context(&[], false, &[], &HashMap::new())
         );
+    }
+
+    #[test]
+    fn sandboxed_command_prefixes_wrapper_argv() {
+        let sandbox = vec!["bwrap".into(), "--".into()];
+        let command = vec!["cargo".into(), "test".into()];
+
+        assert_eq!(
+            sandboxed_command(&sandbox, &command),
+            vec!["bwrap", "--", "cargo", "test"]
+        );
+        assert_eq!(sandboxed_command(&[], &command), command);
     }
 
     #[test]
@@ -4839,6 +4887,7 @@ mod tests {
             project_commands: vec![],
             language_commands: HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
@@ -4848,8 +4897,12 @@ mod tests {
         let command_config = commands();
         let selected =
             select_test_command_with_history(dir.path(), &command_config, &mutation, None);
-        let command_ctx =
-            selected.cache_context(&command_config.build_command, false, &HashMap::new());
+        let command_ctx = selected.cache_context(
+            &command_config.build_command,
+            false,
+            &command_config.sandbox_command,
+            &HashMap::new(),
+        );
         let context_hash = cache_context_fingerprint(dir.path());
         let test_context_index = TestContextIndex::build(dir.path());
         let relevant_test_hash =
@@ -5189,6 +5242,7 @@ mod tests {
             BaselineTimingConfig {
                 test_command: &command,
                 build_command: &command,
+                sandbox_command: &[],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(5),
                 env: &HashMap::new(),
@@ -5254,6 +5308,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5276,6 +5331,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["false".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5314,6 +5370,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5337,6 +5394,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["nonexistent_binary_xyz_12345".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5360,6 +5418,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["sleep".to_string(), "10".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5404,6 +5463,7 @@ mod tests {
                 "-c".to_string(),
                 format!("touch {}", marker.display()),
             ],
+            &[],
             BuildCommand {
                 argv: &[
                     "sh".to_string(),
@@ -5438,6 +5498,7 @@ mod tests {
         // Build succeeds → test runs and fails → Killed
         let outcome = run_single_mutation(
             &["false".to_string()], // test fails = killed
+            &[],
             BuildCommand {
                 argv: &["true".to_string()], // build succeeds
                 explicit: true,
@@ -5467,6 +5528,7 @@ mod tests {
                 "-c".to_string(),
                 format!("touch {}", test_marker.display()),
             ],
+            &[],
             BuildCommand {
                 argv: &[
                     "sh".to_string(),
@@ -5502,6 +5564,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5524,6 +5587,7 @@ mod tests {
 
         let outcome = run_single_mutation(
             &["true".to_string()],
+            &[],
             BuildCommand {
                 argv: &[],
                 explicit: false,
@@ -5542,6 +5606,7 @@ mod tests {
     #[test]
     fn empty_command_returns_build_error() {
         let outcome = run_command(
+            &[],
             &[],
             &PathBuf::from("."),
             Duration::from_secs(5),
@@ -5562,6 +5627,7 @@ mod tests {
                 "-c".to_string(),
                 "echo out; echo err >&2".to_string(),
             ],
+            &[],
             &PathBuf::from("."),
             Duration::from_secs(5),
             true,
@@ -5585,6 +5651,7 @@ mod tests {
                 "-c".to_string(),
                 format!("yes x | head -c {bytes_to_write}"),
             ],
+            &[],
             &PathBuf::from("."),
             Duration::from_secs(5),
             true,
@@ -5614,6 +5681,7 @@ mod tests {
                 "-c".to_string(),
                 "printf out; (sleep 1; printf late) &".to_string(),
             ],
+            &[],
             &PathBuf::from("."),
             Duration::from_secs(5),
             true,
@@ -5642,6 +5710,7 @@ mod tests {
                 "-c".to_string(),
                 "(sleep 1; printf late) & sleep 10".to_string(),
             ],
+            &[],
             &PathBuf::from("."),
             Duration::from_millis(100),
             true,
@@ -5700,6 +5769,7 @@ while [ ! -s "$ESCAPED_PID" ]; do sleep 0.01; done
 sleep 10"#
                     .to_string(),
             ],
+            &[],
             dir.path(),
             Duration::from_millis(200),
             true,
@@ -5728,6 +5798,7 @@ sleep 10"#
                 "-c".to_string(),
                 "(sleep 0.5; touch \"$MARKER\") &".to_string(),
             ],
+            &[],
             dir.path(),
             Duration::from_secs(5),
             false,
@@ -5758,6 +5829,7 @@ sleep 10"#
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
@@ -5822,6 +5894,7 @@ sleep 10"#
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -5891,6 +5964,7 @@ int main(void) {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec!["cc".into(), "calc.c".into(), "-o".into(), "calc".into()],
+                sandbox_command: vec![],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
@@ -5960,6 +6034,7 @@ int main() {
                     "-o".into(),
                     "calc".into(),
                 ],
+                sandbox_command: vec![],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
@@ -6016,6 +6091,7 @@ esac
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6070,6 +6146,7 @@ touch side_effect
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6127,6 +6204,7 @@ esac
             project_commands: vec![],
             language_commands: HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
@@ -6143,6 +6221,7 @@ esac
         let cache_ctx = cache_selected.cache_context(
             &commands.build_command,
             commands.build_command_explicit,
+            &commands.sandbox_command,
             &cache_env,
         );
         let cache_ctx = format!(
@@ -6229,6 +6308,7 @@ class Calc {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec!["javac".into(), "Calc.java".into()],
+                sandbox_command: vec![],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
@@ -6287,6 +6367,7 @@ mod tests {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(60),
                 language_timeouts: HashMap::new(),
@@ -6339,6 +6420,7 @@ mod tests {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6383,6 +6465,7 @@ mod tests {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6439,6 +6522,7 @@ mod tests {
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6511,6 +6595,7 @@ sleep 0.2
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6585,6 +6670,7 @@ sleep 0.2
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6650,6 +6736,7 @@ rmdir "$lock"
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6660,6 +6747,7 @@ rmdir "$lock"
             let cache_ctx = selected.cache_context(
                 &commands.build_command,
                 commands.build_command_explicit,
+                &commands.sandbox_command,
                 &env,
             );
             let cache_ctx = format!(
@@ -6745,6 +6833,7 @@ rmdir "$lock"
                     "-c".into(),
                     "grep -q build_error *.txt && exit 1; exit 0".into(),
                 ],
+                sandbox_command: vec![],
                 build_command_explicit: true,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6817,6 +6906,7 @@ rmdir "$lock"
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6883,6 +6973,7 @@ rmdir "$lock"
                 project_commands: vec![],
                 language_commands: lang_cmds,
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -6929,6 +7020,7 @@ rmdir "$lock"
                 project_commands: vec![],
                 language_commands: lang_cmds,
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -7000,6 +7092,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -7079,6 +7172,7 @@ exit 1"#
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -7134,6 +7228,7 @@ exit 1"#
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
@@ -7189,6 +7284,7 @@ exit 1"#
                 project_commands: vec![],
                 language_commands: HashMap::new(),
                 build_command: vec![],
+                sandbox_command: vec![],
                 build_command_explicit: false,
                 timeout: Duration::from_secs(5),
                 language_timeouts,

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -116,6 +116,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
             project_commands: vec![],
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
             language_timeouts: std::collections::HashMap::new(),

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -72,6 +72,7 @@ fn run_fixture(case: FixtureCase) {
             project_commands: vec![],
             language_commands: HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
             language_timeouts: HashMap::new(),
@@ -91,7 +92,11 @@ fn run_fixture(case: FixtureCase) {
     };
 
     let report = runner.run(mutations).report;
-    assert!(report.total > 0, "{} fixture should execute mutations", case.name);
+    assert!(
+        report.total > 0,
+        "{} fixture should execute mutations",
+        case.name
+    );
     assert_eq!(
         report.timeout, 0,
         "{} fixture should not time out",

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -75,6 +75,7 @@ fn verify_mutation_outcomes_match_independent_replay() {
             project_commands: vec![],
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
+            sandbox_command: vec![],
             build_command_explicit: false,
             timeout: Duration::from_secs(30),
             language_timeouts: std::collections::HashMap::new(),

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -95,6 +95,13 @@ schemata = true
 # Default: unset
 coverage_file = "coverage/lcov.info"
 
+# Optional LCOV gate thresholds.
+# Type: float percentage
+# Default: unset
+# min_line_coverage = 80.0
+# min_diff_coverage = 90.0
+# fail_on_uncovered_diff = false
+
 # Optional JSON source-line to test-name map for targeted test runs.
 # Type: string path
 # Default: unset

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -24,6 +24,13 @@ command = ["go", "test", "./..."]
 # Default: []
 # build_command = ["go", "build", "./..."]
 
+# Optional sandbox wrapper prefixed to every build and test command.
+# Leave unset to run directly on the host or CI runner.
+# Example: bwrap, firejail, docker, podman, sandbox-exec, or a custom wrapper.
+# Type: array of strings
+# Default: []
+# sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--"]
+
 # Per-mutation timeout in seconds.
 # Type: integer
 # Default: 30


### PR DESCRIPTION
Implements the optional \[test\] sandbox_command wrapper for build and test execution, documents the security model, and wires the setting through cache identity and tests. Validation: cargo test; cargo clippy --all-targets --all-features -- -D warnings; cargo fmt -- --check