### PR TITLE
Add coverage command bridge for togi check

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ togi check --build-cmd "cargo check"
 # Only mutate lines covered by an LCOV file
 togi check --coverage-file coverage/lcov.info
 
+# Run your own coverage command, then consume the generated LCOV
+togi check --coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info
+
 # Gate on line and diff coverage thresholds
 togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90
 togi check --coverage-file coverage/lcov.info --fail-on-uncovered-diff
@@ -212,6 +215,7 @@ base = "origin/main"
 max_per_run = 20
 max_per_file = 20
 schemata = true
+# coverage_command = ["./scripts/collect-coverage.sh"]
 coverage_file = "coverage/lcov.info"
 min_line_coverage = 80.0
 min_diff_coverage = 90.0
@@ -335,6 +339,9 @@ For large repos, togi can avoid work before the runner starts and can also
 fail the run when LCOV coverage is below a threshold:
 
 - `--coverage-file coverage/lcov.info` keeps only mutations on covered lines
+- `--coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info`
+  runs a user-provided command before mutation generation, then reads the
+  resulting LCOV file. `TOGI_COVERAGE_FILE` is exported for the command.
 - `--min-line-coverage 80` fails when overall LCOV line coverage is below 80%
 - `--min-diff-coverage 90` fails when changed-line coverage is below 90%
 - `--fail-on-uncovered-diff` fails when any changed line is uncovered
@@ -342,6 +349,7 @@ fail the run when LCOV coverage is below a threshold:
 - `--test-selection-file coverage/test-selection.json` narrows each mutant to tests that cover that line when the configured runner supports test selection
 
 ```bash
+togi check --coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info
 togi test-map --path . --output coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --test-selection-file coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,10 @@ pub struct CheckArgs {
     #[arg(long)]
     pub coverage_file: Option<PathBuf>,
 
+    /// Command to generate an LCOV file before mutation filtering
+    #[arg(long)]
+    pub coverage_cmd: Option<String>,
+
     /// Fail if overall LCOV line coverage is below this percentage
     #[arg(long)]
     pub min_line_coverage: Option<f64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,8 @@ pub struct MutationConfig {
     #[serde(default = "default_max_per_run")]
     pub max_per_run: usize,
     pub coverage_file: Option<PathBuf>,
+    #[serde(default)]
+    pub coverage_command: Vec<String>,
     pub test_selection_file: Option<PathBuf>,
     #[serde(default)]
     pub min_line_coverage: Option<f64>,
@@ -440,6 +442,7 @@ impl Default for MutationConfig {
             max_per_run: default_max_per_run(),
             max_per_file: default_max_per_file(),
             coverage_file: None,
+            coverage_command: vec![],
             test_selection_file: None,
             min_line_coverage: None,
             min_diff_coverage: None,
@@ -547,6 +550,7 @@ impl Config {
 
         template.push_str(
             "# coverage_file = \"coverage/lcov.info\"  # enable LCOV filtering and coverage gates\n\
+             # coverage_command = [\"./scripts/collect-coverage.sh\"]  # generate LCOV before mutation filtering\n\
              # min_line_coverage = 80.0  # fail if overall LCOV line coverage drops below this\n\
              # min_diff_coverage = 90.0  # fail if changed-line coverage drops below this\n\
              # fail_on_uncovered_diff = false  # fail if any changed line is uncovered\n",
@@ -928,6 +932,19 @@ coverage_file = "coverage.lcov"
         assert_eq!(
             config.mutations.coverage_file,
             Some(PathBuf::from("coverage.lcov"))
+        );
+    }
+
+    #[test]
+    fn parse_coverage_command_option() {
+        let toml_str = r#"
+[mutations]
+coverage_command = ["./scripts/collect-coverage.sh"]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.mutations.coverage_command,
+            vec!["./scripts/collect-coverage.sh"]
         );
     }
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -12,7 +12,6 @@ pub struct CoverageStats {
     pub covered_lines: CoverageMap,
     pub total_lines: CoverageMap,
 }
-
 #[derive(Debug, Clone, Serialize)]
 pub struct CoverageMetric {
     pub covered: usize,
@@ -486,5 +485,4 @@ end_of_record
         assert_eq!(report.uncovered_changed_lines[0].lines, vec![11]);
         assert!(!report.fail_on_uncovered_diff);
     }
-
 }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -486,4 +486,5 @@ end_of_record
         assert_eq!(report.uncovered_changed_lines[0].lines, vec![11]);
         assert!(!report.fail_on_uncovered_diff);
     }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1566,7 +1566,10 @@ jobs = 4
 
         let err = resolve_config(cfg).unwrap_err();
 
-        assert!(err.to_string().contains("coverage collection command requires"));
+        assert!(
+            err.to_string()
+                .contains("coverage collection command requires")
+        );
         Ok(())
     }
 
@@ -1587,7 +1590,6 @@ jobs = 4
         assert!(err.to_string().contains("timeout_multiplier"));
         Ok(())
     }
-
     #[test]
     fn calibrated_timeout_uses_slowest_baseline_duration() {
         let timeout = calibrated_timeout_seconds(
@@ -1771,5 +1773,4 @@ example.com/calc/calc.go:9.29,10.11 1 0
         assert_eq!(file.get("6").unwrap(), &vec!["TestAdd".to_string()]);
         assert!(!file.contains_key("9"));
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ struct ExecuteOptions {
     cancelled: Arc<AtomicBool>,
 }
 
+#[derive(Debug)]
 struct ResolvedCheckConfig {
     config: togi::config::Config,
     fail_fast: bool,
@@ -271,34 +272,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let coverage_gate_active = config.mutations.min_line_coverage.is_some()
         || config.mutations.min_diff_coverage.is_some()
         || config.mutations.fail_on_uncovered_diff;
-    let coverage_stats = if let Some(ref cov_path) = config.mutations.coverage_file {
-        let resolved_cov_path = if cov_path.is_relative() {
-            project_root.join(cov_path)
-        } else {
-            cov_path.to_path_buf()
-        };
-        match std::fs::read_to_string(&resolved_cov_path) {
-            Ok(cov_content) => Some(togi::coverage::parse_lcov_stats(
-                &cov_content,
-                &project_root,
-            )),
-            Err(e) => {
-                if coverage_gate_active {
-                    return Err(anyhow::anyhow!(
-                        "could not read coverage file {}: {e}",
-                        resolved_cov_path.display()
-                    ));
-                }
-                eprintln!(
-                    "warning: could not read coverage file {}: {e} — running all mutations",
-                    resolved_cov_path.display()
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let coverage_stats = resolve_coverage_stats(&config, &project_root, coverage_gate_active)?;
 
     if coverage_gate_active {
         let stats = coverage_stats
@@ -519,6 +493,10 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
     if let Some(path) = cfg.coverage_file {
         config.mutations.coverage_file = Some(path);
     }
+    if let Some(cmd) = cfg.coverage_cmd {
+        config.mutations.coverage_command =
+            shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --coverage-cmd: {e}"))?;
+    }
     if let Some(value) = cfg.min_line_coverage {
         validate_coverage_percentage(value, "--min-line-coverage")?;
         config.mutations.min_line_coverage = Some(value);
@@ -548,13 +526,19 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         config.mutations.operators = ops;
     }
 
+    if !config.mutations.coverage_command.is_empty() && config.mutations.coverage_file.is_none() {
+        anyhow::bail!(
+            "coverage collection command requires an LCOV output path; set [mutations] coverage_file or --coverage-file"
+        );
+    }
     if (config.mutations.min_line_coverage.is_some()
         || config.mutations.min_diff_coverage.is_some()
         || config.mutations.fail_on_uncovered_diff)
         && config.mutations.coverage_file.is_none()
+        && config.mutations.coverage_command.is_empty()
     {
         anyhow::bail!(
-            "coverage gates require an LCOV file; set [mutations] coverage_file or --coverage-file"
+            "coverage gates require a coverage source; set [mutations] coverage_file, coverage_command, or use the corresponding CLI flags"
         );
     }
 
@@ -585,6 +569,107 @@ fn validate_coverage_percentage(value: f64, flag: &str) -> anyhow::Result<()> {
     if !value.is_finite() || !(0.0..=100.0).contains(&value) {
         anyhow::bail!("{flag} must be a finite percentage between 0 and 100");
     }
+    Ok(())
+}
+
+fn resolve_coverage_stats(
+    config: &togi::config::Config,
+    project_root: &Path,
+    coverage_gate_active: bool,
+) -> anyhow::Result<Option<togi::coverage::CoverageStats>> {
+    if !config.mutations.coverage_command.is_empty() {
+        let coverage_file = config
+            .mutations
+            .coverage_file
+            .as_ref()
+            .expect("coverage command should be validated to require coverage_file");
+        let resolved_cov_path = resolve_coverage_path(coverage_file, project_root);
+        run_coverage_command(
+            &config.mutations.coverage_command,
+            &resolved_cov_path,
+            project_root,
+        )?;
+    }
+
+    let Some(cov_path) = config.mutations.coverage_file.as_ref() else {
+        return Ok(None);
+    };
+    let resolved_cov_path = resolve_coverage_path(cov_path, project_root);
+    let coverage_required = coverage_gate_active || !config.mutations.coverage_command.is_empty();
+
+    match std::fs::read_to_string(&resolved_cov_path) {
+        Ok(cov_content) => Ok(Some(togi::coverage::parse_lcov_stats(
+            &cov_content,
+            project_root,
+        ))),
+        Err(e) => {
+            if coverage_required {
+                return Err(anyhow::anyhow!(
+                    "could not read coverage file {}: {e}",
+                    resolved_cov_path.display()
+                ));
+            }
+            eprintln!(
+                "warning: could not read coverage file {}: {e} — running all mutations",
+                resolved_cov_path.display()
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn resolve_coverage_path(path: &Path, project_root: &Path) -> PathBuf {
+    if path.is_relative() {
+        project_root.join(path)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+fn run_coverage_command(
+    command: &[String],
+    coverage_file: &Path,
+    project_root: &Path,
+) -> anyhow::Result<()> {
+    let Some(program) = command.first() else {
+        anyhow::bail!("coverage command is empty");
+    };
+    if let Some(parent) = coverage_file.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "could not create parent directory for coverage file {}",
+                coverage_file.display()
+            )
+        })?;
+    }
+
+    // foxguard: ignore[rs/no-command-injection]
+    // The coverage command is explicit user configuration and is executed
+    // directly as argv without a shell.
+    let output = std::process::Command::new(program)
+        .args(&command[1..])
+        .current_dir(project_root)
+        .env("TOGI_COVERAGE_FILE", coverage_file)
+        .output()
+        .with_context(|| format!("failed to run coverage command `{}`", command.join(" ")))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "coverage command `{}` failed with status {}.\nstdout:\n{}\nstderr:\n{}",
+            command.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    if !coverage_file.is_file() {
+        anyhow::bail!(
+            "coverage command `{}` completed but did not produce {}",
+            command.join(" "),
+            coverage_file.display()
+        );
+    }
+
     Ok(())
 }
 
@@ -1348,6 +1433,7 @@ mod tests {
             show_output: false,
             test_cmd: None,
             coverage_file: None,
+            coverage_cmd: None,
             min_line_coverage: None,
             min_diff_coverage: None,
             fail_on_uncovered_diff: false,
@@ -1466,6 +1552,21 @@ jobs = 4
 
         assert_eq!(resolved.config.test.timeout, 12);
         assert!(!resolved.config.test.calibrate_timeout);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_config_rejects_coverage_command_without_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(&config_path, "")?;
+        let mut cfg = check_config();
+        cfg.config = Some(config_path);
+        cfg.coverage_cmd = Some("go test ./...".into());
+
+        let err = resolve_config(cfg).unwrap_err();
+
+        assert!(err.to_string().contains("coverage collection command requires"));
         Ok(())
     }
 
@@ -1670,4 +1771,5 @@ example.com/calc/calc.go:9.29,10.11 1 0
         assert_eq!(file.get("6").unwrap(), &vec!["TestAdd".to_string()]);
         assert!(!file.contains_key("9"));
     }
+
 }


### PR DESCRIPTION
## Summary
- add `--coverage-cmd` and config-backed coverage command support for `togi check`
- require a coverage output file for command-driven LCOV generation and route the results through the existing coverage filter and gate path
- document the new command-driven coverage workflow and validate it with CLI/config tests

## Validation
- cargo test --quiet
- cargo clippy --all-targets --all-features -- -D warnings
- foxguard . --format json --severity high

Closes #394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag and configuration option to run a user-provided command to generate LCOV coverage before processing; the command is invoked with an environment variable pointing to the expected LCOV output. Validation now requires an output coverage source when coverage gates are enabled and will error or warn appropriately if generation/reading fails.

* **Documentation**
  * Updated docs with usage examples for the new coverage command and TOML configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->