### PR TITLE
Add built-in Go coverage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ togi check --build-cmd "cargo check"
 # Only mutate lines covered by an LCOV file
 togi check --coverage-file coverage/lcov.info
 
+# Ask togi to collect coverage itself when the project is supported
+togi check --coverage auto
+
 # Run your own coverage command, then consume the generated LCOV
 togi check --coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info
 
@@ -215,6 +218,7 @@ base = "origin/main"
 max_per_run = 20
 max_per_file = 20
 schemata = true
+# coverage = "auto"
 # coverage_command = ["./scripts/collect-coverage.sh"]
 coverage_file = "coverage/lcov.info"
 min_line_coverage = 80.0
@@ -338,6 +342,8 @@ Schemata are enabled by default. They batch compatible mutations into one build 
 For large repos, togi can avoid work before the runner starts and can also
 fail the run when LCOV coverage is below a threshold:
 
+- `--coverage auto` asks togi to collect coverage through a built-in adapter
+  when the current project is supported. Today that built-in path supports Go.
 - `--coverage-file coverage/lcov.info` keeps only mutations on covered lines
 - `--coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info`
   runs a user-provided command before mutation generation, then reads the
@@ -349,6 +355,7 @@ fail the run when LCOV coverage is below a threshold:
 - `--test-selection-file coverage/test-selection.json` narrows each mutant to tests that cover that line when the configured runner supports test selection
 
 ```bash
+togi check --coverage auto
 togi check --coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info
 togi test-map --path . --output coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --test-selection-file coverage/test-selection.json

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,12 +102,16 @@ pub struct CheckArgs {
     #[arg(long)]
     pub test_cmd: Option<String>,
 
+    /// Coverage collection mode for supported ecosystems
+    #[arg(long, value_enum, conflicts_with = "coverage_cmd")]
+    pub coverage: Option<crate::config::CoverageMode>,
+
     /// LCOV coverage file — only mutate lines with test coverage
     #[arg(long)]
     pub coverage_file: Option<PathBuf>,
 
     /// Command to generate an LCOV file before mutation filtering
-    #[arg(long)]
+    #[arg(long, conflicts_with = "coverage")]
     pub coverage_cmd: Option<String>,
 
     /// Fail if overall LCOV line coverage is below this percentage
@@ -284,6 +288,26 @@ mod tests {
                 assert_eq!(args.min_line_coverage, Some(80.0));
                 assert_eq!(args.min_diff_coverage, Some(90.0));
                 assert!(args.fail_on_uncovered_diff);
+            }
+            _ => panic!("expected Check command"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn coverage_collection_arguments_are_accepted() -> anyhow::Result<()> {
+        let cli = Cli::try_parse_from([
+            "togi",
+            "check",
+            "--coverage",
+            "auto",
+            "--coverage-file",
+            "coverage/lcov.info",
+        ])?;
+        match cli.command {
+            Commands::Check(args) => {
+                assert_eq!(args.coverage, Some(crate::config::CoverageMode::Auto));
+                assert_eq!(args.coverage_file, Some(PathBuf::from("coverage/lcov.info")));
             }
             _ => panic!("expected Check command"),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,7 +307,10 @@ mod tests {
         match cli.command {
             Commands::Check(args) => {
                 assert_eq!(args.coverage, Some(crate::config::CoverageMode::Auto));
-                assert_eq!(args.coverage_file, Some(PathBuf::from("coverage/lcov.info")));
+                assert_eq!(
+                    args.coverage_file,
+                    Some(PathBuf::from("coverage/lcov.info"))
+                );
             }
             _ => panic!("expected Check command"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,6 +135,13 @@ impl ResourceProfile {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum CoverageMode {
+    Auto,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DiffConfig {
@@ -147,6 +154,8 @@ pub struct DiffConfig {
 pub struct MutationConfig {
     #[serde(default = "default_max_per_run")]
     pub max_per_run: usize,
+    #[serde(default)]
+    pub coverage: Option<CoverageMode>,
     pub coverage_file: Option<PathBuf>,
     #[serde(default)]
     pub coverage_command: Vec<String>,
@@ -247,6 +256,11 @@ struct ProjectInspection {
     has_tsconfig: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinCoverageAdapter {
+    Go,
+}
+
 impl ProjectInspection {
     fn scan(project_root: &Path) -> Self {
         Self {
@@ -323,6 +337,13 @@ impl ProjectInspection {
         }
         vec![]
     }
+
+    fn detect_builtin_coverage_adapter(&self) -> Option<BuiltinCoverageAdapter> {
+        if self.has_go_mod {
+            return Some(BuiltinCoverageAdapter::Go);
+        }
+        None
+    }
 }
 
 pub fn detect_test_command(project_root: &Path) -> Vec<String> {
@@ -368,6 +389,10 @@ pub fn failfast_args(command: &[String]) -> Vec<String> {
 
 pub fn detect_build_command(project_root: &Path) -> Vec<String> {
     ProjectInspection::scan(project_root).detect_build_command()
+}
+
+pub fn detect_builtin_coverage_adapter(project_root: &Path) -> Option<BuiltinCoverageAdapter> {
+    ProjectInspection::scan(project_root).detect_builtin_coverage_adapter()
 }
 
 fn default_timeout() -> u64 {
@@ -441,6 +466,7 @@ impl Default for MutationConfig {
         Self {
             max_per_run: default_max_per_run(),
             max_per_file: default_max_per_file(),
+            coverage: None,
             coverage_file: None,
             coverage_command: vec![],
             test_selection_file: None,
@@ -549,7 +575,8 @@ impl Config {
         );
 
         template.push_str(
-            "# coverage_file = \"coverage/lcov.info\"  # enable LCOV filtering and coverage gates\n\
+            "# coverage = \"auto\"  # collect coverage through a built-in adapter when supported\n\
+             # coverage_file = \"coverage/lcov.info\"  # enable LCOV filtering and coverage gates\n\
              # coverage_command = [\"./scripts/collect-coverage.sh\"]  # generate LCOV before mutation filtering\n\
              # min_line_coverage = 80.0  # fail if overall LCOV line coverage drops below this\n\
              # min_diff_coverage = 90.0  # fail if changed-line coverage drops below this\n\
@@ -936,12 +963,14 @@ coverage_file = "coverage.lcov"
     }
 
     #[test]
-    fn parse_coverage_command_option() {
+    fn parse_coverage_collection_options() {
         let toml_str = r#"
 [mutations]
+coverage = "auto"
 coverage_command = ["./scripts/collect-coverage.sh"]
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mutations.coverage, Some(CoverageMode::Auto));
         assert_eq!(
             config.mutations.coverage_command,
             vec!["./scripts/collect-coverage.sh"]
@@ -998,6 +1027,16 @@ fail_on_uncovered_diff = true
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("CMakeLists.txt"), "").unwrap();
         assert_eq!(detect_test_command(dir.path()), vec!["ctest"]);
+    }
+
+    #[test]
+    fn detect_builtin_go_coverage_adapter() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "").unwrap();
+        assert_eq!(
+            detect_builtin_coverage_adapter(dir.path()),
+            Some(BuiltinCoverageAdapter::Go)
+        );
     }
 
     #[test]

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -535,7 +535,10 @@ end_of_record
         let lcov = stats_to_lcov(&coverage);
         let reparsed = parse_lcov_stats(&lcov, Path::new("/project"));
 
-        let covered = reparsed.covered_lines.get(Path::new("src/main.go")).unwrap();
+        let covered = reparsed
+            .covered_lines
+            .get(Path::new("src/main.go"))
+            .unwrap();
         assert!(covered.contains(&4));
         assert!(!covered.contains(&5));
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -288,6 +288,36 @@ pub fn diff_coverage_report(
     }
 }
 
+pub fn stats_to_lcov(coverage: &CoverageStats) -> String {
+    let mut files: Vec<&PathBuf> = coverage.total_lines.keys().collect();
+    files.sort();
+
+    let mut out = String::new();
+    for file in files {
+        out.push_str("SF:");
+        out.push_str(&file.to_string_lossy());
+        out.push('\n');
+
+        let mut lines: Vec<usize> = coverage
+            .total_lines
+            .get(file)
+            .into_iter()
+            .flat_map(|lines| lines.iter().copied())
+            .collect();
+        lines.sort_unstable();
+        lines.dedup();
+
+        let covered = coverage.covered_lines.get(file);
+        for line in lines {
+            let hits = covered.is_some_and(|covered| covered.contains(&line)) as u8;
+            out.push_str(&format!("DA:{line},{hits}\n"));
+        }
+        out.push_str("end_of_record\n");
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -484,5 +514,33 @@ end_of_record
         );
         assert_eq!(report.uncovered_changed_lines[0].lines, vec![11]);
         assert!(!report.fail_on_uncovered_diff);
+    }
+    #[test]
+    fn stats_to_lcov_round_trips() {
+        let mut coverage = CoverageStats {
+            covered_lines: CoverageMap::new(),
+            total_lines: CoverageMap::new(),
+        };
+        coverage
+            .covered_lines
+            .entry(PathBuf::from("src/main.go"))
+            .or_default()
+            .insert(4);
+        coverage
+            .total_lines
+            .entry(PathBuf::from("src/main.go"))
+            .or_default()
+            .extend([4, 5]);
+
+        let lcov = stats_to_lcov(&coverage);
+        let reparsed = parse_lcov_stats(&lcov, Path::new("/project"));
+
+        let covered = reparsed.covered_lines.get(Path::new("src/main.go")).unwrap();
+        assert!(covered.contains(&4));
+        assert!(!covered.contains(&5));
+
+        let total = reparsed.total_lines.get(Path::new("src/main.go")).unwrap();
+        assert!(total.contains(&4));
+        assert!(total.contains(&5));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,9 +530,7 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
     }
 
     if config.mutations.coverage.is_some() && !config.mutations.coverage_command.is_empty() {
-        anyhow::bail!(
-            "choose either built-in coverage collection or coverage_command, not both"
-        );
+        anyhow::bail!("choose either built-in coverage collection or coverage_command, not both");
     }
     if !config.mutations.coverage_command.is_empty() && config.mutations.coverage_file.is_none() {
         anyhow::bail!(
@@ -803,7 +801,10 @@ fn parse_go_coverprofile_stats(
         for line_no in start_line..=end_line {
             total_lines.entry(file.clone()).or_default().insert(line_no);
             if execution_count > 0 {
-                covered_lines.entry(file.clone()).or_default().insert(line_no);
+                covered_lines
+                    .entry(file.clone())
+                    .or_default()
+                    .insert(line_no);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,6 +490,9 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         config.test.command =
             shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --test-cmd: {e}"))?;
     }
+    if let Some(mode) = cfg.coverage {
+        config.mutations.coverage = Some(mode);
+    }
     if let Some(path) = cfg.coverage_file {
         config.mutations.coverage_file = Some(path);
     }
@@ -526,6 +529,11 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         config.mutations.operators = ops;
     }
 
+    if config.mutations.coverage.is_some() && !config.mutations.coverage_command.is_empty() {
+        anyhow::bail!(
+            "choose either built-in coverage collection or coverage_command, not both"
+        );
+    }
     if !config.mutations.coverage_command.is_empty() && config.mutations.coverage_file.is_none() {
         anyhow::bail!(
             "coverage collection command requires an LCOV output path; set [mutations] coverage_file or --coverage-file"
@@ -535,10 +543,11 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         || config.mutations.min_diff_coverage.is_some()
         || config.mutations.fail_on_uncovered_diff)
         && config.mutations.coverage_file.is_none()
+        && config.mutations.coverage.is_none()
         && config.mutations.coverage_command.is_empty()
     {
         anyhow::bail!(
-            "coverage gates require a coverage source; set [mutations] coverage_file, coverage_command, or use the corresponding CLI flags"
+            "coverage gates require a coverage source; set [mutations] coverage_file, coverage_command, coverage = \"auto\", or use the corresponding CLI flags"
         );
     }
 
@@ -577,6 +586,16 @@ fn resolve_coverage_stats(
     project_root: &Path,
     coverage_gate_active: bool,
 ) -> anyhow::Result<Option<togi::coverage::CoverageStats>> {
+    if let Some(mode) = config.mutations.coverage {
+        let output_path = config
+            .mutations
+            .coverage_file
+            .as_ref()
+            .map(|path| resolve_coverage_path(path, project_root));
+        return collect_builtin_coverage_stats(mode, project_root, output_path.as_deref())
+            .map(Some);
+    }
+
     if !config.mutations.coverage_command.is_empty() {
         let coverage_file = config
             .mutations
@@ -671,6 +690,128 @@ fn run_coverage_command(
     }
 
     Ok(())
+}
+
+fn collect_builtin_coverage_stats(
+    mode: togi::config::CoverageMode,
+    project_root: &Path,
+    output_path: Option<&Path>,
+) -> anyhow::Result<togi::coverage::CoverageStats> {
+    match mode {
+        togi::config::CoverageMode::Auto => collect_auto_coverage_stats(project_root, output_path),
+    }
+}
+
+fn collect_auto_coverage_stats(
+    project_root: &Path,
+    output_path: Option<&Path>,
+) -> anyhow::Result<togi::coverage::CoverageStats> {
+    match togi::config::detect_builtin_coverage_adapter(project_root) {
+        Some(togi::config::BuiltinCoverageAdapter::Go) => {
+            collect_go_builtin_coverage_stats(project_root, output_path)
+        }
+        None => anyhow::bail!(
+            "built-in coverage auto is not supported for this project yet. Supported ecosystems: Go. Use --coverage-cmd ... plus --coverage-file ... for other projects."
+        ),
+    }
+}
+
+fn collect_go_builtin_coverage_stats(
+    project_root: &Path,
+    output_path: Option<&Path>,
+) -> anyhow::Result<togi::coverage::CoverageStats> {
+    let module_path = go_module_path(project_root)?;
+    let tempdir = tempfile::tempdir()?;
+    let profile_path = tempdir.path().join("coverage.out");
+    let output = std::process::Command::new("go")
+        .arg("test")
+        .arg("./...")
+        .arg("-coverpkg")
+        .arg("./...")
+        .arg("-coverprofile")
+        .arg(&profile_path)
+        .current_dir(project_root)
+        .output()
+        .context("failed to run built-in Go coverage collection")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "built-in Go coverage collection failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let profile = std::fs::read_to_string(&profile_path)
+        .context("could not read Go coverage profile produced by built-in coverage collection")?;
+    let stats = parse_go_coverprofile_stats(project_root, project_root, &module_path, &profile)?;
+
+    if let Some(output_path) = output_path {
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "could not create parent directory for coverage file {}",
+                    output_path.display()
+                )
+            })?;
+        }
+        std::fs::write(output_path, togi::coverage::stats_to_lcov(&stats)).with_context(|| {
+            format!(
+                "could not write generated coverage file {}",
+                output_path.display()
+            )
+        })?;
+    }
+
+    Ok(stats)
+}
+
+fn parse_go_coverprofile_stats(
+    repo_root: &Path,
+    module_root: &Path,
+    module_path: &str,
+    profile: &str,
+) -> anyhow::Result<togi::coverage::CoverageStats> {
+    let mut covered_lines = togi::coverage::CoverageMap::new();
+    let mut total_lines = togi::coverage::CoverageMap::new();
+
+    for line in profile.lines().skip(1) {
+        let Some((location, fields)) = line.split_once(' ') else {
+            continue;
+        };
+        let fields: Vec<&str> = fields.split_whitespace().collect();
+        if fields.len() < 2 {
+            continue;
+        }
+
+        let execution_count = fields[1]
+            .parse::<u64>()
+            .with_context(|| format!("invalid Go coverage execution count in `{line}`"))?;
+        let Some((file, range)) = location.rsplit_once(':') else {
+            continue;
+        };
+        let Some((start, end)) = range.split_once(',') else {
+            continue;
+        };
+        let start_line = parse_go_cover_line(start)?;
+        let end_line = parse_go_cover_line(end)?;
+        let file = PathBuf::from(normalize_go_cover_file(
+            repo_root,
+            module_root,
+            module_path,
+            file,
+        ));
+
+        for line_no in start_line..=end_line {
+            total_lines.entry(file.clone()).or_default().insert(line_no);
+            if execution_count > 0 {
+                covered_lines.entry(file.clone()).or_default().insert(line_no);
+            }
+        }
+    }
+
+    Ok(togi::coverage::CoverageStats {
+        covered_lines,
+        total_lines,
+    })
 }
 
 fn warn_if_resource_oversubscribed(jobs: usize) {
@@ -1432,6 +1573,7 @@ mod tests {
             verbose: false,
             show_output: false,
             test_cmd: None,
+            coverage: None,
             coverage_file: None,
             coverage_cmd: None,
             min_line_coverage: None,
@@ -1552,6 +1694,25 @@ jobs = 4
 
         assert_eq!(resolved.config.test.timeout, 12);
         assert!(!resolved.config.test.calibrate_timeout);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_config_accepts_builtin_coverage_auto_without_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(&config_path, "")?;
+        let mut cfg = check_config();
+        cfg.config = Some(config_path);
+        cfg.coverage = Some(togi::config::CoverageMode::Auto);
+
+        let resolved = resolve_config(cfg)?;
+
+        assert_eq!(
+            resolved.config.mutations.coverage,
+            Some(togi::config::CoverageMode::Auto)
+        );
+        assert!(resolved.config.mutations.coverage_file.is_none());
         Ok(())
     }
 
@@ -1772,5 +1933,29 @@ example.com/calc/calc.go:9.29,10.11 1 0
         assert_eq!(file.get("4").unwrap(), &vec!["TestAdd".to_string()]);
         assert_eq!(file.get("6").unwrap(), &vec!["TestAdd".to_string()]);
         assert!(!file.contains_key("9"));
+    }
+    #[test]
+    fn parse_go_coverprofile_stats_tracks_total_and_covered_lines() {
+        let profile = r#"mode: set
+example.com/calc/calc.go:4.24,6.2 1 1
+example.com/calc/calc.go:9.29,10.11 1 0
+"#;
+
+        let stats = parse_go_coverprofile_stats(
+            Path::new("/repo/module"),
+            Path::new("/repo/module"),
+            "example.com/calc",
+            profile,
+        )
+        .unwrap();
+
+        let file = stats.covered_lines.get(Path::new("calc.go")).unwrap();
+        assert!(file.contains(&4));
+        assert!(file.contains(&6));
+        assert!(!file.contains(&9));
+
+        let total = stats.total_lines.get(Path::new("calc.go")).unwrap();
+        assert!(total.contains(&4));
+        assert!(total.contains(&10));
     }
 }


### PR DESCRIPTION
## Summary
- add `--coverage auto` and config-backed built-in coverage collection selection
- implement the first built-in adapter for Go and serialize its results into the existing LCOV-backed filtering and gating pipeline
- extend docs and tests for the built-in coverage path while reusing the command-bridge foundation from #397

## Validation
- cargo test --quiet
- cargo clippy --all-targets --all-features -- -D warnings
- foxguard . --format json --severity high

Implements #395

Stacked on #397.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--coverage auto` CLI flag and `coverage = "auto"` config option for automatic coverage collection in supported projects (currently Go)
  * Made `--coverage-cmd` and `--coverage` mutually exclusive

* **Documentation**
  * Updated README with `--coverage auto` usage examples and configuration guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->