### PR TITLE
docs: prefer release installs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ togi's differentiator: multi-language + diff-targeted by default + single binary
 
 ## Install
 
+Prefer a versioned GitHub Release and verify the published checksums:
+
+```bash
+TOGI_VERSION=vX.Y.Z
+curl -fsSLo togi.tar.gz \
+  "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/togi-linux-x86_64.tar.gz"
+curl -fsSLo checksums.txt \
+  "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/checksums.txt"
+sha256sum --ignore-missing -c checksums.txt
+tar xzf togi.tar.gz
+install -m 0755 ./togi "$HOME/.local/bin/togi"
+```
+
+If you intentionally want a source-based install tied to a reviewed revision:
+
 ```bash
 cargo install --git https://github.com/Darkroom4364/togi --rev <commit-sha> --locked
 ```
@@ -535,7 +550,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
-      - run: cargo install --git https://github.com/Darkroom4364/togi --rev <reviewed-commit-sha> --locked
+      - run: |
+          TOGI_VERSION=vX.Y.Z
+          curl -fsSLo togi.tar.gz \
+            "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/togi-linux-x86_64.tar.gz"
+          curl -fsSLo checksums.txt \
+            "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/checksums.txt"
+          sha256sum --ignore-missing -c checksums.txt
+          tar xzf togi.tar.gz
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 ./togi "$HOME/.local/bin/togi"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: togi check --base origin/main --format github --fail-under 80
 ```
 


### PR DESCRIPTION
## Summary
- make versioned GitHub Release artifacts the primary install path in the README
- keep source-based `cargo install --git --rev` as an explicit secondary option
- update the CI example to download a pinned release binary plus checksums instead of installing from git

Closes #386.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to prioritize versioned GitHub Release binary downloads, including SHA256 checksum verification before extracting and installing `togi` to `~/.local/bin`
  * Kept the existing Cargo/source-based installation steps as an alternative
  * Revised the example GitHub Actions workflow to download the release artifact and `checksums.txt`, verify checksums, extract/install the binary, and add `~/.local/bin` to `$GITHUB_PATH` for subsequent steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->