### PR TITLE
Fix schemata build failures on Rust let conditions (#409)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3393,11 +3393,11 @@ fn run_command(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("warning: could not spawn command {:?}: {e}", &command[0]);
+            eprintln!("warning: could not spawn command {:?}: {e}", command[0]);
             return MutationOutcome::build_error_with(
                 "command",
                 command.to_vec(),
-                format!("could not spawn command {:?}: {e}", &command[0]),
+                format!("could not spawn command {:?}: {e}", command[0]),
             );
         }
     };

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -80,6 +80,7 @@ pub enum SchemaSkipReason {
     OriginalMismatch,
     CompileTimeContext,
     OverlappingRange,
+    UnsupportedSyntaxContext,
 }
 
 impl SchemaSkipReason {
@@ -92,6 +93,7 @@ impl SchemaSkipReason {
             SchemaSkipReason::OriginalMismatch => "original_mismatch",
             SchemaSkipReason::CompileTimeContext => "compile_time_context",
             SchemaSkipReason::OverlappingRange => "overlapping_range",
+            SchemaSkipReason::UnsupportedSyntaxContext => "unsupported_syntax_context",
         }
     }
 }
@@ -1130,31 +1132,70 @@ fn rust_expression_range_for_mutation(
         )));
     }
 
-    match mutation.operator.as_str() {
+    let range = match mutation.operator.as_str() {
         "eq_to_neq" | "lt_to_lte" | "gt_to_gte" | "and_to_or" | "or_to_and" | "mul_to_div"
         | "div_to_mul" | "mod_to_mul" | "plus_to_minus" | "minus_to_plus" => {
             smallest_rust_node_range(root, mutation.byte_range.clone(), |node| {
                 node.kind() == "binary_expression"
-            })
+            })?
         }
         "true_to_false" | "false_to_true" | "zero_to_one" | "string_to_empty"
         | "increment_numeric" | "decrement_numeric" => {
-            exact_rust_node_range(root, mutation.byte_range.clone())
+            exact_rust_node_range(root, mutation.byte_range.clone())?
         }
         "remove_unary_not" | "remove_unary_neg" => {
             smallest_rust_node_range(root, mutation.byte_range.clone(), |node| {
                 node.kind() == "unary_expression"
-            })
+            })?
         }
         "negate_condition" => {
             source_slice(source, mutation.byte_range.clone())?;
-            Ok(mutation.byte_range.clone())
+            mutation.byte_range.clone()
         }
-        _ => Err(SchemaRewriteError::new(format!(
-            "accepted Rust schema operator has no rewrite strategy: {}",
-            mutation.operator
-        ))),
+        _ => {
+            return Err(SchemaRewriteError::new(format!(
+                "accepted Rust schema operator has no rewrite strategy: {}",
+                mutation.operator
+            )));
+        }
+    };
+
+    if rust_range_conflicts_with_let_condition(root, range.clone()) {
+        return Err(SchemaRewriteError::new(format!(
+            "mutation {} overlaps a Rust let condition and cannot be expression-wrapped",
+            mutation.id
+        )));
     }
+    Ok(range)
+}
+
+/// Return true when an expression range cannot be lifted into a `__togi_select`
+/// closure because it overlaps a Rust `let` condition (`if let`, `while let`,
+/// or a let-chain). `let` conditions are only legal directly in `if`/`while`
+/// condition position, so a range that spans one — or sits inside one outside
+/// its `value` expression, such as a pattern — is not valid closure body code.
+fn rust_range_conflicts_with_let_condition(
+    root: tree_sitter::Node<'_>,
+    range: std::ops::Range<usize>,
+) -> bool {
+    let mut conflicts = false;
+    visit_nodes(root, &mut |node| {
+        if conflicts || node.kind() != "let_condition" {
+            return;
+        }
+        let node_range = node.byte_range();
+        if range.end <= node_range.start || node_range.end <= range.start {
+            return;
+        }
+        let contained_in_value = node.child_by_field_name("value").is_some_and(|value| {
+            let value_range = value.byte_range();
+            value_range.start <= range.start && range.end <= value_range.end
+        });
+        if !contained_in_value {
+            conflicts = true;
+        }
+    });
+    conflicts
 }
 
 fn smallest_c_node_range(
@@ -2239,6 +2280,12 @@ fn schema_conflict_range(
         }
         let source = source.ok_or(SchemaSkipReason::MissingSource)?;
         let tree = rust_tree.ok_or(SchemaSkipReason::InvalidRange)?;
+        if rust_range_conflicts_with_let_condition(
+            tree.root_node(),
+            schema_mutation.mutation.byte_range.clone(),
+        ) {
+            return Err(SchemaSkipReason::UnsupportedSyntaxContext);
+        }
         return rust_expression_range_for_mutation(
             tree.root_node(),
             source,
@@ -3703,5 +3750,172 @@ mod tests {
             assert!(rewritten.contains("func __togi_active("));
             parse_go_source(&rewritten).unwrap();
         }
+    }
+
+    #[test]
+    fn plan_falls_back_for_rust_if_let_condition_mutation() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(peer_ip: Option<std::net::IpAddr>) {\n    if let Some(peer_ip) = peer_ip {\n        log_ip(peer_ip);\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let condition = "let Some(peer_ip) = peer_ip";
+        let start = source.find(condition).unwrap();
+        let plan = plan(
+            dir.path(),
+            vec![mutation(
+                "rust",
+                "src/lib.rs",
+                condition,
+                "!(let Some(peer_ip) = peer_ip)",
+                start..start + condition.len(),
+                "negate_condition",
+            )],
+        );
+
+        assert!(plan.selected.is_empty());
+        assert_eq!(plan.fallback.len(), 1);
+        assert_eq!(
+            plan.fallback[0].reason,
+            SchemaSkipReason::UnsupportedSyntaxContext
+        );
+    }
+
+    #[test]
+    fn plan_falls_back_for_rust_while_let_pattern_mutation() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(mut it: std::vec::IntoIter<i32>) {\n    while let Some(0) = it.next() {\n        tick();\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let start = source.find("Some(0)").unwrap() + "Some(".len();
+        let plan = plan(
+            dir.path(),
+            vec![mutation(
+                "rust",
+                "src/lib.rs",
+                "0",
+                "1",
+                start..start + 1,
+                "zero_to_one",
+            )],
+        );
+
+        assert!(plan.selected.is_empty());
+        assert_eq!(plan.fallback.len(), 1);
+        assert_eq!(
+            plan.fallback[0].reason,
+            SchemaSkipReason::UnsupportedSyntaxContext
+        );
+    }
+
+    #[test]
+    fn plan_falls_back_for_rust_let_chain_condition_mutation() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(mut it: std::vec::IntoIter<i32>, x: i32) {\n    if x > 0 && let Some(y) = it.next() {\n        use_pair(x, y);\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let condition = "x > 0 && let Some(y) = it.next()";
+        let start = source.find(condition).unwrap();
+        let plan = plan(
+            dir.path(),
+            vec![mutation(
+                "rust",
+                "src/lib.rs",
+                condition,
+                "!(x > 0 && let Some(y) = it.next())",
+                start..start + condition.len(),
+                "negate_condition",
+            )],
+        );
+
+        assert!(plan.selected.is_empty());
+        assert_eq!(plan.fallback.len(), 1);
+        assert_eq!(
+            plan.fallback[0].reason,
+            SchemaSkipReason::UnsupportedSyntaxContext
+        );
+    }
+
+    #[test]
+    fn plan_keeps_rust_mutations_inside_let_condition_value() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(a: i32, b: i32) -> i32 {\n    if let Some(sum) = Some(a + b) {\n        sum\n    } else {\n        0\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let start = source.find("a + b").unwrap();
+        let plan = plan(
+            dir.path(),
+            vec![mutation(
+                "rust",
+                "src/lib.rs",
+                "+",
+                "-",
+                start + 2..start + 3,
+                "plus_to_minus",
+            )],
+        );
+
+        assert!(plan.fallback.is_empty());
+        assert_eq!(plan.selected.len(), 1);
+
+        let rewrites = rewrite_rust_files(dir.path(), &plan.selected).unwrap();
+        assert_eq!(rewrites.len(), 1);
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(rewritten.contains("__togi_select(7, || { a + b }, || { a - b })"));
+        parse_rust_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn plan_keeps_rust_binary_mutation_beside_let_chain() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(mut it: std::vec::IntoIter<i32>, x: i32) {\n    if x > 0 && let Some(y) = it.next() {\n        use_pair(x, y);\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let start = source.find("x > 0").unwrap() + "x ".len();
+        let plan = plan(
+            dir.path(),
+            vec![mutation(
+                "rust",
+                "src/lib.rs",
+                ">",
+                ">=",
+                start..start + 1,
+                "gt_to_gte",
+            )],
+        );
+
+        assert!(plan.fallback.is_empty());
+        assert_eq!(plan.selected.len(), 1);
+
+        let rewrites = rewrite_rust_files(dir.path(), &plan.selected).unwrap();
+        let rewritten = String::from_utf8(rewrites[0].content.clone()).unwrap();
+        assert!(
+            rewritten.contains(
+                "__togi_select(7, || { x > 0 }, || { x >= 0 }) && let Some(y) = it.next()"
+            )
+        );
+        parse_rust_source(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn rewrite_rust_files_rejects_let_condition_wrap() {
+        let dir = TempDir::new().unwrap();
+        let source = "fn f(peer_ip: Option<std::net::IpAddr>) {\n    if let Some(peer_ip) = peer_ip {\n        log_ip(peer_ip);\n    }\n}\n";
+        write_source(&dir, "src/lib.rs", source);
+
+        let condition = "let Some(peer_ip) = peer_ip";
+        let start = source.find(condition).unwrap();
+        let selected = vec![SchemaMutation {
+            mutation: mutation(
+                "rust",
+                "src/lib.rs",
+                condition,
+                "!(let Some(peer_ip) = peer_ip)",
+                start..start + condition.len(),
+                "negate_condition",
+            ),
+            kind: SchemaKind::Expression,
+        }];
+
+        assert!(rewrite_rust_files(dir.path(), &selected).is_err());
     }
 }

--- a/src/schemata.rs
+++ b/src/schemata.rs
@@ -3758,6 +3758,10 @@ mod tests {
         let source = "fn f(peer_ip: Option<std::net::IpAddr>) {\n    if let Some(peer_ip) = peer_ip {\n        log_ip(peer_ip);\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
 
+        // These tests depend on the tree-sitter-rust grammar shape.
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_condition");
+
         let condition = "let Some(peer_ip) = peer_ip";
         let start = source.find(condition).unwrap();
         let plan = plan(
@@ -3786,6 +3790,9 @@ mod tests {
         let source = "fn f(mut it: std::vec::IntoIter<i32>) {\n    while let Some(0) = it.next() {\n        tick();\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
 
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_condition");
+
         let start = source.find("Some(0)").unwrap() + "Some(".len();
         let plan = plan(
             dir.path(),
@@ -3812,6 +3819,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let source = "fn f(mut it: std::vec::IntoIter<i32>, x: i32) {\n    if x > 0 && let Some(y) = it.next() {\n        use_pair(x, y);\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
+
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_chain");
 
         let condition = "x > 0 && let Some(y) = it.next()";
         let start = source.find(condition).unwrap();
@@ -3841,6 +3851,9 @@ mod tests {
         let source = "fn f(a: i32, b: i32) -> i32 {\n    if let Some(sum) = Some(a + b) {\n        sum\n    } else {\n        0\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
 
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_condition");
+
         let start = source.find("a + b").unwrap();
         let plan = plan(
             dir.path(),
@@ -3869,6 +3882,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let source = "fn f(mut it: std::vec::IntoIter<i32>, x: i32) {\n    if x > 0 && let Some(y) = it.next() {\n        use_pair(x, y);\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
+
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_chain");
 
         let start = source.find("x > 0").unwrap() + "x ".len();
         let plan = plan(
@@ -3901,6 +3917,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let source = "fn f(peer_ip: Option<std::net::IpAddr>) {\n    if let Some(peer_ip) = peer_ip {\n        log_ip(peer_ip);\n    }\n}\n";
         write_source(&dir, "src/lib.rs", source);
+
+        let rust = adapter_for_language("rust").unwrap();
+        assert_parsed_node_kind(&dir, "src/lib.rs", rust, "let_condition");
 
         let condition = "let Some(peer_ip) = peer_ip";
         let start = source.find(condition).unwrap();


### PR DESCRIPTION
## Summary

Fixes #409.

Mutations overlapping a Rust `if let` / `while let` condition were expression-wrapped as `__togi_select(id, || { let ... }, ...)`. `let` conditions are only legal directly in `if`/`while` condition position — never in a closure body — so the rewritten source failed `cargo check` and every mutant in the schema batch died as `build_error` (73/219 mutants, 33%, in the eidolon run that reported this).

## Fix

- **Plan time**: `schema_conflict_range` routes mutations whose byte range overlaps a `let_condition` node to fallback with a new explicit `SchemaSkipReason::UnsupportedSyntaxContext` — visible in reports as `unsupported_syntax_context`.
- **Rewrite time**: `rust_expression_range_for_mutation` refuses such ranges, so even direct `rewrite_rust_files` callers get an error instead of invalid source (the runner already falls back to regular runs on rewrite errors).
- **Fast path kept** where valid: mutations inside the `let` condition's *value* (`if let Some(s) = Some(a + b)`) and plain boolean conjuncts in let-chains (`x > 0 && let Some(y) = ...`) still use schemata. Both wrapped forms verified to compile under edition 2024 rustc.

Fallback `!(let ...)` mutants run individually and report an isolated build error — the correct outcome for a mutant that does not compile, instead of poisoning the shared schema build.

## Tests

Six new unit tests in `src/schemata.rs`: fallback for if-let / while-let-pattern / let-chain condition mutations, fast path kept for value and let-chain-conjunct mutations (with re-parse of rewritten source), and the rewrite-path rejection. `cargo test`, `cargo clippy -- -D warnings`, and `rustfmt --check` on the changed file all pass.

## Real-world A/B (eidolon, 28-mutant subset incl. the reported sites)

| | old binary | this branch |
|---|---|---|
| `schema_build` let-wrap failure | 25/28 build_error, one shared fingerprint | gone |
| let-condition mutants | batch-poisoned | 6 × `unsupported_syntax_context` fallback, run in isolation |

The A/B run also surfaced a separate batch-poison bug (`E0382` move-in-closure wrap); filed as a new issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Rust `if let`, `while let`, and let-chain conditions during schema execution.
  * Unsupported mutations now safely fall back instead of attempting invalid rewrites.
  * Mutations within supported expression values continue to be selected and rewritten correctly.
  * Added safeguards to reject unsupported direct rewrites of `let`-condition wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->