### PR TITLE
Stop reusing verdicts cached before source context changed (#410)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,10 +16,10 @@ use std::sync::Mutex;
 const CACHE_DIR: &str = ".togi-cache";
 
 /// Bump when mutation/operator/cache semantics change without a package version bump.
-const CACHE_SCHEMA_VERSION: &str = "2";
+const CACHE_SCHEMA_VERSION: &str = "3";
 
 const HISTORY_FILE: &str = "history.json";
-const HISTORY_SCHEMA_VERSION: u32 = 1;
+const HISTORY_SCHEMA_VERSION: u32 = 2;
 
 const TOGI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -380,6 +380,41 @@ mod tests {
         .unwrap();
 
         assert_eq!(lookup(tmp.path(), &key), None);
+    }
+
+    #[test]
+    fn history_with_older_schema_version_loads_empty() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let entry = IncrementalHistoryEntry {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            result: MutationResult::Survived,
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+            covering_tests: vec![],
+            killer_test: None,
+        };
+        let stale = IncrementalHistoryFile {
+            schema_version: HISTORY_SCHEMA_VERSION - 1,
+            entries: vec![entry],
+        };
+        fs::create_dir_all(cache_dir(tmp.path())).unwrap();
+        fs::write(
+            history_path(tmp.path()),
+            serde_json::to_vec(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let store = IncrementalHistoryStore::load(tmp.path());
+        let query = IncrementalHistoryQuery {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+        };
+        assert_eq!(store.lookup(&query), None);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -767,6 +767,11 @@ fn collect_cache_context_files(project_root: &Path, dir: &Path, out: &mut Vec<Pa
     }
 }
 
+/// Files whose content can change mutation verdicts beyond the mutated file
+/// itself: build manifests, CI workflows, tests — and any source file, since
+/// sources both shape which tests compile and run (e.g. Rust `mod` wiring) and
+/// can carry colocated tests (`#[cfg(test)]` modules, specs). A verdict cached
+/// before such a change must not be reused (#410).
 fn is_cache_context_file(relative: &Path) -> bool {
     let path_key = normalized_cache_path(Path::new(""), relative).to_ascii_lowercase();
     let file_name = relative
@@ -775,8 +780,12 @@ fn is_cache_context_file(relative: &Path) -> bool {
         .unwrap_or("")
         .to_ascii_lowercase();
 
+    if has_source_context_extension(&file_name) {
+        return true;
+    }
+
     if matches!(
-        path_key.as_str(),
+        file_name.as_str(),
         "togi.toml"
             | "cargo.toml"
             | "cargo.lock"
@@ -829,6 +838,32 @@ fn is_cache_context_file(relative: &Path) -> bool {
         || file_name.contains(".spec.")
         || file_name.ends_with("test.java")
         || file_name.ends_with("tests.java")
+}
+
+/// Extensions of source files togi can mutate. Any of them can influence test
+/// compilation or execution, so all of them are verdict-cache context.
+fn has_source_context_extension(file_name: &str) -> bool {
+    matches!(
+        Path::new(file_name)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or(""),
+        "go" | "rs"
+            | "py"
+            | "ts"
+            | "tsx"
+            | "js"
+            | "jsx"
+            | "java"
+            | "c"
+            | "cc"
+            | "cpp"
+            | "cxx"
+            | "h"
+            | "hpp"
+            | "cs"
+            | "rb"
+    )
 }
 
 fn has_test_context_extension(file_name: &str) -> bool {
@@ -2593,6 +2628,9 @@ impl TestRunner {
             let mutation = &schema_mutation.mutation;
             let mut env = self.env.clone();
             env.insert("TOGI_MUTANT".to_string(), mutation.id.to_string());
+            // Cache keys must not embed the per-mutant TOGI_MUTANT id: ids are
+            // reassigned whenever the mutation set changes, which would orphan
+            // every cached verdict from earlier runs.
             let prepared = PreparedMutationRun::new(
                 &self.project_root,
                 mutation,
@@ -2602,7 +2640,7 @@ impl TestRunner {
                     source_contents: &source_contents,
                     cache_context_fingerprint: cache_context_hash,
                     test_context_index: &test_context_index,
-                    env: &env,
+                    env: &self.env,
                 },
             );
             let argv = if language == "go" {
@@ -4076,10 +4114,10 @@ mod tests {
             b"pub fn value() -> i32 { 1 }",
         )
         .unwrap();
-        assert_eq!(
+        assert_ne!(
             cache_context_fingerprint(dir.path()),
             initial,
-            "regular source files are already covered by per-mutation content hashes"
+            "source files are verdict context: they shape test compilation and module wiring (#410)"
         );
 
         std::fs::create_dir_all(dir.path().join("tests")).unwrap();
@@ -4148,9 +4186,14 @@ mod tests {
 
         let clean = git_cache_context_fingerprint(root).expect("clean git fingerprint");
         std::fs::write(root.join("src/lib.rs"), b"pub fn value() -> i32 { 2 }\n").unwrap();
-        assert_eq!(
-            git_cache_context_fingerprint(root).expect("dirty source should still use git"),
-            clean
+        assert!(
+            git_cache_context_fingerprint(root).is_none(),
+            "dirty source files should fall back to filesystem hashing"
+        );
+        assert_ne!(
+            cache_context_fingerprint(root),
+            clean,
+            "source edits must change the cache context fingerprint"
         );
 
         std::fs::write(
@@ -4162,6 +4205,63 @@ mod tests {
             git_cache_context_fingerprint(root).is_none(),
             "dirty test files should fall back to filesystem hashing"
         );
+    }
+
+    #[test]
+    fn cache_context_fingerprint_changes_for_new_source_file() {
+        if !git_available() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("Cargo.toml"), b"[package]\nname = \"fixture\"\n").unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub fn value() -> i32 { 1 }\n").unwrap();
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let before = cache_context_fingerprint(root);
+        // A brand-new source file joining the diff (tracked via `git add -N`)
+        // must invalidate verdicts cached before it existed (#410).
+        std::fs::write(root.join("src/codec.rs"), b"pub fn decode() -> i32 { 1 }\n").unwrap();
+        assert_ne!(cache_context_fingerprint(root), before);
+    }
+
+    #[test]
+    fn cache_context_fingerprint_changes_when_src_test_module_edited() {
+        if !git_available() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("Cargo.toml"), b"[package]\nname = \"fixture\"\n").unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            b"pub fn value() -> i32 { 1 }\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn value() {\n        assert_eq!(super::value(), 1);\n    }\n}\n",
+        )
+        .unwrap();
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let before = cache_context_fingerprint(root);
+        // Tests colocated in a source file are verdict context too (#410).
+        std::fs::write(
+            root.join("src/lib.rs"),
+            b"pub fn value() -> i32 { 1 }\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn value() {\n        assert_eq!(super::value(), 2);\n    }\n}\n",
+        )
+        .unwrap();
+        assert_ne!(cache_context_fingerprint(root), before);
     }
 
     fn git_available() -> bool {
@@ -4946,6 +5046,82 @@ mod tests {
         };
         let forced = forced_runner.run(vec![mutation]).report;
         assert_eq!(forced.results[0].1, MutationResult::Killed);
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_history_invalidated_by_source_context_change() -> anyhow::Result<()> {
+        let (dir, file, mutation) = make_test_setup();
+
+        let commands = || CommandConfig {
+            command: failing_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+
+        let command_config = commands();
+        let selected = select_test_command(dir.path(), &command_config, &mutation);
+        let command_ctx = selected.cache_context(
+            &command_config.build_command,
+            false,
+            &command_config.sandbox_command,
+            &HashMap::new(),
+        );
+        let context_hash = cache_context_fingerprint(dir.path());
+        let test_context_index = TestContextIndex::build(dir.path());
+        let relevant_test_hash =
+            test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
+        let source = std::fs::read(&file)?;
+        let query = incremental_history_query(
+            dir.path(),
+            &mutation,
+            &source,
+            &command_ctx,
+            relevant_test_hash,
+        );
+        cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity.clone(),
+            mutation_description: query.mutation_description.clone(),
+            result: MutationResult::Survived,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: selected.selected_tests.clone(),
+            killer_test: None,
+        });
+
+        // A source file added after the verdict was recorded — e.g. a module
+        // wiring change or a colocated test — must invalidate the restore (#410).
+        std::fs::create_dir_all(dir.path().join("src"))?;
+        std::fs::write(
+            dir.path().join("src/codec.rs"),
+            "pub fn decode() -> i32 { 1 }\n",
+        )?;
+
+        let runner = TestRunner {
+            commands: commands(),
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let report = runner.run(vec![mutation]).report;
+        assert_eq!(report.results[0].1, MutationResult::Killed);
         Ok(())
     }
 
@@ -6197,8 +6373,9 @@ esac
             language_timeouts: HashMap::new(),
             test_selection: None,
         };
-        let mut cache_env = env.clone();
-        cache_env.insert("TOGI_MUTANT".to_string(), first.id.to_string());
+        // The seeded entry is computed without TOGI_MUTANT; the schemata runner
+        // sets it per mutant at execution time but must still hit the cache.
+        let cache_env = env.clone();
         let selected = select_test_command(dir.path(), &commands, &first);
         let cache_selected = SelectedTestCommand {
             argv: selected.argv,


### PR DESCRIPTION
## Summary

Fixes #410.

Mutants in a brand-new source file were reported `survived` even though the suite provably kills them. Investigation (minimal repro + the original repo's own `.togi-cache/history.json`) shows the mechanism is **stale verdict reuse that skips execution entirely**, not narrowed test selection:

1. An earlier run recorded `Survived` for the file's byte-identical content while it was present via `git add -N` but **not yet wired into the module tree** — mutants genuinely survived because nothing executed them.
2. After wiring (`mod` declaration, colocated `#[cfg(test)]` tests), every key component stayed valid: the verdict-cache/history context fingerprint hashed only root-level manifests, CI workflows, and test-dir/test-named files. Ordinary `src/*` files — module wiring, colocated tests — were invisible to it.
3. Later runs restored the stale `Survived` without running a single test (`↻ cached`). `--force-rerun` bypassed the restore and killed them.

## Fix (cache key correctness, three parts)

- **`is_cache_context_file` widened**: every source file of a supported language is now verdict context (sources shape which tests compile/run and can carry colocated tests), and manifests match by file name at any depth (workspace-member manifests never matched). Clean trees still hash git index object IDs; dirty trees hash worktree contents. Trade-off: any source edit invalidates cached verdicts — conservative, but correct.
- **Schema bumps** (`CACHE_SCHEMA_VERSION` 2→3, `HISTORY_SCHEMA_VERSION` 1→2): flush entries recorded under the blind key.
- **Schemata keys drop `TOGI_MUTANT`**: mutant ids are reassigned whenever the mutation set changes, so embedding the env var orphaned every schemata-recorded cache/history entry (the original repo's history shows ~70 unique command hashes). Cache reuse across runs now works for schemata. (Separate commit, plus a commit with the same clippy-1.97 unblock as #411.)

## Tests

- Fingerprint changes when a new source file appears (`git add -N` scenario) and when a colocated `#[cfg(test)]` module is edited — the two #410 gaps; two existing tests that encoded the old assumption updated.
- End-to-end: a recorded `Survived` is **not** restored after a source context change — the mutant re-runs and is killed.
- History from an older schema version loads empty; schemata cache test now proves hits without `TOGI_MUTANT` in the key.
- `cargo test` (488), stable `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo fmt --check` all pass.

## Repro validation

Against a from-scratch fixture of the issue scenario (hex codec + roundtrip test, poisoned cache): **before** — 0/20 killed, all verdicts `↻ cached`, zero tests executed; **after** — 15 killed / 5 genuinely survived (untested uppercase hex arm ×4, one equivalent mutant), zero cached restores.

## Out of scope (noted in #410)

On a cold first run, mutants in a source file that is not part of the build genuinely survive (nothing executes them) — faithful reporting of a miswired crate. A loud warning for "mutated file unreachable from the crate root" is a possible follow-up. Also worth a look later: `preferred_killer_test` matches on (identity, description) only and could include `source_hash`; it can only reorder tests, never produce a false verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated caching so verdicts are invalidated when source/context files change, including newly added files and `#[cfg(test)]` edits.
  * Improved cache-context behavior so git “dirty” source changes correctly trigger filesystem hashing.
  * Prevented reuse of incompatible incremental history cache formats by treating stale schema versions as empty.
  * Refined command-failure reporting for more consistent output.

* **Tests**
  * Added/updated coverage for source-context-driven cache invalidation, incremental history schema compatibility, and filesystem fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->