### PR TITLE
Add dogfood mutation score badge (#420)

### DIFF
--- a/.github/scripts/dogfood-mutation-score.sh
+++ b/.github/scripts/dogfood-mutation-score.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Runs a bounded dogfood mutation check and writes a shields.io endpoint JSON
+# with the resulting mutation score. Used by the dogfood-badge workflow.
+set -euo pipefail
+
+output_path="${1:-mutation-score.json}"
+togi_bin="${TOGI_BIN:-./target/release/togi}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for the dogfood badge update" >&2
+  exit 1
+fi
+
+report_path="${RUNNER_TEMP:-/tmp}/togi-dogfood-score-report.json"
+raw_report_path="${RUNNER_TEMP:-/tmp}/togi-dogfood-score-report.raw"
+
+set +e
+"$togi_bin" check \
+  --all \
+  --path src/report/json.rs \
+  --test-cmd "cargo test --locked" \
+  --calibrate-timeout \
+  --timeout-multiplier 4 \
+  --timeout-slack 2 \
+  --format json \
+  >"$raw_report_path"
+status=$?
+set -e
+
+case "$status" in
+  0|1)
+    ;;
+  *)
+    echo "Dogfood run failed unexpectedly with exit code $status" >&2
+    if [[ -f "$raw_report_path" ]]; then
+      cat "$raw_report_path" >&2
+    fi
+    exit "$status"
+    ;;
+esac
+
+sed -n '/^{/,$p' "$raw_report_path" >"$report_path"
+
+if ! jq -e '.tested > 0 and .timeout == 0 and .build_errors == 0 and .partial == false' "$report_path" >/dev/null; then
+  echo "Dogfood run produced an invalid report:" >&2
+  cat "$report_path" >&2
+  exit 1
+fi
+
+score="$(jq -r '.mutation_score | round' "$report_path")"
+
+jq -n --argjson score "$score" '{
+  schemaVersion: 1,
+  label: "mutation score (dogfood)",
+  message: "\($score)%",
+  color: "brightgreen"
+}' >"$output_path"
+
+python3 -m json.tool "$output_path" >/dev/null
+
+echo "Dogfood mutation score: ${score}% -> ${output_path}"

--- a/.github/workflows/dogfood-badge.yml
+++ b/.github/workflows/dogfood-badge.yml
@@ -1,0 +1,50 @@
+name: Dogfood Badge
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dogfood-badge
+  cancel-in-progress: false
+
+jobs:
+  mutation-score:
+    name: Update mutation score badge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          cache-bin: false
+      - name: Build togi
+        run: cargo build --locked --release
+      - name: Run dogfood mutation check
+        run: ./.github/scripts/dogfood-mutation-score.sh "$RUNNER_TEMP/mutation-score.json"
+      - name: Publish to badges branch
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin badges >/dev/null 2>&1; then
+            git fetch origin badges
+            git checkout badges
+          else
+            git checkout --orphan badges
+            git rm -rf .
+          fi
+          cp "$RUNNER_TEMP/mutation-score.json" mutation-score.json
+          git add mutation-score.json
+          if git diff --cached --quiet; then
+            echo "Mutation score unchanged; nothing to commit."
+            exit 0
+          fi
+          git commit -m "Update dogfood mutation score badge"
+          git push origin badges

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Darkroom4364/togi/actions/workflows/ci.yml/badge.svg)](https://github.com/Darkroom4364/togi/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Rust](https://img.shields.io/badge/rust-1.87%2B-orange.svg)](Cargo.toml)
+[![mutation score](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Darkroom4364/togi/badges/mutation-score.json)](https://github.com/Darkroom4364/togi/actions/workflows/dogfood-badge.yml)
 
 togi (鍛 — Japanese for "sharpening") is a fast, diff-targeted mutation testing engine for pull requests.
 


### PR DESCRIPTION
## Summary

Publishes togi's own mutation kill rate as a README badge, maintained automatically.

- **`.github/scripts/dogfood-mutation-score.sh`** — runs a bounded dogfood check (same scope and validity gate as the existing CI dogfood smoke test: `--all --path src/report/json.rs`, requires `tested > 0`, no timeouts, no build errors, non-partial), extracts `mutation_score` from the JSON report, writes a shields.io endpoint JSON, and validates it with `python3 -m json.tool`.
- **`.github/workflows/dogfood-badge.yml`** — weekly schedule (Mon 06:00 UTC) + `workflow_dispatch`. Builds togi (release), runs the script, then commits `mutation-score.json` to the dedicated `badges` branch (created as an orphan branch if missing; skipped when the score is unchanged). Third-party actions pinned to full SHAs per repo policy.
- **`README.md`** — shields.io endpoint badge next to the existing badges, linked to the workflow.

## Design decisions

- **No commits to `main`**: the badge payload lives on an unprotected `badges` branch that `GITHUB_TOKEN` can push to; shields.io reads it via `raw.githubusercontent.com`.
- **Scope**: `src/report/json.rs` (4 mutations) rather than a moving PR-diff target — stable, cheap (measured ~45s end-to-end locally on top of a warm build), and identical to what the blocking CI dogfood job already validates. A wider `src/report/` scope was measured but exceeded 5 minutes, so it was rejected.
- **Kill rate source**: the report's own `mutation_score` field, rounded to a percent; badge stays `brightgreen` and simply never updates when a run is invalid (the workflow fails instead of publishing a bad number).
- The `badges` branch has been seeded with an initial `mutation-score.json` (100%) so the badge renders immediately; the workflow owns all future updates.

## Verification

- Ran the script locally end-to-end (debug binary): produced `{"schemaVersion":1,"label":"mutation score (dogfood)","message":"100%","color":"brightgreen"}` in ~47s; JSON validated.
- Verified the live chain: `raw.githubusercontent.com/Darkroom4364/togi/badges/mutation-score.json` serves the JSON and the shields endpoint renders "mutation score (dogfood): 100%".
- `cargo test --locked`, `cargo +stable clippy --locked --all-targets --all-features -- -D warnings`, `cargo fmt -- --check`, and `check-pinned-actions.sh` all pass; workflow YAML parses.
- The scheduled trigger cannot be exercised from a PR; smoke-test post-merge via **Actions → Dogfood Badge → Run workflow** (`workflow_dispatch` is wired up).

Fixes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated mutation score badge to the project README.
  * Added scheduled and manually triggered checks to generate and publish the badge data.
  * Added validation to ensure mutation score reports are complete and reliable.

* **Documentation**
  * Updated the README with a link to the mutation score workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->