### PR TITLE
feat: classify zero-coverage mutants as uncovered, not survived

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,12 @@ fail the run when LCOV coverage is below a threshold:
 
 - `--coverage auto` asks togi to collect coverage through a built-in adapter
   when the current project is supported. Today that built-in path supports Go.
-- `--coverage-file coverage/lcov.info` keeps only mutations on covered lines
+- `--coverage-file coverage/lcov.info` runs only mutations on covered lines.
+  Mutants on lines the coverage data reports as never executed are not run —
+  they are guaranteed survivors — and are reported as `uncovered` instead of
+  `survived`: visible in the terminal and JSON reports, but excluded from the
+  survivor count, the mutation-score denominator, and `--fail-under` gating.
+  Files or lines missing from the coverage data are filtered out as before.
 - `--coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info`
   runs a user-provided command before mutation generation, then reads the
   resulting LCOV file. `TOGI_COVERAGE_FILE` is exported for the command.
@@ -380,6 +385,15 @@ togi test-map --path . --output coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --test-selection-file coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90
 ```
+
+`uncovered` classification and the coverage gates answer different questions.
+The gates (`--min-line-coverage`, `--min-diff-coverage`,
+`--fail-on-uncovered-diff`) run before mutation generation and fail the whole
+run when the diff's coverage is too weak. The `uncovered` classification keeps
+individual zero-coverage mutants from inflating the survivor count when the
+gates let the run proceed — use the gates to block under-covered diffs, and
+the classification to keep surviving-mutant reports free of zero-coverage
+noise.
 
 The selection file is a JSON map of source file to line number to test names.
 Entries can be strings or objects with `name` and optional `duration_ms`; timed

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -22,6 +22,9 @@ pub struct Baseline {
 }
 
 /// Build a baseline from a mutation report.
+///
+/// Only executed mutants count: build errors and coverage-suppressed
+/// (uncovered) mutants are excluded from per-file and overall totals.
 pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Baseline {
     let mut files: HashMap<String, FileScore> = HashMap::new();
     for (mutation, result) in &report.results {
@@ -35,7 +38,9 @@ pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Basel
             killed: 0,
             total: 0,
         });
-        if *result != crate::MutationResult::BuildError {
+        if *result != crate::MutationResult::BuildError
+            && *result != crate::MutationResult::Uncovered
+        {
             entry.total += 1;
             if *result == crate::MutationResult::Killed {
                 entry.killed += 1;
@@ -43,7 +48,7 @@ pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Basel
         }
     }
     let killed = report.killed;
-    let total = report.total.saturating_sub(report.build_errors);
+    let total = report.tested_count();
     Baseline {
         files,
         killed,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -436,6 +436,7 @@ mod tests {
             MutationResult::Survived,
             MutationResult::Timeout,
             MutationResult::BuildError,
+            MutationResult::Uncovered,
         ]
         .iter()
         .enumerate()

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -193,34 +193,67 @@ pub fn parse_lcov_stats(content: &str, project_root: &Path) -> CoverageStats {
     }
 }
 
-/// Filter mutations to only those on lines present in the coverage map.
-/// Warns about files that have mutations but are missing from coverage data.
-pub fn filter_by_coverage(
-    mutations: Vec<crate::Mutation>,
-    coverage: &CoverageMap,
-    project_root: &Path,
-) -> Vec<crate::Mutation> {
-    let mut warned_files: HashSet<PathBuf> = HashSet::new();
+/// Mutations partitioned by line-coverage data.
+#[derive(Debug, Default)]
+pub struct CoverageClassification {
+    /// Mutations on lines known to be covered by the test suite.
+    pub covered: Vec<crate::Mutation>,
+    /// Mutations on lines tracked by coverage data but never executed.
+    pub uncovered: Vec<crate::Mutation>,
+}
 
-    mutations
-        .into_iter()
-        .filter(|m| {
-            let rel = normalize_repo_relative_path(&m.file, project_root);
-            match coverage.get(&rel) {
-                Some(lines) => lines.contains(&m.line),
-                None => {
-                    if warned_files.insert(rel.clone()) {
-                        eprintln!(
-                            "warning: {} has mutations but is missing from coverage data — \
-                             all its mutations will be filtered out",
-                            rel.display()
-                        );
-                    }
-                    false
-                }
+/// Partition mutations into those on covered lines and those on lines with
+/// known zero coverage.
+///
+/// A mutation lands in `uncovered` only when coverage data for its file exists
+/// and its line is tracked but has zero executions. Mutations on files or
+/// lines missing from the coverage data keep the historical filter behavior:
+/// they are dropped (with a per-file warning for files absent from the data),
+/// exactly as before coverage-informed classification existed.
+pub fn classify_by_coverage(
+    mutations: Vec<crate::Mutation>,
+    coverage: &CoverageStats,
+    project_root: &Path,
+) -> CoverageClassification {
+    let mut warned_files: HashSet<PathBuf> = HashSet::new();
+    let mut classification = CoverageClassification::default();
+
+    for m in mutations {
+        let rel = normalize_repo_relative_path(&m.file, project_root);
+        let file_known =
+            coverage.total_lines.contains_key(&rel) || coverage.covered_lines.contains_key(&rel);
+        if !file_known {
+            if warned_files.insert(rel.clone()) {
+                eprintln!(
+                    "warning: {} has mutations but is missing from coverage data — \
+                     all its mutations will be filtered out",
+                    rel.display()
+                );
             }
-        })
-        .collect()
+            continue;
+        }
+
+        let line_tracked = coverage
+            .total_lines
+            .get(&rel)
+            .is_some_and(|lines| lines.contains(&m.line));
+        if !line_tracked {
+            // No coverage information for this line — historical behavior.
+            continue;
+        }
+
+        let line_covered = coverage
+            .covered_lines
+            .get(&rel)
+            .is_some_and(|lines| lines.contains(&m.line));
+        if line_covered {
+            classification.covered.push(m);
+        } else {
+            classification.uncovered.push(m);
+        }
+    }
+
+    classification
 }
 
 pub fn line_coverage_metric(coverage: &CoverageStats) -> CoverageMetric {
@@ -383,11 +416,11 @@ end_of_record
     }
 
     #[test]
-    fn filter_matches_dot_relative_lcov_paths() {
+    fn classify_matches_dot_relative_lcov_paths() {
         let root = Path::new("/project");
         let lcov = "SF:./src/lib.rs\nDA:42,1\nend_of_record\n";
-        let coverage = parse_lcov(lcov, root);
-        assert!(coverage.contains_key(Path::new("src/lib.rs")));
+        let coverage = parse_lcov_stats(lcov, root);
+        assert!(coverage.covered_lines.contains_key(Path::new("src/lib.rs")));
 
         let mutations = vec![crate::Mutation {
             id: 0,
@@ -402,9 +435,10 @@ end_of_record
             byte_range: 0..2,
         }];
 
-        let filtered = filter_by_coverage(mutations, &coverage, root);
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].line, 42);
+        let classified = classify_by_coverage(mutations, &coverage, root);
+        assert_eq!(classified.covered.len(), 1);
+        assert_eq!(classified.covered[0].line, 42);
+        assert!(classified.uncovered.is_empty());
     }
 
     #[test]
@@ -441,44 +475,104 @@ end_of_record
     }
 
     #[test]
-    fn filter_removes_uncovered_mutations() {
+    fn classify_separates_covered_from_zero_coverage_lines() {
         let root = Path::new("/project");
-        let mut coverage = CoverageMap::new();
-        coverage
-            .entry(PathBuf::from("src/main.go"))
-            .or_default()
-            .insert(10);
-
+        let lcov = "\
+SF:/project/src/main.go
+DA:10,1
+DA:20,0
+end_of_record
+";
+        let coverage = parse_lcov_stats(lcov, root);
+        let make_mutation = |id: u32, line: usize| crate::Mutation {
+            id,
+            file: root.join("src/main.go"),
+            language: "go".into(),
+            line,
+            column: 1,
+            operator: "lt_to_lte".into(),
+            description: "< to <=".into(),
+            original: "<".into(),
+            replacement: "<=".into(),
+            byte_range: 0..1,
+        };
         let mutations = vec![
-            crate::Mutation {
-                id: 0,
-                file: root.join("src/main.go"),
-                language: "go".into(),
-                line: 10,
-                column: 1,
-                operator: "lt_to_lte".into(),
-                description: "< to <=".into(),
-                original: "<".into(),
-                replacement: "<=".into(),
-                byte_range: 0..1,
-            },
-            crate::Mutation {
-                id: 1,
-                file: root.join("src/main.go"),
-                language: "go".into(),
-                line: 20,
-                column: 1,
-                operator: "lt_to_lte".into(),
-                description: "< to <=".into(),
-                original: "<".into(),
-                replacement: "<=".into(),
-                byte_range: 0..1,
-            },
+            make_mutation(0, 10), // covered
+            make_mutation(1, 20), // tracked but zero coverage
         ];
 
-        let filtered = filter_by_coverage(mutations, &coverage, root);
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].line, 10);
+        let classified = classify_by_coverage(mutations, &coverage, root);
+        assert_eq!(classified.covered.len(), 1);
+        assert_eq!(classified.covered[0].line, 10);
+        assert_eq!(classified.uncovered.len(), 1);
+        assert_eq!(classified.uncovered[0].line, 20);
+    }
+
+    #[test]
+    fn classify_drops_mutations_without_coverage_data() {
+        let root = Path::new("/project");
+        let lcov = "\
+SF:/project/src/main.go
+DA:10,1
+end_of_record
+";
+        let coverage = parse_lcov_stats(lcov, root);
+        let make_mutation = |id: u32, file: &str, line: usize| crate::Mutation {
+            id,
+            file: root.join(file),
+            language: "go".into(),
+            line,
+            column: 1,
+            operator: "lt_to_lte".into(),
+            description: "< to <=".into(),
+            original: "<".into(),
+            replacement: "<=".into(),
+            byte_range: 0..1,
+        };
+        let mutations = vec![
+            make_mutation(0, "src/main.go", 99),  // line not tracked
+            make_mutation(1, "src/other.go", 10), // file missing from coverage
+        ];
+
+        // Missing data means no classification change: neither mutation is
+        // classified as uncovered, and (historical filter behavior) neither runs.
+        let classified = classify_by_coverage(mutations, &coverage, root);
+        assert!(classified.covered.is_empty());
+        assert!(classified.uncovered.is_empty());
+    }
+
+    #[test]
+    fn classify_treats_file_with_only_zero_coverage_lines_as_known() {
+        let root = Path::new("/project");
+        let lcov = "\
+SF:/project/src/dead.go
+DA:5,0
+end_of_record
+";
+        let coverage = parse_lcov_stats(lcov, root);
+        // File has no covered lines at all, so it is absent from covered_lines.
+        assert!(
+            !coverage
+                .covered_lines
+                .contains_key(Path::new("src/dead.go"))
+        );
+
+        let mutations = vec![crate::Mutation {
+            id: 0,
+            file: root.join("src/dead.go"),
+            language: "go".into(),
+            line: 5,
+            column: 1,
+            operator: "lt_to_lte".into(),
+            description: "< to <=".into(),
+            original: "<".into(),
+            replacement: "<=".into(),
+            byte_range: 0..1,
+        }];
+
+        let classified = classify_by_coverage(mutations, &coverage, root);
+        assert!(classified.covered.is_empty());
+        assert_eq!(classified.uncovered.len(), 1);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,11 @@ pub enum MutationResult {
     Survived,
     Timeout,
     BuildError,
+    /// The mutation sits on a line that coverage data reports as never
+    /// executed by the test suite. Such mutants are not run: they are
+    /// guaranteed survivors and carry no signal. Only produced when line
+    /// coverage data is available for the mutated file and line.
+    Uncovered,
 }
 
 impl fmt::Display for MutationResult {
@@ -89,6 +94,7 @@ impl fmt::Display for MutationResult {
             MutationResult::Survived => write!(f, "survived"),
             MutationResult::Timeout => write!(f, "timeout"),
             MutationResult::BuildError => write!(f, "build error"),
+            MutationResult::Uncovered => write!(f, "uncovered"),
         }
     }
 }
@@ -152,6 +158,25 @@ pub struct MutationReport {
     pub survived: usize,
     pub timeout: usize,
     pub build_errors: usize,
+}
+
+impl MutationReport {
+    /// Mutants classified as [`MutationResult::Uncovered`] (zero-coverage
+    /// lines). Derived from `results` so it can never drift out of sync.
+    pub fn uncovered_count(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::Uncovered)
+            .count()
+    }
+
+    /// Mutants actually executed against the test suite: everything except
+    /// build errors and coverage-suppressed (uncovered) mutants.
+    pub fn tested_count(&self) -> usize {
+        self.total
+            .saturating_sub(self.build_errors)
+            .saturating_sub(self.uncovered_count())
+    }
 }
 
 /// Timing captured from the unmutated baseline run used for timeout calibration.
@@ -387,6 +412,7 @@ mod tests {
         assert_eq!(MutationResult::Survived.to_string(), "survived");
         assert_eq!(MutationResult::Timeout.to_string(), "timeout");
         assert_eq!(MutationResult::BuildError.to_string(), "build error");
+        assert_eq!(MutationResult::Uncovered.to_string(), "uncovered");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,11 @@ fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
             println!("Why it was not testable:");
             println!("  The mutation made the project fail its build check.");
         }
+        "uncovered" => {
+            println!("Why it was not executed:");
+            println!("  Coverage data shows this line is never executed by the test suite.");
+            println!("  Add a test that reaches this line to make the mutant meaningful.");
+        }
         other => {
             println!("Result: {other}");
         }
@@ -290,16 +295,19 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     }
 
     let mutations = generate_mutations(&changed_files, &config, &project_root)?;
-    let mut mutations =
+    let mut classified =
         filter_mutations(mutations, &config, &project_root, coverage_stats.as_ref())?;
 
     if let Some((k, n)) = shard {
-        let total = mutations.len();
-        mutations.retain(|m| m.id as usize % n == k - 1);
-        eprintln!("Shard {k}/{n}: {} of {total} mutations", mutations.len());
+        let total = classified.to_run.len();
+        classified.to_run.retain(|m| m.id as usize % n == k - 1);
+        eprintln!(
+            "Shard {k}/{n}: {} of {total} mutations",
+            classified.to_run.len()
+        );
     }
 
-    if mutations.is_empty() {
+    if classified.to_run.is_empty() && classified.uncovered.is_empty() {
         println!("No mutations generated. Possible causes:");
         println!("  - Changed files are in an unsupported language");
         println!("  - All mutable nodes were filtered out (test files, noisy patterns)");
@@ -308,11 +316,11 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     }
 
     if dry_run {
-        print_dry_run(&mutations);
+        print_dry_run(&classified.to_run);
         return Ok(());
     }
 
-    let baseline_timing = if config.test.calibrate_timeout {
+    let baseline_timing = if config.test.calibrate_timeout && !classified.to_run.is_empty() {
         eprintln!("Measuring baseline test runtime...");
         let measurement = togi::runner::measure_baseline_timing(
             &project_root,
@@ -351,31 +359,35 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         None
     };
 
-    eprintln!("Running {} mutations...", mutations.len());
-
     let project_root_ref = project_root.clone();
-    let outcome = execute(
-        mutations,
-        config,
-        project_root,
-        ExecuteOptions {
-            verbose,
-            show_output,
-            build_command_explicit: has_explicit_build_cmd,
-            force_default_command: has_custom_test_cmd,
-            force_default_timeout: has_cli_timeout,
-            early_stop,
-            env: profile_env,
-            force_rerun,
-            cancelled,
-        },
-    );
-
-    let mut report = outcome.report;
+    let (mut report, run_cancelled) = if classified.to_run.is_empty() {
+        // Every generated mutant sits on a zero-coverage line: nothing to run.
+        (coverage_only_report(&config, has_explicit_build_cmd), false)
+    } else {
+        eprintln!("Running {} mutations...", classified.to_run.len());
+        let outcome = execute(
+            classified.to_run,
+            config,
+            project_root,
+            ExecuteOptions {
+                verbose,
+                show_output,
+                build_command_explicit: has_explicit_build_cmd,
+                force_default_command: has_custom_test_cmd,
+                force_default_timeout: has_cli_timeout,
+                early_stop,
+                env: profile_env,
+                force_rerun,
+                cancelled,
+            },
+        );
+        (outcome.report, outcome.cancelled)
+    };
     report.baseline_timing = baseline_timing;
+    merge_uncovered(&mut report, classified.uncovered);
     togi::report::print_report(&report, output_format)?;
 
-    if outcome.cancelled {
+    if run_cancelled {
         eprintln!("Interrupted; skipping baseline and PR comment updates.");
         exit_with(_lock, 130);
     }
@@ -1017,24 +1029,22 @@ fn generate_mutations(
     )
 }
 
+/// Mutations partitioned for the run: `to_run` executes against the test
+/// suite; `uncovered` sits on lines with known zero coverage and is reported
+/// as `uncovered` without being executed.
+struct ClassifiedMutations {
+    to_run: Vec<Mutation>,
+    uncovered: Vec<Mutation>,
+}
+
 fn filter_mutations(
     mutations: Vec<Mutation>,
     config: &togi::config::Config,
     project_root: &Path,
     coverage_stats: Option<&togi::coverage::CoverageStats>,
-) -> anyhow::Result<Vec<Mutation>> {
-    let mut mutations = if let Some(coverage) = coverage_stats {
-        let before = mutations.len();
-        let filtered =
-            togi::coverage::filter_by_coverage(mutations, &coverage.covered_lines, project_root);
-        if before > filtered.len() {
-            eprintln!(
-                "Coverage filter: {} of {} mutations on covered lines",
-                filtered.len(),
-                before
-            );
-        }
-        filtered
+) -> anyhow::Result<ClassifiedMutations> {
+    let mut classified = if let Some(coverage) = coverage_stats {
+        split_by_coverage(mutations, coverage, project_root)
     } else if let Some(ref cov_path) = config.mutations.coverage_file {
         let resolved_cov_path = if std::path::Path::new(cov_path).is_relative() {
             project_root.join(cov_path)
@@ -1043,39 +1053,106 @@ fn filter_mutations(
         };
         match std::fs::read_to_string(&resolved_cov_path) {
             Ok(cov_content) => {
-                let coverage = togi::coverage::parse_lcov(&cov_content, project_root);
-                let before = mutations.len();
-                let filtered =
-                    togi::coverage::filter_by_coverage(mutations, &coverage, project_root);
-                if before > filtered.len() {
-                    eprintln!(
-                        "Coverage filter: {} of {} mutations on covered lines",
-                        filtered.len(),
-                        before
-                    );
-                }
-                filtered
+                let coverage = togi::coverage::parse_lcov_stats(&cov_content, project_root);
+                split_by_coverage(mutations, &coverage, project_root)
             }
             Err(e) => {
                 eprintln!(
                     "warning: could not read coverage file {}: {e} — running all mutations",
                     resolved_cov_path.display()
                 );
-                mutations
+                ClassifiedMutations {
+                    to_run: mutations,
+                    uncovered: Vec::new(),
+                }
             }
         }
     } else {
-        mutations
+        ClassifiedMutations {
+            to_run: mutations,
+            uncovered: Vec::new(),
+        }
     };
-    if config.mutations.max_per_run > 0 && mutations.len() > config.mutations.max_per_run {
+    if config.mutations.max_per_run > 0 && classified.to_run.len() > config.mutations.max_per_run {
         eprintln!(
             "warning: mutation count capped at max_per_run ({}). Increase in togi.toml or use --dry-run to preview.",
             config.mutations.max_per_run
         );
-        mutations.truncate(config.mutations.max_per_run);
+        classified.to_run.truncate(config.mutations.max_per_run);
     }
 
-    Ok(mutations)
+    Ok(classified)
+}
+
+fn split_by_coverage(
+    mutations: Vec<Mutation>,
+    coverage: &togi::coverage::CoverageStats,
+    project_root: &Path,
+) -> ClassifiedMutations {
+    let before = mutations.len();
+    let classified = togi::coverage::classify_by_coverage(mutations, coverage, project_root);
+    let covered = classified.covered.len();
+    if covered < before {
+        eprintln!("Coverage: {covered} of {before} mutations on covered lines");
+        let uncovered = classified.uncovered.len();
+        if uncovered > 0 {
+            eprintln!(
+                "Coverage: {uncovered} mutant{} on zero-coverage lines will be reported as uncovered (not executed)",
+                if uncovered == 1 { "" } else { "s" }
+            );
+        }
+    }
+    ClassifiedMutations {
+        to_run: classified.covered,
+        uncovered: classified.uncovered,
+    }
+}
+
+/// Merge coverage-suppressed mutants into the report as `Uncovered`.
+///
+/// They count toward `total`/`planned_total` (they were part of the scheduled
+/// work) but stay out of the tested denominator; see
+/// `MutationReport::tested_count`.
+fn merge_uncovered(report: &mut togi::MutationReport, uncovered: Vec<Mutation>) {
+    let n = uncovered.len();
+    if n == 0 {
+        return;
+    }
+    report.results.extend(
+        uncovered
+            .into_iter()
+            .map(|m| (m, togi::MutationResult::Uncovered)),
+    );
+    report.total += n;
+    report.planned_total += n;
+}
+
+/// Build an empty execution report for runs where every generated mutant was
+/// coverage-suppressed and nothing had to be executed.
+fn coverage_only_report(
+    config: &togi::config::Config,
+    build_command_explicit: bool,
+) -> togi::MutationReport {
+    togi::MutationReport {
+        results: Vec::new(),
+        build_error_diagnostics: Vec::new(),
+        schemata: None,
+        baseline_timing: None,
+        duration: Duration::ZERO,
+        test_command: Some(config.test.command.clone()),
+        build_command: if build_command_explicit {
+            config.test.build_command.clone()
+        } else {
+            Vec::new()
+        },
+        planned_total: 0,
+        early_stop_reason: None,
+        total: 0,
+        killed: 0,
+        survived: 0,
+        timeout: 0,
+        build_errors: 0,
+    }
 }
 
 fn print_dry_run(mutations: &[Mutation]) {

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -43,10 +43,16 @@ pub fn print_report(report: &MutationReport) {
         println!("{line}");
     }
 
-    let tested = report.total.saturating_sub(report.build_errors);
+    let tested = report.tested_count();
     let score = super::mutation_score(report);
+    let uncovered = report.uncovered_count();
+    let uncovered_str = if uncovered > 0 {
+        format!(", {uncovered} uncovered")
+    } else {
+        String::new()
+    };
     eprintln!(
-        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors)",
+        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors{uncovered_str})",
         score, report.killed, report.survived, report.timeout, report.build_errors
     );
     if report.total < report.planned_total {
@@ -156,6 +162,15 @@ mod tests {
         assert!(lines[0].contains("file=src/b.rs"));
         assert!(lines[0].contains("op_b"));
         assert!(lines[0].contains("survived one"));
+    }
+
+    #[test]
+    fn uncovered_mutations_emit_no_annotations() {
+        let report = report_with(vec![(
+            mutation("src/dead.rs", 7, "op", "desc"),
+            MutationResult::Uncovered,
+        )]);
+        assert!(annotations(&report).is_empty());
     }
 
     #[test]

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -6,16 +6,17 @@ use std::fmt::Write;
 struct FileStats {
     total: usize,
     build_errors: usize,
+    uncovered: usize,
     killed: usize,
     mutations: Vec<MutationEntry>,
 }
 
 impl FileStats {
     fn score_pct(&self) -> f64 {
-        let tested = self.total.saturating_sub(self.build_errors);
+        let tested = self.tested();
         if tested > 0 {
             (self.killed as f64 / tested as f64) * 100.0
-        } else if self.total == 0 {
+        } else if self.total == self.uncovered {
             100.0
         } else {
             0.0
@@ -23,7 +24,9 @@ impl FileStats {
     }
 
     fn tested(&self) -> usize {
-        self.total.saturating_sub(self.build_errors)
+        self.total
+            .saturating_sub(self.build_errors)
+            .saturating_sub(self.uncovered)
     }
 }
 
@@ -46,13 +49,16 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             MutationResult::Survived => "survived",
             MutationResult::Timeout => "timeout",
             MutationResult::BuildError => "build_error",
+            MutationResult::Uncovered => "uncovered",
         };
         let killed = matches!(result, MutationResult::Killed);
         let build_error = matches!(result, MutationResult::BuildError);
+        let uncovered = matches!(result, MutationResult::Uncovered);
 
         let stats = files.entry(file_path).or_insert(FileStats {
             total: 0,
             build_errors: 0,
+            uncovered: 0,
             killed: 0,
             mutations: Vec::new(),
         });
@@ -62,6 +68,9 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         }
         if build_error {
             stats.build_errors += 1;
+        }
+        if uncovered {
+            stats.uncovered += 1;
         }
         stats.mutations.push(MutationEntry {
             line: mutation.line,
@@ -73,8 +82,14 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         });
     }
 
-    let tested = report.total.saturating_sub(report.build_errors);
+    let tested = report.tested_count();
     let score_pct = super::mutation_score(report);
+    let uncovered = report.uncovered_count();
+    let uncovered_str = if uncovered > 0 {
+        format!(", {uncovered} uncovered")
+    } else {
+        String::new()
+    };
 
     let mut html = String::new();
     write!(
@@ -94,7 +109,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     write!(
         html,
         "<div class=\"summary\"><span class=\"score\">{:.1}%</span> mutation score \
-         &mdash; {}/{} killed, {} survived, {} timeout, {} build errors \
+         &mdash; {}/{} killed, {} survived, {} timeout, {} build errors{} \
          &mdash; {:.2}s</div>",
         score_pct,
         report.killed,
@@ -102,6 +117,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         report.survived,
         report.timeout,
         report.build_errors,
+        uncovered_str,
         report.duration.as_secs_f64()
     )?;
     if report.total < report.planned_total {
@@ -225,6 +241,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
                 "killed" => "result-killed",
                 "survived" => "result-survived",
                 "timeout" => "result-timeout",
+                "uncovered" => "result-uncovered",
                 _ => "result-build-error",
             };
             write!(
@@ -310,6 +327,7 @@ code{font-family:'SF Mono',Menlo,monospace;font-size:.82rem}
 .orig{color:#e94560;text-decoration:line-through}
 .repl{color:#53d769}
 .result-killed{opacity:.6}
+.result-uncovered{opacity:.6}
 .result-survived{background:rgba(233,69,96,.08)}
 .result-timeout{background:rgba(255,200,50,.06)}
 .result-build-error{background:rgba(255,200,50,.06)}
@@ -348,6 +366,35 @@ mod tests {
         assert!(html.contains("changed &lt; to &lt;="));
         assert!(html.contains("killed"));
         assert!(html.contains("survived"));
+    }
+
+    #[test]
+    fn html_lists_uncovered_mutants_and_excludes_them_from_score() {
+        let mut report = sample_report();
+        report.results.push((
+            Mutation {
+                id: 2,
+                file: PathBuf::from("src/dead.rs"),
+                language: String::new(),
+                line: 3,
+                column: 1,
+                operator: "op".to_string(),
+                description: "d".to_string(),
+                original: "x".to_string(),
+                replacement: "y".to_string(),
+                byte_range: 0..1,
+            },
+            MutationResult::Uncovered,
+        ));
+        report.total = 3;
+        report.planned_total = 3;
+
+        let html = generate_report(&report).unwrap();
+        assert!(html.contains("uncovered"));
+        assert!(html.contains("result-uncovered"));
+        assert!(html.contains(", 1 uncovered"));
+        // 1 killed of 2 tested (killed + survived) → 50%.
+        assert!(html.contains("50.0%"));
     }
 
     #[test]

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -12,6 +12,8 @@ struct JsonReport {
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    uncovered: usize,
     partial: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     early_stop_reason: Option<String>,
@@ -125,6 +127,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
                 MutationResult::Survived => "survived".to_string(),
                 MutationResult::Timeout => "timeout".to_string(),
                 MutationResult::BuildError => "build_error".to_string(),
+                MutationResult::Uncovered => "uncovered".to_string(),
             },
             column: Some(m.column),
             original: Some(m.original.clone()),
@@ -166,7 +169,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         })
         .collect();
 
-    let tested = report.total.saturating_sub(report.build_errors);
+    let tested = report.tested_count();
     let json_report = JsonReport {
         total: report.total,
         planned_total: report.planned_total,
@@ -175,6 +178,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         survived: report.survived,
         timeout: report.timeout,
         build_errors: report.build_errors,
+        uncovered: report.uncovered_count(),
         partial: report.total < report.planned_total,
         early_stop_reason: report.early_stop_reason.clone(),
         mutation_score: super::mutation_score(report),
@@ -228,6 +232,47 @@ mod tests {
         actual.sort_unstable();
         expected.sort_unstable();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn json_output_lists_uncovered_mutants() {
+        let mut report = sample_report();
+        report.results.push((
+            Mutation {
+                id: 2,
+                file: PathBuf::from("src/dead.rs"),
+                language: String::new(),
+                line: 3,
+                column: 1,
+                operator: "op".to_string(),
+                description: "d".to_string(),
+                original: "x".to_string(),
+                replacement: "y".to_string(),
+                byte_range: 0..1,
+            },
+            MutationResult::Uncovered,
+        ));
+        report.total = 3;
+        report.planned_total = 3;
+
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(value["uncovered"], 1);
+        // Uncovered mutants are excluded from the tested denominator:
+        // 1 killed of 2 tested (killed + survived) → 50%.
+        assert_eq!(value["tested"], 2);
+        assert_eq!(value["mutation_score"], 50.0);
+        let mutations = value["mutations"].as_array().unwrap();
+        assert_eq!(mutations[2]["result"], "uncovered");
+    }
+
+    #[test]
+    fn json_output_omits_uncovered_key_when_zero() {
+        let report = sample_report();
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(value.get("uncovered").is_none());
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,12 +10,15 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
 
-/// Compute mutation score as a percentage, excluding build errors from the denominator.
+/// Compute mutation score as a percentage, excluding build errors and
+/// coverage-suppressed (uncovered) mutants from the denominator.
 pub fn mutation_score(report: &MutationReport) -> f64 {
-    let tested = report.total.saturating_sub(report.build_errors);
+    let tested = report.tested_count();
     if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == 0 {
+    } else if report.total == report.uncovered_count() {
+        // Nothing was executed: either the report is empty or every mutant
+        // sat on a zero-coverage line. Vacuous pass, same as an empty report.
         100.0
     } else {
         0.0
@@ -164,6 +167,12 @@ fn label_or_unknown(value: &str) -> String {
     }
 }
 
+/// serde `skip_serializing_if` helper: omit zero counts so reports without
+/// coverage-suppressed mutants keep their previous shape byte-for-byte.
+pub(crate) fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
 pub fn print_report(
     report: &crate::MutationReport,
     format: crate::cli::OutputFormat,
@@ -212,7 +221,8 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
     use std::fmt::Write;
 
     let score = mutation_score(report);
-    let tested = report.total.saturating_sub(report.build_errors);
+    let tested = report.tested_count();
+    let uncovered = report.uncovered_count();
     let emoji = if report.survived == 0 && report.timeout == 0 && report.build_errors == 0 {
         "✓"
     } else if score >= 80.0 {
@@ -232,9 +242,14 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
     } else {
         String::new()
     };
+    let uncovered_str = if uncovered > 0 {
+        format!(", {uncovered} uncovered")
+    } else {
+        String::new()
+    };
     writeln!(
         md,
-        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors — {:.2}s",
+        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors{uncovered_str} — {:.2}s",
         report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
     ).unwrap();
     if report.total < report.planned_total {
@@ -762,5 +777,71 @@ mod tests {
         let md = format_pr_comment(&report, Some(40.0));
         assert!(md.contains("vs baseline"), "should include baseline delta");
         assert!(md.contains("+10.0%"), "50% - 40% = +10%");
+    }
+
+    fn uncovered_report(results: Vec<(Mutation, MutationResult)>) -> MutationReport {
+        let total = results.len();
+        let killed = results
+            .iter()
+            .filter(|(_, r)| *r == MutationResult::Killed)
+            .count();
+        MutationReport {
+            results,
+            build_error_diagnostics: vec![],
+            schemata: None,
+            baseline_timing: None,
+            duration: std::time::Duration::from_secs(1),
+            test_command: None,
+            build_command: vec![],
+            planned_total: total,
+            early_stop_reason: None,
+            total,
+            killed,
+            survived: 0,
+            timeout: 0,
+            build_errors: 0,
+        }
+    }
+
+    #[test]
+    fn mutation_score_excludes_uncovered_mutants() {
+        // 1 of 1 executed mutants killed + 2 uncovered → 100%, not 33%.
+        let report = uncovered_report(vec![
+            report_mutation(0, "src/a.rs", MutationResult::Killed),
+            report_mutation(1, "src/b.rs", MutationResult::Uncovered),
+            report_mutation(2, "src/c.rs", MutationResult::Uncovered),
+        ]);
+        assert_eq!(report.uncovered_count(), 2);
+        assert_eq!(report.tested_count(), 1);
+        assert_eq!(mutation_score(&report), 100.0);
+    }
+
+    #[test]
+    fn mutation_score_is_100_when_all_mutants_uncovered() {
+        let report = uncovered_report(vec![
+            report_mutation(0, "src/a.rs", MutationResult::Uncovered),
+            report_mutation(1, "src/b.rs", MutationResult::Uncovered),
+        ]);
+        assert_eq!(report.tested_count(), 0);
+        assert_eq!(mutation_score(&report), 100.0);
+    }
+
+    #[test]
+    fn pr_comment_includes_uncovered_count_when_present() {
+        let report = uncovered_report(vec![
+            report_mutation(0, "src/a.rs", MutationResult::Killed),
+            report_mutation(1, "src/b.rs", MutationResult::Uncovered),
+        ]);
+        let md = format_pr_comment(&report, None);
+        assert!(md.contains("1 uncovered"), "got: {md}");
+        // Uncovered mutants are not failures and do not block the checkmark.
+        assert!(md.contains("✓"), "got: {md}");
+    }
+
+    #[test]
+    fn pr_comment_omits_uncovered_count_when_zero() {
+        let report = crate::test_helpers::sample_report();
+        let md = format_pr_comment(&report, None);
+        assert!(!md.contains("uncovered"), "got: {md}");
     }
 }

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -61,6 +61,8 @@ struct SarifInvocationProperties {
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    uncovered: usize,
     mutation_score: f64,
 }
 
@@ -150,8 +152,10 @@ pub fn print_report(report: &MutationReport) -> Result<()> {
 
 /// Serialize report to a SARIF 2.1.0 string (for testing and programmatic use).
 ///
-/// Emits one result per surviving mutant; killed, timeout, and build-error
-/// mutants are not findings and only appear in the invocation totals.
+/// Emits one result per surviving mutant; killed, timeout, build-error, and
+/// uncovered mutants are not findings. Uncovered mutants are deliberately not
+/// code-scanning results (a zero-coverage line is not an actionable surviving
+/// mutant); they only appear in the invocation totals.
 pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
     let registry = registry_descriptions();
     let surviving: Vec<&Mutation> = report
@@ -195,6 +199,7 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
                     survived: report.survived,
                     timeout: report.timeout,
                     build_errors: report.build_errors,
+                    uncovered: report.uncovered_count(),
                     mutation_score: super::mutation_score(report),
                 },
             }],
@@ -390,6 +395,34 @@ mod tests {
         assert_eq!(run["results"], serde_json::json!([]));
         assert_eq!(run["tool"]["driver"]["rules"], serde_json::json!([]));
         assert_eq!(run["invocations"][0]["properties"]["mutation_score"], 100.0);
+    }
+
+    #[test]
+    fn sarif_uncovered_mutants_produce_no_results_but_appear_in_totals() {
+        let report = report_with(vec![
+            (
+                mutation(0, "src/a.rs", 1, "op_a", "covered and killed"),
+                MutationResult::Killed,
+            ),
+            (
+                mutation(1, "src/dead.rs", 9, "op_b", "zero coverage"),
+                MutationResult::Uncovered,
+            ),
+        ]);
+        let value = parse(&report);
+        // Uncovered mutants are not code-scanning findings.
+        assert_eq!(value["runs"][0]["results"], serde_json::json!([]));
+        let properties = &value["runs"][0]["invocations"][0]["properties"];
+        assert_eq!(properties["uncovered"], 1);
+        // Score excludes uncovered mutants: 1 killed of 1 tested → 100%.
+        assert_eq!(properties["mutation_score"], 100.0);
+    }
+
+    #[test]
+    fn sarif_omits_uncovered_property_when_zero() {
+        let value = parse(&sample_report());
+        let properties = &value["runs"][0]["invocations"][0]["properties"];
+        assert!(properties.get("uncovered").is_none());
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -54,6 +54,20 @@ fn format_report(report: &MutationReport, color: bool) -> String {
             }
             MutationResult::Timeout => ("⏱ TIMEOUT", None),
             MutationResult::BuildError => ("⚠ BUILD ERROR", None),
+            MutationResult::Uncovered => {
+                let mut detail = String::new();
+                writeln!(
+                    detail,
+                    "              {}",
+                    if color {
+                        dim("Line has zero test coverage; mutant not executed.")
+                    } else {
+                        "Line has zero test coverage; mutant not executed.".to_string()
+                    }
+                )
+                .unwrap();
+                ("○ UNCOVERED", Some(detail))
+            }
         };
 
         if color {
@@ -61,6 +75,7 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                 MutationResult::Killed => green(tag),
                 MutationResult::Survived => red(tag),
                 MutationResult::Timeout | MutationResult::BuildError => yellow(tag),
+                MutationResult::Uncovered => dim(tag),
             };
             writeln!(
                 out,
@@ -89,9 +104,15 @@ fn format_report(report: &MutationReport, color: bool) -> String {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     writeln!(out, "{separator}").unwrap();
+    let uncovered = report.uncovered_count();
+    let uncovered_str = if uncovered > 0 {
+        format!(", {uncovered} uncovered")
+    } else {
+        String::new()
+    };
     writeln!(
         out,
-        "Results: {} killed, {} survived, {} timeout, {} build errors",
+        "Results: {} killed, {} survived, {} timeout, {} build errors{uncovered_str}",
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
@@ -439,6 +460,36 @@ mod tests {
         ]);
         let output = format_report_plain(&report);
         assert!(!output.contains("All mutations caused build errors"));
+    }
+
+    #[test]
+    fn terminal_output_lists_uncovered_mutants_distinctly() {
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Uncovered),
+        ]);
+        let output = format_report_plain(&report);
+        assert!(
+            output
+                .lines()
+                .any(|line| line.contains("UNCOVERED") && line.contains("src/b.rs:2")),
+            "got: {output}"
+        );
+        assert!(output.contains("Line has zero test coverage; mutant not executed."));
+        assert!(
+            output
+                .contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 uncovered")
+        );
+        // Uncovered mutants are excluded from the tested denominator.
+        assert!(output.contains("Mutation score (test kills only): 100.0%"));
+    }
+
+    #[test]
+    fn terminal_output_omits_uncovered_count_when_zero() {
+        let report = report(vec![(mutation(1, "src/a.rs", 1), MutationResult::Killed)]);
+        let output = format_report_plain(&report);
+        assert!(output.contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors\n"));
+        assert!(!output.contains("uncovered"));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1216,7 +1216,7 @@ fn measure_baseline_command(
     }
 
     match outcome.result {
-        MutationResult::Survived => Ok(duration),
+        MutationResult::Survived | MutationResult::Uncovered => Ok(duration),
         MutationResult::Killed => {
             let output = baseline_failure_output(outcome.test_output.as_deref());
             bail!(
@@ -1826,7 +1826,7 @@ impl EarlyStopState {
         match result {
             MutationResult::Killed => counts.killed += 1,
             MutationResult::Survived => counts.survived += 1,
-            MutationResult::Timeout => {}
+            MutationResult::Timeout | MutationResult::Uncovered => {}
             MutationResult::BuildError => counts.build_errors += 1,
         }
 
@@ -2252,6 +2252,7 @@ fn record_progress(
                 MutationResult::Survived => "\u{2717} survived",
                 MutationResult::Timeout => "⧖ timeout",
                 MutationResult::BuildError => "⚠ build error",
+                MutationResult::Uncovered => "◌ uncovered",
             };
             eprintln!(
                 "  [{}/{}] {}  {}:{} \u{2014} {}",
@@ -2766,6 +2767,7 @@ impl TestRunner {
                     MutationResult::Survived => "✗ survived",
                     MutationResult::Timeout => "⧖ timeout",
                     MutationResult::BuildError => "⚠ build error",
+                    MutationResult::Uncovered => "◌ uncovered",
                 };
                 eprintln!(
                     "  [schema] {}  {}:{} — {}",
@@ -2849,6 +2851,9 @@ impl TestRunner {
                 MutationResult::Survived => survived += 1,
                 MutationResult::Timeout => timeout_count += 1,
                 MutationResult::BuildError => build_errors += 1,
+                // Uncovered mutants never reach the runner; they are merged
+                // into the report by the caller and derived from `results`.
+                MutationResult::Uncovered => {}
             }
             if let Some(diagnostic) = record.build_error_diagnostic {
                 build_error_diagnostics.push(diagnostic);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -136,6 +136,137 @@ fn check_dry_run_lists_mutations() {
         .stdout(predicate::str::contains("mutations would be generated"));
 }
 
+/// Extend the fixture so mutants land on two lines: line 4 (the added `if`)
+/// and line 7 (`return a - b`).
+fn setup_two_line_mutation_repo() -> TempDir {
+    let dir = setup_git_repo();
+    fs::write(
+        dir.path().join("main.go"),
+        "package main\n\nfunc add(a, b int) int {\n\tif a > b {\n\t\treturn a\n\t}\n\treturn a - b\n}\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn check_classifies_zero_coverage_mutants_as_uncovered() {
+    let dir = setup_two_line_mutation_repo();
+    // Line 4 covered; line 7 tracked but never executed.
+    fs::write(
+        dir.path().join("lcov.info"),
+        "SF:main.go\nDA:4,1\nDA:7,0\nend_of_record\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "false",
+            "--coverage-file",
+            "lcov.info",
+            "--fail-under",
+            "100",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // `false` kills every executed mutant. The zero-coverage mutant must not
+    // count as a survivor, so the run passes even with --fail-under 100.
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("reported as uncovered"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["killed"], 3);
+    assert_eq!(value["survived"], 0);
+    assert_eq!(value["uncovered"], 1);
+    assert_eq!(value["mutation_score"], 100.0);
+
+    let mutations = value["mutations"].as_array().unwrap();
+    let uncovered: Vec<_> = mutations
+        .iter()
+        .filter(|m| m["result"] == "uncovered")
+        .collect();
+    assert_eq!(uncovered.len(), 1);
+    assert_eq!(uncovered[0]["line"], 7);
+    assert_eq!(uncovered[0]["file"], "main.go");
+}
+
+#[test]
+fn check_all_mutants_uncovered_skips_execution() {
+    let dir = setup_two_line_mutation_repo();
+    // Both mutated lines have zero coverage: nothing should execute.
+    fs::write(
+        dir.path().join("lcov.info"),
+        "SF:main.go\nDA:4,0\nDA:7,0\nend_of_record\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "false",
+            "--coverage-file",
+            "lcov.info",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("Running"),
+        "no mutations should execute: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["total"], 4);
+    assert_eq!(value["killed"], 0);
+    assert_eq!(value["survived"], 0);
+    assert_eq!(value["uncovered"], 4);
+    assert_eq!(value["mutation_score"], 100.0);
+    assert!(
+        value["mutations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["result"] == "uncovered")
+    );
+}
+
 #[test]
 fn check_warns_when_fail_fast_is_ignored_for_custom_test_cmd() {
     let dir = setup_git_repo();

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -90,7 +90,9 @@ max_per_file = 20
 # Default: true
 schemata = true
 
-# Optional LCOV file. When set, togi only keeps mutations on covered lines.
+# Optional LCOV file. When set, togi runs only mutations on covered lines;
+# mutations on lines with known zero coverage are reported as "uncovered"
+# (not executed, not counted as survivors).
 # Type: string path
 # Default: unset
 coverage_file = "coverage/lcov.info"


### PR DESCRIPTION
Fixes #417

## Summary

A mutant on a line the test suite never executes is guaranteed to survive and carries zero signal. Previously, when coverage data was available (`--coverage-file`, `--coverage-cmd`, or `--coverage auto`), such mutants were silently dropped by the coverage filter — invisible in reports.

This PR gives them a distinct verdict: **`uncovered`**. Zero-coverage mutants are no longer executed (they cannot fail), are listed distinctly in reports so the coverage gap stays visible, and no longer inflate the survivor count or any gating derived from it.

## Design decisions

- **New `MutationResult::Uncovered` variant** rather than a parallel classification field. It is the less invasive option: `survived` semantics are untouched for every existing consumer (report filters match on `Survived` explicitly, so uncovered mutants naturally fall out of survivor lists), the verdict travels through the existing `results` pipeline into every report format, and serde serialization for caches gains one self-describing string. The runner never produces it — uncovered mutants are classified before execution in `main.rs` and merged into the report afterwards.
- **Conservative classification** (`coverage::classify_by_coverage`): a mutant is `uncovered` only when its file is present in the coverage data **and** its line is tracked with zero executions (uses `total_lines` vs `covered_lines` from `parse_lcov_stats`). Files or lines missing from coverage data keep the exact previous behavior (filtered out, with the same per-file warning). This also fixes a subtle old behavior where a file with *only* zero-coverage lines was treated as "missing from coverage data".
- **Score formula**: `mutation_score = killed / tested` where `tested = total - build_errors - uncovered` (previously `total - build_errors`). The formula is centralized in `MutationReport::tested_count()` and `uncovered_count()` (derived from `results`, so counts can never drift). `--fail-under`, early-stop projections, baselines, and the `survived > 0` exit gate all consume these and therefore exclude uncovered mutants automatically. When nothing was executed (empty run or every mutant uncovered), the score is a vacuous 100%, matching the existing empty-report behavior.
- **Uncovered mutants count toward `total`/`planned_total`** so `total == results.len()` stays invariant and partial-report detection is unchanged; they stay out of the tested denominator.
- **SARIF**: uncovered mutants are deliberately **not** emitted as code-scanning results — a zero-coverage line is not an actionable surviving mutant, and flagging it as a `warning` finding would recreate the noise this PR removes. They appear only in the invocation totals (`uncovered` property, omitted when zero).
- **No new config knob**: classification only activates when coverage data is present, which is already opt-in. Without coverage data, behavior is unchanged, so an opt-out flag would be dead weight. The coverage gates remain the way to *fail* on weak coverage.
- **Interaction with the gates** (documented in README): `--min-line-coverage` / `--min-diff-coverage` / `--fail-on-uncovered-diff` run before mutation generation and fail the whole run on under-covered diffs; `uncovered` classification keeps individual zero-coverage mutants out of the survivor count when the gates let the run proceed.

## Report surfaces

- Terminal: `○ UNCOVERED` rows with a "zero test coverage" note; `Results:` line appends `, N uncovered` only when N > 0.
- JSON: per-mutation `result: "uncovered"`; top-level `uncovered` count omitted when zero (schema unchanged otherwise).
- GitHub format: no annotations for uncovered mutants; summary line appends the count when non-zero.
- HTML: muted `uncovered` rows, per-file scores exclude them, summary appends the count when non-zero.
- PR comment: summary appends `, N uncovered` when non-zero; uncovered mutants don't block the ✓.
- `togi explain` explains the new verdict.

## Behavior without coverage data

Unchanged, byte-for-byte: classification only runs when coverage stats resolve, the uncovered count is derived (always 0 without classification), and every new report field/segment is omitted when it is zero — including the JSON schema (the schema-stability test is unmodified).

## Test coverage

- Unit: `classify_by_coverage` (covered/zero-coverage split, missing file, untracked line, all-zero file) with LCOV fixtures; score formula and `tested_count`/`uncovered_count`; terminal, JSON, SARIF, GitHub, HTML, PR-comment rendering with and without uncovered mutants.
- Integration (`tests/cli.rs`): `togi check` over a fixture repo with an LCOV file where one of four mutants sits on a zero-coverage line — asserts it is reported `uncovered`, the other three execute, `--fail-under 100` passes (exit 0); and the all-uncovered case where execution is skipped entirely.
- `cargo test`, `cargo +stable clippy --locked --all-targets --all-features -- -D warnings`, and `cargo fmt -- --check` all pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutations on lines with known zero coverage are now reported as **uncovered** instead of **survived**.
  * Uncovered mutations are excluded from mutation-score calculations and survivor counts.
  * Reports now display uncovered counts across terminal, HTML, JSON, SARIF, GitHub, and PR comment formats.
  * Mutation runs skip uncovered mutations when all eligible lines lack coverage.

* **Documentation**
  * Expanded coverage-file guidance and configuration examples to explain uncovered classifications and coverage gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->