### PR TITLE
Learned mutant selection: opt-in subsumption skipping (#418)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ togi check --force-rerun
 # Disable structured incremental history for one run
 togi check --no-incremental-history
 
+# Skip mutants that share a recorded killer test with an earlier mutant
+# (learned subsumption clusters; opt-in, requires incremental history)
+togi check --learned-selection
+
 # Generate a config file
 togi init
 ```

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -23,8 +23,9 @@ pub struct Baseline {
 
 /// Build a baseline from a mutation report.
 ///
-/// Only executed mutants count: build errors and coverage-suppressed
-/// (uncovered) mutants are excluded from per-file and overall totals.
+/// Only executed mutants count: build errors, coverage-suppressed
+/// (uncovered), and learned-selection (subsumed) mutants are excluded from
+/// per-file and overall totals.
 pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Baseline {
     let mut files: HashMap<String, FileScore> = HashMap::new();
     for (mutation, result) in &report.results {
@@ -40,6 +41,7 @@ pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Basel
         });
         if *result != crate::MutationResult::BuildError
             && *result != crate::MutationResult::Uncovered
+            && *result != crate::MutationResult::Subsumed
         {
             entry.total += 1;
             if *result == crate::MutationResult::Killed {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -171,6 +171,33 @@ impl IncrementalHistoryStore {
             .cloned()
     }
 
+    /// Killer test from the latest `Killed` history entry for this mutation
+    /// whose source and command hashes still match the current run — the
+    /// evidence learned selection clusters on. Returns `None` when there is
+    /// no such entry, the verdict was not `Killed`, or no killer test was
+    /// recorded.
+    pub fn learned_killer_test(
+        &self,
+        mutation_identity: &str,
+        mutation_description: &str,
+        source_hash: u64,
+        command_hash: u64,
+    ) -> Option<String> {
+        let history = self.state.lock().ok()?;
+        history
+            .entries
+            .iter()
+            .rev()
+            .find(|entry| {
+                entry.mutation_identity == mutation_identity
+                    && entry.mutation_description == mutation_description
+                    && entry.source_hash == source_hash
+                    && entry.command_hash == command_hash
+                    && entry.result == MutationResult::Killed
+            })
+            .and_then(|entry| entry.killer_test.clone())
+    }
+
     pub fn record(&self, entry: IncrementalHistoryEntry) {
         let Ok(mut history) = self.state.lock() else {
             eprintln!("warning: incremental history mutex poisoned");
@@ -557,6 +584,78 @@ mod tests {
                 &["test_add".into(), "test_max".into()]
             ),
             Some("test_max".into())
+        );
+        Ok(())
+    }
+
+    fn killed_entry(killer_test: Option<&str>) -> IncrementalHistoryEntry {
+        IncrementalHistoryEntry {
+            mutation_identity: "src/lib.rs:0..1:op".into(),
+            mutation_description: "desc".into(),
+            result: MutationResult::Killed,
+            source_hash: 1,
+            command_hash: 2,
+            relevant_test_hash: 3,
+            covering_tests: vec!["test_add".into()],
+            killer_test: killer_test.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn learned_killer_test_matches_killed_entry_with_current_hashes() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        store.record(killed_entry(Some("test_add")));
+
+        let reloaded = IncrementalHistoryStore::load(tmp.path());
+        assert_eq!(
+            reloaded.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            Some("test_add".into())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn learned_killer_test_rejects_mismatched_hashes() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        store.record(killed_entry(Some("test_add")));
+
+        assert_eq!(
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 9, 2),
+            None
+        );
+        assert_eq!(
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 9),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn learned_killer_test_rejects_non_killed_verdict() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        let mut entry = killed_entry(Some("test_add"));
+        entry.result = MutationResult::Survived;
+        store.record(entry);
+
+        assert_eq!(
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn learned_killer_test_rejects_missing_killer() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = IncrementalHistoryStore::load(tmp.path());
+        store.record(killed_entry(None));
+
+        assert_eq!(
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            None
         );
         Ok(())
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -437,6 +437,7 @@ mod tests {
             MutationResult::Timeout,
             MutationResult::BuildError,
             MutationResult::Uncovered,
+            MutationResult::Subsumed,
         ]
         .iter()
         .enumerate()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,7 +137,7 @@ pub struct CheckArgs {
 
     /// Skip mutants that share a recorded killer test with an earlier mutant
     /// of the same run and file (learned subsumption clusters; requires
-    /// incremental history, ignored under --force-rerun)
+    /// incremental history)
     #[arg(long)]
     pub learned_selection: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,12 @@ pub struct CheckArgs {
     #[arg(long)]
     pub no_incremental_history: bool,
 
+    /// Skip mutants that share a recorded killer test with an earlier mutant
+    /// of the same run and file (learned subsumption clusters; requires
+    /// incremental history, ignored under --force-rerun)
+    #[arg(long)]
+    pub learned_selection: bool,
+
     /// Re-run mutations even when cache or history has a matching result
     #[arg(long)]
     pub force_rerun: bool,
@@ -276,6 +282,22 @@ mod tests {
                 assert!(args.no_incremental_history);
                 assert!(args.force_rerun);
             }
+            _ => panic!("expected Check command"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn learned_selection_is_opt_in() -> anyhow::Result<()> {
+        let default = Cli::try_parse_from(["togi", "check"])?;
+        match default.command {
+            Commands::Check(args) => assert!(!args.learned_selection),
+            _ => panic!("expected Check command"),
+        }
+
+        let enabled = Cli::try_parse_from(["togi", "check", "--learned-selection"])?;
+        match enabled.command {
+            Commands::Check(args) => assert!(args.learned_selection),
             _ => panic!("expected Check command"),
         }
         Ok(())

--- a/src/learned.rs
+++ b/src/learned.rs
@@ -1,0 +1,186 @@
+//! Learned mutant selection (`--learned-selection`).
+//!
+//! Mutants that always die to the same killer test are redundant: mutation
+//! subsumption theory says executing one member of such a cluster yields the
+//! same signal as executing all of them. Incremental history records the
+//! killer test per killed mutant, so a later run can cluster this run's
+//! mutants by shared killer test and skip the redundant members.
+//!
+//! Killer-test equality is only a conservative *proxy* for subsumption, so
+//! skipping is strictly opt-in and strictly evidence-based: a mutant is only
+//! ever skipped when history holds a `Killed` verdict with a recorded killer
+//! test whose source and command hashes still match the current run. Any
+//! doubt (no entry, stale hashes, non-killed verdict, no killer test) means
+//! the mutant executes normally.
+
+use crate::Mutation;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// How a run's mutations were partitioned by learned selection.
+#[derive(Debug, Default)]
+pub struct LearnedPartition {
+    /// Mutants to execute: every unclustered mutant plus the canonical
+    /// (first in run order) member of each cluster.
+    pub to_run: Vec<Mutation>,
+    /// Mutants classified as subsumed: non-canonical cluster members,
+    /// reported as [`crate::MutationResult::Subsumed`] without execution.
+    pub subsumed: Vec<Mutation>,
+    /// Number of clusters of size ≥ 2 — i.e. how many canonical mutants the
+    /// subsumed ones were folded into.
+    pub clusters: usize,
+}
+
+/// Partition `mutations` (in run order) into those to execute and those
+/// subsumed by a canonical cluster sibling.
+///
+/// `killer_for` returns the recorded killer test for a mutation when history
+/// holds a still-matching `Killed` entry for it, and `None` otherwise. Two
+/// mutations cluster when they are in the same file and share a killer test;
+/// the first cluster member in run order is canonical and executes.
+pub fn partition_subsumed(
+    mutations: Vec<Mutation>,
+    mut killer_for: impl FnMut(&Mutation) -> Option<String>,
+) -> LearnedPartition {
+    let mut cluster_sizes: HashMap<(PathBuf, String), usize> = HashMap::new();
+    let mut partition = LearnedPartition::default();
+
+    for mutation in mutations {
+        let key = killer_for(&mutation).map(|killer| (mutation.file.clone(), killer));
+        match key {
+            Some(key) => {
+                let size = cluster_sizes.entry(key).or_insert(0);
+                *size += 1;
+                if *size == 1 {
+                    // First member of the cluster: the canonical mutant.
+                    partition.to_run.push(mutation);
+                } else {
+                    partition.subsumed.push(mutation);
+                }
+            }
+            None => partition.to_run.push(mutation),
+        }
+    }
+
+    partition.clusters = cluster_sizes.values().filter(|size| **size >= 2).count();
+    partition
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mutation(id: u32, file: &str) -> Mutation {
+        Mutation {
+            id,
+            file: PathBuf::from(file),
+            language: String::new(),
+            line: id as usize,
+            column: 1,
+            operator: "op".into(),
+            description: format!("mutation {id}"),
+            original: "x".into(),
+            replacement: "y".into(),
+            byte_range: 0..1,
+        }
+    }
+
+    fn killer_map<'a>(
+        entries: &'a [(u32, &'a str)],
+    ) -> impl FnMut(&Mutation) -> Option<String> + 'a {
+        move |mutation| {
+            entries
+                .iter()
+                .find(|(id, _)| *id == mutation.id)
+                .map(|(_, killer)| killer.to_string())
+        }
+    }
+
+    #[test]
+    fn shared_killer_in_same_file_clusters_and_keeps_first_as_canonical() {
+        let partition = partition_subsumed(
+            vec![
+                mutation(1, "src/a.rs"),
+                mutation(2, "src/a.rs"),
+                mutation(3, "src/a.rs"),
+            ],
+            killer_map(&[(1, "test_add"), (2, "test_add"), (3, "test_add")]),
+        );
+
+        assert_eq!(
+            partition.to_run.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert_eq!(
+            partition.subsumed.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        assert_eq!(partition.clusters, 1);
+    }
+
+    #[test]
+    fn missing_killer_runs_normally() {
+        let partition = partition_subsumed(
+            vec![mutation(1, "src/a.rs"), mutation(2, "src/a.rs")],
+            killer_map(&[(1, "test_add")]),
+        );
+
+        assert_eq!(partition.to_run.len(), 2);
+        assert!(partition.subsumed.is_empty());
+        assert_eq!(partition.clusters, 0);
+    }
+
+    #[test]
+    fn different_killers_do_not_cluster() {
+        let partition = partition_subsumed(
+            vec![mutation(1, "src/a.rs"), mutation(2, "src/a.rs")],
+            killer_map(&[(1, "test_add"), (2, "test_sub")]),
+        );
+
+        assert_eq!(partition.to_run.len(), 2);
+        assert!(partition.subsumed.is_empty());
+        assert_eq!(partition.clusters, 0);
+    }
+
+    #[test]
+    fn shared_killer_across_files_does_not_cluster() {
+        let partition = partition_subsumed(
+            vec![mutation(1, "src/a.rs"), mutation(2, "src/b.rs")],
+            killer_map(&[(1, "test_add"), (2, "test_add")]),
+        );
+
+        assert_eq!(partition.to_run.len(), 2);
+        assert!(partition.subsumed.is_empty());
+        assert_eq!(partition.clusters, 0);
+    }
+
+    #[test]
+    fn independent_clusters_partition_in_run_order() {
+        let partition = partition_subsumed(
+            vec![
+                mutation(1, "src/a.rs"),
+                mutation(2, "src/a.rs"),
+                mutation(3, "src/a.rs"),
+                mutation(4, "src/a.rs"),
+                mutation(5, "src/a.rs"),
+            ],
+            killer_map(&[
+                (1, "test_add"),
+                (2, "test_sub"),
+                (3, "test_add"),
+                (4, "test_sub"),
+                (5, "test_mul"),
+            ]),
+        );
+
+        assert_eq!(
+            partition.to_run.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![1, 2, 5]
+        );
+        assert_eq!(
+            partition.subsumed.iter().map(|m| m.id).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+        assert_eq!(partition.clusters, 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod coverage;
 pub mod diff;
 pub mod languages;
+pub mod learned;
 pub mod lock;
 pub mod mapper;
 pub mod mutator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,12 @@ pub enum MutationResult {
     /// guaranteed survivors and carry no signal. Only produced when line
     /// coverage data is available for the mutated file and line.
     Uncovered,
+    /// The mutation shares a recorded killer test with an earlier mutant of
+    /// the same run and file (a learned subsumption cluster). It is not
+    /// executed: the canonical cluster member's verdict carries the signal.
+    /// Only produced when `--learned-selection` is enabled and incremental
+    /// history holds a matching `Killed` entry with a killer test.
+    Subsumed,
 }
 
 impl fmt::Display for MutationResult {
@@ -95,6 +101,7 @@ impl fmt::Display for MutationResult {
             MutationResult::Timeout => write!(f, "timeout"),
             MutationResult::BuildError => write!(f, "build error"),
             MutationResult::Uncovered => write!(f, "uncovered"),
+            MutationResult::Subsumed => write!(f, "subsumed"),
         }
     }
 }
@@ -170,12 +177,23 @@ impl MutationReport {
             .count()
     }
 
+    /// Mutants classified as [`MutationResult::Subsumed`] (learned selection).
+    /// Derived from `results` so it can never drift out of sync.
+    pub fn subsumed_count(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|(_, result)| *result == MutationResult::Subsumed)
+            .count()
+    }
+
     /// Mutants actually executed against the test suite: everything except
-    /// build errors and coverage-suppressed (uncovered) mutants.
+    /// build errors, coverage-suppressed (uncovered), and learned-selection
+    /// (subsumed) mutants.
     pub fn tested_count(&self) -> usize {
         self.total
             .saturating_sub(self.build_errors)
             .saturating_sub(self.uncovered_count())
+            .saturating_sub(self.subsumed_count())
     }
 }
 
@@ -413,6 +431,7 @@ mod tests {
         assert_eq!(MutationResult::Timeout.to_string(), "timeout");
         assert_eq!(MutationResult::BuildError.to_string(), "build error");
         assert_eq!(MutationResult::Uncovered.to_string(), "uncovered");
+        assert_eq!(MutationResult::Subsumed.to_string(), "subsumed");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ struct ExecuteOptions {
     early_stop: togi::runner::EarlyStopConfig,
     env: HashMap<String, String>,
     force_rerun: bool,
+    learned_selection: bool,
     cancelled: Arc<AtomicBool>,
 }
 
@@ -239,6 +240,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let check_baseline = cfg.check_baseline;
     let pr_comment = cfg.pr_comment.clone();
     let force_rerun = cfg.force_rerun;
+    let learned_selection = cfg.learned_selection;
 
     let resolved = resolve_config(cfg)?;
     let ResolvedCheckConfig {
@@ -385,6 +387,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
                 early_stop,
                 env: profile_env,
                 force_rerun,
+                learned_selection,
                 cancelled,
             },
         );
@@ -1249,6 +1252,7 @@ fn execute(
         env: options.env,
         incremental_history: config.mutations.incremental_history,
         force_rerun: options.force_rerun,
+        learned_selection: options.learned_selection,
         cancelled: options.cancelled,
     };
 
@@ -1666,6 +1670,7 @@ mod tests {
             fail_on_uncovered_diff: false,
             test_selection_file: None,
             no_incremental_history: false,
+            learned_selection: false,
             force_rerun: false,
             build_cmd: None,
             fail_fast: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,13 @@ fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
             println!("  Coverage data shows this line is never executed by the test suite.");
             println!("  Add a test that reaches this line to make the mutant meaningful.");
         }
+        "subsumed" => {
+            println!("Why it was not executed:");
+            println!(
+                "  Learned selection clustered it with an earlier mutant that shares its recorded killer test."
+            );
+            println!("  Re-run without --learned-selection to execute every mutant.");
+        }
         other => {
             println!("Result: {other}");
         }

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -51,8 +51,14 @@ pub fn print_report(report: &MutationReport) {
     } else {
         String::new()
     };
+    let subsumed = report.subsumed_count();
+    let subsumed_str = if subsumed > 0 {
+        format!(", {subsumed} subsumed")
+    } else {
+        String::new()
+    };
     eprintln!(
-        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors{uncovered_str})",
+        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str})",
         score, report.killed, report.survived, report.timeout, report.build_errors
     );
     if report.total < report.planned_total {

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -7,6 +7,7 @@ struct FileStats {
     total: usize,
     build_errors: usize,
     uncovered: usize,
+    subsumed: usize,
     killed: usize,
     mutations: Vec<MutationEntry>,
 }
@@ -16,7 +17,7 @@ impl FileStats {
         let tested = self.tested();
         if tested > 0 {
             (self.killed as f64 / tested as f64) * 100.0
-        } else if self.total == self.uncovered {
+        } else if self.total == self.uncovered + self.subsumed {
             100.0
         } else {
             0.0
@@ -27,6 +28,7 @@ impl FileStats {
         self.total
             .saturating_sub(self.build_errors)
             .saturating_sub(self.uncovered)
+            .saturating_sub(self.subsumed)
     }
 }
 
@@ -50,15 +52,18 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             MutationResult::Timeout => "timeout",
             MutationResult::BuildError => "build_error",
             MutationResult::Uncovered => "uncovered",
+            MutationResult::Subsumed => "subsumed",
         };
         let killed = matches!(result, MutationResult::Killed);
         let build_error = matches!(result, MutationResult::BuildError);
         let uncovered = matches!(result, MutationResult::Uncovered);
+        let subsumed = matches!(result, MutationResult::Subsumed);
 
         let stats = files.entry(file_path).or_insert(FileStats {
             total: 0,
             build_errors: 0,
             uncovered: 0,
+            subsumed: 0,
             killed: 0,
             mutations: Vec::new(),
         });
@@ -71,6 +76,9 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         }
         if uncovered {
             stats.uncovered += 1;
+        }
+        if subsumed {
+            stats.subsumed += 1;
         }
         stats.mutations.push(MutationEntry {
             line: mutation.line,
@@ -87,6 +95,12 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     let uncovered = report.uncovered_count();
     let uncovered_str = if uncovered > 0 {
         format!(", {uncovered} uncovered")
+    } else {
+        String::new()
+    };
+    let subsumed = report.subsumed_count();
+    let subsumed_str = if subsumed > 0 {
+        format!(", {subsumed} subsumed")
     } else {
         String::new()
     };
@@ -109,7 +123,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     write!(
         html,
         "<div class=\"summary\"><span class=\"score\">{:.1}%</span> mutation score \
-         &mdash; {}/{} killed, {} survived, {} timeout, {} build errors{} \
+         &mdash; {}/{} killed, {} survived, {} timeout, {} build errors{}{} \
          &mdash; {:.2}s</div>",
         score_pct,
         report.killed,
@@ -118,6 +132,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
         report.timeout,
         report.build_errors,
         uncovered_str,
+        subsumed_str,
         report.duration.as_secs_f64()
     )?;
     if report.total < report.planned_total {
@@ -242,6 +257,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
                 "survived" => "result-survived",
                 "timeout" => "result-timeout",
                 "uncovered" => "result-uncovered",
+                "subsumed" => "result-subsumed",
                 _ => "result-build-error",
             };
             write!(
@@ -328,6 +344,7 @@ code{font-family:'SF Mono',Menlo,monospace;font-size:.82rem}
 .repl{color:#53d769}
 .result-killed{opacity:.6}
 .result-uncovered{opacity:.6}
+.result-subsumed{opacity:.6}
 .result-survived{background:rgba(233,69,96,.08)}
 .result-timeout{background:rgba(255,200,50,.06)}
 .result-build-error{background:rgba(255,200,50,.06)}
@@ -393,6 +410,35 @@ mod tests {
         assert!(html.contains("uncovered"));
         assert!(html.contains("result-uncovered"));
         assert!(html.contains(", 1 uncovered"));
+        // 1 killed of 2 tested (killed + survived) → 50%.
+        assert!(html.contains("50.0%"));
+    }
+
+    #[test]
+    fn html_lists_subsumed_mutants_and_excludes_them_from_score() {
+        let mut report = sample_report();
+        report.results.push((
+            Mutation {
+                id: 2,
+                file: PathBuf::from("src/dup.rs"),
+                language: String::new(),
+                line: 4,
+                column: 1,
+                operator: "op".to_string(),
+                description: "d".to_string(),
+                original: "x".to_string(),
+                replacement: "y".to_string(),
+                byte_range: 0..1,
+            },
+            MutationResult::Subsumed,
+        ));
+        report.total = 3;
+        report.planned_total = 3;
+
+        let html = generate_report(&report).unwrap();
+        assert!(html.contains("subsumed"));
+        assert!(html.contains("result-subsumed"));
+        assert!(html.contains(", 1 subsumed"));
         // 1 killed of 2 tested (killed + survived) → 50%.
         assert!(html.contains("50.0%"));
     }

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -14,6 +14,8 @@ struct JsonReport {
     build_errors: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
     uncovered: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    subsumed: usize,
     partial: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     early_stop_reason: Option<String>,
@@ -128,6 +130,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
                 MutationResult::Timeout => "timeout".to_string(),
                 MutationResult::BuildError => "build_error".to_string(),
                 MutationResult::Uncovered => "uncovered".to_string(),
+                MutationResult::Subsumed => "subsumed".to_string(),
             },
             column: Some(m.column),
             original: Some(m.original.clone()),
@@ -179,6 +182,7 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         timeout: report.timeout,
         build_errors: report.build_errors,
         uncovered: report.uncovered_count(),
+        subsumed: report.subsumed_count(),
         partial: report.total < report.planned_total,
         early_stop_reason: report.early_stop_reason.clone(),
         mutation_score: super::mutation_score(report),
@@ -273,6 +277,47 @@ mod tests {
         let json_str = to_json_string(&report).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert!(value.get("uncovered").is_none());
+    }
+
+    #[test]
+    fn json_output_lists_subsumed_mutants() {
+        let mut report = sample_report();
+        report.results.push((
+            Mutation {
+                id: 2,
+                file: PathBuf::from("src/dup.rs"),
+                language: String::new(),
+                line: 4,
+                column: 1,
+                operator: "op".to_string(),
+                description: "d".to_string(),
+                original: "x".to_string(),
+                replacement: "y".to_string(),
+                byte_range: 0..1,
+            },
+            MutationResult::Subsumed,
+        ));
+        report.total = 3;
+        report.planned_total = 3;
+
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(value["subsumed"], 1);
+        // Subsumed mutants are excluded from the tested denominator:
+        // 1 killed of 2 tested (killed + survived) → 50%.
+        assert_eq!(value["tested"], 2);
+        assert_eq!(value["mutation_score"], 50.0);
+        let mutations = value["mutations"].as_array().unwrap();
+        assert_eq!(mutations[2]["result"], "subsumed");
+    }
+
+    #[test]
+    fn json_output_omits_subsumed_key_when_zero() {
+        let report = sample_report();
+        let json_str = to_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(value.get("subsumed").is_none());
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,15 +10,17 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
 
-/// Compute mutation score as a percentage, excluding build errors and
-/// coverage-suppressed (uncovered) mutants from the denominator.
+/// Compute mutation score as a percentage, excluding build errors,
+/// coverage-suppressed (uncovered), and learned-selection (subsumed) mutants
+/// from the denominator.
 pub fn mutation_score(report: &MutationReport) -> f64 {
     let tested = report.tested_count();
     if tested > 0 {
         (report.killed as f64 / tested as f64) * 100.0
-    } else if report.total == report.uncovered_count() {
+    } else if report.total == report.uncovered_count() + report.subsumed_count() {
         // Nothing was executed: either the report is empty or every mutant
-        // sat on a zero-coverage line. Vacuous pass, same as an empty report.
+        // sat on a zero-coverage line or was subsumed by a cluster sibling.
+        // Vacuous pass, same as an empty report.
         100.0
     } else {
         0.0
@@ -168,7 +170,8 @@ fn label_or_unknown(value: &str) -> String {
 }
 
 /// serde `skip_serializing_if` helper: omit zero counts so reports without
-/// coverage-suppressed mutants keep their previous shape byte-for-byte.
+/// coverage-suppressed or subsumed mutants keep their previous shape
+/// byte-for-byte.
 pub(crate) fn is_zero(value: &usize) -> bool {
     *value == 0
 }
@@ -223,6 +226,7 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
     let score = mutation_score(report);
     let tested = report.tested_count();
     let uncovered = report.uncovered_count();
+    let subsumed = report.subsumed_count();
     let emoji = if report.survived == 0 && report.timeout == 0 && report.build_errors == 0 {
         "✓"
     } else if score >= 80.0 {
@@ -247,9 +251,14 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
     } else {
         String::new()
     };
+    let subsumed_str = if subsumed > 0 {
+        format!(", {subsumed} subsumed")
+    } else {
+        String::new()
+    };
     writeln!(
         md,
-        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors{uncovered_str} — {:.2}s",
+        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str} — {:.2}s",
         report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
     ).unwrap();
     if report.total < report.planned_total {
@@ -843,5 +852,37 @@ mod tests {
         let report = crate::test_helpers::sample_report();
         let md = format_pr_comment(&report, None);
         assert!(!md.contains("uncovered"), "got: {md}");
+    }
+
+    #[test]
+    fn mutation_score_excludes_subsumed_mutants() {
+        // 1 of 1 executed mutants killed + 2 subsumed → 100%, not 33%.
+        let report = uncovered_report(vec![
+            report_mutation(0, "src/a.rs", MutationResult::Killed),
+            report_mutation(1, "src/b.rs", MutationResult::Subsumed),
+            report_mutation(2, "src/b.rs", MutationResult::Subsumed),
+        ]);
+        assert_eq!(report.subsumed_count(), 2);
+        assert_eq!(report.tested_count(), 1);
+        assert_eq!(mutation_score(&report), 100.0);
+    }
+
+    #[test]
+    fn pr_comment_includes_subsumed_count_when_present() {
+        let report = uncovered_report(vec![
+            report_mutation(0, "src/a.rs", MutationResult::Killed),
+            report_mutation(1, "src/b.rs", MutationResult::Subsumed),
+        ]);
+        let md = format_pr_comment(&report, None);
+        assert!(md.contains("1 subsumed"), "got: {md}");
+        // Subsumed mutants are not failures and do not block the checkmark.
+        assert!(md.contains("✓"), "got: {md}");
+    }
+
+    #[test]
+    fn pr_comment_omits_subsumed_count_when_zero() {
+        let report = crate::test_helpers::sample_report();
+        let md = format_pr_comment(&report, None);
+        assert!(!md.contains("subsumed"), "got: {md}");
     }
 }

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -63,6 +63,8 @@ struct SarifInvocationProperties {
     build_errors: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
     uncovered: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    subsumed: usize,
     mutation_score: f64,
 }
 
@@ -152,10 +154,12 @@ pub fn print_report(report: &MutationReport) -> Result<()> {
 
 /// Serialize report to a SARIF 2.1.0 string (for testing and programmatic use).
 ///
-/// Emits one result per surviving mutant; killed, timeout, build-error, and
-/// uncovered mutants are not findings. Uncovered mutants are deliberately not
-/// code-scanning results (a zero-coverage line is not an actionable surviving
-/// mutant); they only appear in the invocation totals.
+/// Emits one result per surviving mutant; killed, timeout, build-error,
+/// uncovered, and subsumed mutants are not findings. Uncovered mutants are
+/// deliberately not code-scanning results (a zero-coverage line is not an
+/// actionable surviving mutant), and subsumed mutants were never executed
+/// (their cluster canonical carries the signal); both only appear in the
+/// invocation totals.
 pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
     let registry = registry_descriptions();
     let surviving: Vec<&Mutation> = report
@@ -200,6 +204,7 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
                     timeout: report.timeout,
                     build_errors: report.build_errors,
                     uncovered: report.uncovered_count(),
+                    subsumed: report.subsumed_count(),
                     mutation_score: super::mutation_score(report),
                 },
             }],
@@ -423,6 +428,34 @@ mod tests {
         let value = parse(&sample_report());
         let properties = &value["runs"][0]["invocations"][0]["properties"];
         assert!(properties.get("uncovered").is_none());
+    }
+
+    #[test]
+    fn sarif_subsumed_mutants_produce_no_results_but_appear_in_totals() {
+        let report = report_with(vec![
+            (
+                mutation(0, "src/a.rs", 1, "op_a", "canonical kill"),
+                MutationResult::Killed,
+            ),
+            (
+                mutation(1, "src/a.rs", 5, "op_b", "same killer test"),
+                MutationResult::Subsumed,
+            ),
+        ]);
+        let value = parse(&report);
+        // Subsumed mutants are not code-scanning findings.
+        assert_eq!(value["runs"][0]["results"], serde_json::json!([]));
+        let properties = &value["runs"][0]["invocations"][0]["properties"];
+        assert_eq!(properties["subsumed"], 1);
+        // Score excludes subsumed mutants: 1 killed of 1 tested → 100%.
+        assert_eq!(properties["mutation_score"], 100.0);
+    }
+
+    #[test]
+    fn sarif_omits_subsumed_property_when_zero() {
+        let value = parse(&sample_report());
+        let properties = &value["runs"][0]["invocations"][0]["properties"];
+        assert!(properties.get("subsumed").is_none());
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -68,6 +68,21 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                 .unwrap();
                 ("○ UNCOVERED", Some(detail))
             }
+            MutationResult::Subsumed => {
+                let mut detail = String::new();
+                writeln!(
+                    detail,
+                    "              {}",
+                    if color {
+                        dim("Same recorded killer test as an earlier mutant; not executed.")
+                    } else {
+                        "Same recorded killer test as an earlier mutant; not executed."
+                            .to_string()
+                    }
+                )
+                .unwrap();
+                ("◌ SUBSUMED", Some(detail))
+            }
         };
 
         if color {
@@ -75,7 +90,7 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                 MutationResult::Killed => green(tag),
                 MutationResult::Survived => red(tag),
                 MutationResult::Timeout | MutationResult::BuildError => yellow(tag),
-                MutationResult::Uncovered => dim(tag),
+                MutationResult::Uncovered | MutationResult::Subsumed => dim(tag),
             };
             writeln!(
                 out,
@@ -110,9 +125,15 @@ fn format_report(report: &MutationReport, color: bool) -> String {
     } else {
         String::new()
     };
+    let subsumed = report.subsumed_count();
+    let subsumed_str = if subsumed > 0 {
+        format!(", {subsumed} subsumed")
+    } else {
+        String::new()
+    };
     writeln!(
         out,
-        "Results: {} killed, {} survived, {} timeout, {} build errors{uncovered_str}",
+        "Results: {} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str}",
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
@@ -490,6 +511,36 @@ mod tests {
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors\n"));
         assert!(!output.contains("uncovered"));
+    }
+
+    #[test]
+    fn terminal_output_lists_subsumed_mutants_distinctly() {
+        let report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Subsumed),
+        ]);
+        let output = format_report_plain(&report);
+        assert!(
+            output
+                .lines()
+                .any(|line| line.contains("SUBSUMED") && line.contains("src/b.rs:2")),
+            "got: {output}"
+        );
+        assert!(output.contains("Same recorded killer test as an earlier mutant; not executed."));
+        assert!(
+            output
+                .contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 subsumed")
+        );
+        // Subsumed mutants are excluded from the tested denominator.
+        assert!(output.contains("Mutation score (test kills only): 100.0%"));
+    }
+
+    #[test]
+    fn terminal_output_omits_subsumed_count_when_zero() {
+        let report = report(vec![(mutation(1, "src/a.rs", 1), MutationResult::Killed)]);
+        let output = format_report_plain(&report);
+        assert!(output.contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors\n"));
+        assert!(!output.contains("subsumed"));
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -118,18 +118,8 @@ fn format_report(report: &MutationReport, color: bool) -> String {
 
     let separator = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
     writeln!(out, "{separator}").unwrap();
-    let uncovered = report.uncovered_count();
-    let uncovered_str = if uncovered > 0 {
-        format!(", {uncovered} uncovered")
-    } else {
-        String::new()
-    };
-    let subsumed = report.subsumed_count();
-    let subsumed_str = if subsumed > 0 {
-        format!(", {subsumed} subsumed")
-    } else {
-        String::new()
-    };
+    let uncovered_str = count_suffix(report.uncovered_count(), "uncovered");
+    let subsumed_str = count_suffix(report.subsumed_count(), "subsumed");
     writeln!(
         out,
         "Results: {} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str}",
@@ -196,6 +186,15 @@ fn format_report(report: &MutationReport, color: bool) -> String {
     }
 
     out
+}
+
+/// ", N label" suffix for summary lines, empty when the count is zero.
+fn count_suffix(count: usize, label: &str) -> String {
+    if count > 0 {
+        format!(", {count} {label}")
+    } else {
+        String::new()
+    }
 }
 
 fn format_build_error_groups(report: &MutationReport) -> String {

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -76,8 +76,7 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                     if color {
                         dim("Same recorded killer test as an earlier mutant; not executed.")
                     } else {
-                        "Same recorded killer test as an earlier mutant; not executed."
-                            .to_string()
+                        "Same recorded killer test as an earlier mutant; not executed.".to_string()
                     }
                 )
                 .unwrap();
@@ -528,8 +527,7 @@ mod tests {
         );
         assert!(output.contains("Same recorded killer test as an earlier mutant; not executed."));
         assert!(
-            output
-                .contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 subsumed")
+            output.contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 subsumed")
         );
         // Subsumed mutants are excluded from the tested denominator.
         assert!(output.contains("Mutation score (test kills only): 100.0%"));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -182,7 +182,7 @@ pub struct TestRunner {
     /// Re-run mutations instead of trusting cache or incremental history hits.
     pub force_rerun: bool,
     /// Skip mutants subsumed by a shared recorded killer test (opt-in;
-    /// requires `incremental_history`, ignored under `force_rerun`).
+    /// requires `incremental_history`).
     pub learned_selection: bool,
     /// Set to true externally (e.g. Ctrl+C handler) to stop spawning new mutations.
     pub cancelled: Arc<AtomicBool>,
@@ -2332,10 +2332,11 @@ impl TestRunner {
 
     /// Partition mutations into those to execute and those subsumed by a
     /// shared recorded killer test (opt-in learned selection). Conservative:
-    /// without the flag, without incremental history, or under --force-rerun
-    /// every mutation executes, exactly as before.
+    /// without the flag or without incremental history every mutation
+    /// executes, exactly as before. `--force-rerun` still bypasses verdict
+    /// restore for the canonical mutants but does not disable clustering.
     fn split_subsumed(&self, mutations: Vec<Mutation>) -> (Vec<Mutation>, Vec<Mutation>) {
-        if !self.learned_selection || !self.incremental_history || self.force_rerun {
+        if !self.learned_selection || !self.incremental_history {
             return (mutations, Vec::new());
         }
         let history = cache::IncrementalHistoryStore::load(&self.project_root);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1216,7 +1216,9 @@ fn measure_baseline_command(
     }
 
     match outcome.result {
-        MutationResult::Survived | MutationResult::Uncovered => Ok(duration),
+        MutationResult::Survived | MutationResult::Uncovered | MutationResult::Subsumed => {
+            Ok(duration)
+        }
         MutationResult::Killed => {
             let output = baseline_failure_output(outcome.test_output.as_deref());
             bail!(
@@ -1826,7 +1828,7 @@ impl EarlyStopState {
         match result {
             MutationResult::Killed => counts.killed += 1,
             MutationResult::Survived => counts.survived += 1,
-            MutationResult::Timeout | MutationResult::Uncovered => {}
+            MutationResult::Timeout | MutationResult::Uncovered | MutationResult::Subsumed => {}
             MutationResult::BuildError => counts.build_errors += 1,
         }
 
@@ -2253,6 +2255,7 @@ fn record_progress(
                 MutationResult::Timeout => "⧖ timeout",
                 MutationResult::BuildError => "⚠ build error",
                 MutationResult::Uncovered => "◌ uncovered",
+                MutationResult::Subsumed => "◌ subsumed",
             };
             eprintln!(
                 "  [{}/{}] {}  {}:{} \u{2014} {}",
@@ -2768,6 +2771,7 @@ impl TestRunner {
                     MutationResult::Timeout => "⧖ timeout",
                     MutationResult::BuildError => "⚠ build error",
                     MutationResult::Uncovered => "◌ uncovered",
+                MutationResult::Subsumed => "◌ subsumed",
                 };
                 eprintln!(
                     "  [schema] {}  {}:{} — {}",
@@ -2853,7 +2857,9 @@ impl TestRunner {
                 MutationResult::BuildError => build_errors += 1,
                 // Uncovered mutants never reach the runner; they are merged
                 // into the report by the caller and derived from `results`.
-                MutationResult::Uncovered => {}
+                // Subsumed mutants are merged the same way by `merge_subsumed`
+                // after the run; neither counts toward any tally here.
+                MutationResult::Uncovered | MutationResult::Subsumed => {}
             }
             if let Some(diagnostic) = record.build_error_diagnostic {
                 build_error_diagnostics.push(diagnostic);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -181,6 +181,9 @@ pub struct TestRunner {
     pub incremental_history: bool,
     /// Re-run mutations instead of trusting cache or incremental history hits.
     pub force_rerun: bool,
+    /// Skip mutants subsumed by a shared recorded killer test (opt-in;
+    /// requires `incremental_history`, ignored under `force_rerun`).
+    pub learned_selection: bool,
     /// Set to true externally (e.g. Ctrl+C handler) to stop spawning new mutations.
     pub cancelled: Arc<AtomicBool>,
 }
@@ -2290,15 +2293,85 @@ fn record_progress(
     }
 }
 
+/// Merge history-subsumed mutants into the report as `Subsumed`.
+///
+/// Mirrors `merge_uncovered` in main.rs: they count toward
+/// `total`/`planned_total` (they were part of the scheduled work) but stay
+/// out of the tested denominator; see `MutationReport::tested_count`.
+fn merge_subsumed(report: &mut MutationReport, subsumed: Vec<Mutation>) {
+    let n = subsumed.len();
+    if n == 0 {
+        return;
+    }
+    report
+        .results
+        .extend(subsumed.into_iter().map(|m| (m, MutationResult::Subsumed)));
+    report.total += n;
+    report.planned_total += n;
+}
+
 impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
     pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
+        let (mutations, subsumed) = self.split_subsumed(mutations);
         let planned_total = mutations.len();
         let early_stop = EarlyStopState::for_config(self.early_stop.clone(), planned_total);
-        self.run_regular_with_state(mutations, early_stop, planned_total)
+        let mut outcome = self.run_regular_with_state(mutations, early_stop, planned_total);
+        merge_subsumed(&mut outcome.report, subsumed);
+        outcome
     }
 
     pub fn run_with_schemata(&self, mutations: Vec<Mutation>) -> RunOutcome {
+        // Learned selection runs before schemata planning so subsumed
+        // mutants never end up in schema rewrites.
+        let (mutations, subsumed) = self.split_subsumed(mutations);
+        let mut outcome = self.run_with_schemata_planned(mutations);
+        merge_subsumed(&mut outcome.report, subsumed);
+        outcome
+    }
+
+    /// Partition mutations into those to execute and those subsumed by a
+    /// shared recorded killer test (opt-in learned selection). Conservative:
+    /// without the flag, without incremental history, or under --force-rerun
+    /// every mutation executes, exactly as before.
+    fn split_subsumed(&self, mutations: Vec<Mutation>) -> (Vec<Mutation>, Vec<Mutation>) {
+        if !self.learned_selection || !self.incremental_history || self.force_rerun {
+            return (mutations, Vec::new());
+        }
+        let history = cache::IncrementalHistoryStore::load(&self.project_root);
+        let source_contents = SourceContentCache::default();
+        let partition = crate::learned::partition_subsumed(mutations, |mutation| {
+            let source = source_contents.content_for(&self.project_root, &mutation.file)?;
+            let selected = select_test_command_with_history(
+                &self.project_root,
+                &self.commands,
+                mutation,
+                Some(&history),
+            );
+            let command_ctx = selected.cache_context(
+                &self.commands.build_command,
+                self.commands.build_command_explicit,
+                &self.commands.sandbox_command,
+                &self.env,
+            );
+            history.learned_killer_test(
+                &cache_identity(&self.project_root, mutation),
+                &mutation.description,
+                cache::hash_bytes(&source),
+                cache::hash_str(&command_ctx),
+            )
+        });
+        if !partition.subsumed.is_empty() {
+            eprintln!(
+                "learned selection: {} mutants subsumed into {} canonical mutants",
+                partition.subsumed.len(),
+                partition.clusters
+            );
+        }
+        (partition.to_run, partition.subsumed)
+    }
+
+    fn run_with_schemata_planned(&self, mutations: Vec<Mutation>) -> RunOutcome {
         let start = Instant::now();
         if mutations.is_empty() {
             return self.outcome_from_records(Vec::new(), start.elapsed());
@@ -2771,7 +2844,7 @@ impl TestRunner {
                     MutationResult::Timeout => "⧖ timeout",
                     MutationResult::BuildError => "⚠ build error",
                     MutationResult::Uncovered => "◌ uncovered",
-                MutationResult::Subsumed => "◌ subsumed",
+                    MutationResult::Subsumed => "◌ subsumed",
                 };
                 eprintln!(
                     "  [schema] {}  {}:{} — {}",
@@ -5076,6 +5149,7 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
         let cached = cached_runner.run(vec![mutation.clone()]).report;
@@ -5093,6 +5167,7 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: true,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
         let forced = forced_runner.run(vec![mutation]).report;
@@ -5169,10 +5244,153 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
         let report = runner.run(vec![mutation]).report;
         assert_eq!(report.results[0].1, MutationResult::Killed);
+        Ok(())
+    }
+
+    /// Three applicable mutations in one file with distinct identities.
+    fn make_killer_cluster_setup() -> (tempfile::TempDir, PathBuf, Vec<Mutation>) {
+        let (dir, file, base) = make_test_setup();
+        let mut second = base.clone();
+        second.id = 2;
+        second.byte_range = 6..11;
+        second.original = "world".into();
+        second.replacement = "hello".into();
+        second.operator = "test_b".into();
+        second.description = "mutation b".into();
+        let mut third = base.clone();
+        third.id = 3;
+        third.replacement = "WORLD".into();
+        third.operator = "test_c".into();
+        third.description = "mutation c".into();
+        (dir, file, vec![base, second, third])
+    }
+
+    /// Seed a Killed entry with a shared killer test for each mutation.
+    ///
+    /// `relevant_test_hash` is deliberately stale so verdict restore misses:
+    /// the canonical mutant really executes, making the subsumed siblings'
+    /// skipped execution observable in the report.
+    fn seed_killer_cluster_history(dir: &Path, file: &Path, mutations: &[Mutation]) {
+        let commands = CommandConfig {
+            command: failing_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let store = cache::IncrementalHistoryStore::load(dir);
+        let source = std::fs::read(file).expect("source file should exist");
+        for mutation in mutations {
+            let selected = select_test_command(dir, &commands, mutation);
+            let command_ctx = selected.cache_context(
+                &commands.build_command,
+                false,
+                &commands.sandbox_command,
+                &HashMap::new(),
+            );
+            store.record(cache::IncrementalHistoryEntry {
+                mutation_identity: cache_identity(dir, mutation),
+                mutation_description: mutation.description.clone(),
+                result: MutationResult::Killed,
+                source_hash: cache::hash_bytes(&source),
+                command_hash: cache::hash_str(&command_ctx),
+                relevant_test_hash: 3,
+                covering_tests: vec!["test_shared".into()],
+                killer_test: Some("test_shared".into()),
+            });
+        }
+    }
+
+    fn killer_cluster_runner(dir: &Path, learned_selection: bool) -> TestRunner {
+        TestRunner {
+            commands: CommandConfig {
+                command: failing_command(),
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                sandbox_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[test]
+    fn learned_selection_subsumes_shared_killer_cluster() -> anyhow::Result<()> {
+        let (dir, file, mutations) = make_killer_cluster_setup();
+        seed_killer_cluster_history(dir.path(), &file, &mutations);
+
+        let report = killer_cluster_runner(dir.path(), true)
+            .run(mutations)
+            .report;
+
+        // Only the canonical mutant (first in run order) executed; its two
+        // cluster siblings were classified Subsumed without execution.
+        assert_eq!(report.total, 3);
+        assert_eq!(report.killed, 1);
+        assert_eq!(report.subsumed_count(), 2);
+        assert_eq!(report.tested_count(), 1);
+        let result_for = |id: u32| {
+            report
+                .results
+                .iter()
+                .find(|(mutation, _)| mutation.id == id)
+                .map(|(_, result)| *result)
+        };
+        assert_eq!(result_for(1), Some(MutationResult::Killed));
+        assert_eq!(result_for(2), Some(MutationResult::Subsumed));
+        assert_eq!(result_for(3), Some(MutationResult::Subsumed));
+        // Subsumed mutants stay out of the score denominator: 1/1 → 100%.
+        assert_eq!(crate::report::mutation_score(&report), 100.0);
+        Ok(())
+    }
+
+    #[test]
+    fn learned_selection_disabled_by_default_executes_everything() -> anyhow::Result<()> {
+        let (dir, file, mutations) = make_killer_cluster_setup();
+        seed_killer_cluster_history(dir.path(), &file, &mutations);
+
+        let report = killer_cluster_runner(dir.path(), false)
+            .run(mutations)
+            .report;
+
+        assert_eq!(report.total, 3);
+        assert_eq!(report.tested_count(), 3);
+        assert_eq!(report.killed, 3);
+        assert_eq!(report.subsumed_count(), 0);
+        assert!(
+            report
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Killed)
+        );
         Ok(())
     }
 
@@ -6059,6 +6277,7 @@ sleep 10"#
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled,
         };
 
@@ -6124,6 +6343,7 @@ sleep 10"#
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6194,6 +6414,7 @@ int main(void) {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6264,6 +6485,7 @@ int main() {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6321,6 +6543,7 @@ esac
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6376,6 +6599,7 @@ touch side_effect
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6463,6 +6687,7 @@ esac
             env,
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6520,6 +6745,7 @@ func second(c, d int) bool { return c == d }
             env: HashMap::new(),
             incremental_history: false,
             force_rerun: true,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6600,6 +6826,7 @@ class Calc {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6666,6 +6893,7 @@ mod tests {
             },
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6712,6 +6940,7 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6760,6 +6989,7 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6817,6 +7047,7 @@ mod tests {
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6887,6 +7118,7 @@ sleep 0.2
             env,
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -6962,6 +7194,7 @@ sleep 0.2
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7051,6 +7284,7 @@ rmdir "$lock"
                 env,
                 incremental_history: true,
                 force_rerun: false,
+                learned_selection: false,
                 cancelled: Arc::new(AtomicBool::new(false)),
             };
 
@@ -7125,6 +7359,7 @@ rmdir "$lock"
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7198,6 +7433,7 @@ rmdir "$lock"
             env,
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7265,6 +7501,7 @@ rmdir "$lock"
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7312,6 +7549,7 @@ rmdir "$lock"
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7384,6 +7622,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7464,6 +7703,7 @@ exit 1"#
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7520,6 +7760,7 @@ exit 1"#
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 
@@ -7576,6 +7817,7 @@ exit 1"#
             env: HashMap::new(),
             incremental_history: true,
             force_rerun: false,
+            learned_selection: false,
             cancelled: Arc::new(AtomicBool::new(false)),
         };
 

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -132,6 +132,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
         env: go_env,
         incremental_history: true,
         force_rerun: false,
+        learned_selection: false,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -88,6 +88,7 @@ fn run_fixture(case: FixtureCase) {
         env: HashMap::new(),
         incremental_history: false,
         force_rerun: true,
+        learned_selection: false,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -91,6 +91,7 @@ fn verify_mutation_outcomes_match_independent_replay() {
         env: go_env.clone(),
         incremental_history: true,
         force_rerun: false,
+        learned_selection: false,
         cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 


### PR DESCRIPTION
## Summary

Fixes #418. Mutants that history shows always die to the same killer test are redundant (subsumption). New opt-in `--learned-selection` flag: before execution, this run's mutants are clustered by shared recorded `killer_test` from incremental history (same file, both previously `Killed`, hashes still current — i.e. entries eligible for verdict restore anyway). Within each cluster of size ≥ 2, the first mutant in run order executes; the rest are classified `subsumed` and skipped.

## Design

- **Conservative**: no killer test recorded, mismatched source/command hash, verdict not Killed, or no history at all → execute normally. Disabled by default → zero behavior change (also composes with `--force-rerun`).
- **`MutationResult::Subsumed`** follows the `Uncovered` pattern (#425): excluded from the survivor count, `mutation_score`, and `--fail-under`; listed distinctly in terminal/JSON/HTML; not emitted as SARIF code-scanning results. Counted in the terminal summary line.
- Subsumed mutants are removed before schemata planning (never enter schema rewrites).
- Killer-test equality is a conservative proxy for subsumption — noted in code and docs.

## Tests

Unit tests for clustering (shared killer → clustered; mismatched hash/verdict/missing killer → not; `Subsumed` scoring/report plumbing), runner-level tests with seeded history (skipped execution, verdict in report), default-unchanged tests. Full suite (545), stable clippy, fmt all green.

Measured reduction on togi itself (bounded 6-mutant diff, seeded history): **6 → 3 executed mutants (−50%) at identical kill signal** — details in the measurement comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in learned mutant selection with `togi check --learned-selection`, allowing previously identified redundant mutants to be skipped.
  * Added “subsumed” mutation reporting across terminal, HTML, JSON, GitHub, PR comment, and SARIF outputs.
  * Mutation scores now exclude subsumed mutants from testing denominators.

* **Documentation**
  * Documented the new option, including its incremental-history requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
