### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"


### PR DESCRIPTION
Version bump to 0.2.0.

Since 0.1.0: schemata let-condition fix (#409/#411), stale-verdict cache fix (#410/#413), schema_build batch resilience (#412/#421), lock-acquisition robustness (#416/#422), uncovered mutant classification (#417/#425), SARIF output (#419/#424), dogfood badge (#420/#423), learned selection (#418/#427), polyglot demo (#426), plus dependabot + CI automation updates. Tag v0.2.0 after merge to trigger the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.0 to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->