### PR TITLE
fix: route polyglot demo tests by language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 .codex/
 .claude/
 togi.toml
+!tests/fixtures/polyglot/togi.toml
 editors/vscode/node_modules/
 editors/vscode/*.vsix

--- a/examples/polyglot-demo.sh
+++ b/examples/polyglot-demo.sh
@@ -28,6 +28,8 @@ cp -r "$FIXTURE"/* "$WORK/"
 cd "$WORK"
 
 git init -q
+git config user.email "togi-demo@example.invalid"
+git config user.name "togi demo"
 git commit --allow-empty -q -m "empty"
 git add -A
 git commit -q -m "add calc helpers in go, rust, and python"

--- a/tests/fixtures/polyglot/togi.toml
+++ b/tests/fixtures/polyglot/togi.toml
@@ -1,0 +1,10 @@
+[test]
+command = ["cargo", "test"]
+timeout = 30
+jobs = 1
+
+[test.languages.go]
+command = ["go", "test", "./..."]
+
+[test.languages.python]
+command = ["python3", "-m", "unittest"]

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -221,8 +221,12 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
             "polyglot demo did not route {expected} to its language test suite\nstdout:\n{stdout}"
         );
     }
+    let results_line = stdout
+        .lines()
+        .find(|line| line.starts_with("Results: "))
+        .expect("polyglot demo should print a result summary");
     assert!(
-        stdout.contains("0 timeout, 0 build errors"),
+        results_line.ends_with(", 0 timeout, 0 build errors"),
         "polyglot demo reported a timeout or build error\nstdout:\n{stdout}"
     );
 }

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -214,10 +214,15 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
     for expected in [
         "✓ KILLED      calc.go:5 — zero_to_one",
         "✓ KILLED      calc.py:2 — increment_numeric",
+        "✓ KILLED      src/lib.rs:2 — negate_condition",
     ] {
         assert!(
             stdout.contains(expected),
             "polyglot demo did not route {expected} to its language test suite\nstdout:\n{stdout}"
         );
     }
+    assert!(
+        stdout.contains("0 timeout, 0 build errors"),
+        "polyglot demo reported a timeout or build error\nstdout:\n{stdout}"
+    );
 }

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -192,10 +192,15 @@ fn ruby_fixture_runs_end_to_end() {
 #[test]
 #[ignore]
 fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
+    // The demo creates commits, so it must not rely on a CI runner's identity.
+    let clean_home = tempfile::tempdir().unwrap();
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let output = Command::new("bash")
         .arg("examples/polyglot-demo.sh")
         .current_dir(&root)
+        .env("HOME", clean_home.path())
+        .env("XDG_CONFIG_HOME", clean_home.path().join("config"))
+        .env("GIT_CONFIG_NOSYSTEM", "1")
         .output()
         .expect("failed to run polyglot demo");
     assert!(

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -225,8 +225,11 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
         .lines()
         .find(|line| line.starts_with("Results: "))
         .expect("polyglot demo should print a result summary");
+    let has_clean_results = ["0 timeout", "0 build errors"]
+        .into_iter()
+        .all(|expected| results_line.split(", ").any(|field| field == expected));
     assert!(
-        results_line.ends_with(", 0 timeout, 0 build errors"),
+        has_clean_results,
         "polyglot demo reported a timeout or build error\nstdout:\n{stdout}"
     );
 }

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -186,3 +186,33 @@ fn ruby_fixture_runs_end_to_end() {
         file: "calc.rb",
     });
 }
+
+/// Proves the documented polyglot demo routes mutations to each language's
+/// configured test suite, rather than applying the Rust default everywhere.
+#[test]
+#[ignore]
+fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output = Command::new("bash")
+        .arg("examples/polyglot-demo.sh")
+        .current_dir(&root)
+        .output()
+        .expect("failed to run polyglot demo");
+    assert!(
+        output.status.success(),
+        "polyglot demo failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "✓ KILLED      calc.go:5 — zero_to_one",
+        "✓ KILLED      calc.py:2 — increment_numeric",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "polyglot demo did not route {expected} to its language test suite\nstdout:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- configure the polyglot fixture with Rust, Go, and Python test commands
- add an end-to-end regression for language-specific test routing
- track the fixture config despite the root togi.toml ignore rule

## Test
- cargo test --locked --test integration -- --ignored polyglot_demo_routes_mutations_to_each_language_test_suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/updated a polyglot test configuration fixture with language-specific commands (Rust, Go, Python).
  * Added a smoke-test that runs the polyglot demo, verifies mutation routing markers for each language suite, and confirms zero timeouts and build errors.
* **Chores**
  * Adjusted ignore rules to include the polyglot fixture in test runs.
* **Improvements**
  * Updated the polyglot demo script to set local Git author identity before creating commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->