### PR TITLE
test: cover TypeScript and C# runtime fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,12 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: stable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.14.1
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 8.0.x
       - name: Integration tests
         run: cargo test --locked -- --ignored
 

--- a/tests/fixtures/csharp/Calc.cs
+++ b/tests/fixtures/csharp/Calc.cs
@@ -1,0 +1,7 @@
+public static class Calc
+{
+    public static bool IsBig(int x)
+    {
+        return x + 1 > 3;
+    }
+}

--- a/tests/fixtures/csharp/CalcTest.cs
+++ b/tests/fixtures/csharp/CalcTest.cs
@@ -1,0 +1,24 @@
+public static class CalcTest
+{
+    public static void Main()
+    {
+        AssertFalse(Calc.IsBig(2));
+        AssertTrue(Calc.IsBig(3));
+    }
+
+    private static void AssertTrue(bool value)
+    {
+        if (!value)
+        {
+            throw new System.Exception("expected true");
+        }
+    }
+
+    private static void AssertFalse(bool value)
+    {
+        if (value)
+        {
+            throw new System.Exception("expected false");
+        }
+    }
+}

--- a/tests/fixtures/csharp/run-tests.sh
+++ b/tests/fixtures/csharp/run-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="$(mktemp -d)"
+trap 'rm -rf "$build_dir"' EXIT
+export DOTNET_CLI_HOME="$build_dir/dotnet-cli"
+export NUGET_PACKAGES="$build_dir/nuget"
+
+cp Calc.cs CalcTest.cs "$build_dir"
+cat > "$build_dir/Fixture.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+EOF
+
+dotnet restore "$build_dir/Fixture.csproj" --ignore-failed-sources --nologo
+dotnet run --project "$build_dir/Fixture.csproj" --configuration Release --no-restore --nologo

--- a/tests/fixtures/typescript/calc.ts
+++ b/tests/fixtures/typescript/calc.ts
@@ -1,0 +1,5 @@
+function isBig(x: number): boolean {
+    return x + 1 > 3;
+}
+
+module.exports = { isBig };

--- a/tests/fixtures/typescript/run-tests.sh
+++ b/tests/fixtures/typescript/run-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node test_calc.ts

--- a/tests/fixtures/typescript/test_calc.ts
+++ b/tests/fixtures/typescript/test_calc.ts
@@ -1,0 +1,16 @@
+const { isBig } = require("./calc.ts");
+
+function assertTrue(value: boolean): void {
+    if (!value) {
+        throw new Error("expected true");
+    }
+}
+
+function assertFalse(value: boolean): void {
+    if (value) {
+        throw new Error("expected false");
+    }
+}
+
+assertFalse(isBig(2));
+assertTrue(isBig(3));

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -2,8 +2,6 @@
 //! image. These prove more than mutation generation by running the full
 //! mutation -> test-command -> outcome pipeline across several languages.
 //!
-//! TypeScript and C# still rely on parser/unit coverage today and need
-//! dedicated runtime fixtures separately.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -31,7 +29,7 @@ fn source_line_count(path: &Path) -> usize {
         .max(1)
 }
 
-fn run_fixture(case: FixtureCase) {
+fn run_fixture(case: FixtureCase) -> togi::MutationReport {
     let root = fixture_path(case.dir);
     togi::cache::clear(&root).expect("failed to clear togi cache");
 
@@ -119,6 +117,7 @@ fn run_fixture(case: FixtureCase) {
         "{} fixture: {} total, {} killed, {} survived",
         case.name, report.total, report.killed, report.survived
     );
+    report
 }
 
 /// Requires `bash` plus the language toolchains bundled on the Ubuntu CI image.
@@ -185,6 +184,36 @@ fn ruby_fixture_runs_end_to_end() {
         dir: "ruby",
         file: "calc.rb",
     });
+}
+
+/// Requires bash plus Node.js 24.14.1 for native TypeScript type stripping.
+#[test]
+#[ignore]
+fn typescript_fixture_runs_end_to_end() {
+    let report = run_fixture(FixtureCase {
+        name: "typescript",
+        dir: "typescript",
+        file: "calc.ts",
+    });
+    assert!(
+        report.killed > 0,
+        "typescript fixture should kill at least one mutation"
+    );
+}
+
+/// Requires bash plus the .NET 8 SDK.
+#[test]
+#[ignore]
+fn csharp_fixture_runs_end_to_end() {
+    let report = run_fixture(FixtureCase {
+        name: "csharp",
+        dir: "csharp",
+        file: "Calc.cs",
+    });
+    assert!(
+        report.killed > 0,
+        "csharp fixture should kill at least one mutation"
+    );
 }
 
 /// Proves the documented polyglot demo routes mutations to each language's


### PR DESCRIPTION
## Summary
- Add package-free TypeScript and C# runtime smoke fixtures with independent assertion harnesses.
- Register ignored end-to-end mutation/report smoke coverage and provision Node 24.14.1 plus .NET 8 only in Integration Tests.

## Local tests
- `cargo test --locked` — 599 passed, 11 ignored
- `bash run-tests.sh` (from `tests/fixtures/typescript`)
- `cargo test --locked --test integration typescript_fixture_runs_end_to_end -- --ignored --nocapture` — 7 killed, 0 survived
- `cargo test --locked csharp`
- `cargo test --locked --test integration polyglot_demo_routes_mutations_to_each_language_test_suite -- --ignored`
- `cargo fmt -- --check`
- `./.github/scripts/check-pinned-actions.sh`

C# end-to-end is CI-only locally because `dotnet` is absent (`dotnet: command not found`).