### PR TITLE
docs: add cargo cache step to CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-
       - run: |
           TOGI_VERSION=vX.Y.Z
           curl -fsSLo togi.tar.gz \


### PR DESCRIPTION
Without `actions/cache`, every CI run cold-compiles the full Rust workspace — making mutation testing impractical on shared runners. The build alone can exceed the per-mutant timeout before any mutants are evaluated.

## Change
- Add `actions/cache@v4` step after `rust-toolchain` in the CI Integration example
- Arch-aware cache key (`runner.arch`) prevents cross-architecture poisoning when runners switch between x86_64 and ARM64

## Why
Hit this exact issue integrating togi into a real Rust project. The workflow looked correct but produced zero useful signal because every mutant cold-compiled the full dependency tree. With cache, subsequent runs complete in seconds instead of minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CI integration example to include caching for Rust dependencies and build artifacts.
  * Added cache keying based on the operating system, architecture, and lockfile changes, with fallback restoration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->