### PR TITLE
Block mutation runs when the unmutated test suite fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,6 @@ use togi::{BaselineTiming, ChangedFile, Mutation};
 struct ExecuteOptions {
     verbose: bool,
     show_output: bool,
-    build_command_explicit: bool,
-    force_default_command: bool,
-    force_default_timeout: bool,
     early_stop: togi::runner::EarlyStopConfig,
     env: HashMap<String, String>,
     force_rerun: bool,
@@ -329,44 +326,82 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         return Ok(());
     }
 
-    let baseline_timing = if config.test.calibrate_timeout && !classified.to_run.is_empty() {
-        eprintln!("Measuring baseline test runtime...");
-        let measurement = togi::runner::measure_baseline_timing(
+    let baseline_mutations = classified
+        .to_run
+        .iter()
+        .chain(&classified.uncovered)
+        .cloned()
+        .collect::<Vec<_>>();
+    let (baseline_timing, commands) = if baseline_mutations.is_empty() {
+        (None, None)
+    } else {
+        let mut commands = command_config(
+            &config,
             &project_root,
-            togi::runner::BaselineTimingConfig {
-                test_command: &config.test.command,
-                build_command: &config.test.build_command,
-                sandbox_command: &config.test.sandbox_command,
-                build_command_explicit: has_explicit_build_cmd,
-                timeout: baseline_measurement_timeout(config.test.timeout),
+            has_explicit_build_cmd,
+            has_custom_test_cmd,
+            has_cli_timeout,
+        );
+        if config.test.calibrate_timeout {
+            eprintln!("Measuring baseline test runtime...");
+        } else {
+            eprintln!("Checking baseline test suites...");
+        }
+        let measurement = match togi::runner::check_baseline_health(
+            &project_root,
+            &baseline_mutations,
+            togi::runner::BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: config
+                    .test
+                    .calibrate_timeout
+                    .then(|| baseline_measurement_timeout(config.test.timeout)),
+                schemata_enabled: config.mutations.schemata,
                 env: &profile_env,
                 cancelled: &cancelled,
                 respect_workspace_ignores: config.mutations.respect_workspace_ignores,
             },
-        )?;
-        let timeout_secs = calibrated_timeout_seconds(
-            measurement.build_duration,
-            measurement.test_duration,
-            config.test.timeout_multiplier,
-            config.test.timeout_slack,
-        );
-        config.test.timeout = timeout_secs;
-        let timing = BaselineTiming {
-            build_command: if has_explicit_build_cmd {
-                config.test.build_command.clone()
-            } else {
-                vec![]
-            },
-            build_duration: measurement.build_duration,
-            test_command: config.test.command.clone(),
-            test_duration: measurement.test_duration,
-            calibrated_timeout: Duration::from_secs(timeout_secs),
+        ) {
+            Ok(measurement) => measurement,
+            Err(_) if cancelled.load(Ordering::Acquire) => exit_with(_lock, 130),
+            Err(error) => return Err(error),
         };
-        eprintln!("{}", baseline_timing_summary(&timing));
-        Some(timing)
-    } else {
-        None
+        let baseline_timing = if config.test.calibrate_timeout {
+            if let Some(measurement) = calibration_measurement(&measurement) {
+                let timeout_secs = calibrated_timeout_seconds(
+                    measurement.build_duration,
+                    measurement.test_duration,
+                    config.test.timeout_multiplier,
+                    config.test.timeout_slack,
+                );
+                config.test.timeout = timeout_secs;
+                commands.timeout = Duration::from_secs(timeout_secs);
+                let timing = BaselineTiming {
+                    build_command: if has_explicit_build_cmd {
+                        config.test.build_command.clone()
+                    } else {
+                        vec![]
+                    },
+                    build_duration: measurement.build_duration,
+                    test_command: measurement.test_command.clone(),
+                    test_duration: measurement.test_duration,
+                    calibrated_timeout: Duration::from_secs(timeout_secs),
+                };
+                eprintln!("{}", baseline_timing_summary(&timing));
+                Some(timing)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        (baseline_timing, Some(commands))
     };
+
+    if cancelled.load(Ordering::Acquire) {
+        eprintln!("Interrupted; skipping mutation report and side effects.");
+        exit_with(_lock, 130);
+    }
 
     let project_root_ref = project_root.clone();
     let (mut report, run_cancelled) = if classified.to_run.is_empty() {
@@ -377,30 +412,28 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         let outcome = execute(
             classified.to_run,
             config,
+            commands.expect("baseline commands should exist for scheduled mutations"),
             project_root,
             ExecuteOptions {
                 verbose,
                 show_output,
-                build_command_explicit: has_explicit_build_cmd,
-                force_default_command: has_custom_test_cmd,
-                force_default_timeout: has_cli_timeout,
                 early_stop,
                 env: profile_env,
                 force_rerun,
                 learned_selection,
-                cancelled,
+                cancelled: cancelled.clone(),
             },
         );
         (outcome.report, outcome.cancelled)
     };
+    if run_cancelled || cancelled.load(Ordering::Acquire) {
+        eprintln!("Interrupted; skipping mutation report and side effects.");
+        exit_with(_lock, 130);
+    }
+
     report.baseline_timing = baseline_timing;
     merge_uncovered(&mut report, classified.uncovered);
     togi::report::print_report(&report, output_format)?;
-
-    if run_cancelled {
-        eprintln!("Interrupted; skipping baseline and PR comment updates.");
-        exit_with(_lock, 130);
-    }
 
     let current = togi::baseline::from_report(&report, &project_root_ref);
     let mut should_fail = false;
@@ -855,6 +888,21 @@ fn validate_timeout_calibration(multiplier: f64) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn calibration_measurement(
+    measurement: &togi::runner::BaselineHealthMeasurement,
+) -> Option<&togi::runner::BaselineSuiteMeasurement> {
+    measurement
+        .suites
+        .iter()
+        .filter(|suite| suite.uses_default_timeout)
+        .max_by_key(|suite| {
+            suite
+                .build_duration
+                .filter(|duration| *duration > suite.test_duration)
+                .unwrap_or(suite.test_duration)
+        })
+}
+
 fn calibrated_timeout_seconds(
     build_duration: Option<Duration>,
     test_duration: Duration,
@@ -1183,61 +1231,79 @@ fn print_dry_run(mutations: &[Mutation]) {
     }
 }
 
-fn execute(
-    mutations: Vec<Mutation>,
-    config: togi::config::Config,
-    project_root: PathBuf,
-    options: ExecuteOptions,
-) -> togi::runner::RunOutcome {
-    let mut language_commands: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
-    let mut language_timeouts: std::collections::HashMap<String, Duration> =
-        std::collections::HashMap::new();
-    for (lang, lang_config) in config.test.languages {
-        language_commands.insert(lang.clone(), lang_config.command);
-        if let Some(t) = lang_config.timeout {
-            language_timeouts.insert(lang, Duration::from_secs(t));
-        }
-    }
+fn command_config(
+    config: &togi::config::Config,
+    project_root: &Path,
+    build_command_explicit: bool,
+    force_default_command: bool,
+    force_default_timeout: bool,
+) -> togi::runner::CommandConfig {
+    let language_commands = config
+        .test
+        .languages
+        .iter()
+        .map(|(language, language_config)| (language.clone(), language_config.command.clone()))
+        .collect();
+    let language_timeouts = config
+        .test
+        .languages
+        .iter()
+        .filter_map(|(language, language_config)| {
+            language_config
+                .timeout
+                .map(|timeout| (language.clone(), Duration::from_secs(timeout)))
+        })
+        .collect();
     let project_commands = config
         .projects
-        .into_values()
+        .values()
         .map(|project| {
             let (command, timeout) = project
                 .test
-                .map(|test| (test.command, test.timeout))
+                .as_ref()
+                .map(|test| (test.command.clone(), test.timeout))
                 .unwrap_or((None, None));
             togi::runner::ProjectCommandConfig {
-                path: project.path,
+                path: project.path.clone(),
                 command,
                 timeout: timeout.map(Duration::from_secs),
             }
         })
         .collect();
-    let test_selection = load_test_selection(
-        config.mutations.test_selection_file.as_deref(),
-        &project_root,
-    );
+
+    togi::runner::CommandConfig {
+        command: config.test.command.clone(),
+        sandbox_command: config.test.sandbox_command.clone(),
+        force_default_command,
+        force_default_timeout,
+        project_commands,
+        language_commands,
+        build_command: if build_command_explicit {
+            config.test.build_command.clone()
+        } else {
+            vec![]
+        },
+        build_command_explicit,
+        timeout: Duration::from_secs(config.test.timeout),
+        language_timeouts,
+        test_selection: load_test_selection(
+            config.mutations.test_selection_file.as_deref(),
+            project_root,
+        ),
+    }
+}
+
+fn execute(
+    mutations: Vec<Mutation>,
+    config: togi::config::Config,
+    commands: togi::runner::CommandConfig,
+    project_root: PathBuf,
+    options: ExecuteOptions,
+) -> togi::runner::RunOutcome {
     let use_schemata = config.mutations.schemata;
 
     let runner = togi::runner::TestRunner {
-        commands: togi::runner::CommandConfig {
-            command: config.test.command,
-            sandbox_command: config.test.sandbox_command,
-            force_default_command: options.force_default_command,
-            force_default_timeout: options.force_default_timeout,
-            project_commands,
-            language_commands,
-            build_command: if options.build_command_explicit {
-                config.test.build_command
-            } else {
-                vec![]
-            },
-            build_command_explicit: options.build_command_explicit,
-            timeout: Duration::from_secs(config.test.timeout),
-            language_timeouts,
-            test_selection,
-        },
+        commands,
         parallelism: config.test.jobs,
         project_root,
         verbose: options.verbose,
@@ -1851,6 +1917,36 @@ jobs = 4
         );
 
         assert_eq!(timeout, 5);
+    }
+
+    #[test]
+    fn calibration_uses_the_slowest_default_timeout_route() {
+        let measurement = togi::runner::BaselineHealthMeasurement {
+            suites: vec![
+                togi::runner::BaselineSuiteMeasurement {
+                    build_duration: None,
+                    test_command: vec!["fast".into()],
+                    test_duration: Duration::from_secs(1),
+                    uses_default_timeout: true,
+                },
+                togi::runner::BaselineSuiteMeasurement {
+                    build_duration: None,
+                    test_command: vec!["slow".into()],
+                    test_duration: Duration::from_secs(4),
+                    uses_default_timeout: true,
+                },
+                togi::runner::BaselineSuiteMeasurement {
+                    build_duration: Some(Duration::from_secs(10)),
+                    test_command: vec!["explicit".into()],
+                    test_duration: Duration::from_secs(10),
+                    uses_default_timeout: false,
+                },
+            ],
+        };
+
+        let selected = calibration_measurement(&measurement).unwrap();
+
+        assert_eq!(selected.test_command, vec!["slow"]);
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -214,11 +214,44 @@ pub struct BaselineTimingConfig<'a> {
     pub cancelled: &'a AtomicBool,
     pub respect_workspace_ignores: bool,
 }
+/// Configuration for validating unmutated test suites before mutation execution.
+pub struct BaselineHealthConfig<'a> {
+    /// Commands and routing used for the pending mutations.
+    pub commands: &'a CommandConfig,
+    /// More generous deadline used only while measuring routes that inherit the
+    /// global timeout for calibration.
+    pub default_measurement_timeout: Option<Duration>,
+    /// Whether Go mutations may run through schemata, which requires an
+    /// uncached `go test` command.
+    pub schemata_enabled: bool,
+    /// Extra environment variables passed to every spawned command.
+    pub env: &'a HashMap<String, String>,
+    /// Stops baseline execution when cancellation is requested.
+    pub cancelled: &'a AtomicBool,
+    /// Whether the isolated baseline workspace honors ignore files.
+    pub respect_workspace_ignores: bool,
+}
+
+/// One passing unmutated test suite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineSuiteMeasurement {
+    pub build_duration: Option<Duration>,
+    pub test_command: Vec<String>,
+    pub test_duration: Duration,
+    pub uses_default_timeout: bool,
+}
+
+/// Passing baselines suitable for timeout calibration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaselineHealthMeasurement {
+    pub suites: Vec<BaselineSuiteMeasurement>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SelectedTestCommand {
     argv: Vec<String>,
     timeout: Duration,
+    uses_default_timeout: bool,
     selected_tests: Vec<String>,
 }
 
@@ -268,19 +301,7 @@ fn select_test_command_with_history(
     mutation: &Mutation,
     history: Option<&cache::IncrementalHistoryStore>,
 ) -> SelectedTestCommand {
-    let project_info = matching_project_command(project_root, commands, mutation);
-
-    let mut argv = project_info
-        .filter(|_| !commands.force_default_command)
-        .and_then(|project| project.command.as_ref())
-        .or_else(|| {
-            (!commands.force_default_command)
-                .then(|| commands.language_commands.get(mutation.language.as_str()))
-                .flatten()
-        })
-        .unwrap_or(&commands.command)
-        .clone();
-    let mut selected_tests = Vec::new();
+    let mut selected = select_unnarrowed_test_command(project_root, commands, mutation);
 
     if let Some(test_selection) = &commands.test_selection {
         if let Some(mut tests) = test_selection.tests_for(project_root, mutation) {
@@ -293,27 +314,50 @@ fn select_test_command_with_history(
             }) {
                 tests.sort_by_key(|test| if *test == preferred { 0 } else { 1 });
             }
-            argv = narrow_test_command(argv, &tests);
-            selected_tests = tests;
+            selected.argv = narrow_test_command(selected.argv, &tests);
+            selected.selected_tests = tests;
         }
     }
 
+    selected
+}
+
+fn select_unnarrowed_test_command(
+    project_root: &Path,
+    commands: &CommandConfig,
+    mutation: &Mutation,
+) -> SelectedTestCommand {
+    let project_info = matching_project_command(project_root, commands, mutation);
+    let argv = project_info
+        .filter(|_| !commands.force_default_command)
+        .and_then(|project| project.command.as_ref())
+        .or_else(|| {
+            (!commands.force_default_command)
+                .then(|| commands.language_commands.get(mutation.language.as_str()))
+                .flatten()
+        })
+        .unwrap_or(&commands.command)
+        .clone();
+
+    let (timeout, uses_default_timeout) = if commands.force_default_timeout {
+        (commands.timeout, true)
+    } else if let Some(timeout) = project_info.and_then(|project| project.timeout) {
+        (timeout, false)
+    } else if let Some(timeout) = commands
+        .language_timeouts
+        .get(mutation.language.as_str())
+        .copied()
+    {
+        (timeout, false)
+    } else {
+        (commands.timeout, true)
+    };
+
     SelectedTestCommand {
         argv,
-        timeout: if commands.force_default_timeout {
-            commands.timeout
-        } else {
-            project_info
-                .and_then(|project| project.timeout)
-                .or_else(|| {
-                    commands
-                        .language_timeouts
-                        .get(mutation.language.as_str())
-                        .copied()
-                })
-                .unwrap_or(commands.timeout)
-        },
-        selected_tests,
+        timeout,
+        uses_default_timeout,
+        selected_tests: Vec::new(),
     }
 }
 
@@ -1200,6 +1244,123 @@ pub fn measure_baseline_timing(
         build_duration,
         test_duration,
     })
+}
+/// Run every unmutated test suite that the pending mutations would use.
+///
+/// Test selection is intentionally not applied: a narrowed command cannot
+/// establish that the full effective suite is healthy. Each suite runs in a
+/// fresh isolated workspace, with the opt-in build command immediately
+/// preceding its test command.
+pub fn check_baseline_health(
+    project_root: &Path,
+    mutations: &[Mutation],
+    config: BaselineHealthConfig<'_>,
+) -> anyhow::Result<BaselineHealthMeasurement> {
+    let suites = resolve_baseline_suites(
+        project_root,
+        config.commands,
+        mutations,
+        config.schemata_enabled,
+    );
+    if suites.is_empty() {
+        bail!("no baseline test suites were selected");
+    }
+
+    let mut measurements = Vec::with_capacity(suites.len());
+    for suite in suites {
+        let workspace = copy_workspace_with_options(project_root, config.respect_workspace_ignores)
+            .with_context(|| "could not create baseline health workspace")?;
+        let root = workspace.root();
+        let timeout = baseline_suite_timeout(&suite, config.default_measurement_timeout);
+        let build_duration = if config.commands.build_command_explicit
+            && !config.commands.build_command.is_empty()
+        {
+            Some(measure_baseline_command(
+                "baseline build command",
+                &config.commands.build_command,
+                &config.commands.sandbox_command,
+                root,
+                timeout,
+                config.env,
+                config.cancelled,
+            )?)
+        } else {
+            None
+        };
+        let test_duration = measure_baseline_command(
+            "baseline test command",
+            &suite.argv,
+            &config.commands.sandbox_command,
+            root,
+            timeout,
+            config.env,
+            config.cancelled,
+        )?;
+        measurements.push(BaselineSuiteMeasurement {
+            build_duration,
+            test_command: suite.argv,
+            test_duration,
+            uses_default_timeout: suite.default_timeout.is_some(),
+        });
+    }
+
+    Ok(BaselineHealthMeasurement {
+        suites: measurements,
+    })
+}
+
+struct ResolvedBaselineSuite {
+    argv: Vec<String>,
+    default_timeout: Option<Duration>,
+    explicit_timeout: Option<Duration>,
+}
+
+fn baseline_suite_timeout(
+    suite: &ResolvedBaselineSuite,
+    default_measurement_timeout: Option<Duration>,
+) -> Duration {
+    let default_timeout = suite
+        .default_timeout
+        .map(|timeout| default_measurement_timeout.unwrap_or(timeout));
+    match (default_timeout, suite.explicit_timeout) {
+        (Some(default), Some(explicit)) => default.min(explicit),
+        (Some(timeout), None) | (None, Some(timeout)) => timeout,
+        (None, None) => unreachable!("baseline suite has a timeout"),
+    }
+}
+
+fn resolve_baseline_suites(
+    project_root: &Path,
+    commands: &CommandConfig,
+    mutations: &[Mutation],
+    schemata_enabled: bool,
+) -> Vec<ResolvedBaselineSuite> {
+    let mut suites = Vec::new();
+    for mutation in mutations {
+        let mut selected = select_unnarrowed_test_command(project_root, commands, mutation);
+        if schemata_enabled && mutation.language == "go" {
+            selected.argv = force_go_no_test_cache(selected.argv);
+        }
+        if let Some(existing) = suites
+            .iter_mut()
+            .find(|suite: &&mut ResolvedBaselineSuite| suite.argv == selected.argv)
+        {
+            let timeout = if selected.uses_default_timeout {
+                &mut existing.default_timeout
+            } else {
+                &mut existing.explicit_timeout
+            };
+            *timeout =
+                Some(timeout.map_or(selected.timeout, |current| current.min(selected.timeout)));
+        } else {
+            suites.push(ResolvedBaselineSuite {
+                argv: selected.argv,
+                default_timeout: selected.uses_default_timeout.then_some(selected.timeout),
+                explicit_timeout: (!selected.uses_default_timeout).then_some(selected.timeout),
+            });
+        }
+    }
+    suites
 }
 
 fn measure_baseline_command(
@@ -3098,11 +3259,23 @@ impl TestRunner {
             schema_rewrites_for_language(&self.project_root, language, schema_mutations)?;
         apply_schema_rewrites_to_workspace(&self.project_root, workspace.root(), &rewrites)?;
 
+        let timeout = schema_mutations
+            .iter()
+            .map(|schema_mutation| {
+                select_unnarrowed_test_command(
+                    &self.project_root,
+                    &self.commands,
+                    &schema_mutation.mutation,
+                )
+                .timeout
+            })
+            .max()
+            .unwrap_or(self.commands.timeout);
         let build = run_command(
             &self.commands.build_command,
             &self.commands.sandbox_command,
             workspace.root(),
-            self.commands.timeout,
+            timeout,
             true,
             &self.env,
             &self.cancelled,
@@ -3278,7 +3451,7 @@ fn run_schema_workspace_mutation(
             &runner.commands.build_command,
             &runner.commands.sandbox_command,
             workspace_root,
-            runner.commands.timeout,
+            timeout,
             true,
             &runner.env,
             &runner.cancelled,
@@ -4874,11 +5047,13 @@ mod tests {
         let selected = SelectedTestCommand {
             argv: vec!["cargo test".into()],
             timeout: Duration::from_secs(2),
+            uses_default_timeout: false,
             selected_tests: Vec::new(),
         };
         let ambiguous = SelectedTestCommand {
             argv: vec!["cargo".into(), "test".into()],
             timeout: Duration::from_secs(2),
+            uses_default_timeout: false,
             selected_tests: Vec::new(),
         };
 
@@ -6052,6 +6227,245 @@ mod tests {
         assert!(measurement.test_duration <= Duration::from_secs(5));
         Ok(())
     }
+    #[test]
+    fn baseline_suites_ignore_line_to_test_narrowing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut commands = test_command_config();
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            dir.path(),
+            Path::new("src/lib.rs"),
+            1,
+            vec!["only_this_test".into()],
+        );
+        commands.test_selection = Some(selection);
+        let mutation = make_test_mutation(Path::new("src/lib.rs"));
+
+        let suites = resolve_baseline_suites(dir.path(), &commands, &[mutation], false);
+
+        assert_eq!(suites.len(), 1);
+        assert_eq!(suites[0].argv, vec!["cargo", "test"]);
+        assert!(suites[0].default_timeout.is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_isolates_source_and_target_between_routes() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().join("project");
+        let log = dir.path().join("baseline.log");
+        std::fs::create_dir_all(root.join("services/api"))?;
+        std::fs::create_dir_all(root.join("src"))?;
+        std::fs::write(root.join("src/lib.rs"), "clean")?;
+        std::fs::write(root.join("worker.go"), "package worker")?;
+        std::fs::write(root.join("services/api/main.go"), "package api")?;
+
+        let global_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "test \"$(cat target/build-state)\" = generated || exit 1; echo global >> \"$BASELINE_LOG\"; printf changed > src/lib.rs; printf leaked > target/from-global".into(),
+        ];
+        let language_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "test \"$(cat src/lib.rs)\" = clean && test \"$(cat target/build-state)\" = generated && test ! -e target/from-global || exit 1; echo language >> \"$BASELINE_LOG\"; printf leaked > target/from-language".into(),
+        ];
+        let project_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "test \"$(cat src/lib.rs)\" = clean && test \"$(cat target/build-state)\" = generated && test ! -e target/from-global && test ! -e target/from-language || exit 1; echo project >> \"$BASELINE_LOG\"".into(),
+        ];
+        let build_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "mkdir -p target; printf generated > target/build-state; echo build >> \"$BASELINE_LOG\"".into(),
+        ];
+        let mut commands = test_command_config();
+        commands.command = global_command.clone();
+        commands
+            .language_commands
+            .insert("go".into(), language_command);
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(project_command),
+            timeout: None,
+        });
+        commands.build_command = build_command;
+        commands.build_command_explicit = true;
+
+        let mut env = HashMap::new();
+        env.insert(
+            "BASELINE_LOG".to_string(),
+            log.to_string_lossy().into_owned(),
+        );
+        let mut language_mutation = make_test_mutation(Path::new("worker.go"));
+        language_mutation.language = "go".into();
+        let mut project_mutation = make_test_mutation(Path::new("services/api/main.go"));
+        project_mutation.language = "go".into();
+        let mutations = vec![
+            make_test_mutation(Path::new("src/lib.rs")),
+            language_mutation.clone(),
+            project_mutation,
+            language_mutation,
+        ];
+
+        let measurement = check_baseline_health(
+            &root,
+            &mutations,
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: None,
+                schemata_enabled: false,
+                env: &env,
+                cancelled: &AtomicBool::new(false),
+                respect_workspace_ignores: false,
+            },
+        )?;
+
+        assert_eq!(measurement.suites.len(), 3);
+        assert_eq!(measurement.suites[0].test_command, global_command);
+        assert_eq!(
+            std::fs::read_to_string(log)?.lines().collect::<Vec<_>>(),
+            vec!["build", "global", "build", "language", "build", "project"]
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_uses_explicit_route_timeout_while_calibrating() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("worker.go"), "package worker").unwrap();
+        let mut commands = test_command_config();
+        commands.language_commands.insert(
+            "go".into(),
+            vec!["sh".into(), "-c".into(), "sleep 1".into()],
+        );
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_millis(50));
+        let mut mutation = make_test_mutation(Path::new("worker.go"));
+        mutation.language = "go".into();
+
+        let err = check_baseline_health(
+            dir.path(),
+            &[mutation],
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: Some(Duration::from_secs(60)),
+                schemata_enabled: false,
+                env: &HashMap::new(),
+                cancelled: &AtomicBool::new(false),
+                respect_workspace_ignores: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out after 0.05s"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_checks_identical_commands_at_each_effective_deadline() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("default.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("worker.go"), "package worker").unwrap();
+        let command = vec!["sh".into(), "-c".into(), "sleep 2".into()];
+        let mut commands = test_command_config();
+        commands.command = command.clone();
+        commands.timeout = Duration::from_secs(1);
+        commands.language_commands.insert("go".into(), command);
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_secs(5));
+        let mut language_mutation = make_test_mutation(Path::new("worker.go"));
+        language_mutation.language = "go".into();
+
+        let err = check_baseline_health(
+            dir.path(),
+            &[
+                make_test_mutation(Path::new("default.rs")),
+                language_mutation,
+            ],
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: None,
+                schemata_enabled: false,
+                env: &HashMap::new(),
+                cancelled: &AtomicBool::new(false),
+                respect_workspace_ignores: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out after 1.00s"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_keeps_explicit_identical_deadline_while_calibrating_in_reverse_order() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("default.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("worker.go"), "package worker").unwrap();
+        let command = vec!["sh".into(), "-c".into(), "sleep 1".into()];
+        let mut commands = test_command_config();
+        commands.command = command.clone();
+        commands.language_commands.insert("go".into(), command);
+        commands
+            .language_timeouts
+            .insert("go".into(), Duration::from_millis(50));
+        let mut language_mutation = make_test_mutation(Path::new("worker.go"));
+        language_mutation.language = "go".into();
+
+        let err = check_baseline_health(
+            dir.path(),
+            &[
+                language_mutation,
+                make_test_mutation(Path::new("default.rs")),
+            ],
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: Some(Duration::from_secs(60)),
+                schemata_enabled: false,
+                env: &HashMap::new(),
+                cancelled: &AtomicBool::new(false),
+                respect_workspace_ignores: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out after 0.05s"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_uses_explicit_project_timeout_while_calibrating() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("services/api")).unwrap();
+        std::fs::write(dir.path().join("services/api/main.go"), "package api").unwrap();
+        let mut commands = test_command_config();
+        commands.project_commands.push(ProjectCommandConfig {
+            path: PathBuf::from("services/api"),
+            command: Some(vec!["sh".into(), "-c".into(), "sleep 1".into()]),
+            timeout: Some(Duration::from_millis(50)),
+        });
+
+        let err = check_baseline_health(
+            dir.path(),
+            &[make_test_mutation(Path::new("services/api/main.go"))],
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: Some(Duration::from_secs(60)),
+                schemata_enabled: false,
+                env: &HashMap::new(),
+                cancelled: &AtomicBool::new(false),
+                respect_workspace_ignores: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out after 0.05s"));
+    }
 
     #[test]
     fn workspace_pool_creates_slots_and_reuses_after_drop() {
@@ -6921,6 +7335,65 @@ esac
 
     #[cfg(unix)]
     #[test]
+    fn schemata_build_uses_project_route_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("services/api")).unwrap();
+        let source = "package api\nfunc same(a, b int) bool { return a == b }\n";
+        std::fs::write(dir.path().join("services/api/calc.go"), source).unwrap();
+        let mutation = go_operator_mutation(0, "services/api/calc.go", source, 0);
+        let test_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "case \"$(cat services/api/calc.go)\" in *__togi_active*) exit 1 ;; *) exit 2 ;; esac"
+                .into(),
+        ];
+        let runner = TestRunner {
+            commands: CommandConfig {
+                command: successful_command(),
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![ProjectCommandConfig {
+                    path: PathBuf::from("services/api"),
+                    command: Some(test_command),
+                    timeout: Some(Duration::from_secs(2)),
+                }],
+                language_commands: HashMap::new(),
+                build_command: vec!["sh".into(), "-c".into(), "sleep 1".into()],
+                sandbox_command: vec![],
+                build_command_explicit: true,
+                timeout: Duration::from_millis(50),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![mutation]).report;
+
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert!(
+            report
+                .schemata
+                .expect("schemata report")
+                .fallback_reasons
+                .iter()
+                .all(|reason| reason.reason != "schema_build_failure")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn run_with_schemata_resets_workspace_between_schema_mutants() {
         let dir = tempfile::tempdir().unwrap();
         let source = "\
@@ -7020,6 +7493,7 @@ esac
         let cache_selected = SelectedTestCommand {
             argv: selected.argv,
             timeout: selected.timeout,
+            uses_default_timeout: selected.uses_default_timeout,
             selected_tests: selected.selected_tests,
         };
         let cache_ctx = cache_selected.cache_context(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 #[cfg(unix)]
-use std::os::unix::process::CommandExt;
+use std::os::unix::{fs::PermissionsExt, process::CommandExt};
 use std::path::Path;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
@@ -148,6 +148,7 @@ fn setup_two_line_mutation_repo() -> TempDir {
     dir
 }
 
+#[cfg(unix)]
 #[test]
 fn check_classifies_zero_coverage_mutants_as_uncovered() {
     let dir = setup_two_line_mutation_repo();
@@ -157,6 +158,16 @@ fn check_classifies_zero_coverage_mutants_as_uncovered() {
         "SF:main.go\nDA:4,1\nDA:7,0\nend_of_record\n",
     )
     .unwrap();
+    let expected = tempfile::NamedTempFile::new().unwrap();
+    fs::write(
+        expected.path(),
+        fs::read(dir.path().join("main.go")).unwrap(),
+    )
+    .unwrap();
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(&format!("cmp -s main.go {}", shell_quote(expected.path())))
+    );
 
     let output = togi()
         .args([
@@ -166,7 +177,7 @@ fn check_classifies_zero_coverage_mutants_as_uncovered() {
             "--format",
             "json",
             "--test-cmd",
-            "false",
+            &test_cmd,
             "--coverage-file",
             "lcov.info",
             "--fail-under",
@@ -176,8 +187,9 @@ fn check_classifies_zero_coverage_mutants_as_uncovered() {
         .output()
         .unwrap();
 
-    // `false` kills every executed mutant. The zero-coverage mutant must not
-    // count as a survivor, so the run passes even with --fail-under 100.
+    // The command passes for the unmutated file and kills each executed
+    // mutant. The zero-coverage mutant must not count as a survivor, so the
+    // run passes even with --fail-under 100.
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -228,7 +240,7 @@ fn check_all_mutants_uncovered_skips_execution() {
             "--format",
             "json",
             "--test-cmd",
-            "false",
+            "true",
             "--coverage-file",
             "lcov.info",
         ])
@@ -268,6 +280,78 @@ fn check_all_mutants_uncovered_skips_execution() {
 }
 
 #[test]
+fn check_all_mutants_uncovered_aborts_when_baseline_test_fails() {
+    let dir = setup_two_line_mutation_repo();
+    fs::write(
+        dir.path().join("lcov.info"),
+        "SF:main.go\nDA:4,0\nDA:7,0\nend_of_record\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "false",
+            "--coverage-file",
+            "lcov.info",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("baseline test command failed (`false`)")
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
+fn check_all_mutants_uncovered_aborts_when_baseline_build_fails() {
+    let dir = setup_two_line_mutation_repo();
+    fs::write(
+        dir.path().join("lcov.info"),
+        "SF:main.go\nDA:4,0\nDA:7,0\nend_of_record\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+            "--build-cmd",
+            "false",
+            "--coverage-file",
+            "lcov.info",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("baseline build command failed (`false`)")
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
 fn check_warns_when_fail_fast_is_ignored_for_custom_test_cmd() {
     let dir = setup_git_repo();
 
@@ -301,7 +385,7 @@ fn check_format_json_outputs_valid_json() {
             "--format",
             "json",
             "--test-cmd",
-            "false",
+            "true",
         ])
         .current_dir(dir.path())
         .output()
@@ -315,6 +399,784 @@ fn check_format_json_outputs_valid_json() {
     });
     assert!(value.get("total").is_some());
     assert!(value.get("mutations").is_some());
+}
+
+#[test]
+fn check_aborts_before_mutations_when_baseline_test_fails() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--test-cmd",
+            "false",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline test command failed (`false`)"));
+    assert!(!stderr.contains("Running 1 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(
+        !dir.path().join(".togi-cache").exists(),
+        "baseline failure must not create mutation cache entries"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_schemata_cannot_bypass_a_source_sensitive_baseline_failure() {
+    let dir = setup_git_repo();
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text("if grep -Fq 'if a > b' main.go; then exit 1; fi")
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--operators",
+            "gt_to_gte",
+            "--test-cmd",
+            &test_cmd,
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline test command failed"));
+    assert!(!stderr.contains("Running 1 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_failing_baseline_does_not_accept_a_preseeded_exact_cache_verdict() {
+    let dir = setup_git_repo();
+    let log = dir.path().join("cache-baseline.log");
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(
+            "if [ \"$TOGI_BASELINE_MODE\" = fail ] && grep -Fq 'if a > b' main.go; then echo baseline-failed >> \"$TOGI_TEST_LOG\"; exit 1; fi; if grep -Fq 'if a > b' main.go; then echo baseline-pass >> \"$TOGI_TEST_LOG\"; else echo mutant >> \"$TOGI_TEST_LOG\"; fi"
+        )
+    );
+
+    let seeded = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--test-cmd",
+            &test_cmd,
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("TOGI_BASELINE_MODE", "pass")
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        seeded.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&seeded.stdout),
+        String::from_utf8_lossy(&seeded.stderr)
+    );
+    assert!(
+        dir.path().join(".togi-cache").exists(),
+        "the first run must seed an exact cache verdict"
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--test-cmd",
+            &test_cmd,
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("TOGI_BASELINE_MODE", "fail")
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline test command failed"));
+    assert!(!stderr.contains("Running 1 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert_eq!(
+        fs::read_to_string(log).unwrap().lines().collect::<Vec<_>>(),
+        vec!["baseline-pass", "mutant", "baseline-failed"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_schemata_baselines_go_with_the_no_cache_argv() {
+    let dir = setup_git_repo();
+    let fake_bin = dir.path().join("fake-go-bin");
+    let log = dir.path().join("fake-go.log");
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test]
+command = ["go", "test", "./..."]
+timeout = 5
+
+[mutations]
+schemata = true
+"#,
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("PATH", fake_go_path_env(&fake_bin))
+        .env("TOGI_GO_LOG", &log)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline test command failed"));
+    assert!(stderr.contains("-count=1"));
+    assert_eq!(fs::read_to_string(log).unwrap(), "no-cache");
+    assert!(!stderr.contains("Running 1 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_no_schemata_keeps_the_raw_go_test_argv() {
+    let dir = setup_git_repo();
+    let fake_bin = dir.path().join("fake-go-bin");
+    let log = dir.path().join("fake-go.log");
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test]
+command = ["go", "test", "./..."]
+timeout = 5
+"#,
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("PATH", fake_go_path_env(&fake_bin))
+        .env("TOGI_GO_LOG", &log)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["survived"], 1);
+    assert_eq!(fs::read_to_string(log).unwrap(), "rawraw");
+}
+
+#[test]
+fn check_runs_mutations_after_a_passing_baseline() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--test-cmd",
+            "true",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Checking baseline test suites..."));
+    assert!(stderr.contains("Running 1 mutations..."));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["total"], 1);
+    assert_eq!(value["survived"], 1);
+    assert!(dir.path().join(".togi-cache").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_calibration_reuses_the_passing_baseline_run() {
+    let dir = setup_git_repo();
+    let log = dir.path().join("baseline-runs.log");
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(
+            "if grep -q 'if a > b' main.go; then echo baseline >> \"$TOGI_TEST_LOG\"; else echo mutant >> \"$TOGI_TEST_LOG\"; fi"
+        )
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--test-cmd",
+            &test_cmd,
+            "--calibrate-timeout",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(log).unwrap().lines().collect::<Vec<_>>(),
+        vec!["baseline", "mutant"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_calibration_extends_a_slow_global_default_route() {
+    let dir = setup_git_repo();
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test]
+command = ["sh", "-c", "sleep 2"]
+timeout = 1
+calibrate_timeout = true
+timeout_multiplier = 1.0
+timeout_slack = 1
+"#,
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["timeout"], 0);
+    assert!(
+        value["baseline_timing"]["calibrated_timeout_ms"]
+            .as_u64()
+            .is_some_and(|timeout| timeout >= 3_000)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_calibration_uses_the_slowest_default_route() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    for args in [
+        &["init"][..],
+        &["config", "user.email", "test@example.com"],
+        &["config", "user.name", "Test"],
+    ] {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+    fs::write(
+        root.join("a.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a >= b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("z.go"),
+        "package sample\n\nfunc compare(a, b int) bool { return a >= b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        r#"
+[test]
+command = ["true"]
+timeout = 1
+calibrate_timeout = true
+timeout_multiplier = 1.0
+timeout_slack = 1
+
+[test.languages.go]
+command = ["sh", "-c", "sleep 2"]
+"#,
+    )
+    .unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    fs::write(
+        root.join("a.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("z.go"),
+        "package sample\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--max-per-run",
+            "2",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["timeout"], 0);
+    assert!(
+        value["baseline_timing"]["calibrated_timeout_ms"]
+            .as_u64()
+            .is_some_and(|timeout| timeout >= 3_000)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_calibration_uses_a_slow_project_route_without_an_explicit_timeout() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    for args in [
+        &["init"][..],
+        &["config", "user.email", "test@example.com"],
+        &["config", "user.name", "Test"],
+    ] {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+    fs::create_dir_all(root.join("zproject")).unwrap();
+    fs::write(
+        root.join("a.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a >= b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("zproject/main.go"),
+        "package sample\n\nfunc compare(a, b int) bool { return a >= b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        r#"
+[test]
+command = ["true"]
+timeout = 1
+calibrate_timeout = true
+timeout_multiplier = 1.0
+timeout_slack = 1
+
+[projects.api]
+path = "zproject"
+
+[projects.api.test]
+command = ["sh", "-c", "sleep 2"]
+"#,
+    )
+    .unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    fs::write(
+        root.join("a.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("zproject/main.go"),
+        "package sample\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--max-per-run",
+            "2",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["timeout"], 0);
+    assert!(
+        value["baseline_timing"]["calibrated_timeout_ms"]
+            .as_u64()
+            .is_some_and(|timeout| timeout >= 3_000)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_baselines_global_language_and_project_routes() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("services/api")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("worker.go"),
+        "package worker\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("services/api/main.go"),
+        "package api\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        r#"
+[test]
+command = ["sh", "-c", 'if grep -Fq "a > b" src/lib.rs; then echo global >> "$TOGI_TEST_LOG"; fi; exit 0']
+
+[test.languages.go]
+command = ["sh", "-c", 'if grep -Fq "a > b" worker.go; then echo language >> "$TOGI_TEST_LOG"; fi; exit 0']
+
+[projects.api]
+path = "services/api"
+
+[projects.api.test]
+command = ["sh", "-c", 'if grep -Fq "a > b" services/api/main.go; then echo project >> "$TOGI_TEST_LOG"; fi; exit 0']
+"#,
+    )
+    .unwrap();
+    let log = root.join("baseline-routes.log");
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--max-per-run",
+            "3",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut baseline_routes = fs::read_to_string(log)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    baseline_routes.sort();
+    assert_eq!(baseline_routes, vec!["global", "language", "project"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn check_aborts_before_mutation_work_when_a_later_project_baseline_fails() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    fs::create_dir_all(root.join("zproject")).unwrap();
+    fs::write(
+        root.join("a.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("m.go"),
+        "package worker\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("zproject/main.go"),
+        "package api\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        r#"
+[test]
+command = ["sh", "-c", 'if grep -Fq "a > b" a.rs; then echo global >> "$TOGI_TEST_LOG"; fi; exit 0']
+
+[test.languages.go]
+command = ["sh", "-c", 'if grep -Fq "a > b" m.go; then echo language >> "$TOGI_TEST_LOG"; fi; exit 0']
+
+[projects.api]
+path = "zproject"
+
+[projects.api.test]
+command = ["sh", "-c", 'if grep -Fq "a > b" zproject/main.go; then echo project-failed >> "$TOGI_TEST_LOG"; exit 1; fi; exit 0']
+"#,
+    )
+    .unwrap();
+    let log = root.join("baseline-routes.log");
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--max-per-run",
+            "3",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline test command failed"), "{stderr}");
+    assert!(!stderr.contains("Running 3 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!root.join(".togi-cache").exists());
+    assert_eq!(
+        fs::read_to_string(log).unwrap().lines().collect::<Vec<_>>(),
+        vec!["global", "language", "project-failed"]
+    );
 }
 
 #[test]
@@ -358,12 +1220,8 @@ fn check_format_sarif_outputs_valid_sarif() {
 
 #[cfg(unix)]
 #[test]
-fn check_format_json_includes_build_error_diagnostics() {
+fn check_aborts_before_report_when_baseline_build_fails() {
     let dir = setup_git_repo();
-    let build_cmd = format!(
-        "{} not-a-togi-command",
-        shell_quote(&assert_cmd::cargo::cargo_bin("togi"))
-    );
 
     let output = togi()
         .args([
@@ -375,58 +1233,53 @@ fn check_format_json_includes_build_error_diagnostics() {
             "--test-cmd",
             "true",
             "--build-cmd",
-            &build_cmd,
+            "false",
             "--no-schemata",
             "--operators",
             "gt_to_gte",
             "--max-per-run",
-            "1",
-            "--jobs",
             "1",
         ])
         .current_dir(dir.path())
         .output()
         .unwrap();
 
-    assert!(
-        output.status.success(),
-        "check failed\nstdout:\n{}\nstderr:\n{}",
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
-        panic!(
-            "invalid JSON output: {e}\nstdout: {}",
-            String::from_utf8_lossy(&output.stdout)
-        )
-    });
-
-    assert_eq!(value["build_errors"], 1);
-    assert_eq!(value["mutations"][0]["result"], "build_error");
-    assert!(value["mutations"][0]["build_error_fingerprint"].is_string());
-    assert_eq!(value["build_error_groups"][0]["phase"], "build_command");
-    assert_eq!(value["build_error_groups"][0]["runner"], "regular");
-    assert!(
-        value["build_error_groups"][0]["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("not-a-togi-command"))
-    );
-    assert!(
-        value["build_error_groups"][0]["command"]
-            .as_array()
-            .is_some_and(|command| command
-                .iter()
-                .any(|arg| arg.as_str() == Some("not-a-togi-command")))
-    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline build command failed (`false`)"));
+    assert!(!stderr.contains("Running 1 mutations"));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!dir.path().join(".togi-cache").exists());
 }
 
 #[cfg(unix)]
 #[test]
 fn check_terminal_includes_build_error_diagnostics() {
     let dir = setup_git_repo();
-    let build_cmd = format!(
+    let expected = tempfile::NamedTempFile::new().unwrap();
+    fs::write(
+        expected.path(),
+        fs::read(dir.path().join("main.go")).unwrap(),
+    )
+    .unwrap();
+    let failing_command = format!(
         "{} not-a-togi-command",
         shell_quote(&assert_cmd::cargo::cargo_bin("togi"))
+    );
+    let build_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(&format!(
+            "if cmp -s main.go {}; then exit 0; else exec {failing_command}; fi",
+            shell_quote(expected.path())
+        ))
     );
 
     togi()
@@ -554,6 +1407,126 @@ fn check_baseline_still_honors_fail_under() {
 
 #[cfg(unix)]
 #[test]
+fn interrupted_mutation_exits_130_without_a_report_or_side_effects() {
+    let dir = setup_git_repo();
+    let baseline_marker = dir.path().join("baseline-marker");
+    let mutation_marker = dir.path().join("mutation-marker");
+    let release = dir.path().join("mutation-release");
+    let stdout_path = dir.path().join("togi-stdout.log");
+    let stderr_path = dir.path().join("togi-stderr.log");
+    let pr_comment_path = dir.path().join("togi-pr-comment.md");
+    let baseline_path = dir.path().join(".togi-baseline");
+    let cache_path = dir.path().join(".togi-cache");
+    let test_script = dir.path().join("block-mutant.sh");
+    fs::write(
+        &test_script,
+        format!(
+            "#!/bin/sh\n\
+             baseline={}\n\
+             mutation={}\n\
+             release={}\n\
+             if grep -Fq 'if a > b' main.go; then\n\
+             \tprintf baseline > \"$baseline\"\n\
+             \texit 0\n\
+             fi\n\
+             printf mutation > \"$mutation\"\n\
+             while [ ! -f \"$release\" ]; do\n\
+             \tsleep 0.05\n\
+             done\n",
+            shell_quote(&baseline_marker),
+            shell_quote(&mutation_marker),
+            shell_quote(&release),
+        ),
+    )
+    .unwrap();
+
+    let stdout = fs::File::create(&stdout_path).unwrap();
+    let stderr = fs::File::create(&stderr_path).unwrap();
+    let test_command = format!("sh {}", shell_quote(&test_script));
+    // foxguard: ignore[rs/no-command-injection]
+    // The test launches the just-built `togi` binary from Cargo metadata.
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("togi"))
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--test-cmd",
+            &test_command,
+            "--timeout",
+            "5",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+            "--save-baseline",
+            "--pr-comment",
+            pr_comment_path
+                .to_str()
+                .expect("PR comment path should be utf-8"),
+        ])
+        .current_dir(dir.path())
+        .process_group(0)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .unwrap();
+
+    if !wait_for_path(&baseline_marker, Duration::from_secs(10))
+        || !wait_for_path(&mutation_marker, Duration::from_secs(10))
+    {
+        send_signal_to_process_group(child.id(), libc::SIGKILL);
+        let _ = child.wait();
+        panic!(
+            "baseline or mutation command did not start\nstdout:\n{}\nstderr:\n{}",
+            read_log(&stdout_path),
+            read_log(&stderr_path)
+        );
+    }
+
+    send_signal_to_process_group(child.id(), libc::SIGINT);
+    fs::write(&release, "").unwrap();
+    let status = wait_for_child(&mut child, Duration::from_secs(10)).unwrap_or_else(|message| {
+        send_signal_to_process_group(child.id(), libc::SIGKILL);
+        let _ = child.wait();
+        panic!(
+            "{message}\nstdout:\n{}\nstderr:\n{}",
+            read_log(&stdout_path),
+            read_log(&stderr_path)
+        );
+    });
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "interrupted mutation should exit 130\nstatus: {status:?}\nstdout:\n{}\nstderr:\n{}",
+        read_log(&stdout_path),
+        read_log(&stderr_path)
+    );
+    let stdout = read_log(&stdout_path);
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!stdout.contains("\"total\""));
+    assert!(!stdout.contains("\"killed\""));
+    assert!(!cache_path.exists(), "interrupted mutation wrote a cache");
+    assert!(
+        !baseline_path.exists(),
+        "interrupted mutation wrote a baseline"
+    );
+    assert!(
+        !pr_comment_path.exists(),
+        "interrupted mutation wrote a PR comment"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn interrupted_check_exits_130_without_writing_side_effects() {
     let dir = setup_git_repo();
     let marker = dir.path().join("test-command-started");
@@ -562,6 +1535,7 @@ fn interrupted_check_exits_130_without_writing_side_effects() {
     let stderr_path = dir.path().join("togi-stderr.log");
     let pr_comment_path = dir.path().join("togi-pr-comment.md");
     let baseline_path = dir.path().join(".togi-baseline");
+    let cache_path = dir.path().join(".togi-cache");
     let slow_test = dir.path().join("slow-test.sh");
 
     fs::write(
@@ -649,12 +1623,50 @@ fn interrupted_check_exits_130_without_writing_side_effects() {
         "interrupted check wrote {}",
         pr_comment_path.display()
     );
+    assert!(
+        !cache_path.exists(),
+        "interrupted check wrote {}",
+        cache_path.display()
+    );
+    let stdout = read_log(&stdout_path);
+    assert!(!stdout.contains("mutation_score"));
+    assert!(!stdout.contains("\"killed\""));
 }
 
 #[cfg(unix)]
 fn shell_quote(path: &Path) -> String {
     let value = path.to_str().expect("test path should be utf-8");
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn shell_quote_text(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn fake_go_path_env(fake_bin: &Path) -> std::ffi::OsString {
+    fs::create_dir_all(fake_bin).unwrap();
+    let fake_go = fake_bin.join("go");
+    fs::write(
+        &fake_go,
+        r#"#!/bin/sh
+if [ "$1" = "test" ] && [ "$2" = "-count=1" ]; then
+    printf no-cache >> "$TOGI_GO_LOG"
+    exit 1
+fi
+printf raw >> "$TOGI_GO_LOG"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_go).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_go, permissions).unwrap();
+
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin.to_path_buf()];
+    paths.extend(std::env::split_paths(&inherited));
+    std::env::join_paths(paths).unwrap()
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes #435

- Baselines every effective routed suite before cache or mutation execution.
- Preserves route deadlines and calibration with isolated workspaces and schemata/Go command parity.
- Stops cancellation before report, baseline, or PR-comment side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline health checks before mutation execution.
  * Improved timeout calibration by selecting the slowest applicable test suite.
  * Added support for route-specific timeouts during schema-based builds.

* **Bug Fixes**
  * Prevented mutation execution when all mutations lack coverage or baseline checks fail.
  * Improved handling of interrupted runs, including exit code 130 and suppression of incomplete reports and cache updates.
  * Corrected command and output handling for custom test commands and JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->