### PR TITLE
fix: reject ambiguous automatic test commands

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -247,9 +247,11 @@ struct ProjectInspection {
     has_cargo_toml: bool,
     has_go_mod: bool,
     has_python_project: bool,
+    python_manifest: Option<&'static str>,
     javascript_runner: Option<JavaScriptRunner>,
     has_pom_xml: bool,
     has_gradle: bool,
+    gradle_manifest: Option<&'static str>,
     has_gemfile: bool,
     has_cmake: bool,
     has_dotnet_project: bool,
@@ -263,16 +265,32 @@ pub enum BuiltinCoverageAdapter {
 
 impl ProjectInspection {
     fn scan(project_root: &Path) -> Self {
+        let python_manifest = if project_root.join("pyproject.toml").exists() {
+            Some("pyproject.toml")
+        } else if project_root.join("setup.py").exists() {
+            Some("setup.py")
+        } else if project_root.join("setup.cfg").exists() {
+            Some("setup.cfg")
+        } else {
+            None
+        };
+        let gradle_manifest = if project_root.join("build.gradle").exists() {
+            Some("build.gradle")
+        } else if project_root.join("build.gradle.kts").exists() {
+            Some("build.gradle.kts")
+        } else {
+            None
+        };
+
         Self {
             has_cargo_toml: project_root.join("Cargo.toml").exists(),
             has_go_mod: project_root.join("go.mod").exists(),
-            has_python_project: project_root.join("pyproject.toml").exists()
-                || project_root.join("setup.py").exists()
-                || project_root.join("setup.cfg").exists(),
+            has_python_project: python_manifest.is_some(),
+            python_manifest,
             javascript_runner: JavaScriptRunner::detect(project_root),
             has_pom_xml: project_root.join("pom.xml").exists(),
-            has_gradle: project_root.join("build.gradle").exists()
-                || project_root.join("build.gradle.kts").exists(),
+            has_gradle: gradle_manifest.is_some(),
+            gradle_manifest,
             has_gemfile: project_root.join("Gemfile").exists(),
             has_cmake: project_root.join("CMakeLists.txt").exists(),
             has_dotnet_project: has_file_with_ext(project_root, "sln")
@@ -289,8 +307,8 @@ impl ProjectInspection {
         if self.has_go_mod {
             detected.push(("go.mod", vec!["go".into(), "test".into(), "./...".into()]));
         }
-        if self.has_python_project {
-            detected.push(("pyproject.toml/setup.py", vec!["pytest".into()]));
+        if let Some(manifest) = self.python_manifest {
+            detected.push((manifest, vec!["pytest".into()]));
         }
         if let Some(runner) = self.javascript_runner {
             detected.push(("package.json", runner.test_command()));
@@ -298,8 +316,8 @@ impl ProjectInspection {
         if self.has_pom_xml {
             detected.push(("pom.xml", vec!["mvn".into(), "test".into()]));
         }
-        if self.has_gradle {
-            detected.push(("build.gradle", vec!["./gradlew".into(), "test".into()]));
+        if let Some(manifest) = self.gradle_manifest {
+            detected.push((manifest, vec!["./gradlew".into(), "test".into()]));
         }
         if self.has_gemfile {
             detected.push((
@@ -368,6 +386,61 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
         );
         vec!["make".into(), "test".into()]
     }
+}
+
+#[derive(Debug)]
+pub struct AmbiguousTestCommand {
+    candidates: Vec<&'static str>,
+}
+
+impl AmbiguousTestCommand {
+    pub fn error(&self) -> anyhow::Error {
+        anyhow::anyhow!(
+            "multiple test runtimes detected ({}); set [test] command in togi.toml or pass --test-cmd <command>",
+            self.candidates.join(", ")
+        )
+    }
+
+    pub fn error_for_path(&self, path: &Path) -> anyhow::Error {
+        anyhow::anyhow!(
+            "multiple test runtimes detected ({}); {} has no explicit project or language test command, so set [test] command in togi.toml or pass --test-cmd <command>",
+            self.candidates.join(", "),
+            path.display()
+        )
+    }
+}
+
+#[derive(Debug)]
+pub enum TestCommandResolution {
+    Resolved,
+    Ambiguous(AmbiguousTestCommand),
+}
+
+// Mirrors runner::normalized_cache_path so ambiguity preflight chooses the
+// same project route that runner would select.
+fn normalized_test_command_path(project_root: &Path, path: &Path) -> String {
+    let relative = if path.is_absolute() {
+        path.canonicalize()
+            .ok()
+            .and_then(|path| {
+                project_root
+                    .canonicalize()
+                    .ok()
+                    .and_then(|root| path.strip_prefix(root).ok().map(PathBuf::from))
+            })
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    };
+
+    relative
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Returns failfast args to append to a test command, based on the test runner.
@@ -514,6 +587,66 @@ impl Config {
             .map(|(name, proj)| (name.as_str(), proj))
     }
 
+    /// Returns whether a nonempty configured route could require path-aware command resolution.
+    pub fn has_configured_test_command_routes(&self) -> bool {
+        self.test
+            .languages
+            .values()
+            .any(|language| !language.command.is_empty())
+            || self.projects.values().any(|project| {
+                project
+                    .test
+                    .as_ref()
+                    .and_then(|test| test.command.as_ref())
+                    .is_some_and(|command| !command.is_empty())
+            })
+    }
+
+    /// Mirrors runner project/language precedence before it falls back to the global command.
+    pub fn has_configured_test_command_for_path(
+        &self,
+        project_root: &Path,
+        file_path: &Path,
+        language: &str,
+    ) -> bool {
+        let file_path = normalized_test_command_path(project_root, file_path);
+        let file_parts: Vec<&str> = file_path
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect();
+        let project = self
+            .projects
+            .values()
+            .filter_map(|project| {
+                let project_path = normalized_test_command_path(project_root, &project.path);
+                let project_parts: Vec<&str> = project_path
+                    .split('/')
+                    .filter(|part| !part.is_empty())
+                    .collect();
+                (!project_parts.is_empty()
+                    && project_parts.len() <= file_parts.len()
+                    && file_parts
+                        .iter()
+                        .zip(&project_parts)
+                        .all(|(file, project)| file == project))
+                .then_some((project_parts.len(), project))
+            })
+            .max_by_key(|(len, _)| *len)
+            .map(|(_, project)| project);
+
+        if let Some(command) = project
+            .and_then(|project| project.test.as_ref())
+            .and_then(|test| test.command.as_ref())
+        {
+            return !command.is_empty();
+        }
+
+        self.test
+            .languages
+            .get(language)
+            .is_some_and(|language| !language.command.is_empty())
+    }
+
     /// Warn if any configured language keys don't match known language names.
     pub fn warn_unknown_languages(&self, known: &[&str]) {
         for key in self.test.languages.keys() {
@@ -528,11 +661,29 @@ impl Config {
         }
     }
 
-    /// If no test command was explicitly set in togi.toml, auto-detect from project files.
-    pub fn resolve_test_command(&mut self, project_root: &Path) {
-        if self.test.command.is_empty() {
-            self.test.command = detect_test_command(project_root);
+    /// Resolve a global test command, leaving it unset when detection is ambiguous.
+    pub fn resolve_test_command(&mut self, project_root: &Path) -> TestCommandResolution {
+        if !self.test.command.is_empty() {
+            return TestCommandResolution::Resolved;
         }
+
+        let detected = ProjectInspection::scan(project_root).detected_test_commands();
+        if detected.len() > 1 {
+            return TestCommandResolution::Ambiguous(AmbiguousTestCommand {
+                candidates: detected.iter().map(|(name, _)| *name).collect(),
+            });
+        }
+
+        self.test.command = if let Some((_, command)) = detected.into_iter().next() {
+            command
+        } else {
+            eprintln!(
+                "warning: no known build system found. Falling back to `make test`. \
+                 Set [test] command in togi.toml to override."
+            );
+            vec!["make".into(), "test".into()]
+        };
+        TestCommandResolution::Resolved
     }
 
     /// If no build command was explicitly set in togi.toml, auto-detect from project files.
@@ -1010,6 +1161,26 @@ fail_on_uncovered_diff = true
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("build.gradle.kts"), "").unwrap();
         assert_eq!(detect_test_command(dir.path()), vec!["./gradlew", "test"]);
+    }
+
+    #[test]
+    fn ambiguous_detection_names_actual_manifests() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("setup.cfg"), "").unwrap();
+        std::fs::write(dir.path().join("build.gradle.kts"), "").unwrap();
+        let mut config = Config::default();
+
+        let TestCommandResolution::Ambiguous(ambiguity) = config.resolve_test_command(dir.path())
+        else {
+            panic!("expected ambiguous test command detection");
+        };
+
+        assert!(config.test.command.is_empty());
+
+        assert_eq!(
+            ambiguity.error().to_string(),
+            "multiple test runtimes detected (setup.cfg, build.gradle.kts); set [test] command in togi.toml or pass --test-cmd <command>"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,9 +249,16 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         profile,
     } = resolved;
     let project_root = get_project_root()?;
+    let ambiguous_test_command = match config.resolve_test_command(&project_root) {
+        togi::config::TestCommandResolution::Resolved => None,
+        togi::config::TestCommandResolution::Ambiguous(ambiguity) => Some(ambiguity),
+    };
+    if let Some(ambiguity) = &ambiguous_test_command {
+        if has_custom_test_cmd || !config.has_configured_test_command_routes() {
+            return Err(ambiguity.error());
+        }
+    }
     let _lock = togi::lock::acquire(&project_root)?;
-
-    config.resolve_test_command(&project_root);
     config.resolve_build_command(&project_root);
     warn_if_resource_oversubscribed(config.test.jobs);
     let profile_env = if has_custom_test_cmd {
@@ -278,6 +285,36 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let changed_files = collect_files(&config, all, &paths, dry_run, &project_root)?;
     if changed_files.is_empty() {
         return Ok(());
+    }
+
+    // Ambiguity can be deferred only when runner precedence selects a configured
+    // project or language command for every collected source file.
+    if let Some(ambiguity) = &ambiguous_test_command {
+        for changed_file in &changed_files {
+            if !project_root.join(&changed_file.path).exists() {
+                continue;
+            }
+            let Some(extension) = changed_file
+                .path
+                .extension()
+                .and_then(|extension| extension.to_str())
+            else {
+                continue;
+            };
+            let Some(language) = all_langs
+                .iter()
+                .find(|language| language.extensions().contains(&extension))
+            else {
+                continue;
+            };
+            if !config.has_configured_test_command_for_path(
+                &project_root,
+                &changed_file.path,
+                language.name(),
+            ) {
+                return Err(ambiguity.error_for_path(&changed_file.path));
+            }
+        }
     }
 
     let coverage_gate_active = config.mutations.min_line_coverage.is_some()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -136,6 +136,300 @@ fn check_dry_run_lists_mutations() {
         .stdout(predicate::str::contains("mutations would be generated"));
 }
 
+fn setup_ambiguous_runtime_repo() -> TempDir {
+    let dir = setup_git_repo();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"example\"\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn check_rejects_ambiguous_automatic_test_command() {
+    let dir = setup_ambiguous_runtime_repo();
+
+    togi()
+        .args(["check", "--base", "not-a-valid-revision"])
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "multiple test runtimes detected (Cargo.toml, go.mod)",
+        ))
+        .stderr(predicate::str::contains("[test] command"))
+        .stderr(predicate::str::contains("--test-cmd"));
+
+    assert!(!dir.path().join(".togi.lock").exists());
+}
+
+#[test]
+fn check_rejects_empty_language_route_before_baseline_or_cache() {
+    let dir = setup_ambiguous_runtime_repo();
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test.languages.go]
+command = []
+"#,
+    )
+    .unwrap();
+
+    togi()
+        .args(["check", "--base", "not-a-valid-revision"])
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "multiple test runtimes detected (Cargo.toml, go.mod)",
+        ))
+        .stderr(predicate::str::contains("[test] command"));
+
+    assert!(!dir.path().join(".togi.lock").exists());
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
+fn check_rejects_unrouted_path_when_ambiguity_is_deferred() {
+    let dir = setup_ambiguous_runtime_repo();
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test.languages.rust]
+command = ["true"]
+"#,
+    )
+    .unwrap();
+
+    togi()
+        .args(["check", "--base", "HEAD"])
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "multiple test runtimes detected (Cargo.toml, go.mod)",
+        ))
+        .stderr(predicate::str::contains(
+            "main.go has no explicit project or language test command",
+        ));
+
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_rejects_empty_project_route_before_baseline_or_cache() {
+    let dir = setup_ambiguous_runtime_repo();
+    let log = dir.path().join("language-route.log");
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test.languages.go]
+command = ["sh", "-c", 'echo language-route >> "$TOGI_TEST_LOG"']
+
+[projects.main]
+path = "main.go"
+
+[projects.main.test]
+command = []
+"#,
+    )
+    .unwrap();
+
+    togi()
+        .args(["check", "--base", "HEAD"])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "multiple test runtimes detected (Cargo.toml, go.mod)",
+        ))
+        .stderr(predicate::str::contains(
+            "main.go has no explicit project or language test command",
+        ));
+
+    assert!(!log.exists());
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
+fn check_cli_test_command_overrides_ambiguous_automatic_detection() {
+    let dir = setup_ambiguous_runtime_repo();
+
+    togi()
+        .args(["check", "--base", "HEAD", "--dry-run", "--test-cmd", "true"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mutations would be generated"));
+}
+
+#[test]
+fn check_config_test_command_overrides_ambiguous_automatic_detection() {
+    let dir = setup_ambiguous_runtime_repo();
+    fs::write(
+        dir.path().join("togi.toml"),
+        r#"
+[test]
+command = ["true"]
+"#,
+    )
+    .unwrap();
+
+    togi()
+        .args(["check", "--base", "HEAD", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mutations would be generated"));
+}
+
+#[cfg(unix)]
+#[test]
+fn check_uses_explicit_routes_in_ambiguous_mixed_runtime_repo() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    fs::create_dir_all(root.join("rust/src")).unwrap();
+    fs::create_dir_all(root.join("go")).unwrap();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"mixed\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+    fs::write(root.join("go.mod"), "module example.com/mixed\n\ngo 1.21\n").unwrap();
+    fs::write(
+        root.join("rust/src/lib.rs"),
+        "pub fn compare(a: i32, b: i32) -> bool { a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("go/main.go"),
+        "package sample\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        r#"
+[test.languages.rust]
+command = ["sh", "-c", 'echo rust-route >> "$TOGI_TEST_LOG"']
+
+[projects.go]
+path = "go"
+
+[projects.go.test]
+command = ["sh", "-c", 'echo project-route >> "$TOGI_TEST_LOG"']
+"#,
+    )
+    .unwrap();
+    let log = root.join("routes.log");
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--max-per-run",
+            "2",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let routes = fs::read_to_string(log).unwrap();
+    assert!(routes.lines().any(|route| route == "rust-route"));
+    assert!(routes.lines().any(|route| route == "project-route"));
+}
+
+#[cfg(unix)]
+#[test]
+fn check_uses_absolute_nested_project_route_in_ambiguous_mixed_runtime_repo() {
+    let dir = setup_ambiguous_runtime_repo();
+    let root = dir.path();
+    let services = root.join("services");
+    let api = services.join("api");
+    fs::create_dir_all(&api).unwrap();
+    fs::write(
+        api.join("main.go"),
+        "package api\n\nfunc compare(a, b int) bool { return a > b }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("togi.toml"),
+        format!(
+            r#"
+[test.languages.go]
+command = ["sh", "-c", 'echo language-route >> "$TOGI_TEST_LOG"']
+
+[projects.services]
+path = "{}"
+
+[projects.services.test]
+command = ["sh", "-c", 'echo services-route >> "$TOGI_TEST_LOG"']
+
+[projects.api]
+path = "{}"
+
+[projects.api.test]
+command = ["sh", "-c", 'echo api-route >> "$TOGI_TEST_LOG"']
+"#,
+            services.display(),
+            api.display()
+        ),
+    )
+    .unwrap();
+    let log = root.join("routes.log");
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--max-per-run",
+            "2",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+        ])
+        .env("TOGI_TEST_LOG", &log)
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let routes = fs::read_to_string(log).unwrap();
+    assert!(routes.lines().any(|route| route == "language-route"));
+    assert!(routes.lines().any(|route| route == "api-route"));
+    assert!(!routes.lines().any(|route| route == "services-route"));
+}
+
 /// Extend the fixture so mutants land on two lines: line 4 (the added `if`)
 /// and line 7 (`return a - b`).
 fn setup_two_line_mutation_repo() -> TempDir {


### PR DESCRIPTION
Fixes #438

- Rejects ambiguous automatic global test commands unless every changed source path has a nonempty project/language route.
- Preserves config and CLI overrides and reports exact detected manifests.
- Covers mixed-runtime ambiguity, precedence, absolute routes, and overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic test-command detection by identifying the specific project manifests in use.
  * Added path-aware test-command routing for mixed-language or multi-project repositories.
  * Added clear ambiguity reporting when multiple runtimes are detected.

* **Bug Fixes**
  * Prevented checks from running with unreliable automatic test-command selections.
  * Added validation for changed files without a configured test route.

* **CLI**
  * Explicit command-line or configuration test commands now override ambiguous automatic detection.
  * Added support for validating nested project routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->