### PR TITLE
fix: keep JSON reports standalone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,14 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let known: Vec<&str> = all_langs.iter().map(|l| l.name()).collect();
     config.warn_unknown_languages(&known);
 
-    let changed_files = collect_files(&config, all, &paths, dry_run, &project_root)?;
+    let changed_files = collect_files(
+        &config,
+        all,
+        &paths,
+        dry_run,
+        output_format == togi::cli::OutputFormat::Json,
+        &project_root,
+    )?;
     if changed_files.is_empty() {
         return Ok(());
     }
@@ -1055,6 +1062,7 @@ fn collect_files(
     all: bool,
     paths: &[PathBuf],
     dry_run: bool,
+    json_output: bool,
     project_root: &Path,
 ) -> anyhow::Result<Vec<ChangedFile>> {
     let skip_noisy = config.mutations.skip_noisy_files;
@@ -1070,7 +1078,11 @@ fn collect_files(
             println!("No supported source files found. Nothing to mutate.");
             return Ok(vec![]);
         }
-        println!("Scanning all {} supported files...", files.len());
+        if json_output {
+            eprintln!("Scanning all {} supported files...", files.len());
+        } else {
+            println!("Scanning all {} supported files...", files.len());
+        }
         return Ok(files);
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -668,22 +668,19 @@ fn check_warns_when_fail_fast_is_ignored_for_custom_test_cmd() {
 }
 
 #[test]
-fn check_format_json_outputs_valid_json() {
+fn check_format_json_outputs_standalone_json_for_explain() {
     let dir = setup_git_repo();
 
     let output = togi()
-        .args([
-            "check",
-            "--base",
-            "HEAD",
-            "--format",
-            "json",
-            "--test-cmd",
-            "true",
-        ])
+        .args(["check", "--all", "--format", "json", "--test-cmd", "true"])
         .current_dir(dir.path())
         .output()
         .unwrap();
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Scanning all 1 supported files..."),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
         panic!(
@@ -693,6 +690,25 @@ fn check_format_json_outputs_valid_json() {
     });
     assert!(value.get("total").is_some());
     assert!(value.get("mutations").is_some());
+
+    let report_path = dir.path().join("togi-report.json");
+    fs::write(&report_path, &output.stdout).unwrap();
+    let mutant_id = value["mutations"][0]["id"]
+        .as_u64()
+        .expect("report must contain a mutation")
+        .to_string();
+
+    togi()
+        .args([
+            "explain",
+            &mutant_id,
+            "--report",
+            report_path.to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!("Mutation #{mutant_id}")));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #437

Tests:
- `cargo test --locked --test cli check_format_json_outputs_standalone_json_for_explain -- --exact`
- `cargo test --locked --test cli ambiguous`
- `cargo test --locked`
- `cargo clippy --locked -- -D warnings`
- `cargo fmt --check`