### PR TITLE
fix: report mutation execution provenance

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,3 +1,4 @@
+use crate::MutationResult;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -21,11 +22,27 @@ pub struct Baseline {
     pub total: usize,
 }
 
+/// Whether a report contains any newly executed mutation-test evidence.
+pub fn has_fresh_execution(report: &crate::MutationReport) -> bool {
+    report.tested_count() > 0
+}
+
+/// Whether a report is complete fresh evidence suitable for a baseline.
+///
+/// A partial or mixed report cannot be compared to or persisted as a baseline:
+/// restored verdicts are deliberately excluded from its counters.
+pub fn is_baseline_eligible(report: &crate::MutationReport) -> bool {
+    has_fresh_execution(report)
+        && report.reused_count() == 0
+        && report.total == report.planned_total
+}
+
 /// Build a baseline from a mutation report.
 ///
-/// Only executed mutants count: build errors, coverage-suppressed
-/// (uncovered), and learned-selection (subsumed) mutants are excluded from
-/// per-file and overall totals.
+/// Only mutants whose test suites ran during this invocation contribute to
+/// per-file and overall totals. Restored cache/history verdicts, build errors,
+/// coverage-suppressed (uncovered), and learned-selection (subsumed) mutants
+/// are excluded.
 pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Baseline {
     let mut files: HashMap<String, FileScore> = HashMap::new();
     for (mutation, result) in &report.results {
@@ -35,26 +52,24 @@ pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Basel
             .unwrap_or(&mutation.file)
             .display()
             .to_string();
+        let execution = report.execution_for(mutation.id, *result);
+        if !execution.is_tested() {
+            continue;
+        }
         let entry = files.entry(rel).or_insert(FileScore {
             killed: 0,
             total: 0,
         });
-        if *result != crate::MutationResult::BuildError
-            && *result != crate::MutationResult::Uncovered
-            && *result != crate::MutationResult::Subsumed
-        {
-            entry.total += 1;
-            if *result == crate::MutationResult::Killed {
-                entry.killed += 1;
-            }
+        entry.total += 1;
+        if *result == MutationResult::Killed {
+            entry.killed += 1;
         }
     }
-    let killed = report.killed;
-    let total = report.tested_count();
+    let execution_counts = report.execution_counts();
     Baseline {
         files,
-        killed,
-        total,
+        killed: execution_counts.executed_killed,
+        total: execution_counts.executed,
     }
 }
 
@@ -63,6 +78,23 @@ pub fn save_baseline(baseline: &Baseline, dir: &Path) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(baseline)?;
     std::fs::write(dir.join(BASELINE_FILE), json)?;
     Ok(())
+}
+
+/// Build and persist a baseline only when a report is baseline-eligible.
+///
+/// `Ok(None)` leaves any existing baseline untouched when the report is
+/// partial, contains a reused verdict, or has no mutated test-suite execution.
+pub fn save_baseline_from_report(
+    report: &crate::MutationReport,
+    project_root: &Path,
+) -> anyhow::Result<Option<Baseline>> {
+    if !is_baseline_eligible(report) {
+        return Ok(None);
+    }
+
+    let baseline = from_report(report, project_root);
+    save_baseline(&baseline, project_root)?;
+    Ok(Some(baseline))
 }
 
 /// Load a previously saved baseline from `dir`, returning `Ok(None)` if the file doesn't exist.
@@ -217,6 +249,111 @@ mod tests {
         std::fs::write(dir.path().join(BASELINE_FILE), "not json").unwrap();
 
         assert!(load_baseline(dir.path()).is_err());
+    }
+
+    #[test]
+    fn from_report_excludes_exact_cache_verdicts() {
+        let mut report = crate::test_helpers::sample_report();
+        report
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+
+        let baseline = from_report(&report, Path::new("."));
+
+        assert_eq!(baseline.total, 1);
+        assert_eq!(baseline.killed, 0);
+        assert!(baseline.files.values().all(|score| score.total > 0));
+    }
+
+    #[test]
+    fn from_report_excludes_incremental_history_alongside_exact_cache() {
+        let mut report = crate::test_helpers::sample_report();
+        report
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(1, crate::MutationExecution::IncrementalHistory);
+
+        let baseline = from_report(&report, Path::new("."));
+
+        assert_eq!(baseline.total, 0);
+        assert_eq!(baseline.killed, 0);
+        assert!(baseline.files.is_empty());
+    }
+
+    #[test]
+    fn baseline_requires_complete_fresh_execution() {
+        let fresh = crate::test_helpers::sample_report();
+        assert!(has_fresh_execution(&fresh));
+        assert!(is_baseline_eligible(&fresh));
+
+        let mut partial = crate::test_helpers::sample_report();
+        partial.planned_total += 1;
+        assert!(has_fresh_execution(&partial));
+        assert!(!is_baseline_eligible(&partial));
+
+        let mut mixed = crate::test_helpers::sample_report();
+        mixed
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+        assert!(has_fresh_execution(&mixed));
+        assert!(!is_baseline_eligible(&mixed));
+
+        let mut reused = crate::test_helpers::sample_report();
+        reused
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+        reused
+            .execution_provenance
+            .insert(1, crate::MutationExecution::IncrementalHistory);
+        assert!(!has_fresh_execution(&reused));
+        assert!(!is_baseline_eligible(&reused));
+
+        for result in [
+            MutationResult::BuildError,
+            MutationResult::Uncovered,
+            MutationResult::Subsumed,
+        ] {
+            let mut non_executed = crate::test_helpers::sample_report();
+            for (_, actual) in &mut non_executed.results {
+                *actual = result;
+            }
+            assert!(!has_fresh_execution(&non_executed));
+            assert!(!is_baseline_eligible(&non_executed));
+        }
+    }
+
+    #[test]
+    fn saving_mixed_report_retains_existing_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = crate::test_helpers::sample_report();
+        assert!(
+            save_baseline_from_report(&fresh, dir.path())
+                .unwrap()
+                .is_some()
+        );
+        let before = std::fs::read(dir.path().join(BASELINE_FILE)).unwrap();
+
+        for execution in [
+            crate::MutationExecution::ExactCache,
+            crate::MutationExecution::IncrementalHistory,
+        ] {
+            let mut mixed = crate::test_helpers::sample_report();
+            mixed.execution_provenance.insert(0, execution);
+
+            assert!(has_fresh_execution(&mixed));
+            assert!(!is_baseline_eligible(&mixed));
+            assert!(
+                save_baseline_from_report(&mixed, dir.path())
+                    .unwrap()
+                    .is_none()
+            );
+            assert_eq!(
+                std::fs::read(dir.path().join(BASELINE_FILE)).unwrap(),
+                before
+            );
+        }
     }
 
     fn make_baseline_with_files(files: Vec<(&str, usize, usize)>) -> Baseline {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod schemata;
 #[cfg(test)]
 pub mod test_helpers;
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -107,7 +108,96 @@ impl fmt::Display for MutationResult {
     }
 }
 
-/// Diagnostic details captured when a mutation is classified as a build error.
+/// Where a mutation verdict came from during this run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MutationExecution {
+    /// The mutated test suite ran during this invocation.
+    Executed,
+    /// The verdict was restored from an exact cache key.
+    ExactCache,
+    /// The verdict was restored from incremental history.
+    IncrementalHistory,
+    /// No mutated test suite ran for this mutation.
+    NotExecuted(MutationNonExecutionReason),
+}
+
+impl MutationExecution {
+    pub fn for_result(result: MutationResult) -> Self {
+        match result {
+            MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout => {
+                Self::Executed
+            }
+            MutationResult::BuildError => Self::NotExecuted(MutationNonExecutionReason::BuildError),
+            MutationResult::Uncovered => Self::NotExecuted(MutationNonExecutionReason::Uncovered),
+            MutationResult::Subsumed => Self::NotExecuted(MutationNonExecutionReason::Subsumed),
+        }
+    }
+
+    pub fn is_tested(self) -> bool {
+        self == Self::Executed
+    }
+
+    pub fn is_reused(self) -> bool {
+        matches!(self, Self::ExactCache | Self::IncrementalHistory)
+    }
+
+    pub fn reason(self) -> Option<MutationNonExecutionReason> {
+        match self {
+            Self::NotExecuted(reason) => Some(reason),
+            Self::Executed | Self::ExactCache | Self::IncrementalHistory => None,
+        }
+    }
+
+    pub fn state_name(self) -> &'static str {
+        match self {
+            Self::Executed => "executed",
+            Self::ExactCache => "exact_cache",
+            Self::IncrementalHistory => "incremental_history",
+            Self::NotExecuted(_) => "not_executed",
+        }
+    }
+}
+
+impl fmt::Display for MutationExecution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Executed => write!(f, "executed"),
+            Self::ExactCache => write!(f, "exact cache"),
+            Self::IncrementalHistory => write!(f, "incremental history"),
+            Self::NotExecuted(reason) => write!(f, "not executed: {reason}"),
+        }
+    }
+}
+
+/// Why a mutation did not run its mutated test suite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MutationNonExecutionReason {
+    BuildError,
+    Uncovered,
+    Subsumed,
+}
+
+impl MutationNonExecutionReason {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::BuildError => "build_error",
+            Self::Uncovered => "uncovered",
+            Self::Subsumed => "subsumed",
+        }
+    }
+}
+
+impl fmt::Display for MutationNonExecutionReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BuildError => write!(f, "build error"),
+            Self::Uncovered => write!(f, "uncovered"),
+            Self::Subsumed => write!(f, "subsumed"),
+        }
+    }
+}
+
+/// Diagnostic details captured for an actual build-error mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildErrorDiagnostic {
     pub mutation_id: u32,
@@ -117,7 +207,6 @@ pub struct BuildErrorDiagnostic {
     pub message: String,
     pub fingerprint: String,
 }
-
 impl BuildErrorDiagnostic {
     pub fn new(
         mutation_id: u32,
@@ -149,10 +238,31 @@ impl BuildErrorDiagnostic {
     }
 }
 
+/// Aggregate execution provenance for the mutations present in a report.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MutationExecutionCounts {
+    pub executed: usize,
+    pub executed_killed: usize,
+    pub exact_cache_reused: usize,
+    pub incremental_history_reused: usize,
+    pub not_executed: usize,
+}
+
+impl MutationExecutionCounts {
+    pub fn reused(self) -> usize {
+        self.exact_cache_reused + self.incremental_history_reused
+    }
+}
+
 /// Aggregated results from a mutation testing run
 #[derive(Debug)]
 pub struct MutationReport {
     pub results: Vec<(Mutation, MutationResult)>,
+    /// Explicit provenance for verdicts restored from cache or history, keyed
+    /// by mutation id. Verdicts absent here derive their canonical execution
+    /// state from `MutationResult`.
+    pub execution_provenance: BTreeMap<u32, MutationExecution>,
+    /// Diagnostics for mutations classified as `BuildError`.
     pub build_error_diagnostics: Vec<BuildErrorDiagnostic>,
     pub schemata: Option<SchemataReport>,
     pub baseline_timing: Option<BaselineTiming>,
@@ -187,14 +297,53 @@ impl MutationReport {
             .count()
     }
 
-    /// Mutants actually executed against the test suite: everything except
-    /// build errors, coverage-suppressed (uncovered), and learned-selection
-    /// (subsumed) mutants.
+    /// Explicit cache/history provenance keyed by mutation id.
+    pub fn execution_provenance(&self) -> &BTreeMap<u32, MutationExecution> {
+        &self.execution_provenance
+    }
+
+    /// Return the structured execution state for one mutation verdict.
+    pub fn execution_for(&self, mutation_id: u32, result: MutationResult) -> MutationExecution {
+        self.execution_provenance
+            .get(&mutation_id)
+            .copied()
+            .unwrap_or_else(|| MutationExecution::for_result(result))
+    }
+
+    /// Count fresh executions, restored verdicts, and non-executed outcomes.
+    pub fn execution_counts(&self) -> MutationExecutionCounts {
+        let mut counts = MutationExecutionCounts::default();
+        for (mutation, result) in &self.results {
+            match self.execution_for(mutation.id, *result) {
+                MutationExecution::Executed => {
+                    counts.executed += 1;
+                    if *result == MutationResult::Killed {
+                        counts.executed_killed += 1;
+                    }
+                }
+                MutationExecution::ExactCache => counts.exact_cache_reused += 1,
+                MutationExecution::IncrementalHistory => {
+                    counts.incremental_history_reused += 1;
+                }
+                MutationExecution::NotExecuted(_) => counts.not_executed += 1,
+            }
+        }
+        counts
+    }
+
+    /// Mutants whose test suites ran during this invocation.
     pub fn tested_count(&self) -> usize {
-        self.total
-            .saturating_sub(self.build_errors)
-            .saturating_sub(self.uncovered_count())
-            .saturating_sub(self.subsumed_count())
+        self.execution_counts().executed
+    }
+
+    /// Killed mutants whose test suites ran during this invocation.
+    pub fn executed_killed_count(&self) -> usize {
+        self.execution_counts().executed_killed
+    }
+
+    /// Mutants whose verdicts were restored from cache or history.
+    pub fn reused_count(&self) -> usize {
+        self.execution_counts().reused()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,9 +112,16 @@ struct ExplainMutation {
     operator: String,
     description: String,
     result: String,
+    execution: Option<ExplainMutationExecution>,
     original: Option<String>,
     replacement: Option<String>,
     diff: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ExplainMutationExecution {
+    state: String,
+    reason: Option<String>,
 }
 
 fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
@@ -145,9 +152,38 @@ fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
         println!("{diff}");
     }
 
+    let (execution_state, execution_reason) = mutation
+        .execution
+        .as_ref()
+        .map(|execution| (execution.state.as_str(), execution.reason.as_deref()))
+        .unwrap_or_else(|| match mutation.result.as_str() {
+            "killed" | "survived" | "timeout" => ("executed", None),
+            "build_error" => ("not_executed", Some("build_error")),
+            "uncovered" => ("not_executed", Some("uncovered")),
+            "subsumed" => ("not_executed", Some("subsumed")),
+            _ => ("not_executed", None),
+        });
+    let test_executed = execution_state == "executed";
+    let reused_verdict = matches!(execution_state, "exact_cache" | "incremental_history");
+    let execution_detail = match execution_state {
+        "executed" => "executed".to_string(),
+        "exact_cache" => "reused from exact cache".to_string(),
+        "incremental_history" => "reused from incremental history".to_string(),
+        "not_executed" => match execution_reason {
+            Some(reason) => format!("not executed ({reason})"),
+            None => "not executed".to_string(),
+        },
+        other => format!("not executed ({other})"),
+    };
+
     println!();
-    if let Some(command) = report.test_command.as_ref().filter(|cmd| !cmd.is_empty()) {
-        println!("Test command: {}", serde_json::to_string(command)?);
+    println!("Execution: {execution_detail}");
+    if test_executed {
+        if let Some(command) = report.test_command.as_ref().filter(|cmd| !cmd.is_empty()) {
+            println!("Test command: {}", serde_json::to_string(command)?);
+        }
+    } else {
+        println!("Test command: not run.");
     }
     if let Some(command) = report.build_command.as_ref().filter(|cmd| !cmd.is_empty()) {
         println!("Build check: {}", serde_json::to_string(command)?);
@@ -156,24 +192,42 @@ fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
     match mutation.result.as_str() {
         "survived" => {
             println!("Why it survived:");
-            println!("  The configured test command completed successfully with this mutation.");
+            if test_executed {
+                println!(
+                    "  The configured test command completed successfully with this mutation."
+                );
+            } else {
+                println!("  This verdict was not freshly tested in this invocation.");
+            }
             println!(
                 "  Add an assertion that distinguishes the original behavior from the mutated one."
             );
         }
         "killed" => {
             println!("Why it was killed:");
-            println!(
-                "  The configured test command failed with this mutation, so existing tests caught it."
-            );
+            if test_executed {
+                println!(
+                    "  The configured test command failed with this mutation, so existing tests caught it."
+                );
+            } else {
+                println!("  This verdict was not freshly tested in this invocation.");
+            }
         }
         "timeout" => {
             println!("Why it timed out:");
-            println!("  The configured test command exceeded the mutation timeout.");
+            if test_executed {
+                println!("  The configured test command exceeded the mutation timeout.");
+            } else {
+                println!("  This verdict was not freshly tested in this invocation.");
+            }
         }
         "build_error" => {
             println!("Why it was not testable:");
-            println!("  The mutation made the project fail its build check.");
+            if reused_verdict {
+                println!("  This build-error verdict was not produced in this invocation.");
+            } else {
+                println!("  The mutation made the project fail its build check.");
+            }
         }
         "uncovered" => {
             println!("Why it was not executed:");
@@ -291,6 +345,9 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         &project_root,
     )?;
     if changed_files.is_empty() {
+        if output_format == togi::cli::OutputFormat::Json {
+            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run)?;
+        }
         return Ok(());
     }
 
@@ -358,15 +415,27 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     }
 
     if classified.to_run.is_empty() && classified.uncovered.is_empty() {
-        println!("No mutations generated. Possible causes:");
-        println!("  - Changed files are in an unsupported language");
-        println!("  - All mutable nodes were filtered out (test files, noisy patterns)");
-        println!("  - max_per_run or max_per_file is set to 0 in togi.toml");
+        if output_format == togi::cli::OutputFormat::Json {
+            eprintln!("No mutations generated. Possible causes:");
+            eprintln!("  - Changed files are in an unsupported language");
+            eprintln!("  - All mutable nodes were filtered out (test files, noisy patterns)");
+            eprintln!("  - max_per_run or max_per_file is set to 0 in togi.toml");
+            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run)?;
+        } else {
+            println!("No mutations generated. Possible causes:");
+            println!("  - Changed files are in an unsupported language");
+            println!("  - All mutable nodes were filtered out (test files, noisy patterns)");
+            println!("  - max_per_run or max_per_file is set to 0 in togi.toml");
+        }
         return Ok(());
     }
 
     if dry_run {
-        print_dry_run(&classified.to_run);
+        if output_format == togi::cli::OutputFormat::Json {
+            togi::report::json::print_dry_run(&classified.to_run)?;
+        } else {
+            print_dry_run(&classified.to_run);
+        }
         return Ok(());
     }
 
@@ -408,7 +477,12 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         ) {
             Ok(measurement) => measurement,
             Err(_) if cancelled.load(Ordering::Acquire) => exit_with(_lock, 130),
-            Err(error) => return Err(error),
+            Err(error) => {
+                if let Some(failure) = togi::runner::run_suite_failure(&error) {
+                    togi::report::print_run_suite_failure(failure, output_format)?;
+                }
+                return Err(error);
+            }
         };
         let baseline_timing = if config.test.calibrate_timeout {
             if let Some(measurement) = calibration_measurement(&measurement) {
@@ -479,26 +553,36 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     merge_uncovered(&mut report, classified.uncovered);
     togi::report::print_report(&report, output_format)?;
 
-    let current = togi::baseline::from_report(&report, &project_root_ref);
+    let baseline_eligible = togi::baseline::is_baseline_eligible(&report);
+    let mut current = None;
     let mut should_fail = false;
-
     let partial_report = report.total < report.planned_total;
+    let baseline_actions_allowed = baseline_eligible;
 
-    if partial_report && (save_baseline || check_baseline) {
-        eprintln!("Partial early-stop report; skipping baseline save/check.");
+    if (save_baseline || check_baseline) && !baseline_actions_allowed {
+        if partial_report {
+            eprintln!("Partial early-stop report; skipping baseline save/check.");
+        } else {
+            eprintln!(
+                "Report has no complete fresh execution evidence; skipping baseline save/check."
+            );
+        }
     } else if save_baseline {
-        togi::baseline::save_baseline(&current, &project_root_ref)?;
+        current = togi::baseline::save_baseline_from_report(&report, &project_root_ref)?;
+        debug_assert!(current.is_some(), "eligible report must save a baseline");
         eprintln!("Baseline saved to .togi-baseline");
     }
 
     let mut baseline_score: Option<f64> = None;
     let mut loaded_baseline = false;
-    if check_baseline && !partial_report {
+    if check_baseline && baseline_actions_allowed {
         if let Some(baseline) = togi::baseline::load_baseline(&project_root_ref)? {
             loaded_baseline = true;
             baseline_score = Some(baseline.killed as f64 / baseline.total.max(1) as f64 * 100.0);
-            if togi::baseline::check_regression(&current, &baseline) {
-                let regressions = togi::baseline::per_file_regressions(&current, &baseline);
+            let current = current
+                .get_or_insert_with(|| togi::baseline::from_report(&report, &project_root_ref));
+            if togi::baseline::check_regression(current, &baseline) {
+                let regressions = togi::baseline::per_file_regressions(current, &baseline);
                 eprintln!("Mutation score regression detected!");
                 for r in &regressions {
                     eprintln!(
@@ -1075,7 +1159,11 @@ fn collect_files(
             files.retain(|f| paths.iter().any(|p| f.path.starts_with(p)));
         }
         if files.is_empty() {
-            println!("No supported source files found. Nothing to mutate.");
+            if json_output {
+                eprintln!("No supported source files found. Nothing to mutate.");
+            } else {
+                println!("No supported source files found. Nothing to mutate.");
+            }
             return Ok(vec![]);
         }
         if json_output {
@@ -1088,12 +1176,22 @@ fn collect_files(
 
     let diff_output = get_git_diff(&config.diff.base)?;
     if diff_output.is_empty() {
-        println!(
-            "No changes found in diff against `{}`. Nothing to mutate.",
-            config.diff.base
-        );
-        if dry_run {
-            println!("Hint: use --all --dry-run to preview mutations across all files.");
+        if json_output {
+            eprintln!(
+                "No changes found in diff against `{}`. Nothing to mutate.",
+                config.diff.base
+            );
+            if dry_run {
+                eprintln!("Hint: use --all --dry-run to preview mutations across all files.");
+            }
+        } else {
+            println!(
+                "No changes found in diff against `{}`. Nothing to mutate.",
+                config.diff.base
+            );
+            if dry_run {
+                println!("Hint: use --all --dry-run to preview mutations across all files.");
+            }
         }
         return Ok(vec![]);
     }
@@ -1104,7 +1202,11 @@ fn collect_files(
     }
     files.retain(|f| !togi::diff::matches_user_excludes(&f.path, exclude_globs));
     if files.is_empty() {
-        println!("No added/modified lines found. Nothing to mutate.");
+        if json_output {
+            eprintln!("No added/modified lines found. Nothing to mutate.");
+        } else {
+            println!("No added/modified lines found. Nothing to mutate.");
+        }
         return Ok(vec![]);
     }
     Ok(files)
@@ -1242,6 +1344,7 @@ fn coverage_only_report(
 ) -> togi::MutationReport {
     togi::MutationReport {
         results: Vec::new(),
+        execution_provenance: BTreeMap::new(),
         build_error_diagnostics: Vec::new(),
         schemata: None,
         baseline_timing: None,
@@ -1260,6 +1363,20 @@ fn coverage_only_report(
         timeout: 0,
         build_errors: 0,
     }
+}
+
+fn print_empty_json_check_output(
+    config: &togi::config::Config,
+    build_command_explicit: bool,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if dry_run {
+        togi::report::json::print_dry_run(&[])?;
+    } else {
+        let report = coverage_only_report(config, build_command_explicit);
+        togi::report::json::print_report(&report)?;
+    }
+    Ok(())
 }
 
 fn print_dry_run(mutations: &[Mutation]) {

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -1,9 +1,15 @@
-use crate::{Mutation, MutationReport, MutationResult};
+use crate::{Mutation, MutationExecution, MutationReport, MutationResult};
 
 /// Format a single GitHub Actions warning annotation for a survived mutation.
-fn format_annotation(mutation: &Mutation) -> String {
+fn format_annotation(mutation: &Mutation, execution: MutationExecution) -> String {
+    let provenance = match execution {
+        MutationExecution::Executed => String::new(),
+        MutationExecution::ExactCache => " [reused: exact cache]".to_string(),
+        MutationExecution::IncrementalHistory => " [reused: incremental history]".to_string(),
+        MutationExecution::NotExecuted(reason) => format!(" [not executed: {reason}]"),
+    };
     let message = format!(
-        "Survived mutation: {} ({})",
+        "Survived mutation: {} ({}){provenance}",
         mutation.operator, mutation.description
     );
     format!(
@@ -31,8 +37,10 @@ fn annotations(report: &MutationReport) -> Vec<String> {
     report
         .results
         .iter()
-        .filter(|(_, r)| *r == MutationResult::Survived)
-        .map(|(m, _)| format_annotation(m))
+        .filter(|(_, result)| *result == MutationResult::Survived)
+        .map(|(mutation, result)| {
+            format_annotation(mutation, report.execution_for(mutation.id, *result))
+        })
         .collect()
 }
 
@@ -43,7 +51,8 @@ pub fn print_report(report: &MutationReport) {
         println!("{line}");
     }
 
-    let tested = report.tested_count();
+    let execution_counts = report.execution_counts();
+    let tested = execution_counts.executed;
     let score = super::mutation_score(report);
     let uncovered = report.uncovered_count();
     let uncovered_str = if uncovered > 0 {
@@ -58,9 +67,20 @@ pub fn print_report(report: &MutationReport) {
         String::new()
     };
     eprintln!(
-        "Mutation score: {:.1}% ({} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str})",
-        score, report.killed, report.survived, report.timeout, report.build_errors
+        "Mutation score: {:.1}% ({}/{} freshly executed killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str})",
+        score,
+        execution_counts.executed_killed,
+        tested,
+        report.survived,
+        report.timeout,
+        report.build_errors
     );
+    if execution_counts.reused() > 0 {
+        eprintln!(
+            "Reused verdicts: {} exact-cache, {} incremental-history",
+            execution_counts.exact_cache_reused, execution_counts.incremental_history_reused
+        );
+    }
     if report.total < report.planned_total {
         eprintln!(
             "Partial results: stopped after {}/{} scheduled mutations",
@@ -83,6 +103,7 @@ pub fn print_report(report: &MutationReport) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -122,6 +143,7 @@ mod tests {
             test_command: None,
             build_command: vec![],
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -131,7 +153,7 @@ mod tests {
     #[test]
     fn annotation_format_for_survived_mutation() {
         let m = mutation("src/auth.rs", 47, "lt_to_lte", "changed < to <=");
-        let line = format_annotation(&m);
+        let line = format_annotation(&m, MutationExecution::Executed);
         assert_eq!(
             line,
             "::warning file=src/auth.rs,line=47::Survived mutation: lt_to_lte (changed < to <=)"
@@ -171,6 +193,34 @@ mod tests {
     }
 
     #[test]
+    fn annotations_label_mixed_survivor_provenance() {
+        let mut fresh = mutation("src/fresh.rs", 1, "fresh", "fresh survivor");
+        fresh.id = 1;
+        let mut exact = mutation("src/exact.rs", 2, "exact", "cached survivor");
+        exact.id = 2;
+        let mut history = mutation("src/history.rs", 3, "history", "history survivor");
+        history.id = 3;
+        let mut report = report_with(vec![
+            (fresh, MutationResult::Survived),
+            (exact, MutationResult::Survived),
+            (history, MutationResult::Survived),
+        ]);
+        report
+            .execution_provenance
+            .insert(2, MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(3, MutationExecution::IncrementalHistory);
+
+        let lines = annotations(&report);
+
+        assert_eq!(lines.len(), 3);
+        assert!(!lines[0].contains("reused"));
+        assert!(lines[1].contains("[reused: exact cache]"));
+        assert!(lines[2].contains("[reused: incremental history]"));
+    }
+
+    #[test]
     fn uncovered_mutations_emit_no_annotations() {
         let report = report_with(vec![(
             mutation("src/dead.rs", 7, "op", "desc"),
@@ -182,7 +232,7 @@ mod tests {
     #[test]
     fn annotation_escapes_special_chars_in_path_and_message() {
         let m = mutation("src/odd,name:thing.rs", 10, "op", "msg with %, \r\n chars");
-        let line = format_annotation(&m);
+        let line = format_annotation(&m, MutationExecution::Executed);
         assert_eq!(
             line,
             "::warning file=src/odd%2Cname%3Athing.rs,line=10::Survived mutation: op (msg with %25, %0D%0A chars)"

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 struct FileStats {
     total: usize,
-    build_errors: usize,
+    tested: usize,
     uncovered: usize,
     subsumed: usize,
     killed: usize,
@@ -14,9 +14,8 @@ struct FileStats {
 
 impl FileStats {
     fn score_pct(&self) -> f64 {
-        let tested = self.tested();
-        if tested > 0 {
-            (self.killed as f64 / tested as f64) * 100.0
+        if self.tested > 0 {
+            (self.killed as f64 / self.tested as f64) * 100.0
         } else if self.total == self.uncovered + self.subsumed {
             100.0
         } else {
@@ -25,10 +24,7 @@ impl FileStats {
     }
 
     fn tested(&self) -> usize {
-        self.total
-            .saturating_sub(self.build_errors)
-            .saturating_sub(self.uncovered)
-            .saturating_sub(self.subsumed)
+        self.tested
     }
 }
 
@@ -39,6 +35,7 @@ struct MutationEntry {
     original: String,
     replacement: String,
     result: &'static str,
+    execution: String,
 }
 
 pub fn generate_report(report: &MutationReport) -> Result<String> {
@@ -46,6 +43,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
 
     for (mutation, result) in &report.results {
         let file_path = mutation.file.display().to_string();
+        let execution = report.execution_for(mutation.id, *result);
         let result_str = match result {
             MutationResult::Killed => "killed",
             MutationResult::Survived => "survived",
@@ -54,25 +52,24 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             MutationResult::Uncovered => "uncovered",
             MutationResult::Subsumed => "subsumed",
         };
-        let killed = matches!(result, MutationResult::Killed);
-        let build_error = matches!(result, MutationResult::BuildError);
-        let uncovered = matches!(result, MutationResult::Uncovered);
-        let subsumed = matches!(result, MutationResult::Subsumed);
+        let killed = execution.is_tested() && *result == MutationResult::Killed;
+        let uncovered = *result == MutationResult::Uncovered;
+        let subsumed = *result == MutationResult::Subsumed;
 
         let stats = files.entry(file_path).or_insert(FileStats {
             total: 0,
-            build_errors: 0,
+            tested: 0,
             uncovered: 0,
             subsumed: 0,
             killed: 0,
             mutations: Vec::new(),
         });
         stats.total += 1;
+        if execution.is_tested() {
+            stats.tested += 1;
+        }
         if killed {
             stats.killed += 1;
-        }
-        if build_error {
-            stats.build_errors += 1;
         }
         if uncovered {
             stats.uncovered += 1;
@@ -87,10 +84,12 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             original: mutation.original.clone(),
             replacement: mutation.replacement.clone(),
             result: result_str,
+            execution: execution.to_string(),
         });
     }
 
-    let tested = report.tested_count();
+    let execution_counts = report.execution_counts();
+    let tested = execution_counts.executed;
     let score_pct = super::mutation_score(report);
     let uncovered = report.uncovered_count();
     let uncovered_str = if uncovered > 0 {
@@ -101,6 +100,14 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     let subsumed = report.subsumed_count();
     let subsumed_str = if subsumed > 0 {
         format!(", {subsumed} subsumed")
+    } else {
+        String::new()
+    };
+    let reused_str = if execution_counts.reused() > 0 {
+        format!(
+            ", {} exact-cache reused, {} incremental-history reused",
+            execution_counts.exact_cache_reused, execution_counts.incremental_history_reused
+        )
     } else {
         String::new()
     };
@@ -123,16 +130,17 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
     write!(
         html,
         "<div class=\"summary\"><span class=\"score\">{:.1}%</span> mutation score \
-         &mdash; {}/{} killed, {} survived, {} timeout, {} build errors{}{} \
+         &mdash; {}/{} freshly executed killed, {} survived, {} timeout, {} build errors{}{}{} \
          &mdash; {:.2}s</div>",
         score_pct,
-        report.killed,
+        execution_counts.executed_killed,
         tested,
         report.survived,
         report.timeout,
         report.build_errors,
         uncovered_str,
         subsumed_str,
+        reused_str,
         report.duration.as_secs_f64()
     )?;
     if report.total < report.planned_total {
@@ -247,7 +255,7 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             html,
             "<table><thead><tr>\
             <th>Line</th><th>Operator</th><th>Description</th>\
-            <th>Original</th><th>Replacement</th><th>Result</th>\
+            <th>Original</th><th>Replacement</th><th>Result</th><th>Execution</th>\
             </tr></thead><tbody>"
         )?;
 
@@ -265,14 +273,15 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
                 "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
                  <td><code class=\"orig\">{}</code></td>\
                  <td><code class=\"repl\">{}</code></td>\
-                 <td>{}</td></tr>",
+                 <td>{}</td><td>{}</td></tr>",
                 result_class,
                 m.line,
                 html_escape(&m.operator),
                 html_escape(&m.description),
                 html_escape(&m.original),
                 html_escape(&m.replacement),
-                m.result
+                m.result,
+                html_escape(&m.execution)
             )?;
         }
 
@@ -447,7 +456,7 @@ mod tests {
     fn html_contains_score() {
         let html = generate_report(&sample_report()).unwrap();
         assert!(html.contains("50.0%"));
-        assert!(html.contains("1/2 killed"));
+        assert!(html.contains("1/2 freshly executed killed"));
     }
 
     #[test]
@@ -468,6 +477,7 @@ mod tests {
                 },
                 MutationResult::BuildError,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![BuildErrorDiagnostic::new(
                 1,
                 "regular",
@@ -527,6 +537,7 @@ mod tests {
         }
         let report = MutationReport {
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics,
             schemata: None,
             baseline_timing: None,
@@ -564,6 +575,7 @@ mod tests {
                 },
                 MutationResult::Killed,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -605,6 +617,7 @@ mod tests {
 
         let report = MutationReport {
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,4 +1,5 @@
-use crate::{MutationReport, MutationResult};
+use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
+use crate::{Mutation, MutationReport, MutationResult};
 use anyhow::Result;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -12,6 +13,12 @@ struct JsonReport {
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    executed_killed: Option<usize>,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    exact_cache_reused: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    incremental_history_reused: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
     uncovered: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
@@ -90,6 +97,7 @@ struct JsonMutation {
     operator: String,
     description: String,
     result: String,
+    execution: JsonMutationExecution,
     #[serde(skip_serializing_if = "Option::is_none")]
     column: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,10 +110,114 @@ struct JsonMutation {
     build_error_fingerprint: Option<String>,
 }
 
+#[derive(Serialize)]
+struct JsonMutationExecution {
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct JsonRunSuiteFailure {
+    kind: &'static str,
+    phase: &'static str,
+    command: Vec<String>,
+    outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout_ms: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Serialize)]
+struct JsonDryRun {
+    kind: &'static str,
+    dry_run: bool,
+    planned_total: usize,
+    mutations: Vec<JsonDryRunMutation>,
+}
+
+#[derive(Serialize)]
+struct JsonDryRunMutation {
+    id: u32,
+    file: String,
+    line: usize,
+    column: usize,
+    operator: String,
+    description: String,
+    original: String,
+    replacement: String,
+}
+
 pub fn print_report(report: &MutationReport) -> Result<()> {
     let json = to_json_string(report)?;
     println!("{}", json);
     Ok(())
+}
+
+/// Print a machine-readable mutation preview without executing test suites.
+pub fn print_dry_run(mutations: &[Mutation]) -> Result<()> {
+    println!("{}", to_dry_run_json(mutations)?);
+    Ok(())
+}
+
+/// Serialize a dry-run preview as a document distinct from a mutation report.
+pub fn to_dry_run_json(mutations: &[Mutation]) -> Result<String> {
+    let mutations: Vec<JsonDryRunMutation> = mutations
+        .iter()
+        .map(|mutation| JsonDryRunMutation {
+            id: mutation.id + 1,
+            file: mutation.file.display().to_string(),
+            line: mutation.line,
+            column: mutation.column,
+            operator: mutation.operator.clone(),
+            description: mutation.description.clone(),
+            original: mutation.original.clone(),
+            replacement: mutation.replacement.clone(),
+        })
+        .collect();
+    serde_json::to_string_pretty(&JsonDryRun {
+        kind: "dry_run",
+        dry_run: true,
+        planned_total: mutations.len(),
+        mutations,
+    })
+    .map_err(Into::into)
+}
+
+/// Print a run-level suite failure instead of a mutation report.
+pub fn print_run_suite_failure(failure: &RunSuiteFailure) -> Result<()> {
+    println!("{}", to_run_suite_failure_json(failure)?);
+    Ok(())
+}
+
+/// Serialize a baseline suite failure without inventing mutation verdicts.
+pub fn to_run_suite_failure_json(failure: &RunSuiteFailure) -> Result<String> {
+    let (outcome, output, timeout_ms, detail) = match &failure.outcome {
+        RunSuiteFailureOutcome::Failed { output } => ("failed", output.clone(), None, None),
+        RunSuiteFailureOutcome::TimedOut { timeout } => {
+            ("timed_out", None, Some(timeout.as_millis()), None)
+        }
+        RunSuiteFailureOutcome::CannotRun { detail } => {
+            ("cannot_run", None, None, Some(detail.clone()))
+        }
+    };
+    let phase = match failure.phase {
+        SuiteFailurePhase::Build => "build",
+        SuiteFailurePhase::Test => "test",
+    };
+    serde_json::to_string_pretty(&JsonRunSuiteFailure {
+        kind: "suite_failure",
+        phase,
+        command: failure.command.clone(),
+        outcome,
+        output,
+        timeout_ms,
+        detail,
+    })
+    .map_err(Into::into)
 }
 
 /// Serialize report to a JSON string (for testing and programmatic use).
@@ -118,27 +230,38 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
     let mutations: Vec<JsonMutation> = report
         .results
         .iter()
-        .map(|(m, r)| JsonMutation {
-            id: m.id + 1,
-            file: m.file.display().to_string(),
-            line: m.line,
-            operator: m.operator.clone(),
-            description: m.description.clone(),
-            result: match r {
-                MutationResult::Killed => "killed".to_string(),
-                MutationResult::Survived => "survived".to_string(),
-                MutationResult::Timeout => "timeout".to_string(),
-                MutationResult::BuildError => "build_error".to_string(),
-                MutationResult::Uncovered => "uncovered".to_string(),
-                MutationResult::Subsumed => "subsumed".to_string(),
-            },
-            column: Some(m.column),
-            original: Some(m.original.clone()),
-            replacement: Some(m.replacement.clone()),
-            diff: super::mutation_diff(m),
-            build_error_fingerprint: diagnostic_by_id
-                .get(&m.id)
-                .map(|diagnostic| diagnostic.fingerprint.clone()),
+        .map(|(m, r)| {
+            let execution = report.execution_for(m.id, *r);
+            JsonMutation {
+                id: m.id + 1,
+                file: m.file.display().to_string(),
+                line: m.line,
+                operator: m.operator.clone(),
+                description: m.description.clone(),
+                result: match r {
+                    MutationResult::Killed => "killed".to_string(),
+                    MutationResult::Survived => "survived".to_string(),
+                    MutationResult::Timeout => "timeout".to_string(),
+                    MutationResult::BuildError => "build_error".to_string(),
+                    MutationResult::Uncovered => "uncovered".to_string(),
+                    MutationResult::Subsumed => "subsumed".to_string(),
+                },
+                execution: JsonMutationExecution {
+                    state: execution.state_name(),
+                    reason: execution.reason().map(|reason| reason.name()),
+                },
+                column: Some(m.column),
+                original: Some(m.original.clone()),
+                replacement: Some(m.replacement.clone()),
+                diff: super::mutation_diff(m),
+                build_error_fingerprint: if *r == MutationResult::BuildError {
+                    diagnostic_by_id
+                        .get(&m.id)
+                        .map(|diagnostic| diagnostic.fingerprint.clone())
+                } else {
+                    None
+                },
+            }
         })
         .collect();
     let build_error_groups = super::build_error_groups(report)
@@ -172,15 +295,19 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
         })
         .collect();
 
-    let tested = report.tested_count();
+    let execution_counts = report.execution_counts();
     let json_report = JsonReport {
         total: report.total,
         planned_total: report.planned_total,
-        tested,
+        tested: execution_counts.executed,
         killed: report.killed,
         survived: report.survived,
         timeout: report.timeout,
         build_errors: report.build_errors,
+        executed_killed: (execution_counts.executed_killed != report.killed)
+            .then_some(execution_counts.executed_killed),
+        exact_cache_reused: execution_counts.exact_cache_reused,
+        incremental_history_reused: execution_counts.incremental_history_reused,
         uncovered: report.uncovered_count(),
         subsumed: report.subsumed_count(),
         partial: report.total < report.planned_total,
@@ -221,11 +348,13 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
     use crate::test_helpers::sample_report;
     use crate::{
         BaselineTiming, BuildErrorDiagnostic, Mutation, SchemataFallbackReasonCount, SchemataReport,
     };
     use serde_json::Value;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -355,6 +484,52 @@ mod tests {
         assert_eq!(mutations[0]["operator"], "lt_to_lte");
         assert_eq!(mutations[0]["result"], "killed");
         assert_eq!(mutations[1]["result"], "survived");
+        assert_eq!(mutations[0]["execution"]["state"], "executed");
+        assert_eq!(mutations[1]["execution"]["state"], "executed");
+    }
+
+    #[test]
+    fn json_output_reports_reuse_and_nonexecution_reasons() {
+        let mut report = sample_report();
+        report
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(1, crate::MutationExecution::IncrementalHistory);
+        let mut uncovered = report.results[0].0.clone();
+        uncovered.id = 2;
+        report.results.push((uncovered, MutationResult::Uncovered));
+        let mut subsumed = report.results[1].0.clone();
+        subsumed.id = 3;
+        report.results.push((subsumed, MutationResult::Subsumed));
+        report.total = 4;
+        report.planned_total = 4;
+
+        let value: Value = serde_json::from_str(&to_json_string(&report).unwrap()).unwrap();
+        let mutations = value["mutations"].as_array().unwrap();
+
+        assert_eq!(value["tested"], 0);
+        assert_eq!(value["executed_killed"], 0);
+        assert_eq!(value["exact_cache_reused"], 1);
+        assert_eq!(value["incremental_history_reused"], 1);
+        assert_eq!(value["mutation_score"], 0.0);
+        assert_eq!(
+            mutations[0]["execution"],
+            serde_json::json!({"state": "exact_cache"})
+        );
+        assert_eq!(
+            mutations[1]["execution"],
+            serde_json::json!({"state": "incremental_history"})
+        );
+        assert_eq!(
+            mutations[2]["execution"],
+            serde_json::json!({"state": "not_executed", "reason": "uncovered"})
+        );
+        assert_eq!(
+            mutations[3]["execution"],
+            serde_json::json!({"state": "not_executed", "reason": "subsumed"})
+        );
     }
 
     #[test]
@@ -393,6 +568,7 @@ mod tests {
                 "operator",
                 "description",
                 "result",
+                "execution",
                 "column",
                 "original",
                 "replacement",
@@ -407,6 +583,7 @@ mod tests {
                 "operator",
                 "description",
                 "result",
+                "execution",
                 "column",
                 "original",
                 "replacement",
@@ -475,6 +652,7 @@ mod tests {
                 },
                 MutationResult::BuildError,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -521,6 +699,7 @@ mod tests {
                 },
                 MutationResult::BuildError,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![diagnostic],
             schemata: None,
             baseline_timing: None,
@@ -551,12 +730,17 @@ mod tests {
             value["mutations"][0]["build_error_fingerprint"],
             serde_json::json!(fingerprint)
         );
+        assert_eq!(
+            value["mutations"][0]["execution"],
+            serde_json::json!({"state": "not_executed", "reason": "build_error"})
+        );
     }
 
     #[test]
     fn json_score_100_when_empty_report() {
         let report = MutationReport {
             results: vec![],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -620,5 +804,62 @@ mod tests {
         assert_eq!(mutations[1]["replacement"], "!=");
         // diff is None because the test file doesn't exist on disk
         assert!(mutations[1]["diff"].is_null());
+    }
+
+    #[test]
+    fn json_dry_run_is_distinct_machine_readable_document() {
+        let report = sample_report();
+        let value: Value =
+            serde_json::from_str(&to_dry_run_json(&[report.results[0].0.clone()]).unwrap())
+                .unwrap();
+
+        assert_eq!(value["kind"], "dry_run");
+        assert_eq!(value["dry_run"], true);
+        assert_eq!(value["planned_total"], 1);
+        assert_eq!(value["mutations"][0]["id"], 1);
+        assert!(value["mutations"][0].get("result").is_none());
+        assert!(value.get("mutation_score").is_none());
+    }
+
+    #[test]
+    fn json_suite_failure_has_no_mutation_report_fields() {
+        let failure = RunSuiteFailure {
+            phase: SuiteFailurePhase::Test,
+            command: vec!["false".into()],
+            outcome: RunSuiteFailureOutcome::Failed {
+                output: Some("test output".into()),
+            },
+        };
+
+        let value: Value =
+            serde_json::from_str(&to_run_suite_failure_json(&failure).unwrap()).unwrap();
+
+        assert_eq!(value["kind"], "suite_failure");
+        assert_eq!(value["phase"], "test");
+        assert_eq!(value["command"], serde_json::json!(["false"]));
+        assert_eq!(value["outcome"], "failed");
+        assert_eq!(value["output"], "test output");
+        assert!(value.get("mutations").is_none());
+        assert!(value.get("mutation_score").is_none());
+    }
+
+    #[test]
+    fn json_suite_failure_serializes_cannot_run_detail() {
+        let failure = RunSuiteFailure {
+            phase: SuiteFailurePhase::Build,
+            command: vec!["missing-command".into()],
+            outcome: RunSuiteFailureOutcome::CannotRun {
+                detail: "not found".into(),
+            },
+        };
+
+        let value: Value =
+            serde_json::from_str(&to_run_suite_failure_json(&failure).unwrap()).unwrap();
+
+        assert_eq!(value["phase"], "build");
+        assert_eq!(value["outcome"], "cannot_run");
+        assert_eq!(value["detail"], "not found");
+        assert!(value.get("output").is_none());
+        assert!(value.get("timeout_ms").is_none());
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -10,16 +10,17 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
 
-/// Compute mutation score as a percentage, excluding build errors,
-/// coverage-suppressed (uncovered), and learned-selection (subsumed) mutants
-/// from the denominator.
+/// Compute mutation score from tests executed during this invocation.
+///
+/// Build errors, cache/history reuse, coverage-suppressed (uncovered), and
+/// learned-selection (subsumed) mutants do not contribute to the denominator.
 pub fn mutation_score(report: &MutationReport) -> f64 {
-    let tested = report.tested_count();
-    if tested > 0 {
-        (report.killed as f64 / tested as f64) * 100.0
+    let executions = report.execution_counts();
+    if executions.executed > 0 {
+        (executions.executed_killed as f64 / executions.executed as f64) * 100.0
     } else if report.total == report.uncovered_count() + report.subsumed_count() {
-        // Nothing was executed: either the report is empty or every mutant
-        // sat on a zero-coverage line or was subsumed by a cluster sibling.
+        // Nothing was eligible to execute: either the report is empty or every
+        // mutant sat on a zero-coverage line or was subsumed by a cluster sibling.
         // Vacuous pass, same as an empty report.
         100.0
     } else {
@@ -73,7 +74,9 @@ pub fn build_error_groups(report: &MutationReport) -> Vec<BuildErrorGroup> {
         BTreeMap::<(String, String, String, String, String), BuildErrorGroupAccumulator>::new();
 
     for (mutation, result) in &report.results {
-        if *result != MutationResult::BuildError {
+        if *result != MutationResult::BuildError
+            || report.execution_for(mutation.id, *result).is_reused()
+        {
             continue;
         }
 
@@ -195,6 +198,18 @@ pub fn print_report(
     Ok(())
 }
 
+/// Render a baseline suite failure without fabricating a mutation report.
+pub fn print_run_suite_failure(
+    failure: &crate::runner::RunSuiteFailure,
+    format: crate::cli::OutputFormat,
+) -> anyhow::Result<()> {
+    match format {
+        crate::cli::OutputFormat::Json => json::print_run_suite_failure(failure)?,
+        _ => terminal::print_run_suite_failure(failure),
+    }
+    Ok(())
+}
+
 pub fn print_coverage_gate_report(
     report: &crate::coverage::CoverageGateReport,
     format: crate::cli::OutputFormat,
@@ -220,11 +235,12 @@ pub fn print_coverage_gate_report(
 /// Includes a hidden marker comment so CI pipelines can find/replace
 /// existing togi comments on subsequent runs.
 pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -> String {
-    use crate::MutationResult;
+    use crate::{MutationExecution, MutationResult};
     use std::fmt::Write;
 
+    let execution_counts = report.execution_counts();
     let score = mutation_score(report);
-    let tested = report.tested_count();
+    let tested = execution_counts.executed;
     let uncovered = report.uncovered_count();
     let subsumed = report.subsumed_count();
     let emoji = if report.survived == 0 && report.timeout == 0 && report.build_errors == 0 {
@@ -256,11 +272,25 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
     } else {
         String::new()
     };
+    let reused_str = if execution_counts.reused() > 0 {
+        format!(
+            ", {} exact-cache reused, {} incremental-history reused",
+            execution_counts.exact_cache_reused, execution_counts.incremental_history_reused
+        )
+    } else {
+        String::new()
+    };
     writeln!(
         md,
-        "**{score:.1}%** mutation score{delta_str} — {}/{tested} killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str} — {:.2}s",
-        report.killed, report.survived, report.timeout, report.build_errors, report.duration.as_secs_f64()
-    ).unwrap();
+        "**{score:.1}%** mutation score{delta_str} — {}/{} freshly executed killed, {} survived, {} timeout, {} build errors{uncovered_str}{subsumed_str}{reused_str} — {:.2}s",
+        execution_counts.executed_killed,
+        tested,
+        report.survived,
+        report.timeout,
+        report.build_errors,
+        report.duration.as_secs_f64()
+    )
+    .unwrap();
     if report.total < report.planned_total {
         writeln!(
             md,
@@ -292,14 +322,23 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
         writeln!(md).unwrap();
         writeln!(md, "| File | Line | Operator | Description |").unwrap();
         writeln!(md, "|------|------|----------|-------------|").unwrap();
-        for (m, _) in &survived {
+        for (mutation, result) in survived {
+            let provenance = match report.execution_for(mutation.id, *result) {
+                MutationExecution::Executed => String::new(),
+                MutationExecution::ExactCache => " (reused: exact cache)".to_string(),
+                MutationExecution::IncrementalHistory => {
+                    " (reused: incremental history)".to_string()
+                }
+                MutationExecution::NotExecuted(reason) => format!(" (not executed: {reason})"),
+            };
             writeln!(
                 md,
-                "| `{}` | {} | `{}` | {} |",
-                escape_md_cell(&m.file.display().to_string()),
-                m.line,
-                escape_md_cell(&m.operator),
-                escape_md_cell(&m.description)
+                "| `{}` | {} | `{}` | {}{} |",
+                escape_md_cell(&mutation.file.display().to_string()),
+                mutation.line,
+                escape_md_cell(&mutation.operator),
+                escape_md_cell(&mutation.description),
+                provenance,
             )
             .unwrap();
         }
@@ -384,13 +423,13 @@ pub fn mutation_diff(mutation: &Mutation) -> Option<String> {
             writeln!(diff, " {line}").ok()?;
         }
     }
-
     Some(diff)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use tempfile::TempDir;
 
     fn make_mutation(
@@ -444,6 +483,7 @@ mod tests {
                 report_mutation(1, "src/b.rs", MutationResult::BuildError),
                 report_mutation(2, "src/c.rs", MutationResult::Killed),
             ],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![
                 BuildErrorDiagnostic::new(
                     0,
@@ -483,6 +523,19 @@ mod tests {
         assert_eq!(groups[0].phase, "build_command");
         assert_eq!(groups[0].files.len(), 2);
         assert_eq!(groups[0].examples.len(), 2);
+    }
+
+    #[test]
+    fn build_error_groups_exclude_reused_build_error_verdicts() {
+        let mut report = crate::test_helpers::sample_report();
+        report.results[0].1 = MutationResult::BuildError;
+        report.killed = 0;
+        report.build_errors = 1;
+        report
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+
+        assert!(build_error_groups(&report).is_empty());
     }
 
     #[test]
@@ -598,6 +651,28 @@ mod tests {
     }
 
     #[test]
+    fn pr_comment_labels_mixed_survivor_provenance() {
+        let mut report = uncovered_report(vec![
+            report_mutation(0, "src/fresh.rs", MutationResult::Survived),
+            report_mutation(1, "src/exact.rs", MutationResult::Survived),
+            report_mutation(2, "src/history.rs", MutationResult::Survived),
+        ]);
+        report.survived = 3;
+        report
+            .execution_provenance
+            .insert(1, crate::MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(2, crate::MutationExecution::IncrementalHistory);
+
+        let md = format_pr_comment(&report, None);
+
+        assert!(md.contains("| `src/fresh.rs` | 1 | `eq_to_neq` | Replace == with != |"));
+        assert!(md.contains("Replace == with != (reused: exact cache)"));
+        assert!(md.contains("Replace == with != (reused: incremental history)"));
+    }
+
+    #[test]
     fn pr_comment_no_details_when_all_killed() {
         use crate::{MutationReport, MutationResult};
         use std::time::Duration;
@@ -617,6 +692,7 @@ mod tests {
                 },
                 MutationResult::Killed,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -656,6 +732,7 @@ mod tests {
                 },
                 MutationResult::Timeout,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -696,6 +773,7 @@ mod tests {
                 },
                 MutationResult::BuildError,
             )],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -756,6 +834,7 @@ mod tests {
                     MutationResult::BuildError,
                 ),
             ],
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -796,6 +875,7 @@ mod tests {
             .count();
         MutationReport {
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -823,6 +903,21 @@ mod tests {
         assert_eq!(report.uncovered_count(), 2);
         assert_eq!(report.tested_count(), 1);
         assert_eq!(mutation_score(&report), 100.0);
+    }
+
+    #[test]
+    fn mutation_score_excludes_exact_cache_verdicts() {
+        let mut report = crate::test_helpers::sample_report();
+        report
+            .execution_provenance
+            .insert(0, crate::MutationExecution::ExactCache);
+
+        let counts = report.execution_counts();
+        assert_eq!(counts.executed, 1);
+        assert_eq!(counts.executed_killed, 0);
+        assert_eq!(counts.exact_cache_reused, 1);
+        assert_eq!(report.tested_count(), 1);
+        assert_eq!(mutation_score(&report), 0.0);
     }
 
     #[test]

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -1,4 +1,4 @@
-use crate::{Mutation, MutationReport, MutationResult};
+use crate::{Mutation, MutationExecution, MutationReport, MutationResult};
 use anyhow::Result;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -61,6 +61,12 @@ struct SarifInvocationProperties {
     survived: usize,
     timeout: usize,
     build_errors: usize,
+    tested: usize,
+    executed_killed: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    exact_cache_reused: usize,
+    #[serde(skip_serializing_if = "super::is_zero")]
+    incremental_history_reused: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
     uncovered: usize,
     #[serde(skip_serializing_if = "super::is_zero")]
@@ -75,6 +81,15 @@ struct SarifResult {
     level: &'static str,
     message: SarifMessage,
     locations: Vec<SarifLocation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<SarifResultProperties>,
+}
+
+#[derive(Serialize)]
+struct SarifResultProperties {
+    execution: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonexecution_reason: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -112,7 +127,7 @@ fn artifact_uri(mutation: &Mutation) -> String {
     mutation.file.display().to_string().replace('\\', "/")
 }
 
-fn result_for(mutation: &Mutation) -> SarifResult {
+fn result_for(mutation: &Mutation, execution: MutationExecution) -> SarifResult {
     SarifResult {
         rule_id: mutation.operator.clone(),
         level: "warning",
@@ -135,6 +150,10 @@ fn result_for(mutation: &Mutation) -> SarifResult {
                 },
             },
         }],
+        properties: (!execution.is_tested()).then(|| SarifResultProperties {
+            execution: execution.state_name(),
+            nonexecution_reason: execution.reason().map(|reason| reason.name()),
+        }),
     }
 }
 
@@ -162,15 +181,15 @@ pub fn print_report(report: &MutationReport) -> Result<()> {
 /// invocation totals.
 pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
     let registry = registry_descriptions();
-    let surviving: Vec<&Mutation> = report
+    let surviving: Vec<(&Mutation, MutationExecution)> = report
         .results
         .iter()
-        .filter(|(_, r)| *r == MutationResult::Survived)
-        .map(|(m, _)| m)
+        .filter(|(_, result)| *result == MutationResult::Survived)
+        .map(|(mutation, result)| (mutation, report.execution_for(mutation.id, *result)))
         .collect();
 
     let mut rules: Vec<SarifRule> = Vec::new();
-    for mutation in &surviving {
+    for (mutation, _) in &surviving {
         if rules.iter().any(|rule| rule.id == mutation.operator) {
             continue;
         }
@@ -184,6 +203,7 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
         });
     }
 
+    let execution_counts = report.execution_counts();
     let sarif_report = SarifReport {
         schema: SARIF_SCHEMA,
         version: SARIF_VERSION,
@@ -203,6 +223,10 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
                     survived: report.survived,
                     timeout: report.timeout,
                     build_errors: report.build_errors,
+                    tested: execution_counts.executed,
+                    executed_killed: execution_counts.executed_killed,
+                    exact_cache_reused: execution_counts.exact_cache_reused,
+                    incremental_history_reused: execution_counts.incremental_history_reused,
                     uncovered: report.uncovered_count(),
                     subsumed: report.subsumed_count(),
                     mutation_score: super::mutation_score(report),
@@ -210,7 +234,7 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
             }],
             results: surviving
                 .iter()
-                .map(|mutation| result_for(mutation))
+                .map(|(mutation, execution)| result_for(mutation, *execution))
                 .collect(),
         }],
     };
@@ -223,6 +247,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::sample_report;
     use serde_json::Value;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -270,6 +295,7 @@ mod tests {
             test_command: None,
             build_command: vec![],
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -338,6 +364,56 @@ mod tests {
     }
 
     #[test]
+    fn sarif_survivor_results_include_nonfresh_provenance() {
+        let mut report = report_with(vec![
+            (
+                mutation(0, "src/fresh.rs", 1, "op", "fresh"),
+                MutationResult::Survived,
+            ),
+            (
+                mutation(1, "src/exact.rs", 2, "op", "exact"),
+                MutationResult::Survived,
+            ),
+            (
+                mutation(2, "src/history.rs", 3, "op", "history"),
+                MutationResult::Survived,
+            ),
+            (
+                mutation(3, "src/skipped.rs", 4, "op", "skipped"),
+                MutationResult::Survived,
+            ),
+        ]);
+        report
+            .execution_provenance
+            .insert(1, MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(2, MutationExecution::IncrementalHistory);
+        report.execution_provenance.insert(
+            3,
+            MutationExecution::NotExecuted(crate::MutationNonExecutionReason::Subsumed),
+        );
+
+        let results = parse(&report)["runs"][0]["results"].clone();
+
+        assert!(results[0].get("properties").is_none());
+        assert_eq!(
+            results[1]["properties"],
+            serde_json::json!({"execution": "exact_cache"})
+        );
+        assert_eq!(
+            results[2]["properties"],
+            serde_json::json!({"execution": "incremental_history"})
+        );
+        assert_eq!(
+            results[3]["properties"],
+            serde_json::json!({
+                "execution": "not_executed",
+                "nonexecution_reason": "subsumed"
+            })
+        );
+    }
+    #[test]
     fn sarif_result_has_level_message_and_location() {
         let value = parse(&sample_report());
         let result = &value["runs"][0]["results"][0];
@@ -364,6 +440,8 @@ mod tests {
         assert_eq!(properties["survived"], 1);
         assert_eq!(properties["timeout"], 0);
         assert_eq!(properties["build_errors"], 0);
+        assert_eq!(properties["tested"], 2);
+        assert_eq!(properties["executed_killed"], 1);
         assert_eq!(properties["mutation_score"], 50.0);
     }
 
@@ -507,6 +585,8 @@ mod tests {
                         "survived": 1,
                         "timeout": 0,
                         "build_errors": 0,
+                        "tested": 2,
+                        "executed_killed": 1,
                         "mutation_score": 50.0
                     }
                 }],

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -1,3 +1,4 @@
+use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
 use crate::{MutationReport, MutationResult};
 use std::fmt::Write;
 use std::io::IsTerminal;
@@ -10,15 +11,55 @@ pub fn format_report_plain(report: &MutationReport) -> String {
     format_report(report, false)
 }
 
+/// Print a run-level suite failure instead of a mutation report.
+pub fn print_run_suite_failure(failure: &RunSuiteFailure) {
+    eprint!("{}", format_run_suite_failure(failure));
+}
+
+pub fn format_run_suite_failure(failure: &RunSuiteFailure) -> String {
+    let mut out = String::new();
+    let phase = match failure.phase {
+        SuiteFailurePhase::Build => "build",
+        SuiteFailurePhase::Test => "test",
+    };
+    writeln!(out, "Test suite failure before mutation execution.").unwrap();
+    writeln!(out, "Baseline phase: {phase}").unwrap();
+    writeln!(out, "Command: {}", failure.command.join(" ")).unwrap();
+    match &failure.outcome {
+        RunSuiteFailureOutcome::Failed { output } => {
+            writeln!(out, "Outcome: failed").unwrap();
+            if let Some(output) = output {
+                writeln!(out, "Output:\n{output}").unwrap();
+            }
+        }
+        RunSuiteFailureOutcome::TimedOut { timeout } => {
+            writeln!(
+                out,
+                "Outcome: timed out after {:.2}s",
+                timeout.as_secs_f64()
+            )
+            .unwrap();
+        }
+        RunSuiteFailureOutcome::CannotRun { detail } => {
+            writeln!(out, "Outcome: could not run").unwrap();
+            writeln!(out, "Detail: {detail}").unwrap();
+        }
+    }
+    out
+}
+
 fn format_report(report: &MutationReport, color: bool) -> String {
     let mut out = String::new();
     writeln!(out).unwrap();
+    let execution_counts = report.execution_counts();
 
     for (mutation, result) in &report.results {
         let file = mutation.file.display().to_string();
         let line = mutation.line;
         let operator = &mutation.operator;
         let desc = &mutation.description;
+        let execution = report.execution_for(mutation.id, *result);
+        let execution_text = execution.to_string();
 
         let (tag, extra) = match result {
             MutationResult::Killed => ("✓ KILLED", None),
@@ -93,19 +134,20 @@ fn format_report(report: &MutationReport, color: bool) -> String {
             };
             writeln!(
                 out,
-                "  {} {}:{}  {} {}: {}",
+                "  {} {}:{}  {} {}: {} [{}]",
                 tag_colored,
                 file,
                 line,
                 dim("—"),
                 dim(operator),
-                desc
+                desc,
+                dim(&execution_text)
             )
         } else {
             writeln!(
                 out,
-                "  {:<14}{}:{} — {}: {}",
-                tag, file, line, operator, desc
+                "  {:<14}{}:{} — {}: {} [{}]",
+                tag, file, line, operator, desc, execution_text
             )
         }
         .unwrap();
@@ -126,6 +168,19 @@ fn format_report(report: &MutationReport, color: bool) -> String {
         report.killed, report.survived, report.timeout, report.build_errors
     )
     .unwrap();
+    let exact_cache_reused =
+        count_suffix(execution_counts.exact_cache_reused, "exact-cache reused");
+    let incremental_history_reused = count_suffix(
+        execution_counts.incremental_history_reused,
+        "incremental-history reused",
+    );
+    let not_executed = count_suffix(execution_counts.not_executed, "not executed");
+    writeln!(
+        out,
+        "Execution: {} freshly tested{exact_cache_reused}{incremental_history_reused}{not_executed}",
+        execution_counts.executed
+    )
+    .unwrap();
     if report.total < report.planned_total {
         writeln!(
             out,
@@ -139,7 +194,7 @@ fn format_report(report: &MutationReport, color: bool) -> String {
     }
     writeln!(
         out,
-        "Mutation score (test kills only): {:.1}%",
+        "Mutation score (fresh test kills only): {:.1}%",
         super::mutation_score(report)
     )
     .unwrap();
@@ -289,7 +344,12 @@ fn color_enabled_from_env(is_terminal: bool, env: impl Fn(&str) -> Option<String
 
 /// Guidance text when every mutation is a build error.
 fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
-    if report.build_errors == 0 || report.build_errors != report.total {
+    if report.results.is_empty()
+        || report.results.iter().any(|(mutation, result)| {
+            *result != MutationResult::BuildError
+                || report.execution_for(mutation.id, *result).is_reused()
+        })
+    {
         return None;
     }
     Some(
@@ -306,7 +366,9 @@ fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
     use crate::{BuildErrorDiagnostic, Mutation};
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -346,6 +408,7 @@ mod tests {
 
         MutationReport {
             results,
+            execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
             schemata: None,
             baseline_timing: None,
@@ -360,6 +423,26 @@ mod tests {
             timeout,
             build_errors,
         }
+    }
+
+    #[test]
+    fn terminal_suite_failure_is_not_a_mutation_report() {
+        let failure = RunSuiteFailure {
+            phase: SuiteFailurePhase::Test,
+            command: vec!["false".into()],
+            outcome: RunSuiteFailureOutcome::Failed {
+                output: Some("test output".into()),
+            },
+        };
+
+        let output = format_run_suite_failure(&failure);
+
+        assert!(output.contains("Test suite failure before mutation execution."));
+        assert!(output.contains("Baseline phase: test"));
+        assert!(output.contains("Command: false"));
+        assert!(output.contains("Outcome: failed"));
+        assert!(output.contains("test output"));
+        assert!(!output.contains("Mutation score"));
     }
 
     #[test]
@@ -411,7 +494,7 @@ mod tests {
             ));
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 0 survived, 1 timeout, 1 build errors"));
-        assert!(output.contains("Mutation score (test kills only): 50.0%"));
+        assert!(output.contains("Mutation score (fresh test kills only): 50.0%"));
         assert!(output.contains("Build error diagnostics:"));
         assert!(output.contains("unknown / op / regular / build_command"));
         assert!(output.contains("command: cargo check"));
@@ -426,7 +509,33 @@ mod tests {
         ]);
         let output = format_report_plain(&report);
         assert!(output.contains("Results: 1 killed, 1 survived, 0 timeout, 0 build errors"));
-        assert!(output.contains("Mutation score (test kills only): 50.0%"));
+        assert!(output.contains("Mutation score (fresh test kills only): 50.0%"));
+    }
+
+    #[test]
+    fn terminal_output_shows_execution_provenance() {
+        let mut report = report(vec![
+            (mutation(1, "src/a.rs", 1), MutationResult::Killed),
+            (mutation(2, "src/b.rs", 2), MutationResult::Survived),
+        ]);
+        report
+            .execution_provenance
+            .insert(1, crate::MutationExecution::ExactCache);
+        report
+            .execution_provenance
+            .insert(2, crate::MutationExecution::IncrementalHistory);
+
+        let output = format_report_plain(&report);
+
+        assert!(output.contains("[exact cache]"), "got: {output}");
+        assert!(output.contains("[incremental history]"), "got: {output}");
+        assert!(
+            output.contains(
+                "Execution: 0 freshly tested, 1 exact-cache reused, 1 incremental-history reused"
+            ),
+            "got: {output}"
+        );
+        assert!(output.contains("Mutation score (fresh test kills only): 0.0%"));
     }
 
     #[test]
@@ -482,6 +591,18 @@ mod tests {
     }
 
     #[test]
+    fn reused_build_errors_do_not_show_fresh_build_error_guidance() {
+        let mut report = report(vec![(
+            mutation(1, "src/a.rs", 1),
+            MutationResult::BuildError,
+        )]);
+        report
+            .execution_provenance
+            .insert(report.results[0].0.id, crate::MutationExecution::ExactCache);
+
+        assert!(all_build_error_guidance(&report).is_none());
+    }
+    #[test]
     fn terminal_output_lists_uncovered_mutants_distinctly() {
         let report = report(vec![
             (mutation(1, "src/a.rs", 1), MutationResult::Killed),
@@ -500,7 +621,7 @@ mod tests {
                 .contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 uncovered")
         );
         // Uncovered mutants are excluded from the tested denominator.
-        assert!(output.contains("Mutation score (test kills only): 100.0%"));
+        assert!(output.contains("Mutation score (fresh test kills only): 100.0%"));
     }
 
     #[test]
@@ -529,7 +650,7 @@ mod tests {
             output.contains("Results: 1 killed, 0 survived, 0 timeout, 0 build errors, 1 subsumed")
         );
         // Subsumed mutants are excluded from the tested denominator.
-        assert!(output.contains("Mutation score (test kills only): 100.0%"));
+        assert!(output.contains("Mutation score (fresh test kills only): 100.0%"));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,11 +2,11 @@
 
 use crate::cache::{self, CacheKey};
 use crate::{
-    BuildErrorDiagnostic, Mutation, MutationReport, MutationResult, SchemataFallbackReasonCount,
-    SchemataReport,
+    BuildErrorDiagnostic, Mutation, MutationExecution, MutationReport, MutationResult,
+    SchemataFallbackReasonCount, SchemataReport,
 };
 use anyhow::{Context, bail};
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
 use std::hash::Hasher;
 use std::io::{IsTerminal, Read, Write};
@@ -245,6 +245,72 @@ pub struct BaselineSuiteMeasurement {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaselineHealthMeasurement {
     pub suites: Vec<BaselineSuiteMeasurement>,
+}
+
+/// Which baseline command made a mutation run unsuitable for scoring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuiteFailurePhase {
+    Build,
+    Test,
+}
+
+impl SuiteFailurePhase {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Build => "baseline build command",
+            Self::Test => "baseline test command",
+        }
+    }
+}
+
+/// Structured outcome for a failing unmutated baseline suite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunSuiteFailureOutcome {
+    Failed { output: Option<String> },
+    TimedOut { timeout: Duration },
+    CannotRun { detail: String },
+}
+
+/// A run-level failure that prevents mutation verdicts from being trustworthy.
+///
+/// `src/main.rs` can downcast a `check_baseline_health` error with
+/// [`run_suite_failure`] and render this separately from mutation results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSuiteFailure {
+    pub phase: SuiteFailurePhase,
+    pub command: Vec<String>,
+    pub outcome: RunSuiteFailureOutcome,
+}
+
+impl std::fmt::Display for RunSuiteFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = self.phase.label();
+        let command = command_for_message(&self.command);
+        match &self.outcome {
+            RunSuiteFailureOutcome::Failed { output } => {
+                write!(f, "{label} failed (`{command}`)")?;
+                if let Some(output) = output {
+                    write!(f, ":\n{output}")?;
+                }
+                Ok(())
+            }
+            RunSuiteFailureOutcome::TimedOut { timeout } => write!(
+                f,
+                "{label} timed out after {:.2}s (`{command}`)",
+                timeout.as_secs_f64()
+            ),
+            RunSuiteFailureOutcome::CannotRun { detail } => {
+                write!(f, "{label} could not run (`{command}`): {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunSuiteFailure {}
+
+/// Extract a structured run-level suite failure from baseline health checking.
+pub fn run_suite_failure(error: &anyhow::Error) -> Option<&RunSuiteFailure> {
+    error.downcast_ref::<RunSuiteFailure>()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1219,7 +1285,7 @@ pub fn measure_baseline_timing(
     let root = workspace.root();
     let build_duration = if config.build_command_explicit && !config.build_command.is_empty() {
         Some(measure_baseline_command(
-            "baseline build command",
+            SuiteFailurePhase::Build,
             config.build_command,
             config.sandbox_command,
             root,
@@ -1231,7 +1297,7 @@ pub fn measure_baseline_timing(
         None
     };
     let test_duration = measure_baseline_command(
-        "baseline test command",
+        SuiteFailurePhase::Test,
         config.test_command,
         config.sandbox_command,
         root,
@@ -1276,7 +1342,7 @@ pub fn check_baseline_health(
             && !config.commands.build_command.is_empty()
         {
             Some(measure_baseline_command(
-                "baseline build command",
+                SuiteFailurePhase::Build,
                 &config.commands.build_command,
                 &config.commands.sandbox_command,
                 root,
@@ -1288,7 +1354,7 @@ pub fn check_baseline_health(
             None
         };
         let test_duration = measure_baseline_command(
-            "baseline test command",
+            SuiteFailurePhase::Test,
             &suite.argv,
             &config.commands.sandbox_command,
             root,
@@ -1364,7 +1430,7 @@ fn resolve_baseline_suites(
 }
 
 fn measure_baseline_command(
-    label: &str,
+    phase: SuiteFailurePhase,
     command: &[String],
     sandbox_command: &[String],
     cwd: &Path,
@@ -1383,28 +1449,32 @@ fn measure_baseline_command(
         MutationResult::Survived | MutationResult::Uncovered | MutationResult::Subsumed => {
             Ok(duration)
         }
-        MutationResult::Killed => {
-            let output = baseline_failure_output(outcome.test_output.as_deref());
-            bail!(
-                "{label} failed (`{}`){output}",
-                command_for_message(command)
-            )
+        MutationResult::Killed => Err(RunSuiteFailure {
+            phase,
+            command: command.to_vec(),
+            outcome: RunSuiteFailureOutcome::Failed {
+                output: baseline_failure_output(outcome.test_output.as_deref()),
+            },
         }
-        MutationResult::Timeout => bail!(
-            "{label} timed out after {:.2}s (`{}`)",
-            timeout.as_secs_f64(),
-            command_for_message(command)
-        ),
+        .into()),
+        MutationResult::Timeout => Err(RunSuiteFailure {
+            phase,
+            command: command.to_vec(),
+            outcome: RunSuiteFailureOutcome::TimedOut { timeout },
+        }
+        .into()),
         MutationResult::BuildError => {
             let detail = outcome
                 .build_error_detail
                 .as_ref()
-                .map(|detail| detail.message.as_str())
-                .unwrap_or("command could not run");
-            bail!(
-                "{label} could not run (`{}`): {detail}",
-                command_for_message(command)
-            )
+                .map(|detail| detail.message.clone())
+                .unwrap_or_else(|| "command could not run".to_string());
+            Err(RunSuiteFailure {
+                phase,
+                command: command.to_vec(),
+                outcome: RunSuiteFailureOutcome::CannotRun { detail },
+            }
+            .into())
         }
     }
 }
@@ -1426,12 +1496,9 @@ fn sandboxed_command(sandbox_command: &[String], command: &[String]) -> Vec<Stri
     argv
 }
 
-fn baseline_failure_output(output: Option<&str>) -> String {
-    let Some(output) = output.map(str::trim).filter(|output| !output.is_empty()) else {
-        return String::new();
-    };
-    let excerpt = output.lines().take(6).collect::<Vec<_>>().join("\n");
-    format!(":\n{excerpt}")
+fn baseline_failure_output(output: Option<&str>) -> Option<String> {
+    let output = output.map(str::trim).filter(|output| !output.is_empty())?;
+    Some(output.lines().take(6).collect::<Vec<_>>().join("\n"))
 }
 
 fn create_git_worktree_workspace(
@@ -1882,12 +1949,14 @@ impl Drop for WorkspaceSlot {
 struct QueuedMutation {
     index: usize,
     mutation: Mutation,
+    restore_checked: bool,
 }
 
 #[derive(Debug)]
 struct MutationRunRecord {
     mutation: Mutation,
     result: MutationResult,
+    execution: MutationExecution,
     build_error_diagnostic: Option<BuildErrorDiagnostic>,
 }
 
@@ -1900,9 +1969,20 @@ impl MutationRunRecord {
         Self {
             mutation,
             result,
+            execution: MutationExecution::for_result(result),
             build_error_diagnostic,
         }
     }
+
+    fn with_execution(mut self, execution: MutationExecution) -> Self {
+        self.execution = execution;
+        self
+    }
+}
+
+struct PreclassifiedMutations {
+    fresh: Vec<QueuedMutation>,
+    restored: Vec<(usize, MutationRunRecord)>,
 }
 
 #[derive(Default)]
@@ -1937,6 +2017,7 @@ impl SchemataRunSummary {
 
 #[derive(Default)]
 struct EarlyStopCounts {
+    fresh_eligible_total: usize,
     completed: usize,
     killed: usize,
     survived: usize,
@@ -1945,7 +2026,6 @@ struct EarlyStopCounts {
 
 struct EarlyStopState {
     config: EarlyStopConfig,
-    planned_total: usize,
     stopped: AtomicBool,
     reason: Mutex<Option<String>>,
     counts: Mutex<EarlyStopCounts>,
@@ -1955,10 +2035,12 @@ impl EarlyStopState {
     fn new(config: EarlyStopConfig, planned_total: usize) -> Self {
         Self {
             config,
-            planned_total,
             stopped: AtomicBool::new(false),
             reason: Mutex::new(None),
-            counts: Mutex::new(EarlyStopCounts::default()),
+            counts: Mutex::new(EarlyStopCounts {
+                fresh_eligible_total: planned_total,
+                ..Default::default()
+            }),
         }
     }
 
@@ -1995,8 +2077,26 @@ impl EarlyStopState {
             MutationResult::Timeout | MutationResult::Uncovered | MutationResult::Subsumed => {}
             MutationResult::BuildError => counts.build_errors += 1,
         }
+        self.reevaluate(&counts);
+    }
 
-        let remaining = self.planned_total.saturating_sub(counts.completed);
+    /// Remove a restored cache/history verdict from the fresh-work budget
+    /// without treating its verdict as a newly observed result.
+    fn exclude_restored(&self) {
+        let mut counts = self
+            .counts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        counts.fresh_eligible_total = counts.fresh_eligible_total.saturating_sub(1);
+        self.reevaluate(&counts);
+    }
+
+    fn reevaluate(&self, counts: &EarlyStopCounts) {
+        if self.should_stop() {
+            return;
+        }
+
+        let remaining = counts.fresh_eligible_total.saturating_sub(counts.completed);
         if remaining == 0 {
             return;
         }
@@ -2018,7 +2118,7 @@ impl EarlyStopState {
             let best_killed = counts.killed + remaining;
             let best_score = if best_tested > 0 {
                 (best_killed as f64 / best_tested as f64) * 100.0
-            } else if self.planned_total == 0 {
+            } else if counts.fresh_eligible_total == 0 {
                 100.0
             } else {
                 0.0
@@ -2072,6 +2172,17 @@ fn should_stop_early(early_stop: &Option<Arc<EarlyStopState>>) -> bool {
 fn record_early_stop(shared: &RunShared<'_>, result: MutationResult) {
     if let Some(early_stop) = shared.early_stop {
         early_stop.record(result);
+    }
+}
+
+fn exclude_restored_from_early_stop(
+    early_stop: Option<&Arc<EarlyStopState>>,
+    execution: MutationExecution,
+) {
+    if execution.is_reused() {
+        if let Some(early_stop) = early_stop {
+            early_stop.exclude_restored();
+        }
     }
 }
 
@@ -2172,6 +2283,12 @@ struct PreparedMutationRun {
     cache_key: Option<CacheKey>,
 }
 
+#[derive(Clone, Copy)]
+struct RestoredMutationResult {
+    result: MutationResult,
+    execution: MutationExecution,
+}
+
 struct PreparedMutationContext<'a> {
     commands: &'a CommandConfig,
     history: Option<&'a cache::IncrementalHistoryStore>,
@@ -2245,30 +2362,36 @@ impl PreparedMutationRun {
         project_root: &Path,
         history: Option<&cache::IncrementalHistoryStore>,
         force_rerun: bool,
-    ) -> Option<MutationResult> {
+    ) -> Option<RestoredMutationResult> {
         if force_rerun {
             return None;
         }
-        if let Some(ref key) = self.cache_key {
+        if let Some(key) = &self.cache_key {
             if let Some(result) = cache::lookup(project_root, key) {
                 self.record_history(history, result, None);
-                return Some(result);
+                return Some(RestoredMutationResult {
+                    result,
+                    execution: MutationExecution::ExactCache,
+                });
             }
         }
         if let (Some(history), Some(query)) = (history, self.history_query.as_ref()) {
             if let Some(result) = history.lookup(query) {
-                if let Some(ref key) = self.cache_key {
+                if let Some(key) = &self.cache_key {
                     cache::store(project_root, key, result);
                 }
                 self.record_history(Some(history), result, None);
-                return Some(result);
+                return Some(RestoredMutationResult {
+                    result,
+                    execution: MutationExecution::IncrementalHistory,
+                });
             }
         }
         None
     }
 
     fn store_cache(&self, project_root: &Path, result: MutationResult) {
-        if let Some(ref key) = self.cache_key {
+        if let Some(key) = &self.cache_key {
             cache::store(project_root, key, result);
         }
     }
@@ -2300,7 +2423,11 @@ fn run_queued_mutation(
     reservation: TestSlotReservation,
     shared: RunShared<'_>,
 ) -> Option<(usize, MutationRunRecord)> {
-    let QueuedMutation { index, mutation } = queued;
+    let QueuedMutation {
+        index,
+        mutation,
+        restore_checked,
+    } = queued;
 
     // Stop if cancelled (Ctrl+C).
     if shared.cancelled.load(Ordering::Relaxed) {
@@ -2320,15 +2447,21 @@ fn run_queued_mutation(
         },
     );
 
-    // Check exact cache and then structured history before acquiring a workspace slot.
-    if let Some(result) =
-        prepared.restore_result(shared.project_root, shared.history, shared.force_rerun)
-    {
-        reservation.release();
-        record_progress(&shared, &mutation, result, None, true);
-        record_early_stop(&shared, result);
-        let diagnostic = cached_build_error_diagnostic(&mutation, "regular", result);
-        return Some((index, MutationRunRecord::new(mutation, result, diagnostic)));
+    // Normal runs retain lazy cache lookup; early-stop runs preclassify every
+    // candidate before scheduling and mark fresh entries as already checked.
+    if !restore_checked {
+        if let Some(restored) =
+            prepared.restore_result(shared.project_root, shared.history, shared.force_rerun)
+        {
+            reservation.release();
+            exclude_restored_from_early_stop(shared.early_stop, restored.execution);
+            record_progress(&shared, &mutation, restored.result, None, true);
+            return Some((
+                index,
+                MutationRunRecord::new(mutation, restored.result, None)
+                    .with_execution(restored.execution),
+            ));
+        }
     }
 
     let outcome = {
@@ -2528,13 +2661,89 @@ fn merge_subsumed(report: &mut MutationReport, subsumed: Vec<Mutation>) {
 }
 
 impl TestRunner {
+    /// Resolve reusable verdicts before early-stop decisions so the gate sees
+    /// the complete fresh-work denominator rather than only cache hits
+    /// encountered so far by workers.
+    fn preclassify_for_early_stop(&self, mutations: &[Mutation]) -> PreclassifiedMutations {
+        if !self.early_stop.is_enabled() {
+            return PreclassifiedMutations {
+                fresh: mutations
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(index, mutation)| QueuedMutation {
+                        index,
+                        mutation,
+                        restore_checked: false,
+                    })
+                    .collect(),
+                restored: Vec::new(),
+            };
+        }
+
+        let source_contents = SourceContentCache::default();
+        let cache_context_hash = cache_context_fingerprint(&self.project_root);
+        let test_context_index = TestContextIndex::build(&self.project_root);
+        let history = self
+            .incremental_history
+            .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
+        let mut fresh = Vec::with_capacity(mutations.len());
+        let mut restored = Vec::new();
+        let mut cancelled = false;
+
+        for (index, mutation) in mutations.iter().enumerate() {
+            if cancelled || self.cancelled.load(Ordering::Acquire) {
+                cancelled = true;
+                fresh.push(QueuedMutation {
+                    index,
+                    mutation: mutation.clone(),
+                    restore_checked: false,
+                });
+                continue;
+            }
+
+            let prepared = PreparedMutationRun::new(
+                &self.project_root,
+                mutation,
+                PreparedMutationContext {
+                    commands: &self.commands,
+                    history: history.as_ref(),
+                    source_contents: &source_contents,
+                    cache_context_fingerprint: cache_context_hash,
+                    test_context_index: &test_context_index,
+                    env: &self.env,
+                },
+            );
+            if let Some(restored_result) =
+                prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
+            {
+                restored.push((
+                    index,
+                    MutationRunRecord::new(mutation.clone(), restored_result.result, None)
+                        .with_execution(restored_result.execution),
+                ));
+            } else {
+                fresh.push(QueuedMutation {
+                    index,
+                    mutation: mutation.clone(),
+                    restore_checked: true,
+                });
+            }
+        }
+
+        PreclassifiedMutations { fresh, restored }
+    }
+
     #[allow(clippy::manual_is_multiple_of)]
     pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
         let (mutations, subsumed) = self.split_subsumed(mutations);
         let planned_total = mutations.len();
-        let early_stop = EarlyStopState::for_config(self.early_stop.clone(), planned_total);
+        let preclassified = self.preclassify_for_early_stop(&mutations);
+        let early_stop =
+            EarlyStopState::for_config(self.early_stop.clone(), preclassified.fresh.len());
         let mut outcome = self.run_regular_with_state(
-            mutations,
+            preclassified.fresh,
+            preclassified.restored,
             early_stop,
             planned_total,
             Arc::new(AtomicUsize::new(0)),
@@ -2600,7 +2809,15 @@ impl TestRunner {
             return self.outcome_from_records(Vec::new(), start.elapsed());
         }
         let planned_total = mutations.len();
-        let early_stop = EarlyStopState::for_config(self.early_stop.clone(), planned_total);
+        let preclassified = self.preclassify_for_early_stop(&mutations);
+        let restored_ids: HashSet<u32> = preclassified
+            .restored
+            .iter()
+            .map(|(_, record)| record.mutation.id)
+            .collect();
+        let restore_checked = self.early_stop.is_enabled();
+        let early_stop =
+            EarlyStopState::for_config(self.early_stop.clone(), preclassified.fresh.len());
         let tested_counter = Arc::new(AtomicUsize::new(0));
 
         let index_by_id: HashMap<u32, usize> = mutations
@@ -2612,38 +2829,36 @@ impl TestRunner {
         let mut schema_by_language = HashMap::<String, Vec<crate::schemata::SchemaMutation>>::new();
         let mut fallback_mutations = Vec::new();
         let mut schemata_summary = SchemataRunSummary::default();
+        let mut all_records = preclassified
+            .restored
+            .into_iter()
+            .map(|(_, record)| record)
+            .collect::<Vec<_>>();
 
         for schema_mutation in plan.selected {
             match schema_mutation.mutation.language.as_str() {
                 "c" | "cpp" | "go" | "java" | "rust" => {
-                    schema_by_language
-                        .entry(schema_mutation.mutation.language.clone())
-                        .or_default()
-                        .push(schema_mutation);
+                    if !restored_ids.contains(&schema_mutation.mutation.id) {
+                        schema_by_language
+                            .entry(schema_mutation.mutation.language.clone())
+                            .or_default()
+                            .push(schema_mutation);
+                    }
                 }
                 _ => {
                     schemata_summary.record_fallback("unsupported_runner");
-                    fallback_mutations.push(schema_mutation.mutation);
+                    if !restored_ids.contains(&schema_mutation.mutation.id) {
+                        fallback_mutations.push(schema_mutation.mutation);
+                    }
                 }
             }
         }
         for fallback in plan.fallback {
             schemata_summary.record_fallback(fallback.reason.as_str());
-            fallback_mutations.push(fallback.mutation);
+            if !restored_ids.contains(&fallback.mutation.id) {
+                fallback_mutations.push(fallback.mutation);
+            }
         }
-
-        if schema_by_language.is_empty() {
-            let mut outcome = self.run_regular_with_state(
-                fallback_mutations,
-                early_stop,
-                planned_total,
-                tested_counter,
-            );
-            outcome.report.schemata = Some(schemata_summary.into_report());
-            return outcome;
-        }
-
-        let mut all_records = Vec::new();
         for (language, schema_mutations) in schema_by_language {
             if should_stop_early(&early_stop) {
                 break;
@@ -2654,9 +2869,13 @@ impl TestRunner {
                 &schema_mutations,
                 early_stop.clone(),
                 tested_counter.clone(),
+                restore_checked,
             ) {
                 Ok((records, demoted)) => {
-                    schemata_summary.fast_path += records.len();
+                    schemata_summary.fast_path += records
+                        .iter()
+                        .filter(|record| record.execution.is_tested())
+                        .count();
                     all_records.extend(records);
                     if !demoted.is_empty() {
                         schemata_summary.record_fallbacks("schema_build_failure", demoted.len());
@@ -2680,7 +2899,16 @@ impl TestRunner {
             && !should_stop_early(&early_stop)
         {
             let fallback = self.run_regular_with_state(
-                fallback_mutations,
+                fallback_mutations
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, mutation)| QueuedMutation {
+                        index,
+                        mutation,
+                        restore_checked,
+                    })
+                    .collect(),
+                Vec::new(),
                 early_stop.clone(),
                 planned_total,
                 tested_counter,
@@ -2707,34 +2935,29 @@ impl TestRunner {
     #[allow(clippy::manual_is_multiple_of)]
     fn run_regular_with_state(
         &self,
-        mutations: Vec<Mutation>,
+        mutations: Vec<QueuedMutation>,
+        mut restored: Vec<(usize, MutationRunRecord)>,
         early_stop: Option<Arc<EarlyStopState>>,
         planned_total: usize,
         tested_counter: Arc<AtomicUsize>,
     ) -> RunOutcome {
         let start = Instant::now();
-        let total = mutations.len();
-        if total == 0 {
+        let fresh_total = mutations.len();
+        let total = fresh_total + restored.len();
+        if fresh_total == 0 || self.cancelled.load(Ordering::Acquire) {
+            restored.sort_by_key(|(index, _)| *index);
             return self.outcome_from_records_with_status(
-                Vec::new(),
-                start.elapsed(),
-                planned_total,
-                early_stop.as_ref().and_then(|state| state.reason()),
-            );
-        }
-        if self.cancelled.load(Ordering::Acquire) {
-            return self.outcome_from_records_with_status(
-                Vec::new(),
+                restored.into_iter().map(|(_, record)| record).collect(),
                 start.elapsed(),
                 planned_total,
                 early_stop.as_ref().and_then(|state| state.reason()),
             );
         }
 
-        let counter = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::new(AtomicUsize::new(restored.len()));
         let verbose = self.verbose;
         let is_tty = std::io::stderr().is_terminal();
-        let workspace_slots = workspace_pool_slot_count(self.parallelism, total);
+        let workspace_slots = workspace_pool_slot_count(self.parallelism, fresh_total);
 
         let workspace_pool_result = if self.respect_workspace_ignores {
             WorkspacePool::new(&self.project_root, workspace_slots)
@@ -2745,24 +2968,30 @@ impl TestRunner {
             Ok(pool) => Arc::new(pool),
             Err(e) => {
                 eprintln!("warning: could not create isolated mutation workspaces: {e}");
-                let results = mutations
-                    .into_iter()
-                    .map(|mutation| {
-                        let diagnostic = BuildErrorDiagnostic::new(
-                            mutation.id,
-                            "regular",
-                            "workspace_pool",
-                            vec![],
-                            format!("could not create isolated mutation workspaces: {e}"),
-                        );
+                restored.extend(mutations.into_iter().map(|queued| {
+                    let diagnostic = BuildErrorDiagnostic::new(
+                        queued.mutation.id,
+                        "regular",
+                        "workspace_pool",
+                        vec![],
+                        format!("could not create isolated mutation workspaces: {e}"),
+                    );
+                    (
+                        queued.index,
                         MutationRunRecord::new(
-                            mutation,
+                            queued.mutation,
                             MutationResult::BuildError,
                             Some(diagnostic),
-                        )
-                    })
-                    .collect();
-                return self.outcome_from_records(results, start.elapsed());
+                        ),
+                    )
+                }));
+                restored.sort_by_key(|(index, _)| *index);
+                return self.outcome_from_records_with_status(
+                    restored.into_iter().map(|(_, record)| record).collect(),
+                    start.elapsed(),
+                    planned_total,
+                    early_stop.as_ref().and_then(|state| state.reason()),
+                );
             }
         };
 
@@ -2770,11 +2999,9 @@ impl TestRunner {
         let project_root = Arc::new(self.project_root.clone());
         let build_command = Arc::new(self.commands.build_command.clone());
         let build_command_explicit = self.commands.build_command_explicit;
-        let queue = Arc::new(Mutex::new(
-            mutations.into_iter().enumerate().collect::<VecDeque<_>>(),
-        ));
-        let results = Arc::new(Mutex::new(Vec::new()));
-        let worker_count = workspace_pool.len().min(total).max(1);
+        let queue = Arc::new(Mutex::new(mutations.into_iter().collect::<VecDeque<_>>()));
+        let results = Arc::new(Mutex::new(restored));
+        let worker_count = workspace_pool.len().min(fresh_total).max(1);
         let cache_context_hash = cache_context_fingerprint(&self.project_root);
         let test_context_index = TestContextIndex::build(&self.project_root);
         let history = self
@@ -2823,13 +3050,13 @@ impl TestRunner {
                                 break;
                             }
                         };
-                        let Some((index, mutation)) = next else {
+                        let Some(queued) = next else {
                             break;
                         };
 
                         let outcome = catch_unwind(PanicBoundary(|| {
                             run_queued_mutation(
-                                QueuedMutation { index, mutation },
+                                queued,
                                 reservation,
                                 RunShared {
                                     workspace_pool: workspace_pool.as_ref(),
@@ -2901,12 +3128,14 @@ impl TestRunner {
         schema_mutations: &[crate::schemata::SchemaMutation],
         early_stop: Option<Arc<EarlyStopState>>,
         tested_counter: Arc<AtomicUsize>,
+        restore_checked: bool,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
         self.run_schema_mutations_inner(
             language,
             schema_mutations,
             early_stop,
             tested_counter,
+            restore_checked,
             true,
         )
     }
@@ -2917,6 +3146,7 @@ impl TestRunner {
         schema_mutations: &[crate::schemata::SchemaMutation],
         early_stop: Option<Arc<EarlyStopState>>,
         tested_counter: Arc<AtomicUsize>,
+        restore_checked: bool,
         allow_build_bisection: bool,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
         let rewrites =
@@ -2974,24 +3204,26 @@ impl TestRunner {
             } else {
                 prepared.selected_test.argv.clone()
             };
-            if let Some(result) =
-                prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
-            {
-                reservation.release();
-                if let Some(early_stop) = &early_stop {
-                    early_stop.record(result);
-                }
-                if self.verbose {
-                    eprintln!(
-                        "  [schema] ↻ cached  {}:{} — {}",
-                        mutation.file.display(),
-                        mutation.line,
-                        mutation.operator
+            if !restore_checked {
+                if let Some(restored) =
+                    prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
+                {
+                    reservation.release();
+                    exclude_restored_from_early_stop(early_stop.as_ref(), restored.execution);
+                    if self.verbose {
+                        eprintln!(
+                            "  [schema] ↻ cached  {}:{} — {}",
+                            mutation.file.display(),
+                            mutation.line,
+                            mutation.operator
+                        );
+                    }
+                    results.push(
+                        MutationRunRecord::new(mutation.clone(), restored.result, None)
+                            .with_execution(restored.execution),
                     );
+                    continue;
                 }
-                let diagnostic = cached_build_error_diagnostic(mutation, "schemata", result);
-                results.push(MutationRunRecord::new(mutation.clone(), result, diagnostic));
-                continue;
             }
 
             let mut cacheable = true;
@@ -3075,6 +3307,7 @@ impl TestRunner {
                                     &batch,
                                     early_stop.clone(),
                                     tested_counter.clone(),
+                                    restore_checked,
                                     false,
                                 ) {
                                     Ok((batch_records, batch_demoted)) => {
@@ -3322,6 +3555,7 @@ impl TestRunner {
     ) -> MutationReport {
         let mut results = Vec::with_capacity(all_records.len());
         let mut build_error_diagnostics = Vec::new();
+        let mut execution_provenance = BTreeMap::new();
         let mut total = 0;
         let mut killed = 0;
         let mut survived = 0;
@@ -3329,8 +3563,14 @@ impl TestRunner {
         let mut build_errors = 0;
 
         for record in all_records {
+            let MutationRunRecord {
+                mutation,
+                result,
+                execution,
+                build_error_diagnostic,
+            } = record;
             total += 1;
-            match record.result {
+            match result {
                 MutationResult::Killed => killed += 1,
                 MutationResult::Survived => survived += 1,
                 MutationResult::Timeout => timeout_count += 1,
@@ -3341,14 +3581,19 @@ impl TestRunner {
                 // after the run; neither counts toward any tally here.
                 MutationResult::Uncovered | MutationResult::Subsumed => {}
             }
-            if let Some(diagnostic) = record.build_error_diagnostic {
+            if execution != MutationExecution::for_result(result) {
+                execution_provenance.insert(mutation.id, execution);
+            }
+            if let Some(diagnostic) = build_error_diagnostic {
+                debug_assert_eq!(result, MutationResult::BuildError);
                 build_error_diagnostics.push(diagnostic);
             }
-            results.push((record.mutation, record.result));
+            results.push((mutation, result));
         }
 
         MutationReport {
             results,
+            execution_provenance,
             build_error_diagnostics,
             schemata: None,
             baseline_timing: None,
@@ -3485,17 +3730,25 @@ fn run_schema_workspace_mutation(
 }
 
 fn records_from_report(report: MutationReport) -> Vec<MutationRunRecord> {
-    let mut diagnostics: HashMap<u32, BuildErrorDiagnostic> = report
-        .build_error_diagnostics
+    let MutationReport {
+        results,
+        execution_provenance,
+        build_error_diagnostics,
+        ..
+    } = report;
+    let mut diagnostics: HashMap<u32, BuildErrorDiagnostic> = build_error_diagnostics
         .into_iter()
         .map(|diagnostic| (diagnostic.mutation_id, diagnostic))
         .collect();
-    report
-        .results
+    results
         .into_iter()
         .map(|(mutation, result)| {
+            let execution = execution_provenance
+                .get(&mutation.id)
+                .copied()
+                .unwrap_or_else(|| MutationExecution::for_result(result));
             let diagnostic = diagnostics.remove(&mutation.id);
-            MutationRunRecord::new(mutation, result, diagnostic)
+            MutationRunRecord::new(mutation, result, diagnostic).with_execution(execution)
         })
         .collect()
 }
@@ -3564,26 +3817,6 @@ impl MutationOutcome {
 struct BuildCommand<'a> {
     argv: &'a [String],
     explicit: bool,
-}
-
-/// Cache entries currently persist only [`MutationResult`], so
-/// `cached_build_error_diagnostic` intentionally groups cached build errors
-/// under one synthetic [`BuildErrorDiagnostic::new`] bucket. Persist the
-/// original phase/fingerprint with cached results to restore full fidelity.
-fn cached_build_error_diagnostic(
-    mutation: &Mutation,
-    runner: &str,
-    result: MutationResult,
-) -> Option<BuildErrorDiagnostic> {
-    (result == MutationResult::BuildError).then(|| {
-        BuildErrorDiagnostic::new(
-            mutation.id,
-            runner,
-            "cache",
-            vec![],
-            "build error result restored from cache; diagnostic output unavailable",
-        )
-    })
 }
 
 fn build_error_diagnostic_from_outcome(
@@ -4627,6 +4860,91 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy)]
+    enum ReuseSource {
+        ExactCache,
+        IncrementalHistory,
+    }
+
+    fn seed_reused_survivor(
+        project_root: &Path,
+        commands: &CommandConfig,
+        mutation: &Mutation,
+        reuse_source: ReuseSource,
+    ) -> anyhow::Result<()> {
+        let env = HashMap::new();
+        let selected = select_test_command(project_root, commands, mutation);
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &commands.sandbox_command,
+            &env,
+        );
+        let context_hash = cache_context_fingerprint(project_root);
+        let source_path = if mutation.file.is_absolute() {
+            mutation.file.clone()
+        } else {
+            project_root.join(&mutation.file)
+        };
+        let source = std::fs::read(source_path)?;
+
+        match reuse_source {
+            ReuseSource::ExactCache => {
+                let key = CacheKey::new(
+                    &source,
+                    &cache_identity(project_root, mutation),
+                    &mutation.description,
+                    &format!("{command_context};context={context_hash:016x}"),
+                );
+                cache::store(project_root, &key, MutationResult::Survived);
+            }
+            ReuseSource::IncrementalHistory => {
+                let test_context_index = TestContextIndex::build(project_root);
+                let query = incremental_history_query(
+                    project_root,
+                    mutation,
+                    &source,
+                    &command_context,
+                    test_context_index
+                        .fingerprint_for_tests(&selected.selected_tests, context_hash),
+                );
+                cache::IncrementalHistoryStore::load(project_root).record(
+                    cache::IncrementalHistoryEntry {
+                        mutation_identity: query.mutation_identity,
+                        mutation_description: query.mutation_description,
+                        result: MutationResult::Survived,
+                        source_hash: query.source_hash,
+                        command_hash: query.command_hash,
+                        relevant_test_hash: query.relevant_test_hash,
+                        covering_tests: vec![],
+                        killer_test: None,
+                    },
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn first_run_survives_second_kills_command(state_dir: &Path) -> Vec<String> {
+        vec![
+            "sh".into(),
+            "-c".into(),
+            r#"
+state_dir=$1
+runs=0
+if [ -f "$state_dir/runs" ]; then runs=$(cat "$state_dir/runs"); fi
+runs=$((runs + 1))
+printf '%s\n' "$runs" > "$state_dir/runs"
+test "$runs" -eq 1
+"#
+            .into(),
+            "state".into(),
+            state_dir.display().to_string(),
+        ]
+    }
+
     fn c_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
         let mut mutation = go_operator_mutation(id, file, source, nth);
         mutation.language = "c".into();
@@ -5580,6 +5898,12 @@ mod tests {
         };
         let cached = cached_runner.run(vec![mutation.clone()]).report;
         assert_eq!(cached.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            cached.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::IncrementalHistory
+        );
+        assert_eq!(cached.tested_count(), 0);
+        assert_eq!(cached.execution_counts().incremental_history_reused, 1);
 
         let forced_runner = TestRunner {
             commands: commands(),
@@ -5598,6 +5922,139 @@ mod tests {
         };
         let forced = forced_runner.run(vec![mutation]).report;
         assert_eq!(forced.results[0].1, MutationResult::Killed);
+        assert_eq!(
+            forced.execution_for(forced.results[0].0.id, MutationResult::Killed),
+            MutationExecution::Executed
+        );
+        assert_eq!(forced.tested_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn restored_cache_and_history_verdicts_keep_provenance_without_fake_diagnostics()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mutation = |id: u32, file: &str, description: &str| Mutation {
+            id,
+            file: PathBuf::from(file),
+            language: String::new(),
+            line: 1,
+            column: 1,
+            operator: "test".into(),
+            description: description.into(),
+            original: "hello".into(),
+            replacement: "world".into(),
+            byte_range: 0..5,
+        };
+        let cached = mutation(0, "cached.txt", "cached build error");
+        let historical = mutation(1, "history.txt", "historical survivor");
+        std::fs::write(dir.path().join(&cached.file), "hello")?;
+        std::fs::write(dir.path().join(&historical.file), "hello")?;
+        let commands = CommandConfig {
+            command: successful_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let env = HashMap::new();
+        let context_hash = cache_context_fingerprint(dir.path());
+
+        let selected = select_test_command(dir.path(), &commands, &cached);
+        let context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &commands.sandbox_command,
+            &env,
+        );
+        let key = CacheKey::new(
+            &std::fs::read(dir.path().join(&cached.file))?,
+            &cache_identity(dir.path(), &cached),
+            &cached.description,
+            &format!("{context};context={context_hash:016x}"),
+        );
+        cache::store(dir.path(), &key, MutationResult::BuildError);
+
+        let selected = select_test_command(dir.path(), &commands, &historical);
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &commands.sandbox_command,
+            &env,
+        );
+        let test_context_index = TestContextIndex::build(dir.path());
+        let source = std::fs::read(dir.path().join(&historical.file))?;
+        let query = incremental_history_query(
+            dir.path(),
+            &historical,
+            &source,
+            &command_context,
+            test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash),
+        );
+        cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity,
+            mutation_description: query.mutation_description,
+            result: MutationResult::Survived,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: vec![],
+            killer_test: None,
+        });
+
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env,
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let report = runner.run(vec![cached, historical]).report;
+
+        assert_eq!(
+            report
+                .results
+                .iter()
+                .map(|(_, result)| *result)
+                .collect::<Vec<_>>(),
+            vec![MutationResult::BuildError, MutationResult::Survived]
+        );
+        assert_eq!(report.tested_count(), 0);
+        assert!(report.build_error_diagnostics.is_empty());
+        assert_eq!(
+            report.execution_for(0, MutationResult::BuildError),
+            MutationExecution::ExactCache
+        );
+        assert_eq!(
+            report.execution_for(1, MutationResult::Survived),
+            MutationExecution::IncrementalHistory
+        );
+
+        let json: serde_json::Value =
+            serde_json::from_str(&crate::report::json::to_json_string(&report)?)?;
+        assert_eq!(json["tested"], 0);
+        assert_eq!(json["mutations"][0]["result"], "build_error");
+        assert_eq!(json["mutations"][0]["execution"]["state"], "exact_cache");
+        assert_eq!(json["mutations"][1]["result"], "survived");
+        assert_eq!(
+            json["mutations"][1]["execution"]["state"],
+            "incremental_history"
+        );
+        assert_eq!(json["build_error_groups"], serde_json::json!([]));
         Ok(())
     }
 
@@ -6329,6 +6786,40 @@ mod tests {
             vec!["build", "global", "build", "language", "build", "project"]
         );
         Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_health_exposes_structured_run_suite_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("subject.rs");
+        std::fs::write(&file, "fn subject() {}").unwrap();
+        let mutation = make_test_mutation(&file);
+        let mut commands = test_command_config();
+        commands.command = failing_command();
+        let cancelled = AtomicBool::new(false);
+
+        let error = check_baseline_health(
+            dir.path(),
+            &[mutation],
+            BaselineHealthConfig {
+                commands: &commands,
+                default_measurement_timeout: None,
+                schemata_enabled: false,
+                env: &HashMap::new(),
+                cancelled: &cancelled,
+                respect_workspace_ignores: true,
+            },
+        )
+        .unwrap_err();
+
+        let failure = run_suite_failure(&error).expect("baseline failure should be structured");
+        assert_eq!(failure.phase, SuiteFailurePhase::Test);
+        assert_eq!(failure.command, failing_command());
+        assert!(matches!(
+            &failure.outcome,
+            RunSuiteFailureOutcome::Failed { .. }
+        ));
     }
 
     #[cfg(unix)]
@@ -7540,7 +8031,423 @@ esac
         assert_eq!(report.total, 2);
         assert_eq!(report.results[0].1, MutationResult::Survived);
         assert_eq!(report.results[1].1, MutationResult::Survived);
+        assert_eq!(
+            report.execution_for(report.results[0].0.id, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert_eq!(
+            report.execution_for(report.results[1].0.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(report.tested_count(), 1);
+        assert_eq!(
+            report
+                .schemata
+                .as_ref()
+                .expect("schemata summary")
+                .fast_path,
+            report.tested_count()
+        );
+        assert_eq!(report.execution_counts().exact_cache_reused, 1);
         assert_eq!(runs, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_schemata_marks_incremental_history_reuse() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let source = "package calc\nfunc equal(a, b int) bool { return a == b }\n";
+        std::fs::write(dir.path().join("calc.go"), source)?;
+        let mutation = go_operator_mutation(0, "calc.go", source, 0);
+        let commands = CommandConfig {
+            command: failing_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let selected = select_test_command(dir.path(), &commands, &mutation);
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &commands.sandbox_command,
+            &HashMap::new(),
+        );
+        let source_content = std::fs::read(dir.path().join("calc.go"))?;
+        let context_hash = cache_context_fingerprint(dir.path());
+        let test_context_index = TestContextIndex::build(dir.path());
+        let relevant_test_hash =
+            test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
+        let query = incremental_history_query(
+            dir.path(),
+            &mutation,
+            &source_content,
+            &command_context,
+            relevant_test_hash,
+        );
+        cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity,
+            mutation_description: query.mutation_description,
+            result: MutationResult::Survived,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: vec![],
+            killer_test: None,
+        });
+
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let report = runner.run_with_schemata(vec![mutation]).report;
+        assert_eq!(report.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            report.execution_for(report.results[0].0.id, MutationResult::Survived),
+            MutationExecution::IncrementalHistory
+        );
+        assert_eq!(
+            report
+                .schemata
+                .as_ref()
+                .expect("schemata summary")
+                .fast_path,
+            report.tested_count()
+        );
+        assert_eq!(report.tested_count(), 0);
+        assert_eq!(report.execution_counts().incremental_history_reused, 1);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reused_schemata_survivor_does_not_trigger_early_stop() -> anyhow::Result<()> {
+        for reuse_source in [ReuseSource::ExactCache, ReuseSource::IncrementalHistory] {
+            for (early_stop, gate) in [
+                (
+                    EarlyStopConfig {
+                        max_survivors: Some(1),
+                        fail_under: None,
+                    },
+                    "max survivors",
+                ),
+                (
+                    EarlyStopConfig {
+                        max_survivors: None,
+                        fail_under: Some(100.0),
+                    },
+                    "fail under",
+                ),
+            ] {
+                let dir = tempfile::tempdir()?;
+                let source = "\
+package calc
+func first(a, b int) bool { return a == b }
+func second(a, b int) bool { return a == b }
+func third(a, b int) bool { return a == b }
+";
+                std::fs::write(dir.path().join("calc.go"), source)?;
+                let mutations = (0..3)
+                    .map(|id| go_operator_mutation(id, "calc.go", source, id as usize))
+                    .collect::<Vec<_>>();
+                let commands = CommandConfig {
+                    command: failing_command(),
+                    force_default_command: false,
+                    force_default_timeout: false,
+                    project_commands: vec![],
+                    language_commands: HashMap::new(),
+                    build_command: vec![],
+                    sandbox_command: vec![],
+                    build_command_explicit: false,
+                    timeout: Duration::from_secs(5),
+                    language_timeouts: HashMap::new(),
+                    test_selection: None,
+                };
+                seed_reused_survivor(dir.path(), &commands, &mutations[0], reuse_source)?;
+                let expected_execution = match reuse_source {
+                    ReuseSource::ExactCache => MutationExecution::ExactCache,
+                    ReuseSource::IncrementalHistory => MutationExecution::IncrementalHistory,
+                };
+                let runner = TestRunner {
+                    commands,
+                    parallelism: 1,
+                    project_root: dir.path().to_path_buf(),
+                    verbose: false,
+                    show_output: false,
+                    max_tested: None,
+                    early_stop,
+                    respect_workspace_ignores: true,
+                    env: HashMap::new(),
+                    incremental_history: true,
+                    force_rerun: false,
+                    learned_selection: false,
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                };
+
+                let report = runner.run_with_schemata(mutations).report;
+                let schemata = report.schemata.as_ref().expect("schemata summary");
+
+                assert_eq!(report.total, 3, "{gate} should not stop fresh mutations");
+                assert_eq!(report.survived, 1);
+                assert_eq!(report.killed, 2);
+                assert_eq!(report.tested_count(), 2);
+                assert_eq!(schemata.fast_path, report.tested_count());
+                assert_eq!(
+                    report.execution_for(0, MutationResult::Survived),
+                    expected_execution
+                );
+                assert!(report.early_stop_reason.is_none(), "{gate}: {report:?}");
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn late_restored_schemata_survivor_reduces_fail_under_fresh_budget() -> anyhow::Result<()> {
+        for reuse_source in [ReuseSource::ExactCache, ReuseSource::IncrementalHistory] {
+            let dir = tempfile::tempdir()?;
+            let state = tempfile::tempdir()?;
+            let source = "\
+package calc
+func first(a, b int) bool { return a == b }
+func second(a, b int) bool { return a == b }
+func third(a, b int) bool { return a == b }
+";
+            std::fs::write(dir.path().join("calc.go"), source)?;
+            let mutations = (0..3)
+                .map(|id| go_operator_mutation(id, "calc.go", source, id as usize))
+                .collect::<Vec<_>>();
+            let commands = CommandConfig {
+                command: first_run_survives_second_kills_command(state.path()),
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                sandbox_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            };
+            seed_reused_survivor(dir.path(), &commands, &mutations[2], reuse_source)?;
+            let expected_execution = match reuse_source {
+                ReuseSource::ExactCache => MutationExecution::ExactCache,
+                ReuseSource::IncrementalHistory => MutationExecution::IncrementalHistory,
+            };
+            let runner = TestRunner {
+                commands,
+                parallelism: 1,
+                project_root: dir.path().to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: EarlyStopConfig {
+                    max_survivors: None,
+                    fail_under: Some(60.0),
+                },
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun: false,
+                learned_selection: false,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+
+            let report = runner.run_with_schemata(mutations).report;
+            let runs = std::fs::read_to_string(state.path().join("runs"))?;
+            let schemata = report.schemata.as_ref().expect("schemata summary");
+
+            assert_eq!(report.planned_total, 3);
+            assert_eq!(report.total, 2);
+            assert_eq!(report.survived, 2);
+            assert_eq!(report.killed, 0);
+            assert_eq!(report.tested_count(), 1);
+            assert_eq!(schemata.fast_path, report.tested_count());
+            assert_eq!(
+                report.execution_for(0, MutationResult::Survived),
+                MutationExecution::Executed
+            );
+            assert_eq!(
+                report.execution_for(2, MutationResult::Survived),
+                expected_execution
+            );
+            assert!(report.results.iter().all(|(mutation, _)| mutation.id != 1));
+            assert_eq!(runs.trim(), "1");
+            assert!(
+                report
+                    .early_stop_reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("--fail-under 60.0"))
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn schemata_fallback_preserves_cache_and_history_provenance_through_records()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let go_source = "package calc\nfunc equal(a, b int) bool { return a == b }\n";
+        let python_source = "\
+def first(a, b):
+    return a == b
+
+def second(c, d):
+    return c == d
+";
+        std::fs::write(dir.path().join("calc.go"), go_source)?;
+        std::fs::write(dir.path().join("app.py"), python_source)?;
+        let go = go_operator_mutation(0, "calc.go", go_source, 0);
+        let python = |id, nth| {
+            let offset = python_source
+                .match_indices("==")
+                .nth(nth)
+                .expect("Python source should contain the operator")
+                .0;
+            Mutation {
+                id,
+                file: PathBuf::from("app.py"),
+                language: "python".into(),
+                line: 2 + nth * 3,
+                column: 14,
+                operator: "eq_to_neq".into(),
+                description: "Replace == with !=".into(),
+                original: "==".into(),
+                replacement: "!=".into(),
+                byte_range: offset..offset + 2,
+            }
+        };
+        let python_cached = python(1, 0);
+        let python_history = python(2, 1);
+        let commands = CommandConfig {
+            command: successful_command(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_explicit: false,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let env = HashMap::new();
+        let context_hash = cache_context_fingerprint(dir.path());
+        let test_context_index = TestContextIndex::build(dir.path());
+        let seed_cache = |mutation: &Mutation| -> anyhow::Result<()> {
+            let selected = select_test_command(dir.path(), &commands, mutation);
+            let context = selected.cache_context(
+                &commands.build_command,
+                commands.build_command_explicit,
+                &commands.sandbox_command,
+                &env,
+            );
+            let context = format!("{context};context={context_hash:016x}");
+            let source = std::fs::read(dir.path().join(&mutation.file))?;
+            let key = CacheKey::new(
+                &source,
+                &cache_identity(dir.path(), mutation),
+                &mutation.description,
+                &context,
+            );
+            cache::store(dir.path(), &key, MutationResult::Survived);
+            Ok(())
+        };
+        seed_cache(&go)?;
+        seed_cache(&python_cached)?;
+
+        let selected = select_test_command(dir.path(), &commands, &python_history);
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_explicit,
+            &commands.sandbox_command,
+            &env,
+        );
+        let source = std::fs::read(dir.path().join(&python_history.file))?;
+        let query = incremental_history_query(
+            dir.path(),
+            &python_history,
+            &source,
+            &command_context,
+            test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash),
+        );
+        cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
+            mutation_identity: query.mutation_identity,
+            mutation_description: query.mutation_description,
+            result: MutationResult::Survived,
+            source_hash: query.source_hash,
+            command_hash: query.command_hash,
+            relevant_test_hash: query.relevant_test_hash,
+            covering_tests: vec![],
+            killer_test: None,
+        });
+
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env,
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let report = runner
+            .run_with_schemata(vec![go, python_cached, python_history])
+            .report;
+
+        assert_eq!(report.tested_count(), 0);
+        assert!(report.build_error_diagnostics.is_empty());
+        assert_eq!(
+            report.execution_for(0, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert_eq!(
+            report.execution_for(1, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert_eq!(
+            report.execution_for(2, MutationResult::Survived),
+            MutationExecution::IncrementalHistory
+        );
+        let schemata = report.schemata.as_ref().expect("schemata summary");
+        assert_eq!(schemata.fast_path, report.tested_count());
+        assert_eq!(schemata.fallback, 2);
+
+        let json: serde_json::Value =
+            serde_json::from_str(&crate::report::json::to_json_string(&report)?)?;
+        let mutations = json["mutations"].as_array().expect("mutation array");
+        assert_eq!(mutations[0]["execution"]["state"], "exact_cache");
+        assert_eq!(mutations[1]["execution"]["state"], "exact_cache");
+        assert_eq!(mutations[2]["execution"]["state"], "incremental_history");
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -7964,6 +8871,171 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reused_regular_survivor_does_not_trigger_early_stop() -> anyhow::Result<()> {
+        for reuse_source in [ReuseSource::ExactCache, ReuseSource::IncrementalHistory] {
+            for (early_stop, gate) in [
+                (
+                    EarlyStopConfig {
+                        max_survivors: Some(1),
+                        fail_under: None,
+                    },
+                    "max survivors",
+                ),
+                (
+                    EarlyStopConfig {
+                        max_survivors: None,
+                        fail_under: Some(100.0),
+                    },
+                    "fail under",
+                ),
+            ] {
+                let dir = tempfile::tempdir()?;
+                let mutations = ["cached.txt", "fresh-one.txt", "fresh-two.txt"]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(id, name)| {
+                        let file = dir.path().join(name);
+                        std::fs::write(&file, b"hello world")?;
+                        let mut mutation = make_test_mutation(&file);
+                        mutation.id = u32::try_from(id)?;
+                        mutation.description = format!("early-stop {name}");
+                        Ok::<_, anyhow::Error>(mutation)
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                let commands = CommandConfig {
+                    command: failing_command(),
+                    force_default_command: false,
+                    force_default_timeout: false,
+                    project_commands: vec![],
+                    language_commands: HashMap::new(),
+                    build_command: vec![],
+                    sandbox_command: vec![],
+                    build_command_explicit: false,
+                    timeout: Duration::from_secs(5),
+                    language_timeouts: HashMap::new(),
+                    test_selection: None,
+                };
+                seed_reused_survivor(dir.path(), &commands, &mutations[0], reuse_source)?;
+                let expected_execution = match reuse_source {
+                    ReuseSource::ExactCache => MutationExecution::ExactCache,
+                    ReuseSource::IncrementalHistory => MutationExecution::IncrementalHistory,
+                };
+                let runner = TestRunner {
+                    commands,
+                    parallelism: 1,
+                    project_root: dir.path().to_path_buf(),
+                    verbose: false,
+                    show_output: false,
+                    max_tested: None,
+                    early_stop,
+                    respect_workspace_ignores: true,
+                    env: HashMap::new(),
+                    incremental_history: true,
+                    force_rerun: false,
+                    learned_selection: false,
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                };
+
+                let report = runner.run(mutations).report;
+
+                assert_eq!(report.total, 3, "{gate} should not stop fresh mutations");
+                assert_eq!(report.survived, 1);
+                assert_eq!(report.killed, 2);
+                assert_eq!(report.tested_count(), 2);
+                assert_eq!(
+                    report.execution_for(0, MutationResult::Survived),
+                    expected_execution
+                );
+                assert!(report.early_stop_reason.is_none(), "{gate}: {report:?}");
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn late_restored_regular_survivor_reduces_fail_under_fresh_budget() -> anyhow::Result<()> {
+        for reuse_source in [ReuseSource::ExactCache, ReuseSource::IncrementalHistory] {
+            let dir = tempfile::tempdir()?;
+            let state = tempfile::tempdir()?;
+            let mutations = ["fresh-survivor.txt", "fresh-killer.txt", "cached.txt"]
+                .into_iter()
+                .enumerate()
+                .map(|(id, name)| {
+                    let file = dir.path().join(name);
+                    std::fs::write(&file, b"hello world")?;
+                    let mut mutation = make_test_mutation(&file);
+                    mutation.id = u32::try_from(id)?;
+                    mutation.description = format!("fresh-budget {name}");
+                    Ok::<_, anyhow::Error>(mutation)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            let commands = CommandConfig {
+                command: first_run_survives_second_kills_command(state.path()),
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                sandbox_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            };
+            seed_reused_survivor(dir.path(), &commands, &mutations[2], reuse_source)?;
+            let expected_execution = match reuse_source {
+                ReuseSource::ExactCache => MutationExecution::ExactCache,
+                ReuseSource::IncrementalHistory => MutationExecution::IncrementalHistory,
+            };
+            let runner = TestRunner {
+                commands,
+                parallelism: 1,
+                project_root: dir.path().to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: EarlyStopConfig {
+                    max_survivors: None,
+                    fail_under: Some(60.0),
+                },
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun: false,
+                learned_selection: false,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+
+            let report = runner.run(mutations).report;
+            let runs = std::fs::read_to_string(state.path().join("runs"))?;
+
+            assert_eq!(report.planned_total, 3);
+            assert_eq!(report.total, 2);
+            assert_eq!(report.survived, 2);
+            assert_eq!(report.killed, 0);
+            assert_eq!(report.tested_count(), 1);
+            assert_eq!(
+                report.execution_for(0, MutationResult::Survived),
+                MutationExecution::Executed
+            );
+            assert_eq!(
+                report.execution_for(2, MutationResult::Survived),
+                expected_execution
+            );
+            assert!(report.results.iter().all(|(mutation, _)| mutation.id != 1));
+            assert_eq!(runs.trim(), "1");
+            assert!(
+                report
+                    .early_stop_reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("--fail-under 60.0"))
+            );
+        }
+        Ok(())
+    }
+
     #[cfg(unix)]
     #[test]
     fn max_tested_reservation_caps_execution_before_commands_run() {
@@ -8198,6 +9270,16 @@ rmdir "$lock"
             assert_eq!(report.total, 2);
             assert_eq!(report.results[0].1, cached_result);
             assert_eq!(report.results[1].1, MutationResult::Survived);
+            assert_eq!(
+                report.execution_for(report.results[0].0.id, cached_result),
+                MutationExecution::ExactCache
+            );
+            assert_eq!(
+                report.execution_for(report.results[1].0.id, MutationResult::Survived),
+                MutationExecution::Executed
+            );
+            assert_eq!(report.tested_count(), 1);
+            assert_eq!(report.execution_counts().exact_cache_reused, 1);
             assert_eq!(
                 runs, 1,
                 "cache hits should not consume the max_tested execution budget"

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,6 +1,7 @@
 /// Shared test utilities.
 /// Used across operator, language, and report tests to avoid duplication.
 use crate::{Mutation, MutationReport, MutationResult};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -39,6 +40,7 @@ pub fn sample_report() -> MutationReport {
                 MutationResult::Survived,
             ),
         ],
+        execution_provenance: BTreeMap::new(),
         build_error_diagnostics: vec![],
         schemata: None,
         baseline_timing: None,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -587,8 +587,6 @@ fn check_all_mutants_uncovered_aborts_when_baseline_test_fails() {
             "check",
             "--base",
             "HEAD",
-            "--format",
-            "json",
             "--test-cmd",
             "false",
             "--coverage-file",
@@ -599,9 +597,11 @@ fn check_all_mutants_uncovered_aborts_when_baseline_test_fails() {
         .unwrap();
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("baseline test command failed (`false`)")
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Test suite failure before mutation execution."));
+    assert!(stderr.contains("Baseline phase: test"));
+    assert!(stderr.contains("Outcome: failed"));
+    assert!(stderr.contains("baseline test command failed (`false`)"));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(!stdout.contains("\"killed\""));
     assert!(!stdout.contains("mutation_score"));
@@ -636,12 +636,17 @@ fn check_all_mutants_uncovered_aborts_when_baseline_build_fails() {
         .unwrap();
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("baseline build command failed (`false`)")
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline build command failed (`false`)"));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(!stdout.contains("\"killed\""));
-    assert!(!stdout.contains("mutation_score"));
+    let failure: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("invalid suite-failure JSON: {error}\nstdout:\n{stdout}"));
+    assert_eq!(failure["kind"], "suite_failure");
+    assert_eq!(failure["phase"], "build");
+    assert_eq!(failure["command"], serde_json::json!(["false"]));
+    assert_eq!(failure["outcome"], "failed");
+    assert!(failure.get("mutations").is_none());
+    assert!(failure.get("mutation_score").is_none());
     assert!(!dir.path().join(".togi-cache").exists());
 }
 
@@ -712,6 +717,233 @@ fn check_format_json_outputs_standalone_json_for_explain() {
 }
 
 #[test]
+fn check_format_json_outputs_valid_json() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(value.get("total").is_some());
+    assert!(value.get("mutations").is_some());
+}
+
+#[test]
+fn check_format_json_dry_run_outputs_a_single_preview_document() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--format",
+            "json",
+            "--dry-run",
+            "--test-cmd",
+            "true",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid dry-run JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["kind"], "dry_run");
+    assert_eq!(value["dry_run"], true);
+    assert_eq!(
+        value["planned_total"],
+        value["mutations"].as_array().unwrap().len()
+    );
+    assert!(value.get("mutation_score").is_none());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Scanning all 1 supported files..."),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
+fn check_format_json_no_mutations_outputs_an_empty_report() {
+    let dir = setup_git_repo();
+    assert_command_success(
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .unwrap(),
+        "commit no-diff setup",
+    );
+    assert_command_success(
+        std::process::Command::new("git")
+            .args(["commit", "-m", "second"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap(),
+        "commit no-diff setup",
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid empty-report JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["total"], 0);
+    assert_eq!(value["planned_total"], 0);
+    assert_eq!(value["mutation_score"], 100.0);
+    assert_eq!(value["mutations"], serde_json::json!([]));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("No changes found"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn check_format_json_post_generation_no_mutations_outputs_empty_report() {
+    let dir = setup_git_repo();
+    let main_go = dir.path().join("main.go");
+    fs::write(
+        &main_go,
+        "package main\n\nconst name = \"before\"\n\nfunc main() {}\n",
+    )
+    .unwrap();
+    assert_command_success(
+        std::process::Command::new("git")
+            .args(["add", "main.go"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap(),
+        "stage no-candidate baseline",
+    );
+    assert_command_success(
+        std::process::Command::new("git")
+            .args(["commit", "-m", "no-candidate baseline"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap(),
+        "commit no-candidate baseline",
+    );
+    fs::write(
+        &main_go,
+        "package main\n\nconst name = \"after\"\n\nfunc main() {}\n",
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--operators",
+            "string_to_empty",
+            "--test-cmd",
+            "true",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid post-generation empty-report JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["total"], 0);
+    assert_eq!(value["planned_total"], 0);
+    assert_eq!(value["mutations"], serde_json::json!([]));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No mutations generated"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("No changes found"), "stderr: {stderr}");
+}
+
+#[test]
+fn check_all_no_supported_files_json_outputs_an_empty_report() {
+    let dir = setup_git_repo();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "go.mod",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid no-supported-files JSON output: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(value["total"], 0);
+    assert_eq!(value["mutations"], serde_json::json!([]));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("No supported source files found"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+#[test]
 fn check_aborts_before_mutations_when_baseline_test_fails() {
     let dir = setup_git_repo();
 
@@ -746,10 +978,16 @@ fn check_aborts_before_mutations_when_baseline_test_fails() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let failure: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("invalid suite-failure JSON: {error}\nstdout:\n{stdout}"));
+    assert_eq!(failure["kind"], "suite_failure");
+    assert_eq!(failure["phase"], "test");
+    assert_eq!(failure["command"], serde_json::json!(["false"]));
+    assert_eq!(failure["outcome"], "failed");
     assert!(stderr.contains("baseline test command failed (`false`)"));
     assert!(!stderr.contains("Running 1 mutations"));
-    assert!(!stdout.contains("\"killed\""));
-    assert!(!stdout.contains("mutation_score"));
+    assert!(failure.get("mutations").is_none());
+    assert!(failure.get("mutation_score").is_none());
     assert!(
         !dir.path().join(".togi-cache").exists(),
         "baseline failure must not create mutation cache entries"
@@ -1715,6 +1953,298 @@ fn check_baseline_still_honors_fail_under() {
         .stderr(predicate::str::contains("below --fail-under threshold"));
 }
 
+#[test]
+fn check_skips_baseline_actions_without_fresh_cache_or_history_evidence() {
+    for (reuse_source, expected_state) in [
+        ("exact cache", "exact_cache"),
+        ("incremental history", "incremental_history"),
+    ] {
+        let dir = setup_git_repo();
+        let baseline_path = dir.path().join(".togi-baseline");
+
+        let fresh = togi()
+            .args([
+                "check",
+                "--base",
+                "HEAD",
+                "--format",
+                "json",
+                "--test-cmd",
+                "true",
+                "--no-schemata",
+                "--operators",
+                "gt_to_gte",
+                "--max-per-run",
+                "1",
+                "--jobs",
+                "1",
+                "--fail-under",
+                "0",
+                "--save-baseline",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            fresh.status.success(),
+            "fresh baseline run failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&fresh.stdout),
+            String::from_utf8_lossy(&fresh.stderr)
+        );
+        let baseline_before = fs::read(&baseline_path).unwrap();
+        let saved: serde_json::Value = serde_json::from_slice(&baseline_before).unwrap();
+        assert_eq!(saved["total"], 1, "{reuse_source} fixture needs a baseline");
+
+        for action in ["--save-baseline", "--check-baseline"] {
+            if reuse_source == "incremental history" {
+                let cache_dir = dir.path().join(".togi-cache");
+                for entry in fs::read_dir(&cache_dir).unwrap() {
+                    let entry = entry.unwrap();
+                    if entry.file_type().unwrap().is_file()
+                        && entry.file_name().to_string_lossy() != "history.json"
+                    {
+                        fs::remove_file(entry.path()).unwrap();
+                    }
+                }
+                assert!(cache_dir.join("history.json").exists());
+            }
+            let reused = togi()
+                .args([
+                    "check",
+                    "--base",
+                    "HEAD",
+                    "--format",
+                    "json",
+                    "--test-cmd",
+                    "true",
+                    "--no-schemata",
+                    "--operators",
+                    "gt_to_gte",
+                    "--max-per-run",
+                    "1",
+                    "--jobs",
+                    "1",
+                ])
+                .arg(action)
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            let stderr = String::from_utf8_lossy(&reused.stderr);
+            assert_eq!(
+                reused.status.code(),
+                Some(1),
+                "{reuse_source} {action} verdict must retain normal no-baseline survivor behavior\nstdout:\n{}\nstderr:\n{stderr}",
+                String::from_utf8_lossy(&reused.stdout),
+            );
+            assert_eq!(
+                stderr
+                    .matches("Report has no complete fresh execution evidence; skipping baseline save/check.")
+                    .count(),
+                1,
+                "{reuse_source} {action}: {stderr}"
+            );
+            assert!(
+                !stderr.contains("Baseline saved to .togi-baseline"),
+                "{stderr}"
+            );
+            assert!(
+                !stderr.contains("Mutation score regression detected!"),
+                "{stderr}"
+            );
+            assert_eq!(fs::read(&baseline_path).unwrap(), baseline_before);
+
+            let report: serde_json::Value = serde_json::from_slice(&reused.stdout).unwrap();
+            assert_eq!(
+                report["mutations"][0]["execution"]["state"], expected_state,
+                "{reuse_source} {action}: {report}"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn check_skips_baseline_actions_for_mixed_fresh_and_reused_results() {
+    for action in ["--save-baseline", "--check-baseline"] {
+        let dir = setup_git_repo();
+        fs::write(
+            dir.path().join("history.go"),
+            "package main\n\nfunc history(a, b int) bool {\n\treturn a > b\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("fresh.go"),
+            "package main\n\nfunc fresh(a, b int) bool {\n\treturn a > b\n}\n",
+        )
+        .unwrap();
+        let state = tempfile::NamedTempFile::new().unwrap();
+        fs::write(state.path(), "kill").unwrap();
+        let test_cmd = format!(
+            "sh -c {}",
+            shell_quote_text(&format!(
+                "if grep -Fq '>=' main.go history.go fresh.go; then test \"$(cat {})\" = survive; else exit 0; fi",
+                shell_quote(state.path())
+            ))
+        );
+        let baseline_path = dir.path().join(".togi-baseline");
+
+        let initial = togi()
+            .args([
+                "check",
+                "--all",
+                "--format",
+                "json",
+                "--test-cmd",
+                &test_cmd,
+                "--no-schemata",
+                "--operators",
+                "gt_to_gte",
+                "--max-per-run",
+                "3",
+                "--jobs",
+                "1",
+                "--fail-under",
+                "0",
+                "--save-baseline",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            initial.status.success(),
+            "initial baseline run failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&initial.stdout),
+            String::from_utf8_lossy(&initial.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&initial.stderr).contains("Baseline saved to .togi-baseline")
+        );
+        let initial_report: serde_json::Value = serde_json::from_slice(&initial.stdout).unwrap();
+        assert_eq!(initial_report["mutation_score"].as_f64(), Some(100.0));
+        let baseline_before = fs::read(&baseline_path).unwrap();
+        let baseline: serde_json::Value = serde_json::from_slice(&baseline_before).unwrap();
+        assert_eq!(baseline["killed"], 3);
+        assert_eq!(baseline["total"], 3);
+        fs::remove_dir_all(dir.path().join(".togi-cache")).unwrap();
+
+        fs::write(state.path(), "survive").unwrap();
+        for path in ["history.go", "main.go"] {
+            let seeded = togi()
+                .args([
+                    "check",
+                    "--all",
+                    "--path",
+                    path,
+                    "--format",
+                    "json",
+                    "--test-cmd",
+                    &test_cmd,
+                    "--no-schemata",
+                    "--operators",
+                    "gt_to_gte",
+                    "--max-per-run",
+                    "1",
+                    "--jobs",
+                    "1",
+                    "--fail-under",
+                    "0",
+                ])
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            assert!(
+                seeded.status.success(),
+                "seed {path} failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&seeded.stdout),
+                String::from_utf8_lossy(&seeded.stderr)
+            );
+
+            if path == "history.go" {
+                let cache_dir = dir.path().join(".togi-cache");
+                for entry in fs::read_dir(&cache_dir).unwrap() {
+                    let entry = entry.unwrap();
+                    if entry.file_type().unwrap().is_file()
+                        && entry.file_name().to_string_lossy() != "history.json"
+                    {
+                        fs::remove_file(entry.path()).unwrap();
+                    }
+                }
+                assert!(cache_dir.join("history.json").exists());
+            }
+        }
+
+        let mixed = togi()
+            .args([
+                "check",
+                "--all",
+                "--format",
+                "json",
+                "--test-cmd",
+                &test_cmd,
+                "--no-schemata",
+                "--operators",
+                "gt_to_gte",
+                "--max-per-run",
+                "3",
+                "--jobs",
+                "1",
+            ])
+            .arg(action)
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&mixed.stderr);
+        assert_eq!(
+            mixed.status.code(),
+            Some(1),
+            "mixed {action} must retain normal no-baseline survivor behavior\nstdout:\n{}\nstderr:\n{stderr}",
+            String::from_utf8_lossy(&mixed.stdout)
+        );
+        assert_eq!(
+            stderr
+                .matches(
+                    "Report has no complete fresh execution evidence; skipping baseline save/check."
+                )
+                .count(),
+            1,
+            "{action}: {stderr}"
+        );
+        assert!(
+            !stderr.contains("Baseline saved to .togi-baseline"),
+            "{stderr}"
+        );
+        assert!(
+            !stderr.contains("Mutation score regression detected!"),
+            "{stderr}"
+        );
+        assert_eq!(fs::read(&baseline_path).unwrap(), baseline_before);
+
+        let report: serde_json::Value = serde_json::from_slice(&mixed.stdout).unwrap();
+        assert_eq!(report["tested"].as_u64(), Some(1));
+        assert_eq!(report["exact_cache_reused"].as_u64(), Some(1));
+        assert_eq!(report["incremental_history_reused"].as_u64(), Some(1));
+        assert_eq!(report["killed"].as_u64(), Some(0));
+        assert_eq!(report["survived"].as_u64(), Some(3));
+        assert_eq!(report["mutation_score"].as_f64(), Some(0.0));
+        for (file, expected_state) in [
+            ("main.go", "exact_cache"),
+            ("history.go", "incremental_history"),
+            ("fresh.go", "executed"),
+        ] {
+            let mutation = report["mutations"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|mutation| mutation["file"].as_str() == Some(file))
+                .unwrap_or_else(|| panic!("missing {file} mutation: {report}"));
+            assert_eq!(
+                mutation["execution"]["state"], expected_state,
+                "{action}: {report}"
+            );
+        }
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn interrupted_mutation_exits_130_without_a_report_or_side_effects() {
@@ -2409,6 +2939,141 @@ fn explain_reads_json_report() {
         .success()
         .stdout(predicate::str::contains("Change: + -> -"))
         .stdout(predicate::str::contains("Why it was killed"));
+}
+
+#[test]
+fn explain_reports_reused_cache_verdict_without_claiming_a_test_ran() {
+    let dir = TempDir::new().unwrap();
+    let report_path = dir.path().join("togi-report.json");
+    fs::write(
+        &report_path,
+        r#"{
+  "test_command": ["cargo", "test"],
+  "mutations": [{
+    "id": 1,
+    "file": "src/main.go",
+    "line": 3,
+    "operator": "plus_to_minus",
+    "description": "Replace + with -",
+    "result": "survived",
+    "execution": {"state": "exact_cache"}
+  }]
+}"#,
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "explain",
+            "1",
+            "--report",
+            report_path.to_str().expect("report path should be utf-8"),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "explain cached verdict failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Execution: reused from exact cache"));
+    assert!(stdout.contains("Test command: not run."));
+    assert!(!stdout.contains(r#"Test command: ["cargo","test"]"#));
+}
+
+#[test]
+fn explain_reports_incremental_history_and_structured_nonexecution() {
+    let dir = TempDir::new().unwrap();
+
+    for (index, (label, result, state, reason, execution_text)) in [
+        (
+            "incremental history",
+            "survived",
+            "incremental_history",
+            None,
+            "reused from incremental history",
+        ),
+        (
+            "build error",
+            "build_error",
+            "not_executed",
+            Some("build_error"),
+            "not executed (build_error)",
+        ),
+        (
+            "uncovered",
+            "uncovered",
+            "not_executed",
+            Some("uncovered"),
+            "not executed (uncovered)",
+        ),
+        (
+            "subsumed",
+            "subsumed",
+            "not_executed",
+            Some("subsumed"),
+            "not executed (subsumed)",
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut execution = serde_json::json!({"state": state});
+        if let Some(reason) = reason {
+            execution["reason"] = serde_json::Value::String(reason.into());
+        }
+        let report_path = dir.path().join(format!("report-{index}.json"));
+        fs::write(
+            &report_path,
+            serde_json::to_string(&serde_json::json!({
+                "test_command": ["cargo", "test"],
+                "mutations": [{
+                    "id": 1,
+                    "file": "src/main.go",
+                    "line": 3,
+                    "operator": "plus_to_minus",
+                    "description": label,
+                    "result": result,
+                    "execution": execution,
+                }],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let output = togi()
+            .args([
+                "explain",
+                "1",
+                "--report",
+                report_path.to_str().expect("report path should be utf-8"),
+            ])
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{label} explain failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(&format!("Execution: {execution_text}")),
+            "{label} stdout:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("Test command: not run."),
+            "{label} stdout:\n{stdout}"
+        );
+        assert!(
+            !stdout.contains(r#"Test command: ["cargo","test"]"#),
+            "{label} stdout:\n{stdout}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #436

- Record fresh, cache/history-reused, and non-executed mutation provenance without replacing verdict categories.
- Use fresh executions only for score and baseline accounting; render structured suite failures truthfully.
- Cover JSON, Explain, cache/history, baseline-eligibility, and non-test outcome paths.

Tests:
- `cargo test --locked`
- `cargo clippy --locked -- -D warnings`
- `cargo fmt --check`