### PR TITLE
feat: classify survivors against baseline debt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +251,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dispatch2"
@@ -278,6 +316,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -631,6 +679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +768,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "sha2",
  "shell-words",
  "tempfile",
  "toml",
@@ -875,6 +935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +957,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ toml = "1.1"
 
 # Output
 serde_json = "1"
+sha2 = "0.10"
 
 # Filesystem
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ togi check --check-baseline
 
 Baselines are stored in `.togi-baseline`.
 
+New baselines persist source-validated per-mutant evidence. An eligible `--check-baseline` labels fresh surviving mutants `historic`, `new`, or `non_comparable` in reports, while existing aggregate and per-file score gates remain unchanged.
+
 ## Workspace copies
 
 togi runs mutations in temporary workspace copies so parallel jobs do not observe

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,11 +1,13 @@
-use crate::MutationResult;
+use crate::{Mutation, MutationReport, MutationResult};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Component, Path};
 
 const BASELINE_FILE: &str = ".togi-baseline";
+const MUTANT_SNAPSHOT_VERSION: u32 = 1;
 
 /// Per-file mutation score snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,9 +19,88 @@ pub struct FileScore {
 /// Baseline snapshot of mutation scores.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Baseline {
-    pub files: HashMap<String, FileScore>,
+    pub files: BTreeMap<String, FileScore>,
     pub killed: usize,
     pub total: usize,
+    /// Optional to keep aggregate-only baselines backward compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutant_snapshot: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MutantSnapshotV1 {
+    version: u32,
+    mutants: Vec<BaselineMutant>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaselineMutant {
+    path: String,
+    source_fingerprint: String,
+    byte_start: usize,
+    byte_end: usize,
+    language: String,
+    operator: String,
+    original: String,
+    replacement: String,
+    result: BaselineMutantResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum BaselineMutantResult {
+    Killed,
+    Survived,
+    Timeout,
+}
+
+impl BaselineMutantResult {
+    fn from_result(result: MutationResult) -> Option<Self> {
+        match result {
+            MutationResult::Killed => Some(Self::Killed),
+            MutationResult::Survived => Some(Self::Survived),
+            MutationResult::Timeout => Some(Self::Timeout),
+            MutationResult::BuildError | MutationResult::Uncovered | MutationResult::Subsumed => {
+                None
+            }
+        }
+    }
+}
+
+/// A survivor's relationship to the loaded per-mutant baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurvivorBaselineStatus {
+    Historic,
+    New,
+    NonComparable,
+}
+
+impl SurvivorBaselineStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Historic => "historic",
+            Self::New => "new",
+            Self::NonComparable => "non_comparable",
+        }
+    }
+}
+
+/// External comparison data for report renderers, keyed by mutation id.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SurvivorBaselineComparison {
+    statuses: BTreeMap<u32, SurvivorBaselineStatus>,
+}
+
+impl SurvivorBaselineComparison {
+    pub fn status_for(&self, mutation_id: u32) -> Option<SurvivorBaselineStatus> {
+        self.statuses.get(&mutation_id).copied()
+    }
+
+    pub(crate) fn from_statuses(
+        statuses: BTreeMap<u32, SurvivorBaselineStatus>,
+    ) -> SurvivorBaselineComparison {
+        SurvivorBaselineComparison { statuses }
+    }
 }
 
 /// Whether a report contains any newly executed mutation-test evidence.
@@ -43,15 +124,10 @@ pub fn is_baseline_eligible(report: &crate::MutationReport) -> bool {
 /// per-file and overall totals. Restored cache/history verdicts, build errors,
 /// coverage-suppressed (uncovered), and learned-selection (subsumed) mutants
 /// are excluded.
-pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Baseline {
-    let mut files: HashMap<String, FileScore> = HashMap::new();
+pub fn from_report(report: &MutationReport, project_root: &Path) -> Baseline {
+    let mut files = BTreeMap::new();
     for (mutation, result) in &report.results {
-        let rel = mutation
-            .file
-            .strip_prefix(project_root)
-            .unwrap_or(&mutation.file)
-            .display()
-            .to_string();
+        let rel = baseline_file_path(mutation, project_root);
         let execution = report.execution_for(mutation.id, *result);
         if !execution.is_tested() {
             continue;
@@ -70,7 +146,53 @@ pub fn from_report(report: &crate::MutationReport, project_root: &Path) -> Basel
         files,
         killed: execution_counts.executed_killed,
         total: execution_counts.executed,
+        mutant_snapshot: snapshot_from_report(report, project_root),
     }
+}
+
+fn snapshot_from_report(report: &MutationReport, project_root: &Path) -> Option<serde_json::Value> {
+    let mut source_cache = SourceCache::new(project_root);
+    let mut mutants = report
+        .results
+        .iter()
+        .filter_map(|(mutation, result)| {
+            if !report.execution_for(mutation.id, *result).is_tested() {
+                return None;
+            }
+            let result = BaselineMutantResult::from_result(*result)?;
+            let source = source_cache.source_identity(mutation)?;
+            Some(BaselineMutant {
+                path: source.path.clone(),
+                source_fingerprint: source.fingerprint.clone(),
+                byte_start: mutation.byte_range.start,
+                byte_end: mutation.byte_range.end,
+                language: mutation.language.clone(),
+                operator: mutation.operator.clone(),
+                original: mutation.original.clone(),
+                replacement: mutation.replacement.clone(),
+                result,
+            })
+        })
+        .collect::<Vec<_>>();
+    mutants.sort_by(compare_baseline_mutants);
+    serde_json::to_value(MutantSnapshotV1 {
+        version: MUTANT_SNAPSHOT_VERSION,
+        mutants,
+    })
+    .ok()
+}
+
+fn compare_baseline_mutants(left: &BaselineMutant, right: &BaselineMutant) -> std::cmp::Ordering {
+    left.path
+        .cmp(&right.path)
+        .then_with(|| left.source_fingerprint.cmp(&right.source_fingerprint))
+        .then_with(|| left.byte_start.cmp(&right.byte_start))
+        .then_with(|| left.byte_end.cmp(&right.byte_end))
+        .then_with(|| left.language.cmp(&right.language))
+        .then_with(|| left.operator.cmp(&right.operator))
+        .then_with(|| left.original.cmp(&right.original))
+        .then_with(|| left.replacement.cmp(&right.replacement))
+        .then_with(|| left.result.cmp(&right.result))
 }
 
 /// Persist a baseline snapshot to `.togi-baseline` inside `dir`.
@@ -105,9 +227,302 @@ pub fn load_baseline(dir: &Path) -> anyhow::Result<Option<Baseline>> {
         Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(e).with_context(|| format!("could not read {}", path.display())),
     };
-    let baseline = serde_json::from_str(&data)
+    let mut baseline: Baseline = serde_json::from_str(&data)
         .with_context(|| format!("invalid baseline at {}", path.display()))?;
+    canonicalize_loaded_file_paths(&mut baseline.files)?;
     Ok(Some(baseline))
+}
+
+fn canonicalize_loaded_file_paths(files: &mut BTreeMap<String, FileScore>) -> anyhow::Result<()> {
+    let mut canonical = BTreeMap::new();
+    for (path, score) in std::mem::take(files) {
+        let slash_path = path.replace('\\', "/");
+        if canonical.insert(slash_path.clone(), score).is_some() {
+            anyhow::bail!(
+                "baseline contains colliding file paths after slash normalization: {slash_path}"
+            );
+        }
+    }
+    *files = canonical;
+    Ok(())
+}
+
+struct SourceIdentity {
+    path: String,
+    fingerprint: String,
+    source: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CurrentMutationIdentity {
+    path: String,
+    source_fingerprint: String,
+    byte_start: usize,
+    byte_end: usize,
+    language: String,
+    operator: String,
+    original: String,
+    replacement: String,
+}
+
+fn baseline_file_path(mutation: &Mutation, project_root: &Path) -> String {
+    normalized_project_relative_path(project_root, &mutation.file).unwrap_or_else(|| {
+        mutation
+            .file
+            .strip_prefix(project_root)
+            .unwrap_or(&mutation.file)
+            .display()
+            .to_string()
+    })
+}
+
+struct SourceCache<'a> {
+    project_root: &'a Path,
+    sources: BTreeMap<String, Option<SourceIdentity>>,
+}
+
+impl<'a> SourceCache<'a> {
+    fn new(project_root: &'a Path) -> Self {
+        Self {
+            project_root,
+            sources: BTreeMap::new(),
+        }
+    }
+
+    fn source_identity(&mut self, mutation: &Mutation) -> Option<&SourceIdentity> {
+        let path = normalized_project_relative_path(self.project_root, &mutation.file)?;
+        let project_root = self.project_root;
+        let source = self
+            .sources
+            .entry(path.clone())
+            .or_insert_with(|| {
+                let source = std::fs::read(project_root.join(&path)).ok()?;
+                Some(SourceIdentity {
+                    path,
+                    fingerprint: source_fingerprint(&source),
+                    source,
+                })
+            })
+            .as_ref()?;
+        range_matches(
+            &source.source,
+            mutation.byte_range.start,
+            mutation.byte_range.end,
+            &mutation.original,
+        )
+        .then_some(source)
+    }
+}
+
+fn current_identity(mutation: &Mutation, source: &SourceIdentity) -> CurrentMutationIdentity {
+    CurrentMutationIdentity {
+        path: source.path.clone(),
+        source_fingerprint: source.fingerprint.clone(),
+        byte_start: mutation.byte_range.start,
+        byte_end: mutation.byte_range.end,
+        language: mutation.language.clone(),
+        operator: mutation.operator.clone(),
+        original: mutation.original.clone(),
+        replacement: mutation.replacement.clone(),
+    }
+}
+
+fn normalized_project_relative_path(project_root: &Path, file: &Path) -> Option<String> {
+    let relative = if file.is_absolute() {
+        file.strip_prefix(project_root).ok()?
+    } else {
+        file
+    };
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part.to_str()?;
+                if part.contains('\\') {
+                    return None;
+                }
+                parts.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn range_matches(source: &[u8], start: usize, end: usize, original: &str) -> bool {
+    start <= end
+        && end <= source.len()
+        && source
+            .get(start..end)
+            .is_some_and(|bytes| bytes == original.as_bytes())
+}
+
+fn source_fingerprint(source: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(source))
+}
+
+/// Compare freshly executed current survivors with a loaded per-mutant baseline.
+///
+/// Any missing, malformed, renamed, changed, incomplete, or ambiguous source
+/// evidence is deliberately non-comparable rather than inferred from scores.
+pub fn compare_survivors(
+    report: &MutationReport,
+    baseline: &Baseline,
+    project_root: &Path,
+) -> SurvivorBaselineComparison {
+    let mut id_counts = BTreeMap::<u32, usize>::new();
+    let mut identity_counts = BTreeMap::<CurrentMutationIdentity, usize>::new();
+    let mut source_cache = SourceCache::new(project_root);
+    for (mutation, _) in &report.results {
+        *id_counts.entry(mutation.id).or_default() += 1;
+        if let Some(source) = source_cache.source_identity(mutation) {
+            *identity_counts
+                .entry(current_identity(mutation, source))
+                .or_default() += 1;
+        }
+    }
+
+    let snapshot = snapshot_v1(baseline);
+    let mut statuses = BTreeMap::new();
+    for (mutation, result) in &report.results {
+        if *result != MutationResult::Survived
+            || !report.execution_for(mutation.id, *result).is_tested()
+        {
+            continue;
+        }
+
+        let source = source_cache.source_identity(mutation);
+        let identity = source.map(|source| current_identity(mutation, source));
+        let status = if id_counts.get(&mutation.id).is_some_and(|count| *count > 1)
+            || identity
+                .as_ref()
+                .and_then(|identity| identity_counts.get(identity))
+                .is_some_and(|count| *count > 1)
+        {
+            SurvivorBaselineStatus::NonComparable
+        } else if let (Some(snapshot), Some(source)) = (&snapshot, source) {
+            classify_survivor(mutation, source, baseline, snapshot)
+        } else {
+            SurvivorBaselineStatus::NonComparable
+        };
+        statuses.insert(mutation.id, status);
+    }
+    SurvivorBaselineComparison::from_statuses(statuses)
+}
+
+fn snapshot_v1(baseline: &Baseline) -> Option<MutantSnapshotV1> {
+    let snapshot = baseline.mutant_snapshot.as_ref()?;
+    if snapshot.get("version")?.as_u64()? != u64::from(MUTANT_SNAPSHOT_VERSION) {
+        return None;
+    }
+    let snapshot = serde_json::from_value::<MutantSnapshotV1>(snapshot.clone()).ok()?;
+    (snapshot.version == MUTANT_SNAPSHOT_VERSION).then_some(snapshot)
+}
+
+fn classify_survivor(
+    mutation: &Mutation,
+    source: &SourceIdentity,
+    baseline: &Baseline,
+    snapshot: &MutantSnapshotV1,
+) -> SurvivorBaselineStatus {
+    let Some(path_entries) = complete_path_snapshot(baseline, snapshot, source) else {
+        return SurvivorBaselineStatus::NonComparable;
+    };
+    let mut matching = path_entries
+        .into_iter()
+        .filter(|entry| same_identity(entry, mutation, source));
+    let Some(entry) = matching.next() else {
+        return SurvivorBaselineStatus::New;
+    };
+    if matching.next().is_some() {
+        return SurvivorBaselineStatus::NonComparable;
+    }
+    match entry.result {
+        BaselineMutantResult::Survived => SurvivorBaselineStatus::Historic,
+        BaselineMutantResult::Killed | BaselineMutantResult::Timeout => SurvivorBaselineStatus::New,
+    }
+}
+
+fn complete_path_snapshot<'a>(
+    baseline: &Baseline,
+    snapshot: &'a MutantSnapshotV1,
+    source: &SourceIdentity,
+) -> Option<Vec<&'a BaselineMutant>> {
+    let file_score = baseline.files.get(&source.path)?;
+    if file_score.killed > file_score.total {
+        return None;
+    }
+    let entries = snapshot
+        .mutants
+        .iter()
+        .filter(|entry| entry.path == source.path)
+        .collect::<Vec<_>>();
+    if entries.is_empty()
+        || entries.len() != file_score.total
+        || entries
+            .iter()
+            .any(|entry| !baseline_entry_is_valid(entry, source))
+        || has_duplicate_identity(&entries)
+        || entries
+            .iter()
+            .filter(|entry| entry.result == BaselineMutantResult::Killed)
+            .count()
+            != file_score.killed
+    {
+        return None;
+    }
+    Some(entries)
+}
+
+fn baseline_entry_is_valid(entry: &BaselineMutant, source: &SourceIdentity) -> bool {
+    entry.path == source.path
+        && is_normalized_project_relative_path(&entry.path)
+        && entry.source_fingerprint == source.fingerprint
+        && range_matches(
+            &source.source,
+            entry.byte_start,
+            entry.byte_end,
+            &entry.original,
+        )
+}
+
+fn is_normalized_project_relative_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+fn has_duplicate_identity(entries: &[&BaselineMutant]) -> bool {
+    let mut identities = BTreeSet::new();
+    entries.iter().any(|entry| {
+        !identities.insert((
+            entry.path.as_str(),
+            entry.source_fingerprint.as_str(),
+            entry.byte_start,
+            entry.byte_end,
+            entry.language.as_str(),
+            entry.operator.as_str(),
+            entry.original.as_str(),
+            entry.replacement.as_str(),
+        ))
+    })
+}
+
+fn same_identity(entry: &BaselineMutant, mutation: &Mutation, source: &SourceIdentity) -> bool {
+    entry.path == source.path
+        && entry.source_fingerprint == source.fingerprint
+        && entry.byte_start == mutation.byte_range.start
+        && entry.byte_end == mutation.byte_range.end
+        && entry.language == mutation.language
+        && entry.operator == mutation.operator
+        && entry.original == mutation.original
+        && entry.replacement == mutation.replacement
 }
 
 /// Returns `true` if the current overall score is a regression compared to the baseline.
@@ -167,11 +582,76 @@ pub fn per_file_regressions(current: &Baseline, baseline: &Baseline) -> Vec<File
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+    use std::time::Duration;
 
     fn make_baseline(killed: usize, total: usize) -> Baseline {
         Baseline {
-            files: HashMap::new(),
+            files: BTreeMap::new(),
             killed,
+            total,
+            mutant_snapshot: None,
+        }
+    }
+
+    const FIXTURE_SOURCE: &str = "a < b\nc == d\nx > y\n";
+
+    fn write_fixture_source(root: &Path) {
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/sample.rs"), FIXTURE_SOURCE).unwrap();
+    }
+
+    fn fixture_mutation(
+        id: u32,
+        byte_range: std::ops::Range<usize>,
+        original: &str,
+        line: usize,
+        description: &str,
+    ) -> Mutation {
+        Mutation {
+            id,
+            file: PathBuf::from("src/sample.rs"),
+            language: "rust".to_string(),
+            line,
+            column: byte_range.start + 1,
+            operator: "binary".to_string(),
+            description: description.to_string(),
+            original: original.to_string(),
+            replacement: format!("{original}_replacement"),
+            byte_range,
+        }
+    }
+
+    fn fixture_report(results: Vec<(Mutation, MutationResult)>) -> MutationReport {
+        let total = results.len();
+        MutationReport {
+            killed: results
+                .iter()
+                .filter(|(_, result)| *result == MutationResult::Killed)
+                .count(),
+            survived: results
+                .iter()
+                .filter(|(_, result)| *result == MutationResult::Survived)
+                .count(),
+            timeout: results
+                .iter()
+                .filter(|(_, result)| *result == MutationResult::Timeout)
+                .count(),
+            build_errors: results
+                .iter()
+                .filter(|(_, result)| *result == MutationResult::BuildError)
+                .count(),
+            results,
+            execution_provenance: BTreeMap::new(),
+            build_error_diagnostics: vec![],
+            schemata: None,
+            baseline_timing: None,
+            duration: Duration::ZERO,
+            test_command: None,
+            build_command: vec![],
+            planned_total: total,
+            early_stop_reason: None,
             total,
         }
     }
@@ -215,7 +695,7 @@ mod tests {
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
 
-        let mut files = HashMap::new();
+        let mut files = BTreeMap::new();
         files.insert(
             "src/main.rs".to_string(),
             FileScore {
@@ -227,6 +707,7 @@ mod tests {
             files,
             killed: 3,
             total: 5,
+            mutant_snapshot: None,
         };
 
         save_baseline(&baseline, dir.path()).unwrap();
@@ -235,6 +716,530 @@ mod tests {
         assert_eq!(loaded.killed, 3);
         assert_eq!(loaded.total, 5);
         assert_eq!(loaded.files["src/main.rs"].killed, 3);
+    }
+
+    #[test]
+    fn load_normalizes_legacy_backslash_file_keys_for_per_file_regressions() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(BASELINE_FILE),
+            r#"{"files":{"src\\foo.rs":{"killed":10,"total":10}},"killed":10,"total":10}"#,
+        )
+        .unwrap();
+
+        let baseline = load_baseline(dir.path()).unwrap().unwrap();
+        let current = make_baseline_with_files(vec![("src/foo.rs", 5, 10)]);
+        let regressions = per_file_regressions(&current, &baseline);
+
+        assert_eq!(baseline.killed, 10);
+        assert_eq!(baseline.total, 10);
+        assert_eq!(regressions.len(), 1);
+        assert_eq!(regressions[0].file, "src/foo.rs");
+    }
+
+    #[test]
+    fn load_rejects_colliding_backslash_file_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(BASELINE_FILE),
+            r#"{"files":{"src/foo.rs":{"killed":1,"total":1},"src\\foo.rs":{"killed":0,"total":1}},"killed":1,"total":2}"#,
+        )
+        .unwrap();
+
+        assert!(
+            load_baseline(dir.path())
+                .unwrap_err()
+                .to_string()
+                .contains("colliding file paths")
+        );
+    }
+
+    #[test]
+    fn v1_snapshot_roundtrips_with_deterministic_order() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let report = fixture_report(vec![
+            (
+                fixture_mutation(8, 15..16, ">", 3, "late mutation"),
+                MutationResult::Timeout,
+            ),
+            (
+                fixture_mutation(3, 2..3, "<", 1, "early mutation"),
+                MutationResult::Killed,
+            ),
+        ]);
+        let baseline = from_report(&report, dir.path());
+        let snapshot = snapshot_v1(&baseline).unwrap();
+
+        assert_eq!(snapshot.version, MUTANT_SNAPSHOT_VERSION);
+        assert_eq!(snapshot.mutants.len(), 2);
+        assert_eq!(snapshot.mutants[0].byte_start, 2);
+        assert_eq!(snapshot.mutants[1].byte_start, 15);
+        assert_eq!(
+            snapshot.mutants[0].source_fingerprint,
+            source_fingerprint(FIXTURE_SOURCE.as_bytes())
+        );
+
+        save_baseline(&baseline, dir.path()).unwrap();
+        let first_save = std::fs::read(dir.path().join(BASELINE_FILE)).unwrap();
+        save_baseline(&baseline, dir.path()).unwrap();
+        assert_eq!(
+            std::fs::read(dir.path().join(BASELINE_FILE)).unwrap(),
+            first_save
+        );
+
+        let saved: serde_json::Value = serde_json::from_slice(&first_save).unwrap();
+        assert_eq!(saved["mutant_snapshot"]["version"], MUTANT_SNAPSHOT_VERSION);
+        let loaded = load_baseline(dir.path()).unwrap().unwrap();
+        let loaded_snapshot = snapshot_v1(&loaded).unwrap();
+        assert_eq!(loaded_snapshot.mutants[0].byte_start, 2);
+        assert_eq!(loaded_snapshot.mutants[1].byte_start, 15);
+    }
+
+    #[test]
+    fn snapshot_omits_reused_source_present_verdicts() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+
+        for execution in [
+            crate::MutationExecution::ExactCache,
+            crate::MutationExecution::IncrementalHistory,
+        ] {
+            let mut report = fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "reused survivor"),
+                    MutationResult::Survived,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "fresh killed"),
+                    MutationResult::Killed,
+                ),
+            ]);
+            report.execution_provenance.insert(1, execution);
+
+            let baseline = from_report(&report, dir.path());
+            let serialized = serde_json::to_value(&baseline).unwrap();
+            let mutants = serialized["mutant_snapshot"]["mutants"].as_array().unwrap();
+            assert_eq!(mutants.len(), 1);
+            assert_eq!(mutants[0]["byte_start"], 8);
+            assert_eq!(baseline.files["src/sample.rs"].total, 1);
+        }
+    }
+
+    #[test]
+    fn complete_snapshot_with_unknown_version_preserves_gates_but_is_non_comparable() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline_report = fixture_report(vec![(
+            fixture_mutation(1, 2..3, "<", 1, "baseline killed"),
+            MutationResult::Killed,
+        )]);
+        let current_report = fixture_report(vec![(
+            fixture_mutation(2, 2..3, "<", 1, "current survivor"),
+            MutationResult::Survived,
+        )]);
+        let mut unknown = from_report(&baseline_report, dir.path());
+        let mut snapshot = snapshot_v1(&unknown).unwrap();
+        snapshot.version = 99;
+        unknown.mutant_snapshot = Some(serde_json::to_value(snapshot).unwrap());
+        let current = from_report(&current_report, dir.path());
+
+        assert!(check_regression(&current, &unknown));
+        assert_eq!(per_file_regressions(&current, &unknown).len(), 1);
+        assert_eq!(
+            compare_survivors(&current_report, &unknown, dir.path()).status_for(2),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn incomplete_or_conflicting_path_snapshot_is_non_comparable() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline = from_report(
+            &fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "historic"),
+                    MutationResult::Survived,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "sibling"),
+                    MutationResult::Killed,
+                ),
+            ]),
+            dir.path(),
+        );
+        let current = fixture_report(vec![(
+            fixture_mutation(9, 2..3, "<", 1, "current"),
+            MutationResult::Survived,
+        )]);
+        assert_eq!(
+            compare_survivors(&current, &baseline, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::Historic)
+        );
+
+        let mut truncated = baseline.clone();
+        let mut truncated_snapshot = snapshot_v1(&truncated).unwrap();
+        truncated_snapshot.mutants.pop();
+        truncated.mutant_snapshot = Some(serde_json::to_value(truncated_snapshot).unwrap());
+        assert_eq!(
+            compare_survivors(&current, &truncated, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let mut mixed_fingerprint = baseline.clone();
+        let mut mixed_snapshot = snapshot_v1(&mixed_fingerprint).unwrap();
+        mixed_snapshot.mutants[1].source_fingerprint = "sha256:other".to_string();
+        mixed_fingerprint.mutant_snapshot = Some(serde_json::to_value(mixed_snapshot).unwrap());
+        assert_eq!(
+            compare_survivors(&current, &mixed_fingerprint, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let mut missing_file = baseline.clone();
+        missing_file.files.remove("src/sample.rs");
+        assert_eq!(
+            compare_survivors(&current, &missing_file, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let mut mismatched_total = baseline;
+        mismatched_total
+            .files
+            .get_mut("src/sample.rs")
+            .unwrap()
+            .total = 1;
+        assert_eq!(
+            compare_survivors(&current, &mismatched_total, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn legacy_snapshots_preserve_gates_but_are_non_comparable() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let report = fixture_report(vec![(
+            fixture_mutation(9, 2..3, "<", 1, "current survivor"),
+            MutationResult::Survived,
+        )]);
+        let current = from_report(&report, dir.path());
+
+        std::fs::write(
+            dir.path().join(BASELINE_FILE),
+            r#"{
+  "files": { "src/sample.rs": { "killed": 1, "total": 1 } },
+  "killed": 1,
+  "total": 1
+}"#,
+        )
+        .unwrap();
+        let legacy = load_baseline(dir.path()).unwrap().unwrap();
+        assert!(legacy.mutant_snapshot.is_none());
+        assert!(check_regression(&current, &legacy));
+        assert_eq!(per_file_regressions(&current, &legacy).len(), 1);
+        assert_eq!(
+            compare_survivors(&report, &legacy, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn comparison_classifies_historic_and_new_without_mutable_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline = from_report(
+            &fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "baseline historic"),
+                    MutationResult::Survived,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "baseline killed"),
+                    MutationResult::Killed,
+                ),
+            ]),
+            dir.path(),
+        );
+        let current = fixture_report(vec![
+            (
+                fixture_mutation(91, 2..3, "<", 99, "renumbered historic"),
+                MutationResult::Survived,
+            ),
+            (
+                fixture_mutation(92, 8..10, "==", 98, "renumbered killed"),
+                MutationResult::Survived,
+            ),
+            (
+                fixture_mutation(93, 15..16, ">", 97, "new identity"),
+                MutationResult::Survived,
+            ),
+        ]);
+
+        let comparison = compare_survivors(&current, &baseline, dir.path());
+        assert_eq!(
+            comparison.status_for(91),
+            Some(SurvivorBaselineStatus::Historic)
+        );
+        assert_eq!(comparison.status_for(92), Some(SurvivorBaselineStatus::New));
+        assert_eq!(comparison.status_for(93), Some(SurvivorBaselineStatus::New));
+    }
+
+    #[test]
+    fn comparison_fails_closed_for_ambiguous_current_identity_or_id() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline = from_report(
+            &fixture_report(vec![(
+                fixture_mutation(1, 2..3, "<", 1, "baseline"),
+                MutationResult::Survived,
+            )]),
+            dir.path(),
+        );
+
+        let same_identity = fixture_report(vec![
+            (
+                fixture_mutation(10, 2..3, "<", 1, "first duplicate"),
+                MutationResult::Survived,
+            ),
+            (
+                fixture_mutation(11, 2..3, "<", 2, "second duplicate"),
+                MutationResult::Survived,
+            ),
+        ]);
+        let comparison = compare_survivors(&same_identity, &baseline, dir.path());
+        assert_eq!(
+            comparison.status_for(10),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+        assert_eq!(
+            comparison.status_for(11),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let killed_and_survived = fixture_report(vec![
+            (
+                fixture_mutation(20, 2..3, "<", 1, "killed duplicate"),
+                MutationResult::Killed,
+            ),
+            (
+                fixture_mutation(21, 2..3, "<", 2, "survived duplicate"),
+                MutationResult::Survived,
+            ),
+        ]);
+        assert_eq!(
+            compare_survivors(&killed_and_survived, &baseline, dir.path()).status_for(21),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let duplicate_id = fixture_report(vec![
+            (
+                fixture_mutation(30, 2..3, "<", 1, "survivor"),
+                MutationResult::Survived,
+            ),
+            (
+                fixture_mutation(30, 8..10, "==", 2, "different identity"),
+                MutationResult::Killed,
+            ),
+        ]);
+        assert_eq!(
+            compare_survivors(&duplicate_id, &baseline, dir.path()).status_for(30),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn changed_identity_and_timeout_to_survived_are_new() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let mut baseline_language = fixture_mutation(4, 2..3, "<", 4, "language");
+        baseline_language.language = "go".to_string();
+        let baseline = from_report(
+            &fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "timed out"),
+                    MutationResult::Timeout,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "operator"),
+                    MutationResult::Killed,
+                ),
+                (
+                    fixture_mutation(3, 15..16, ">", 3, "replacement"),
+                    MutationResult::Survived,
+                ),
+                (baseline_language, MutationResult::Killed),
+            ]),
+            dir.path(),
+        );
+        let mut changed_operator = fixture_mutation(11, 8..10, "==", 2, "operator changed");
+        changed_operator.operator = "other_binary".to_string();
+        let mut changed_replacement = fixture_mutation(12, 15..16, ">", 3, "replacement changed");
+        changed_replacement.replacement = "different_replacement".to_string();
+        let mut changed_language = fixture_mutation(13, 2..3, "<", 4, "language changed");
+        changed_language.language = "typescript".to_string();
+        let current = fixture_report(vec![
+            (
+                fixture_mutation(10, 2..3, "<", 1, "timeout now survives"),
+                MutationResult::Survived,
+            ),
+            (changed_operator, MutationResult::Survived),
+            (changed_replacement, MutationResult::Survived),
+            (changed_language, MutationResult::Survived),
+        ]);
+
+        let comparison = compare_survivors(&current, &baseline, dir.path());
+        for id in [10, 11, 12, 13] {
+            assert_eq!(comparison.status_for(id), Some(SurvivorBaselineStatus::New));
+        }
+    }
+
+    #[test]
+    fn comparison_fails_closed_for_changed_renamed_or_missing_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let mutation = fixture_mutation(5, 2..3, "<", 1, "survivor");
+        let report = fixture_report(vec![(mutation.clone(), MutationResult::Survived)]);
+        let baseline = from_report(&report, dir.path());
+
+        std::fs::write(dir.path().join("src/sample.rs"), "a < c\nc == d\nx > y\n").unwrap();
+        assert_eq!(
+            compare_survivors(&report, &baseline, dir.path()).status_for(5),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        write_fixture_source(dir.path());
+        std::fs::rename(
+            dir.path().join("src/sample.rs"),
+            dir.path().join("src/renamed.rs"),
+        )
+        .unwrap();
+        let mut renamed = mutation.clone();
+        renamed.file = PathBuf::from("src/renamed.rs");
+        let renamed_report = fixture_report(vec![(renamed.clone(), MutationResult::Survived)]);
+        assert_eq!(
+            compare_survivors(&renamed_report, &baseline, dir.path()).status_for(5),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        std::fs::remove_file(dir.path().join("src/renamed.rs")).unwrap();
+        assert_eq!(
+            compare_survivors(&renamed_report, &baseline, dir.path()).status_for(5),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn comparison_fails_closed_for_invalid_or_duplicate_snapshot_data() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let mutation = fixture_mutation(5, 2..3, "<", 1, "survivor");
+        let report = fixture_report(vec![(mutation.clone(), MutationResult::Survived)]);
+        let baseline = from_report(&report, dir.path());
+
+        let mut invalid_range = baseline.clone();
+        let mut invalid_snapshot = snapshot_v1(&invalid_range).unwrap();
+        invalid_snapshot.mutants[0].byte_end += 1;
+        invalid_range.mutant_snapshot = Some(serde_json::to_value(invalid_snapshot).unwrap());
+        assert_eq!(
+            compare_survivors(&report, &invalid_range, dir.path()).status_for(5),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let mut duplicate = baseline.clone();
+        let mut duplicate_snapshot = snapshot_v1(&duplicate).unwrap();
+        duplicate_snapshot
+            .mutants
+            .push(duplicate_snapshot.mutants[0].clone());
+        duplicate.mutant_snapshot = Some(serde_json::to_value(duplicate_snapshot).unwrap());
+        assert_eq!(
+            compare_survivors(&report, &duplicate, dir.path()).status_for(5),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+
+        let invalid_mutation = fixture_mutation(6, 2..4, "<", 1, "invalid range");
+        let invalid_report = fixture_report(vec![(invalid_mutation, MutationResult::Survived)]);
+        assert!(
+            snapshot_v1(&from_report(&invalid_report, dir.path()))
+                .unwrap()
+                .mutants
+                .is_empty()
+        );
+        assert_eq!(
+            compare_survivors(&invalid_report, &baseline, dir.path()).status_for(6),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn duplicate_sibling_snapshot_entry_poisons_current_survivor() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline = from_report(
+            &fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "current A"),
+                    MutationResult::Survived,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "sibling B"),
+                    MutationResult::Killed,
+                ),
+            ]),
+            dir.path(),
+        );
+        let current = fixture_report(vec![(
+            fixture_mutation(9, 2..3, "<", 1, "current A"),
+            MutationResult::Survived,
+        )]);
+
+        let mut duplicate_sibling = baseline.clone();
+        let mut snapshot = snapshot_v1(&duplicate_sibling).unwrap();
+        snapshot.mutants.push(snapshot.mutants[1].clone());
+        duplicate_sibling.killed = 2;
+        duplicate_sibling.total = 3;
+        duplicate_sibling
+            .files
+            .get_mut("src/sample.rs")
+            .unwrap()
+            .killed = 2;
+        duplicate_sibling
+            .files
+            .get_mut("src/sample.rs")
+            .unwrap()
+            .total = 3;
+        duplicate_sibling.mutant_snapshot = Some(serde_json::to_value(snapshot).unwrap());
+        assert_eq!(
+            compare_survivors(&current, &duplicate_sibling, dir.path()).status_for(9),
+            Some(SurvivorBaselineStatus::NonComparable)
+        );
+    }
+
+    #[test]
+    fn snapshot_preserves_aggregate_and_per_file_gates() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_source(dir.path());
+        let baseline = from_report(
+            &fixture_report(vec![
+                (
+                    fixture_mutation(1, 2..3, "<", 1, "killed"),
+                    MutationResult::Killed,
+                ),
+                (
+                    fixture_mutation(2, 8..10, "==", 2, "survived"),
+                    MutationResult::Survived,
+                ),
+            ]),
+            dir.path(),
+        );
+        let current = make_baseline_with_files(vec![("src/sample.rs", 0, 2)]);
+
+        assert_eq!(baseline.killed, 1);
+        assert_eq!(baseline.total, 2);
+        assert_eq!(baseline.files["src/sample.rs"].killed, 1);
+        assert!(baseline.mutant_snapshot.is_some());
+        assert!(check_regression(&current, &baseline));
+        assert_eq!(per_file_regressions(&current, &baseline).len(), 1);
     }
 
     #[test]
@@ -357,7 +1362,7 @@ mod tests {
     }
 
     fn make_baseline_with_files(files: Vec<(&str, usize, usize)>) -> Baseline {
-        let mut file_map = HashMap::new();
+        let mut file_map = BTreeMap::new();
         let mut total_killed = 0;
         let mut total_total = 0;
         for (path, killed, total) in files {
@@ -369,6 +1374,7 @@ mod tests {
             files: file_map,
             killed: total_killed,
             total: total_total,
+            mutant_snapshot: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,13 +551,55 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
 
     report.baseline_timing = baseline_timing;
     merge_uncovered(&mut report, classified.uncovered);
-    togi::report::print_report(&report, output_format)?;
 
     let baseline_eligible = togi::baseline::is_baseline_eligible(&report);
-    let mut current = None;
     let mut should_fail = false;
     let partial_report = report.total < report.planned_total;
     let baseline_actions_allowed = baseline_eligible;
+    let mut baseline_score: Option<f64> = None;
+    let mut loaded_baseline = false;
+    let mut survivor_comparison = None;
+    let mut baseline_regressions = None;
+    let mut baseline_load_error = None;
+
+    if check_baseline && baseline_actions_allowed {
+        match togi::baseline::load_baseline(&project_root_ref) {
+            Ok(Some(baseline)) => {
+                loaded_baseline = true;
+                baseline_score =
+                    Some(baseline.killed as f64 / baseline.total.max(1) as f64 * 100.0);
+                survivor_comparison = Some(togi::baseline::compare_survivors(
+                    &report,
+                    &baseline,
+                    &project_root_ref,
+                ));
+                let current = togi::baseline::from_report(&report, &project_root_ref);
+                if togi::baseline::check_regression(&current, &baseline) {
+                    should_fail = true;
+                    baseline_regressions =
+                        Some(togi::baseline::per_file_regressions(&current, &baseline));
+                }
+            }
+            Ok(None) => {}
+            Err(error) => baseline_load_error = Some(error),
+        }
+    }
+
+    togi::report::print_report_with_baseline(&report, output_format, survivor_comparison.as_ref())?;
+
+    if let Some(error) = baseline_load_error {
+        return Err(error);
+    }
+
+    if let Some(regressions) = baseline_regressions {
+        eprintln!("Mutation score regression detected!");
+        for r in regressions {
+            eprintln!(
+                "  {} — {:.1}% → {:.1}%",
+                r.file, r.baseline_pct, r.current_pct
+            );
+        }
+    }
 
     if (save_baseline || check_baseline) && !baseline_actions_allowed {
         if partial_report {
@@ -568,37 +610,19 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
             );
         }
     } else if save_baseline {
-        current = togi::baseline::save_baseline_from_report(&report, &project_root_ref)?;
-        debug_assert!(current.is_some(), "eligible report must save a baseline");
+        let saved = togi::baseline::save_baseline_from_report(&report, &project_root_ref)?;
+        debug_assert!(saved.is_some(), "eligible report must save a baseline");
         eprintln!("Baseline saved to .togi-baseline");
+    } else if check_baseline && !loaded_baseline {
+        eprintln!("warning: no baseline found — use --save-baseline first");
     }
-
-    let mut baseline_score: Option<f64> = None;
-    let mut loaded_baseline = false;
-    if check_baseline && baseline_actions_allowed {
-        if let Some(baseline) = togi::baseline::load_baseline(&project_root_ref)? {
-            loaded_baseline = true;
-            baseline_score = Some(baseline.killed as f64 / baseline.total.max(1) as f64 * 100.0);
-            let current = current
-                .get_or_insert_with(|| togi::baseline::from_report(&report, &project_root_ref));
-            if togi::baseline::check_regression(current, &baseline) {
-                let regressions = togi::baseline::per_file_regressions(current, &baseline);
-                eprintln!("Mutation score regression detected!");
-                for r in &regressions {
-                    eprintln!(
-                        "  {} — {:.1}% → {:.1}%",
-                        r.file, r.baseline_pct, r.current_pct
-                    );
-                }
-                should_fail = true;
-            }
-        } else {
-            eprintln!("warning: no baseline found — use --save-baseline first");
-        }
-    }
-
-    if let Some(ref path) = pr_comment {
-        togi::report::write_pr_comment(&report, path, baseline_score)?;
+    if let Some(path) = &pr_comment {
+        togi::report::write_pr_comment_with_baseline(
+            &report,
+            path,
+            baseline_score,
+            survivor_comparison.as_ref(),
+        )?;
         eprintln!("PR comment written to {}", path.display());
     }
 

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -1,15 +1,22 @@
 use crate::{Mutation, MutationExecution, MutationReport, MutationResult};
 
-/// Format a single GitHub Actions warning annotation for a survived mutation.
-fn format_annotation(mutation: &Mutation, execution: MutationExecution) -> String {
+/// Format a GitHub Actions warning annotation for a survived mutation.
+fn format_annotation_with_baseline(
+    mutation: &Mutation,
+    execution: MutationExecution,
+    status: Option<crate::baseline::SurvivorBaselineStatus>,
+) -> String {
     let provenance = match execution {
         MutationExecution::Executed => String::new(),
         MutationExecution::ExactCache => " [reused: exact cache]".to_string(),
         MutationExecution::IncrementalHistory => " [reused: incremental history]".to_string(),
         MutationExecution::NotExecuted(reason) => format!(" [not executed: {reason}]"),
     };
+    let baseline = status
+        .map(|status| format!(" [baseline: {}]", status.as_str()))
+        .unwrap_or_default();
     let message = format!(
-        "Survived mutation: {} ({}){provenance}",
+        "Survived mutation: {} ({}){provenance}{baseline}",
         mutation.operator, mutation.description
     );
     format!(
@@ -31,15 +38,21 @@ fn escape_property(value: &str) -> String {
     escape_data(value).replace(':', "%3A").replace(',', "%2C")
 }
 
-/// Collect warning annotations for every survived mutation in `report`,
-/// in the same order they appear in `report.results`.
-fn annotations(report: &MutationReport) -> Vec<String> {
+/// Collect warning annotations for every survived mutation in `report`.
+fn annotations_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Vec<String> {
     report
         .results
         .iter()
         .filter(|(_, result)| *result == MutationResult::Survived)
         .map(|(mutation, result)| {
-            format_annotation(mutation, report.execution_for(mutation.id, *result))
+            format_annotation_with_baseline(
+                mutation,
+                report.execution_for(mutation.id, *result),
+                comparison.and_then(|comparison| comparison.status_for(mutation.id)),
+            )
         })
         .collect()
 }
@@ -47,7 +60,14 @@ fn annotations(report: &MutationReport) -> Vec<String> {
 /// Print GitHub Actions workflow annotations for survived mutations.
 /// These show inline on PR diffs.
 pub fn print_report(report: &MutationReport) {
-    for line in annotations(report) {
+    print_report_with_baseline(report, None)
+}
+
+pub fn print_report_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) {
+    for line in annotations_with_baseline(report, comparison) {
         println!("{line}");
     }
 
@@ -153,7 +173,7 @@ mod tests {
     #[test]
     fn annotation_format_for_survived_mutation() {
         let m = mutation("src/auth.rs", 47, "lt_to_lte", "changed < to <=");
-        let line = format_annotation(&m, MutationExecution::Executed);
+        let line = format_annotation_with_baseline(&m, MutationExecution::Executed, None);
         assert_eq!(
             line,
             "::warning file=src/auth.rs,line=47::Survived mutation: lt_to_lte (changed < to <=)"
@@ -166,7 +186,7 @@ mod tests {
             mutation("src/a.rs", 1, "op", "desc"),
             MutationResult::Killed,
         )]);
-        assert!(annotations(&report).is_empty());
+        assert!(annotations_with_baseline(&report, None).is_empty());
     }
 
     #[test]
@@ -185,11 +205,35 @@ mod tests {
                 MutationResult::Timeout,
             ),
         ]);
-        let lines = annotations(&report);
+        let lines = annotations_with_baseline(&report, None);
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("file=src/b.rs"));
         assert!(lines[0].contains("op_b"));
         assert!(lines[0].contains("survived one"));
+    }
+
+    #[test]
+    fn annotations_include_active_survivor_baseline_status_only() {
+        let mut survived = mutation("src/a.rs", 1, "op", "survived");
+        survived.id = 5;
+        let mut killed = mutation("src/b.rs", 2, "op", "killed");
+        killed.id = 6;
+        let report = report_with(vec![
+            (survived, MutationResult::Survived),
+            (killed, MutationResult::Killed),
+        ]);
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (5, crate::baseline::SurvivorBaselineStatus::Historic),
+                (6, crate::baseline::SurvivorBaselineStatus::New),
+            ]));
+
+        let inactive = annotations_with_baseline(&report, None);
+        assert!(!inactive[0].contains("baseline:"));
+        let active = annotations_with_baseline(&report, Some(&comparison));
+        assert_eq!(active.len(), 1);
+        assert!(active[0].ends_with("[baseline: historic]"));
+        assert!(!active[0].contains("baseline: new"));
     }
 
     #[test]
@@ -212,7 +256,7 @@ mod tests {
             .execution_provenance
             .insert(3, MutationExecution::IncrementalHistory);
 
-        let lines = annotations(&report);
+        let lines = annotations_with_baseline(&report, None);
 
         assert_eq!(lines.len(), 3);
         assert!(!lines[0].contains("reused"));
@@ -226,16 +270,20 @@ mod tests {
             mutation("src/dead.rs", 7, "op", "desc"),
             MutationResult::Uncovered,
         )]);
-        assert!(annotations(&report).is_empty());
+        assert!(annotations_with_baseline(&report, None).is_empty());
     }
 
     #[test]
     fn annotation_escapes_special_chars_in_path_and_message() {
         let m = mutation("src/odd,name:thing.rs", 10, "op", "msg with %, \r\n chars");
-        let line = format_annotation(&m, MutationExecution::Executed);
+        let line = format_annotation_with_baseline(
+            &m,
+            MutationExecution::Executed,
+            Some(crate::baseline::SurvivorBaselineStatus::Historic),
+        );
         assert_eq!(
             line,
-            "::warning file=src/odd%2Cname%3Athing.rs,line=10::Survived mutation: op (msg with %25, %0D%0A chars)"
+            "::warning file=src/odd%2Cname%3Athing.rs,line=10::Survived mutation: op (msg with %25, %0D%0A chars) [baseline: historic]"
         );
     }
 

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -36,9 +36,17 @@ struct MutationEntry {
     replacement: String,
     result: &'static str,
     execution: String,
+    baseline_status: Option<&'static str>,
 }
 
 pub fn generate_report(report: &MutationReport) -> Result<String> {
+    generate_report_with_baseline(report, None)
+}
+
+pub fn generate_report_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<String> {
     let mut files: BTreeMap<String, FileStats> = BTreeMap::new();
 
     for (mutation, result) in &report.results {
@@ -85,6 +93,10 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             replacement: mutation.replacement.clone(),
             result: result_str,
             execution: execution.to_string(),
+            baseline_status: (*result == MutationResult::Survived)
+                .then(|| comparison.and_then(|comparison| comparison.status_for(mutation.id)))
+                .flatten()
+                .map(|status| status.as_str()),
         });
     }
 
@@ -251,13 +263,23 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
             stats.score_pct()
         )?;
 
-        write!(
-            html,
-            "<table><thead><tr>\
-            <th>Line</th><th>Operator</th><th>Description</th>\
-            <th>Original</th><th>Replacement</th><th>Result</th><th>Execution</th>\
-            </tr></thead><tbody>"
-        )?;
+        if comparison.is_some() {
+            write!(
+                html,
+                "<table><thead><tr>\
+                <th>Line</th><th>Operator</th><th>Description</th>\
+                <th>Original</th><th>Replacement</th><th>Result</th><th>Baseline</th><th>Execution</th>\
+                </tr></thead><tbody>"
+            )?;
+        } else {
+            write!(
+                html,
+                "<table><thead><tr>\
+                <th>Line</th><th>Operator</th><th>Description</th>\
+                <th>Original</th><th>Replacement</th><th>Result</th><th>Execution</th>\
+                </tr></thead><tbody>"
+            )?;
+        }
 
         for m in &stats.mutations {
             let result_class = match m.result {
@@ -268,21 +290,41 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
                 "subsumed" => "result-subsumed",
                 _ => "result-build-error",
             };
-            write!(
-                html,
-                "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
-                 <td><code class=\"orig\">{}</code></td>\
-                 <td><code class=\"repl\">{}</code></td>\
-                 <td>{}</td><td>{}</td></tr>",
-                result_class,
-                m.line,
-                html_escape(&m.operator),
-                html_escape(&m.description),
-                html_escape(&m.original),
-                html_escape(&m.replacement),
-                m.result,
-                html_escape(&m.execution)
-            )?;
+            if comparison.is_some() {
+                let baseline_status = m.baseline_status.map(html_escape).unwrap_or_default();
+                write!(
+                    html,
+                    "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
+                     <td><code class=\"orig\">{}</code></td>\
+                     <td><code class=\"repl\">{}</code></td>\
+                     <td>{}</td><td>{}</td><td>{}</td></tr>",
+                    result_class,
+                    m.line,
+                    html_escape(&m.operator),
+                    html_escape(&m.description),
+                    html_escape(&m.original),
+                    html_escape(&m.replacement),
+                    m.result,
+                    baseline_status,
+                    html_escape(&m.execution)
+                )?;
+            } else {
+                write!(
+                    html,
+                    "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
+                     <td><code class=\"orig\">{}</code></td>\
+                     <td><code class=\"repl\">{}</code></td>\
+                     <td>{}</td><td>{}</td></tr>",
+                    result_class,
+                    m.line,
+                    html_escape(&m.operator),
+                    html_escape(&m.description),
+                    html_escape(&m.original),
+                    html_escape(&m.replacement),
+                    m.result,
+                    html_escape(&m.execution)
+                )?;
+            }
         }
 
         write!(html, "</tbody></table></section>")?;
@@ -293,7 +335,15 @@ pub fn generate_report(report: &MutationReport) -> Result<String> {
 }
 
 pub fn write_report(report: &MutationReport, path: &std::path::Path) -> Result<()> {
-    let html = generate_report(report)?;
+    write_report_with_baseline(report, path, None)
+}
+
+pub fn write_report_with_baseline(
+    report: &MutationReport,
+    path: &std::path::Path,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<()> {
+    let html = generate_report_with_baseline(report, comparison)?;
     std::fs::write(path, html)?;
     Ok(())
 }
@@ -369,6 +419,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::sample_report;
     use crate::{BuildErrorDiagnostic, Mutation};
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -392,6 +443,28 @@ mod tests {
         assert!(html.contains("changed &lt; to &lt;="));
         assert!(html.contains("killed"));
         assert!(html.contains("survived"));
+    }
+
+    #[test]
+    fn html_adds_baseline_column_for_active_survivor_comparison_only() {
+        let report = sample_report();
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (0, crate::baseline::SurvivorBaselineStatus::New),
+                (1, crate::baseline::SurvivorBaselineStatus::Historic),
+            ]));
+
+        let inactive = generate_report(&report).unwrap();
+        assert_eq!(
+            inactive,
+            generate_report_with_baseline(&report, None).unwrap()
+        );
+        assert!(!inactive.contains("<th>Baseline</th>"));
+
+        let active = generate_report_with_baseline(&report, Some(&comparison)).unwrap();
+        assert!(active.contains("<th>Baseline</th>"));
+        assert!(active.contains("<td>historic</td>"));
+        assert!(!active.contains("<td>new</td>"));
     }
 
     #[test]

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -108,6 +108,8 @@ struct JsonMutation {
     diff: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     build_error_fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_status: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -152,8 +154,14 @@ struct JsonDryRunMutation {
 }
 
 pub fn print_report(report: &MutationReport) -> Result<()> {
-    let json = to_json_string(report)?;
-    println!("{}", json);
+    print_report_with_baseline(report, None)
+}
+
+pub fn print_report_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<()> {
+    println!("{}", to_json_string_with_baseline(report, comparison)?);
     Ok(())
 }
 
@@ -222,6 +230,14 @@ pub fn to_run_suite_failure_json(failure: &RunSuiteFailure) -> Result<String> {
 
 /// Serialize report to a JSON string (for testing and programmatic use).
 pub fn to_json_string(report: &MutationReport) -> Result<String> {
+    to_json_string_with_baseline(report, None)
+}
+
+/// Serialize report with optional per-survivor baseline comparison data.
+pub fn to_json_string_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<String> {
     let diagnostic_by_id: BTreeMap<_, _> = report
         .build_error_diagnostics
         .iter()
@@ -261,6 +277,10 @@ pub fn to_json_string(report: &MutationReport) -> Result<String> {
                 } else {
                     None
                 },
+                baseline_status: (*r == MutationResult::Survived)
+                    .then(|| comparison.and_then(|comparison| comparison.status_for(m.id)))
+                    .flatten()
+                    .map(|status| status.as_str()),
             }
         })
         .collect();
@@ -365,6 +385,26 @@ mod tests {
         actual.sort_unstable();
         expected.sort_unstable();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn json_output_annotates_only_survivors_when_comparison_is_active() {
+        let report = sample_report();
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (0, crate::baseline::SurvivorBaselineStatus::New),
+                (1, crate::baseline::SurvivorBaselineStatus::Historic),
+            ]));
+
+        let annotated: Value = serde_json::from_str(
+            &to_json_string_with_baseline(&report, Some(&comparison)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(annotated["mutations"][1]["baseline_status"], "historic");
+        assert!(annotated["mutations"][0].get("baseline_status").is_none());
+
+        let unannotated: Value = serde_json::from_str(&to_json_string(&report).unwrap()).unwrap();
+        assert!(unannotated["mutations"][1].get("baseline_status").is_none());
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -183,17 +183,26 @@ pub fn print_report(
     report: &crate::MutationReport,
     format: crate::cli::OutputFormat,
 ) -> anyhow::Result<()> {
+    print_report_with_baseline(report, format, None)
+}
+
+/// Render a report with optional per-survivor baseline comparison data.
+pub fn print_report_with_baseline(
+    report: &crate::MutationReport,
+    format: crate::cli::OutputFormat,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> anyhow::Result<()> {
     use crate::cli::OutputFormat;
     match format {
-        OutputFormat::Json => json::print_report(report)?,
-        OutputFormat::Github => github::print_report(report),
+        OutputFormat::Json => json::print_report_with_baseline(report, comparison)?,
+        OutputFormat::Github => github::print_report_with_baseline(report, comparison),
         OutputFormat::Html => {
             let path = std::path::Path::new("togi-report.html");
-            html::write_report(report, path)?;
+            html::write_report_with_baseline(report, path, comparison)?;
             eprintln!("HTML report written to {}", path.display());
         }
-        OutputFormat::Sarif => sarif::print_report(report)?,
-        OutputFormat::Terminal => terminal::print_report(report),
+        OutputFormat::Sarif => sarif::print_report_with_baseline(report, comparison)?,
+        OutputFormat::Terminal => terminal::print_report_with_baseline(report, comparison),
     }
     Ok(())
 }
@@ -235,6 +244,15 @@ pub fn print_coverage_gate_report(
 /// Includes a hidden marker comment so CI pipelines can find/replace
 /// existing togi comments on subsequent runs.
 pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -> String {
+    format_pr_comment_with_baseline(report, baseline_score, None)
+}
+
+/// Generate a markdown PR comment with optional survivor baseline annotations.
+pub fn format_pr_comment_with_baseline(
+    report: &MutationReport,
+    baseline_score: Option<f64>,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> String {
     use crate::{MutationExecution, MutationResult};
     use std::fmt::Write;
 
@@ -320,8 +338,13 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
         )
         .unwrap();
         writeln!(md).unwrap();
-        writeln!(md, "| File | Line | Operator | Description |").unwrap();
-        writeln!(md, "|------|------|----------|-------------|").unwrap();
+        if comparison.is_some() {
+            let _ = writeln!(md, "| File | Line | Operator | Description | Baseline |");
+            let _ = writeln!(md, "|------|------|----------|-------------|----------|");
+        } else {
+            let _ = writeln!(md, "| File | Line | Operator | Description |");
+            let _ = writeln!(md, "|------|------|----------|-------------|");
+        }
         for (mutation, result) in survived {
             let provenance = match report.execution_for(mutation.id, *result) {
                 MutationExecution::Executed => String::new(),
@@ -331,16 +354,32 @@ pub fn format_pr_comment(report: &MutationReport, baseline_score: Option<f64>) -
                 }
                 MutationExecution::NotExecuted(reason) => format!(" (not executed: {reason})"),
             };
-            writeln!(
-                md,
-                "| `{}` | {} | `{}` | {}{} |",
-                escape_md_cell(&mutation.file.display().to_string()),
-                mutation.line,
-                escape_md_cell(&mutation.operator),
-                escape_md_cell(&mutation.description),
-                provenance,
-            )
-            .unwrap();
+            if let Some(comparison) = comparison {
+                let baseline_status = comparison
+                    .status_for(mutation.id)
+                    .map(|status| escape_md_cell(status.as_str()))
+                    .unwrap_or_default();
+                let _ = writeln!(
+                    md,
+                    "| `{}` | {} | `{}` | {}{} | {} |",
+                    escape_md_cell(&mutation.file.display().to_string()),
+                    mutation.line,
+                    escape_md_cell(&mutation.operator),
+                    escape_md_cell(&mutation.description),
+                    provenance,
+                    baseline_status,
+                );
+            } else {
+                let _ = writeln!(
+                    md,
+                    "| `{}` | {} | `{}` | {}{} |",
+                    escape_md_cell(&mutation.file.display().to_string()),
+                    mutation.line,
+                    escape_md_cell(&mutation.operator),
+                    escape_md_cell(&mutation.description),
+                    provenance,
+                );
+            }
         }
         writeln!(md).unwrap();
         writeln!(md, "</details>").unwrap();
@@ -360,10 +399,20 @@ pub fn write_pr_comment(
     path: &std::path::Path,
     baseline_score: Option<f64>,
 ) -> anyhow::Result<()> {
+    write_pr_comment_with_baseline(report, path, baseline_score, None)
+}
+
+/// Write a PR comment with optional survivor baseline annotations.
+pub fn write_pr_comment_with_baseline(
+    report: &MutationReport,
+    path: &std::path::Path,
+    baseline_score: Option<f64>,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let md = format_pr_comment(report, baseline_score);
+    let md = format_pr_comment_with_baseline(report, baseline_score, comparison);
     fs::write(path, md)?;
     Ok(())
 }
@@ -648,6 +697,28 @@ mod tests {
         let md = format_pr_comment(&report, None);
         assert!(md.contains("survived mutation"));
         assert!(md.contains("src/handler.rs"));
+    }
+
+    #[test]
+    fn pr_comment_adds_baseline_column_for_active_survivor_comparison_only() {
+        let report = crate::test_helpers::sample_report();
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (0, crate::baseline::SurvivorBaselineStatus::New),
+                (1, crate::baseline::SurvivorBaselineStatus::Historic),
+            ]));
+
+        let inactive = format_pr_comment(&report, None);
+        assert_eq!(
+            inactive,
+            format_pr_comment_with_baseline(&report, None, None)
+        );
+        assert!(!inactive.contains("| Baseline |"));
+
+        let active = format_pr_comment_with_baseline(&report, None, Some(&comparison));
+        assert!(active.contains("| File | Line | Operator | Description | Baseline |"));
+        assert!(active.contains(" | historic |"));
+        assert!(!active.contains(" | new |"));
     }
 
     #[test]

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -90,6 +90,8 @@ struct SarifResultProperties {
     execution: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     nonexecution_reason: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_status: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -127,7 +129,11 @@ fn artifact_uri(mutation: &Mutation) -> String {
     mutation.file.display().to_string().replace('\\', "/")
 }
 
-fn result_for(mutation: &Mutation, execution: MutationExecution) -> SarifResult {
+fn result_for_with_baseline(
+    mutation: &Mutation,
+    execution: MutationExecution,
+    status: Option<crate::baseline::SurvivorBaselineStatus>,
+) -> SarifResult {
     SarifResult {
         rule_id: mutation.operator.clone(),
         level: "warning",
@@ -150,9 +156,10 @@ fn result_for(mutation: &Mutation, execution: MutationExecution) -> SarifResult 
                 },
             },
         }],
-        properties: (!execution.is_tested()).then(|| SarifResultProperties {
+        properties: (!execution.is_tested() || status.is_some()).then(|| SarifResultProperties {
             execution: execution.state_name(),
             nonexecution_reason: execution.reason().map(|reason| reason.name()),
+            baseline_status: status.map(|status| status.as_str()),
         }),
     }
 }
@@ -166,8 +173,14 @@ fn registry_descriptions() -> BTreeMap<String, String> {
 }
 
 pub fn print_report(report: &MutationReport) -> Result<()> {
-    let sarif = to_sarif_string(report)?;
-    println!("{}", sarif);
+    print_report_with_baseline(report, None)
+}
+
+pub fn print_report_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<()> {
+    println!("{}", to_sarif_string_with_baseline(report, comparison)?);
     Ok(())
 }
 
@@ -180,6 +193,14 @@ pub fn print_report(report: &MutationReport) -> Result<()> {
 /// (their cluster canonical carries the signal); both only appear in the
 /// invocation totals.
 pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
+    to_sarif_string_with_baseline(report, None)
+}
+
+/// Serialize report with optional per-survivor baseline comparison data.
+pub fn to_sarif_string_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> Result<String> {
     let registry = registry_descriptions();
     let surviving: Vec<(&Mutation, MutationExecution)> = report
         .results
@@ -234,7 +255,13 @@ pub fn to_sarif_string(report: &MutationReport) -> Result<String> {
             }],
             results: surviving
                 .iter()
-                .map(|(mutation, execution)| result_for(mutation, *execution))
+                .map(|(mutation, execution)| {
+                    result_for_with_baseline(
+                        mutation,
+                        *execution,
+                        comparison.and_then(|comparison| comparison.status_for(mutation.id)),
+                    )
+                })
                 .collect(),
         }],
     };
@@ -361,6 +388,60 @@ mod tests {
         let results = value["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0]["ruleId"], "op_b");
+    }
+
+    #[test]
+    fn sarif_adds_active_baseline_statuses_only_to_survivor_results() {
+        let mut report = report_with(vec![
+            (
+                mutation(0, "src/killed.rs", 1, "op", "killed"),
+                MutationResult::Killed,
+            ),
+            (
+                mutation(1, "src/fresh.rs", 2, "op", "fresh"),
+                MutationResult::Survived,
+            ),
+            (
+                mutation(2, "src/exact.rs", 3, "op", "exact"),
+                MutationResult::Survived,
+            ),
+        ]);
+        report
+            .execution_provenance
+            .insert(2, MutationExecution::ExactCache);
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (0, crate::baseline::SurvivorBaselineStatus::New),
+                (1, crate::baseline::SurvivorBaselineStatus::Historic),
+                (2, crate::baseline::SurvivorBaselineStatus::NonComparable),
+            ]));
+
+        let inactive = to_sarif_string(&report).unwrap();
+        assert_eq!(
+            inactive,
+            to_sarif_string_with_baseline(&report, None).unwrap()
+        );
+        let inactive: Value = serde_json::from_str(&inactive).unwrap();
+        assert!(
+            inactive["runs"][0]["results"][0]
+                .get("properties")
+                .is_none()
+        );
+
+        let active: Value = serde_json::from_str(
+            &to_sarif_string_with_baseline(&report, Some(&comparison)).unwrap(),
+        )
+        .unwrap();
+        let results = active["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["properties"]["baseline_status"], "historic");
+        assert_eq!(
+            results[1]["properties"],
+            serde_json::json!({
+                "execution": "exact_cache",
+                "baseline_status": "non_comparable"
+            })
+        );
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -4,11 +4,25 @@ use std::fmt::Write;
 use std::io::IsTerminal;
 
 pub fn print_report(report: &MutationReport) {
-    print!("{}", format_report(report, should_colorize()));
+    print!("{}", format_report(report, should_colorize(), None));
+}
+
+pub fn print_report_with_baseline(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) {
+    print!("{}", format_report(report, should_colorize(), comparison));
 }
 
 pub fn format_report_plain(report: &MutationReport) -> String {
-    format_report(report, false)
+    format_report(report, false, None)
+}
+
+pub fn format_report_plain_with_baseline(
+    report: &MutationReport,
+    comparison: &crate::baseline::SurvivorBaselineComparison,
+) -> String {
+    format_report(report, false, Some(comparison))
 }
 
 /// Print a run-level suite failure instead of a mutation report.
@@ -48,7 +62,11 @@ pub fn format_run_suite_failure(failure: &RunSuiteFailure) -> String {
     out
 }
 
-fn format_report(report: &MutationReport, color: bool) -> String {
+fn format_report(
+    report: &MutationReport,
+    color: bool,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+) -> String {
     let mut out = String::new();
     writeln!(out).unwrap();
     let execution_counts = report.execution_counts();
@@ -75,6 +93,11 @@ fn format_report(report: &MutationReport, color: bool) -> String {
                     }
                 )
                 .unwrap();
+                if let Some(status) =
+                    comparison.and_then(|comparison| comparison.status_for(mutation.id))
+                {
+                    let _ = writeln!(detail, "              Baseline: {}", status.as_str());
+                }
                 if let Some(diff) = super::mutation_diff(mutation) {
                     for diff_line in diff.lines() {
                         if color {
@@ -423,6 +446,24 @@ mod tests {
             timeout,
             build_errors,
         }
+    }
+
+    #[test]
+    fn terminal_output_annotates_survivors_only_when_comparing_baselines() {
+        let report = report(vec![
+            (mutation(0, "src/killed.rs", 1), MutationResult::Killed),
+            (mutation(1, "src/survived.rs", 2), MutationResult::Survived),
+        ]);
+        let comparison =
+            crate::baseline::SurvivorBaselineComparison::from_statuses(BTreeMap::from([
+                (0, crate::baseline::SurvivorBaselineStatus::Historic),
+                (1, crate::baseline::SurvivorBaselineStatus::New),
+            ]));
+
+        let annotated = format_report_plain_with_baseline(&report, &comparison);
+        assert!(annotated.contains("Baseline: new"));
+        assert_eq!(annotated.matches("Baseline:").count(), 1);
+        assert!(!format_report_plain(&report).contains("Baseline:"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1907,6 +1907,300 @@ fn check_baseline_allows_existing_survivors() {
         )
     });
     assert!(value["survived"].as_u64().unwrap() > 0);
+    let survivors = value["mutations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|mutation| mutation["result"] == "survived")
+        .collect::<Vec<_>>();
+    assert!(!survivors.is_empty());
+    assert!(
+        survivors
+            .iter()
+            .all(|mutation| mutation["baseline_status"] == "non_comparable")
+    );
+}
+
+#[test]
+fn check_baseline_annotates_historic_survivors_in_a_single_json_document() {
+    let dir = setup_git_repo();
+    let common = [
+        "check",
+        "--base",
+        "HEAD",
+        "--format",
+        "json",
+        "--test-cmd",
+        "true",
+        "--no-schemata",
+        "--operators",
+        "gt_to_gte",
+        "--max-per-run",
+        "1",
+        "--jobs",
+        "1",
+        "--force-rerun",
+        "--no-incremental-history",
+        "--fail-under",
+        "0",
+    ];
+
+    let saved = togi()
+        .args(common)
+        .arg("--save-baseline")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        saved.status.success(),
+        "baseline save failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&saved.stdout),
+        String::from_utf8_lossy(&saved.stderr)
+    );
+    let baseline: serde_json::Value =
+        serde_json::from_slice(&fs::read(dir.path().join(".togi-baseline")).unwrap()).unwrap();
+    assert_eq!(baseline["mutant_snapshot"]["version"], 1);
+
+    let checked = togi()
+        .args(common)
+        .arg("--check-baseline")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        checked.status.success(),
+        "baseline check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&checked.stdout),
+        String::from_utf8_lossy(&checked.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap_or_else(|e| {
+        panic!(
+            "redirected check-baseline JSON was not one document: {e}\nstdout: {}",
+            String::from_utf8_lossy(&checked.stdout)
+        )
+    });
+    let survivors = report["mutations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|mutation| mutation["result"] == "survived")
+        .collect::<Vec<_>>();
+    assert_eq!(survivors.len(), 1);
+    assert_eq!(survivors[0]["baseline_status"], "historic");
+}
+
+#[test]
+fn check_baseline_annotates_historic_survivors_in_terminal() {
+    let dir = setup_git_repo();
+    let common = [
+        "check",
+        "--base",
+        "HEAD",
+        "--test-cmd",
+        "true",
+        "--no-schemata",
+        "--operators",
+        "gt_to_gte",
+        "--max-per-run",
+        "1",
+        "--jobs",
+        "1",
+        "--force-rerun",
+        "--no-incremental-history",
+        "--fail-under",
+        "0",
+    ];
+
+    let saved = togi()
+        .args(common)
+        .arg("--save-baseline")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        saved.status.success(),
+        "baseline save failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&saved.stdout),
+        String::from_utf8_lossy(&saved.stderr)
+    );
+
+    let checked = togi()
+        .args(common)
+        .arg("--check-baseline")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        checked.status.success(),
+        "baseline check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&checked.stdout),
+        String::from_utf8_lossy(&checked.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&checked.stdout)
+            .matches("Baseline: historic")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn check_baseline_annotations_reach_github_html_sarif_and_pr_comment() {
+    let dir = setup_git_repo();
+    let common = [
+        "check",
+        "--base",
+        "HEAD",
+        "--test-cmd",
+        "true",
+        "--no-schemata",
+        "--operators",
+        "gt_to_gte",
+        "--max-per-run",
+        "1",
+        "--jobs",
+        "1",
+        "--force-rerun",
+        "--no-incremental-history",
+        "--fail-under",
+        "0",
+    ];
+
+    let saved = togi()
+        .args(common)
+        .arg("--save-baseline")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        saved.status.success(),
+        "baseline save failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&saved.stdout),
+        String::from_utf8_lossy(&saved.stderr)
+    );
+
+    let github = togi()
+        .args(common)
+        .args(["--format", "github", "--check-baseline"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        github.status.success(),
+        "GitHub report failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&github.stdout),
+        String::from_utf8_lossy(&github.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&github.stdout)
+            .matches("[baseline: historic]")
+            .count(),
+        1
+    );
+
+    let sarif = togi()
+        .args(common)
+        .args(["--format", "sarif", "--check-baseline"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        sarif.status.success(),
+        "SARIF report failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&sarif.stdout),
+        String::from_utf8_lossy(&sarif.stderr)
+    );
+    let sarif: serde_json::Value = serde_json::from_slice(&sarif.stdout).unwrap();
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["properties"]["baseline_status"],
+        "historic"
+    );
+
+    let html = togi()
+        .args(common)
+        .args(["--format", "html", "--check-baseline"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        html.status.success(),
+        "HTML report failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&html.stdout),
+        String::from_utf8_lossy(&html.stderr)
+    );
+    let html = fs::read_to_string(dir.path().join("togi-report.html")).unwrap();
+    assert!(html.contains("<th>Baseline</th>"));
+    assert!(html.contains("<td>historic</td>"));
+
+    let pr_comment = dir.path().join("togi-pr-comment.md");
+    let pr_comment_run = togi()
+        .args(common)
+        .arg("--check-baseline")
+        .arg("--pr-comment")
+        .arg(&pr_comment)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        pr_comment_run.status.success(),
+        "PR comment report failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&pr_comment_run.stdout),
+        String::from_utf8_lossy(&pr_comment_run.stderr)
+    );
+    let pr_comment = fs::read_to_string(pr_comment).unwrap();
+    assert!(pr_comment.contains("| File | Line | Operator | Description | Baseline |"));
+    assert!(pr_comment.contains(" | historic |"));
+}
+
+#[test]
+fn check_baseline_keeps_json_report_when_baseline_is_invalid() {
+    let dir = setup_git_repo();
+    fs::write(dir.path().join(".togi-baseline"), "not json").unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--test-cmd",
+            "true",
+            "--no-schemata",
+            "--operators",
+            "gt_to_gte",
+            "--max-per-run",
+            "1",
+            "--jobs",
+            "1",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--check-baseline",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("invalid baseline"),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid baseline must still leave one report document on stdout: {e}\nstdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    let survivors = report["mutations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|mutation| mutation["result"] == "survived")
+        .collect::<Vec<_>>();
+    assert_eq!(survivors.len(), 1);
+    assert!(survivors[0].get("baseline_status").is_none());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #440

- Adds source-validated per-mutant survivor annotations (`historic`, `new`, and `non_comparable`) across reports.
- Preserves aggregate/per-file score gates and legacy baseline compatibility, including Windows-style file keys.
- Verified `cargo fmt --check`, `cargo test --locked` (688 passed), and release Clippy; ignored suite had 10 passing tests while the C# smoke test requires unavailable `dotnet`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Baseline checks now classify surviving mutations as historic, new, or non-comparable.
  * Reports and pull request comments display baseline status across terminal, JSON, HTML, GitHub, SARIF, and comment formats.
  * New baselines retain per-mutant evidence for more reliable comparisons.
* **Bug Fixes**
  * Improved handling of legacy baseline paths and invalid or incomplete comparison data.
  * Baseline loading errors are reported while still displaying available mutation results.
* **Documentation**
  * Updated baseline documentation to describe evidence storage, survivor classifications, and unchanged score gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->