### PR TITLE
feat: replay exact mutants from JSON reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -121,6 +127,68 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
+
+[[package]]
+name = "cap-tempfile"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f22d5c0b1147e8bd9105fa004450f673c139d7e632f7edc3980f94a51f20f3"
+dependencies = [
+ "cap-std",
+ "rand",
+ "rustix",
+ "rustix-linux-procfs",
+ "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -243,7 +311,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -318,6 +386,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,13 +432,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -409,6 +524,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +562,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -443,6 +597,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -505,6 +665,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,9 +739,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "regex"
@@ -607,8 +817,24 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -702,6 +928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,10 +974,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -760,6 +992,9 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "cap-fs-ext",
+ "cap-std",
+ "cap-tempfile",
  "clap",
  "ctrlc",
  "globset",
@@ -782,7 +1017,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -959,6 +1194,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1248,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,7 +1332,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1049,6 +1340,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1060,10 +1369,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1157,6 +1605,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ sha2 = "0.10"
 tempfile = "3"
 globset = "0.4"
 ignore = "0.4"
+cap-std = "4.0.2"
+cap-tempfile = "4.0.2"
+cap-fs-ext = "4.0.2"
 
 # Shell parsing
 shell-words = "1"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ togi check --format json
 togi check --format json > togi-report.json
 togi explain 1 --report togi-report.json
 
+# Force a fresh replay from a trusted versioned JSON report
+togi replay 1 --report togi-report.json
+
 # GitHub annotations or HTML report
 togi check --format github
 togi check --format html
@@ -542,6 +545,15 @@ test command genuinely needs ignored files copied into the mutation workspace.
 
 togi executes repository-defined build and test commands with the permissions of
 the current user or CI runner.
+
+`togi replay` intentionally executes the report's stored argv and Togi-owned
+environment overrides to reproduce its recorded command context. Replay only
+trusted reports: report commands are not sandboxed by togi. Its no-residue
+guarantee applies only to Togi-owned workspace, cache, history, and lock
+operations; report commands remain responsible for their own behavior.
+
+Replay is unavailable on Windows until its disposable-workspace setup can
+guarantee race-free directory removal.
 
 Workspace copies, timeouts, descendant-process cleanup, and the optional
 `[test] sandbox_command` wrapper improve correctness and reduce exposure, but

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,10 +1,13 @@
+use crate::source_identity::{
+    is_normalized_project_relative_path, normalized_project_relative_path, range_matches,
+    source_fingerprint,
+};
 use crate::{Mutation, MutationReport, MutationResult};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::ErrorKind;
-use std::path::{Component, Path};
+use std::path::Path;
 
 const BASELINE_FILE: &str = ".togi-baseline";
 const MUTANT_SNAPSHOT_VERSION: u32 = 1;
@@ -327,44 +330,6 @@ fn current_identity(mutation: &Mutation, source: &SourceIdentity) -> CurrentMuta
     }
 }
 
-fn normalized_project_relative_path(project_root: &Path, file: &Path) -> Option<String> {
-    let relative = if file.is_absolute() {
-        file.strip_prefix(project_root).ok()?
-    } else {
-        file
-    };
-    let mut parts = Vec::new();
-    for component in relative.components() {
-        match component {
-            Component::Normal(part) => {
-                let part = part.to_str()?;
-                if part.contains('\\') {
-                    return None;
-                }
-                parts.push(part);
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                parts.pop()?;
-            }
-            Component::RootDir | Component::Prefix(_) => return None,
-        }
-    }
-    (!parts.is_empty()).then(|| parts.join("/"))
-}
-
-fn range_matches(source: &[u8], start: usize, end: usize, original: &str) -> bool {
-    start <= end
-        && end <= source.len()
-        && source
-            .get(start..end)
-            .is_some_and(|bytes| bytes == original.as_bytes())
-}
-
-fn source_fingerprint(source: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(source))
-}
-
 /// Compare freshly executed current survivors with a loaded per-mutant baseline.
 ///
 /// Any missing, malformed, renamed, changed, incomplete, or ambiguous source
@@ -488,14 +453,6 @@ fn baseline_entry_is_valid(entry: &BaselineMutant, source: &SourceIdentity) -> b
             entry.byte_end,
             &entry.original,
         )
-}
-
-fn is_normalized_project_relative_path(path: &str) -> bool {
-    !path.is_empty()
-        && !path.contains('\\')
-        && path
-            .split('/')
-            .all(|part| !part.is_empty() && part != "." && part != "..")
 }
 
 fn has_duplicate_identity(entries: &[&BaselineMutant]) -> bool {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,6 +212,19 @@ pub enum Commands {
         #[arg(short, long, default_value = "togi-report.json")]
         report: PathBuf,
     },
+    /// Reapply a mutation from a trusted versioned JSON report; its stored argv/env are executed
+    Replay {
+        /// 1-based mutation id from `togi check --format json`
+        mutant_id: u32,
+
+        /// JSON report file produced by `togi check --format json`
+        #[arg(short, long, default_value = "togi-report.json")]
+        report: PathBuf,
+
+        /// Show captured test output from the fresh replay
+        #[arg(long)]
+        show_output: bool,
+    },
     /// List all available mutation operators
     ListOperators,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,11 @@ pub mod mapper;
 pub mod mutator;
 pub mod operators;
 pub mod parser;
+pub mod replay;
 pub mod report;
 pub mod runner;
 pub mod schemata;
+pub mod source_identity;
 
 #[cfg(test)]
 pub mod test_helpers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,18 @@ fn main() {
                 process::exit(2);
             }
         }
+        togi::cli::Commands::Replay {
+            mutant_id,
+            report,
+            show_output,
+        } => {
+            if let Err(e) =
+                togi::replay::replay_mutation(mutant_id, &report, show_output, cancelled.as_ref())
+            {
+                eprintln!("Error: {e:#}");
+                process::exit(2);
+            }
+        }
         togi::cli::Commands::ListOperators => {
             print_operators();
         }
@@ -346,7 +358,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     )?;
     if changed_files.is_empty() {
         if output_format == togi::cli::OutputFormat::Json {
-            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run)?;
+            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run, &project_root)?;
         }
         return Ok(());
     }
@@ -420,7 +432,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
             eprintln!("  - Changed files are in an unsupported language");
             eprintln!("  - All mutable nodes were filtered out (test files, noisy patterns)");
             eprintln!("  - max_per_run or max_per_file is set to 0 in togi.toml");
-            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run)?;
+            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run, &project_root)?;
         } else {
             println!("No mutations generated. Possible causes:");
             println!("  - Changed files are in an unsupported language");
@@ -445,6 +457,10 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         .chain(&classified.uncovered)
         .cloned()
         .collect::<Vec<_>>();
+    // Snapshot exact source evidence before baseline or mutation commands can
+    // run; JSON serialization revalidates it after the run.
+    let mut replay_capture =
+        togi::replay::ReplayReportCapture::capture(&project_root, &baseline_mutations);
     let (baseline_timing, commands) = if baseline_mutations.is_empty() {
         (None, None)
     } else {
@@ -522,9 +538,13 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     }
 
     let project_root_ref = project_root.clone();
-    let (mut report, run_cancelled) = if classified.to_run.is_empty() {
+    let (mut report, run_cancelled, direct_recipes) = if classified.to_run.is_empty() {
         // Every generated mutant sits on a zero-coverage line: nothing to run.
-        (coverage_only_report(&config, has_explicit_build_cmd), false)
+        (
+            coverage_only_report(&config, has_explicit_build_cmd),
+            false,
+            BTreeMap::new(),
+        )
     } else {
         eprintln!("Running {} mutations...", classified.to_run.len());
         let outcome = execute(
@@ -542,7 +562,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
                 cancelled: cancelled.clone(),
             },
         );
-        (outcome.report, outcome.cancelled)
+        (outcome.report, outcome.cancelled, outcome.replay_recipes)
     };
     if run_cancelled || cancelled.load(Ordering::Acquire) {
         eprintln!("Interrupted; skipping mutation report and side effects.");
@@ -585,7 +605,21 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         }
     }
 
-    togi::report::print_report_with_baseline(&report, output_format, survivor_comparison.as_ref())?;
+    if output_format == togi::cli::OutputFormat::Json {
+        replay_capture.revalidate(&project_root_ref);
+        togi::report::print_report_with_baseline_and_replay(
+            &report,
+            output_format,
+            survivor_comparison.as_ref(),
+            Some((&replay_capture, &direct_recipes)),
+        )?;
+    } else {
+        togi::report::print_report_with_baseline(
+            &report,
+            output_format,
+            survivor_comparison.as_ref(),
+        )?;
+    }
 
     if let Some(error) = baseline_load_error {
         return Err(error);
@@ -1393,12 +1427,20 @@ fn print_empty_json_check_output(
     config: &togi::config::Config,
     build_command_explicit: bool,
     dry_run: bool,
+    project_root: &Path,
 ) -> anyhow::Result<()> {
     if dry_run {
         togi::report::json::print_dry_run(&[])?;
     } else {
         let report = coverage_only_report(config, build_command_explicit);
-        togi::report::json::print_report(&report)?;
+        let mut capture = togi::replay::ReplayReportCapture::capture(project_root, &[]);
+        capture.revalidate(project_root);
+        togi::report::json::print_report_with_baseline_and_replay(
+            &report,
+            None,
+            &capture,
+            &BTreeMap::new(),
+        )?;
     }
     Ok(())
 }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,0 +1,838 @@
+use crate::source_identity::{
+    is_normalized_project_relative_path, normalized_project_relative_path, range_matches,
+    resolve_normalized_project_relative_path, source_fingerprint,
+};
+use crate::{Mutation, MutationExecution, MutationResult};
+use anyhow::Context;
+#[cfg(not(windows))]
+use cap_fs_ext::MetadataExt as CapMetadataExt;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+pub const REPORT_KIND: &str = "mutation_report";
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectRecipeOrigin {
+    Executed,
+    ExactCache,
+    IncrementalHistory,
+}
+
+impl DirectRecipeOrigin {
+    pub(crate) fn from_execution(execution: MutationExecution) -> Option<Self> {
+        match execution {
+            MutationExecution::Executed => Some(Self::Executed),
+            MutationExecution::ExactCache => Some(Self::ExactCache),
+            MutationExecution::IncrementalHistory => Some(Self::IncrementalHistory),
+            MutationExecution::NotExecuted(_) => None,
+        }
+    }
+
+    fn matches_execution(&self, execution: MutationExecution) -> bool {
+        matches!(
+            (self, execution),
+            (Self::Executed, MutationExecution::Executed)
+                | (Self::ExactCache, MutationExecution::ExactCache)
+                | (
+                    Self::IncrementalHistory,
+                    MutationExecution::IncrementalHistory
+                )
+        )
+    }
+}
+
+/// The final, direct one-mutation invocation captured before cache/history
+/// lookup. Commands are already sandbox-prefixed and must be run as-is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegularDirectRecipe {
+    pub test_command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_command: Option<Vec<String>>,
+    pub timeout_ms: u64,
+    pub env: BTreeMap<String, String>,
+    pub respect_workspace_ignores: bool,
+    pub origin: DirectRecipeOrigin,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapturedMutationSource {
+    pub path: String,
+    pub source_fingerprint: String,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub language: String,
+    pub original: String,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReplayReportCapture {
+    source_revision: Option<String>,
+    sources: BTreeMap<u32, CapturedMutationSource>,
+    capture_failed: BTreeSet<u32>,
+}
+
+impl ReplayReportCapture {
+    /// Capture all replay source evidence before any baseline or mutation
+    /// command can execute.
+    pub fn capture(project_root: &Path, mutations: &[Mutation]) -> Self {
+        let source_revision = git_head(project_root).ok();
+        let mut sources = BTreeMap::new();
+        let mut capture_failed = BTreeSet::new();
+        for mutation in mutations {
+            let Some(path) = normalized_project_relative_path(project_root, &mutation.file) else {
+                capture_failed.insert(mutation.id);
+                continue;
+            };
+            let Some(resolved) = resolve_normalized_project_relative_path(project_root, &path)
+            else {
+                capture_failed.insert(mutation.id);
+                continue;
+            };
+            let Ok(source) = std::fs::read(resolved) else {
+                capture_failed.insert(mutation.id);
+                continue;
+            };
+            if !range_matches(
+                &source,
+                mutation.byte_range.start,
+                mutation.byte_range.end,
+                &mutation.original,
+            ) {
+                capture_failed.insert(mutation.id);
+                continue;
+            }
+            sources.insert(
+                mutation.id,
+                CapturedMutationSource {
+                    path,
+                    source_fingerprint: source_fingerprint(&source),
+                    byte_start: mutation.byte_range.start,
+                    byte_end: mutation.byte_range.end,
+                    language: mutation.language.clone(),
+                    original: mutation.original.clone(),
+                    replacement: mutation.replacement.clone(),
+                },
+            );
+        }
+        Self {
+            source_revision,
+            sources,
+            capture_failed,
+        }
+    }
+
+    /// Revalidate initial evidence immediately before JSON serialization. A
+    /// changed revision or target file makes the captured direct invocation
+    /// unavailable instead of publishing a misleading replay recipe.
+    pub fn revalidate(&mut self, project_root: &Path) {
+        let revision_matches = self
+            .source_revision
+            .as_deref()
+            .zip(git_head(project_root).ok().as_deref())
+            .is_some_and(|(expected, current)| expected == current);
+        if !revision_matches {
+            self.capture_failed.extend(self.sources.keys().copied());
+            return;
+        }
+        for (id, source) in &self.sources {
+            let valid = resolve_normalized_project_relative_path(project_root, &source.path)
+                .and_then(|path| std::fs::read(path).ok())
+                .is_some_and(|bytes| {
+                    source_fingerprint(&bytes) == source.source_fingerprint
+                        && range_matches(
+                            &bytes,
+                            source.byte_start,
+                            source.byte_end,
+                            &source.original,
+                        )
+                });
+            if !valid {
+                self.capture_failed.insert(*id);
+            }
+        }
+    }
+
+    pub fn source_revision(&self) -> Option<&str> {
+        self.source_revision.as_deref()
+    }
+
+    pub fn source_for(&self, mutation_id: u32) -> Option<&CapturedMutationSource> {
+        self.sources.get(&mutation_id)
+    }
+
+    pub fn capture_failed(&self, mutation_id: u32) -> bool {
+        self.capture_failed.contains(&mutation_id)
+            || self.source_revision.is_none()
+            || !self.sources.contains_key(&mutation_id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayUnavailableReason {
+    CaptureFailed,
+    Schemata,
+    NotExecuted,
+    MissingDirectRecipe,
+}
+
+impl ReplayUnavailableReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CaptureFailed => "capture_failed",
+            Self::Schemata => "schemata",
+            Self::NotExecuted => "not_executed",
+            Self::MissingDirectRecipe => "missing_direct_recipe",
+        }
+    }
+}
+
+pub fn replay_unavailable_reason(
+    capture: &ReplayReportCapture,
+    mutation_id: u32,
+    result: MutationResult,
+    direct_recipe: Option<&RegularDirectRecipe>,
+    execution: MutationExecution,
+    schemata_enabled: bool,
+) -> Option<ReplayUnavailableReason> {
+    if capture.capture_failed(mutation_id) {
+        return Some(ReplayUnavailableReason::CaptureFailed);
+    }
+    if !matches!(
+        result,
+        MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
+    ) {
+        return Some(ReplayUnavailableReason::NotExecuted);
+    }
+    let Some(recipe) = direct_recipe else {
+        return Some(if schemata_enabled {
+            ReplayUnavailableReason::Schemata
+        } else {
+            ReplayUnavailableReason::MissingDirectRecipe
+        });
+    };
+    if !recipe.origin.matches_execution(execution) {
+        return Some(ReplayUnavailableReason::CaptureFailed);
+    }
+    None
+}
+
+pub fn git_head(project_root: &Path) -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "HEAD"])
+        .current_dir(project_root)
+        .output()
+        .context("could not read Git HEAD")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "could not read Git HEAD: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let revision = String::from_utf8(output.stdout)
+        .context("Git HEAD was not UTF-8")?
+        .trim()
+        .to_owned();
+    if !is_valid_git_revision(&revision) {
+        anyhow::bail!("Git returned an invalid HEAD revision");
+    }
+    Ok(revision)
+}
+
+fn is_valid_git_revision(revision: &str) -> bool {
+    matches!(revision.len(), 40 | 64)
+        && revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayReportV1 {
+    kind: String,
+    schema_version: u32,
+    generator: String,
+    source_revision: String,
+    mutations: Vec<ReplayMutationV1>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReplayMutationV1 {
+    id: u32,
+    line: usize,
+    column: usize,
+    language: String,
+    operator: String,
+    description: String,
+    result: String,
+    source_path: String,
+    byte_start: usize,
+    byte_end: usize,
+    source_fingerprint: String,
+    original: String,
+    replacement: String,
+    replay: StoredReplayRecipe,
+    execution: StoredMutationExecution,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredMutationExecution {
+    state: StoredExecutionState,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StoredExecutionState {
+    Executed,
+    ExactCache,
+    IncrementalHistory,
+    NotExecuted,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StoredReplayRecipe {
+    RegularDirect {
+        test_command: Vec<String>,
+        #[serde(default)]
+        build_command: Option<Vec<String>>,
+        timeout_ms: u64,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+        respect_workspace_ignores: bool,
+        origin: DirectRecipeOrigin,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+struct ValidatedReplay {
+    source_revision: String,
+    source_fingerprint: String,
+    expected: MutationResult,
+    mutation: Mutation,
+    recipe: RegularDirectRecipe,
+}
+
+/// Parse, validate, and force one fresh direct replay from the current Git
+/// project. The report is the complete command/config input; no TOML, cache,
+/// history, learned selection, or schemata configuration is consulted.
+pub fn replay_mutation(
+    mutant_id: u32,
+    report_path: &Path,
+    show_output: bool,
+    cancelled: &AtomicBool,
+) -> anyhow::Result<()> {
+    let validated = validate_report_mutation(read_v1_report(report_path)?, mutant_id)?;
+    let project_root = current_project_root()?;
+    validate_project_and_source(&project_root, &validated)?;
+
+    let fresh = crate::runner::run_replay_mutation(
+        &project_root,
+        &validated.mutation,
+        crate::runner::ReplayRunConfig {
+            test_command: validated.recipe.test_command.clone(),
+            build_command: validated.recipe.build_command.clone(),
+            timeout: Duration::from_millis(validated.recipe.timeout_ms),
+            env: validated
+                .recipe
+                .env
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+            respect_workspace_ignores: validated.recipe.respect_workspace_ignores,
+            source_revision: &validated.source_revision,
+            source_fingerprint: &validated.source_fingerprint,
+            show_output,
+            cancelled,
+        },
+    )?;
+    if fresh.cancelled {
+        anyhow::bail!("replay cancelled");
+    }
+
+    println!("Replay mutation #{mutant_id}");
+    println!(
+        "Expected historical result: {}",
+        result_name(validated.expected)
+    );
+    println!("Fresh result: {}", result_name(fresh.result));
+    println!(
+        "Execution: forced fresh direct execution; cache and history were not read or written."
+    );
+    println!(
+        "Effective command: {}",
+        serde_json::to_string(&validated.recipe.test_command)?
+    );
+    if let Some(build_command) = &validated.recipe.build_command {
+        println!(
+            "Effective build command: {}",
+            serde_json::to_string(build_command)?
+        );
+    }
+    if show_output {
+        if let Some(output) = fresh
+            .test_output
+            .as_deref()
+            .filter(|output| !output.is_empty())
+        {
+            println!("Output:\n{output}");
+        }
+    }
+
+    if fresh.result != validated.expected {
+        anyhow::bail!(
+            "replay divergence: report expected {}, fresh execution returned {}",
+            result_name(validated.expected),
+            result_name(fresh.result)
+        );
+    }
+    Ok(())
+}
+
+fn read_v1_report(report_path: &Path) -> anyhow::Result<ReplayReportV1> {
+    let content = std::fs::read_to_string(report_path)
+        .map_err(|error| anyhow::anyhow!("could not read {}: {error}", report_path.display()))?;
+    let report: ReplayReportV1 = serde_json::from_str(&content).map_err(|error| {
+        anyhow::anyhow!(
+            "could not parse {} as a replayable v1 JSON mutation report: {error}",
+            report_path.display()
+        )
+    })?;
+    if report.kind != REPORT_KIND {
+        anyhow::bail!(
+            "report kind {:?} is not a mutation report; regenerate a v1 JSON report",
+            report.kind
+        );
+    }
+    if report.schema_version != REPORT_SCHEMA_VERSION {
+        anyhow::bail!(
+            "report schema version {} is unsupported; regenerate a v1 JSON report",
+            report.schema_version
+        );
+    }
+    if report.generator.trim().is_empty() {
+        anyhow::bail!("report generator is empty; regenerate a v1 JSON report");
+    }
+    if !is_valid_git_revision(&report.source_revision) {
+        anyhow::bail!("report source revision is invalid; regenerate a v1 JSON report");
+    }
+    Ok(report)
+}
+
+fn validate_report_mutation(
+    report: ReplayReportV1,
+    mutant_id: u32,
+) -> anyhow::Result<ValidatedReplay> {
+    if mutant_id == 0 {
+        anyhow::bail!("mutation id must be a 1-based report-local id");
+    }
+    let source_revision = report.source_revision;
+    let mut matching = report
+        .mutations
+        .into_iter()
+        .filter(|mutation| mutation.id == mutant_id);
+    let mutation = matching
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("mutation id {mutant_id} not found in report"))?;
+    if matching.next().is_some() {
+        anyhow::bail!("report contains duplicate mutation id {mutant_id}");
+    }
+    let execution = mutation.execution;
+    if execution.state == StoredExecutionState::NotExecuted {
+        anyhow::bail!("mutation id {mutant_id} was not executed and is not replayable");
+    }
+    let recipe = match mutation.replay {
+        StoredReplayRecipe::RegularDirect {
+            test_command,
+            build_command,
+            timeout_ms,
+            env,
+            respect_workspace_ignores,
+            origin,
+        } => RegularDirectRecipe {
+            test_command,
+            build_command,
+            timeout_ms,
+            env,
+            respect_workspace_ignores,
+            origin,
+        },
+        StoredReplayRecipe::Unavailable { reason } => {
+            anyhow::bail!("mutation id {mutant_id} is not replayable: {reason}");
+        }
+    };
+    validate_execution_provenance(&execution, &recipe, mutant_id)?;
+    let expected = parse_replayable_result(&mutation.result)?;
+    let validated = ValidatedReplay {
+        source_revision,
+        source_fingerprint: mutation.source_fingerprint,
+        expected,
+        mutation: Mutation {
+            id: mutation.id - 1,
+            file: PathBuf::from(mutation.source_path),
+            language: mutation.language,
+            line: mutation.line,
+            column: mutation.column,
+            operator: mutation.operator,
+            description: mutation.description,
+            original: mutation.original,
+            replacement: mutation.replacement,
+            byte_range: mutation.byte_start..mutation.byte_end,
+        },
+        recipe,
+    };
+    validate_static_replay(&validated)?;
+    Ok(validated)
+}
+
+fn validate_execution_provenance(
+    execution: &StoredMutationExecution,
+    recipe: &RegularDirectRecipe,
+    mutant_id: u32,
+) -> anyhow::Result<()> {
+    if execution.reason.is_some() {
+        anyhow::bail!("mutation id {mutant_id} has an invalid execution provenance reason");
+    }
+    let matches_origin = matches!(
+        (execution.state, &recipe.origin),
+        (StoredExecutionState::Executed, DirectRecipeOrigin::Executed)
+            | (
+                StoredExecutionState::ExactCache,
+                DirectRecipeOrigin::ExactCache
+            )
+            | (
+                StoredExecutionState::IncrementalHistory,
+                DirectRecipeOrigin::IncrementalHistory
+            )
+    );
+    if !matches_origin {
+        anyhow::bail!(
+            "mutation id {mutant_id} execution provenance does not match replay recipe origin"
+        );
+    }
+    Ok(())
+}
+
+fn validate_static_replay(replay: &ValidatedReplay) -> anyhow::Result<()> {
+    validate_replay_source_path(&replay.mutation.file)?;
+    if !is_valid_source_fingerprint(&replay.source_fingerprint) {
+        anyhow::bail!("report source fingerprint is invalid");
+    }
+    if replay.mutation.byte_range.start > replay.mutation.byte_range.end {
+        anyhow::bail!("report mutation byte range is invalid");
+    }
+    validate_recipe(&replay.recipe)
+}
+
+fn validate_replay_source_path(path: &Path) -> anyhow::Result<()> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("report source path is not valid UTF-8"))?;
+    if !is_normalized_project_relative_path(path) {
+        anyhow::bail!("report source path is not a normalized safe project-relative path");
+    }
+    if path.split('/').any(is_replay_control_path_component) {
+        anyhow::bail!("report source path targets a Togi or Git control path");
+    }
+    Ok(())
+}
+
+fn is_replay_control_path_component(component: &str) -> bool {
+    let component = component.to_ascii_lowercase();
+    matches!(
+        component.as_str(),
+        ".git" | ".togi" | ".togi-cache" | ".togi.lock" | ".togi-baseline"
+    ) || component.starts_with(".togi-")
+}
+
+fn parse_replayable_result(result: &str) -> anyhow::Result<MutationResult> {
+    match result {
+        "killed" => Ok(MutationResult::Killed),
+        "survived" => Ok(MutationResult::Survived),
+        "timeout" => Ok(MutationResult::Timeout),
+        _ => anyhow::bail!("report contains a non-replayable historical result {result:?}"),
+    }
+}
+
+fn current_project_root() -> anyhow::Result<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("could not locate current Git project")?;
+    if !output.status.success() {
+        anyhow::bail!("not a git repository; run replay from the report's project root");
+    }
+    let path = String::from_utf8(output.stdout)
+        .context("Git project root was not UTF-8")?
+        .trim()
+        .to_owned();
+    PathBuf::from(path)
+        .canonicalize()
+        .context("could not canonicalize current Git project root")
+}
+
+fn validate_project_and_source(
+    project_root: &Path,
+    replay: &ValidatedReplay,
+) -> anyhow::Result<()> {
+    let current_revision = git_head(project_root)?;
+    if current_revision != replay.source_revision {
+        anyhow::bail!(
+            "report Git HEAD {} does not match current Git HEAD {}",
+            replay.source_revision,
+            current_revision
+        );
+    }
+    validate_replay_source_path(&replay.mutation.file)?;
+    let source_path = replay.mutation.file.to_string_lossy();
+    let resolved = resolve_normalized_project_relative_path(project_root, &source_path)
+        .ok_or_else(|| {
+            anyhow::anyhow!("could not safely resolve report source path {source_path:?}")
+        })?;
+    let canonical_root = project_root
+        .canonicalize()
+        .context("could not canonicalize current Git project root")?;
+    let resolved_relative = normalized_project_relative_path(&canonical_root, &resolved)
+        .ok_or_else(|| anyhow::anyhow!("could not normalize resolved replay source path"))?;
+    if resolved_relative
+        .split('/')
+        .any(is_replay_control_path_component)
+    {
+        anyhow::bail!("resolved replay source path targets a Togi or Git control path");
+    }
+    let metadata = std::fs::metadata(&resolved)
+        .with_context(|| format!("could not inspect replay source {}", resolved.display()))?;
+    if !metadata.is_file() {
+        anyhow::bail!("replay source {} is not a regular file", resolved.display());
+    }
+    #[cfg(not(windows))]
+    if CapMetadataExt::nlink(&metadata) > 1 {
+        // A safe lexical path can otherwise hard-link to Togi control state.
+        anyhow::bail!(
+            "replay source {} has multiple hard links and cannot be isolated safely",
+            resolved.display()
+        );
+    }
+    let source = read_replay_source(&resolved)
+        .with_context(|| format!("could not read replay source {}", resolved.display()))?;
+    if source_fingerprint(&source) != replay.source_fingerprint {
+        anyhow::bail!("report source fingerprint does not match current target source");
+    }
+    if !range_matches(
+        &source,
+        replay.mutation.byte_range.start,
+        replay.mutation.byte_range.end,
+        &replay.mutation.original,
+    ) {
+        anyhow::bail!("report mutation byte range and original bytes do not match target source");
+    }
+    Ok(())
+}
+
+fn read_replay_source(path: &Path) -> std::io::Result<Vec<u8>> {
+    #[cfg(test)]
+    REPLAY_SOURCE_READS.with(|reads| reads.set(reads.get() + 1));
+    std::fs::read(path)
+}
+
+#[cfg(test)]
+thread_local! {
+    static REPLAY_SOURCE_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn is_valid_source_fingerprint(fingerprint: &str) -> bool {
+    fingerprint.strip_prefix("sha256:").is_some_and(|hash| {
+        hash.len() == 64
+            && hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn validate_recipe(recipe: &RegularDirectRecipe) -> anyhow::Result<()> {
+    validate_command(&recipe.test_command, "test")?;
+    if let Some(build_command) = &recipe.build_command {
+        validate_command(build_command, "build")?;
+    }
+    if recipe.timeout_ms == 0 {
+        anyhow::bail!("report replay timeout must be greater than zero");
+    }
+    for (key, value) in &recipe.env {
+        if !is_valid_env_key(key) || value.contains('\0') {
+            anyhow::bail!("report replay environment override is invalid");
+        }
+    }
+    Ok(())
+}
+
+fn validate_command(command: &[String], label: &str) -> anyhow::Result<()> {
+    let Some(program) = command.first() else {
+        anyhow::bail!("report replay {label} command is empty");
+    };
+    if program.is_empty() || command.iter().any(|arg| arg.contains('\0')) {
+        anyhow::bail!("report replay {label} command is invalid");
+    }
+    Ok(())
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(ch) if ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn result_name(result: MutationResult) -> &'static str {
+    match result {
+        MutationResult::Killed => "killed",
+        MutationResult::Survived => "survived",
+        MutationResult::Timeout => "timeout",
+        MutationResult::BuildError => "build_error",
+        MutationResult::Uncovered => "uncovered",
+        MutationResult::Subsumed => "subsumed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn static_test_report(source_path: &str, test_command: Vec<String>) -> ReplayReportV1 {
+        ReplayReportV1 {
+            kind: REPORT_KIND.into(),
+            schema_version: REPORT_SCHEMA_VERSION,
+            generator: "togi/test".into(),
+            source_revision: "a".repeat(40),
+            mutations: vec![ReplayMutationV1 {
+                id: 1,
+                line: 1,
+                column: 1,
+                language: "rust".into(),
+                operator: "op".into(),
+                description: "d".into(),
+                result: "survived".into(),
+                source_path: source_path.into(),
+                byte_start: 0,
+                byte_end: 1,
+                source_fingerprint: format!("sha256:{}", "b".repeat(64)),
+                original: "x".into(),
+                replacement: "y".into(),
+                replay: StoredReplayRecipe::RegularDirect {
+                    test_command,
+                    build_command: None,
+                    timeout_ms: 1,
+                    env: BTreeMap::new(),
+                    respect_workspace_ignores: true,
+                    origin: DirectRecipeOrigin::Executed,
+                },
+                execution: StoredMutationExecution {
+                    state: StoredExecutionState::Executed,
+                    reason: None,
+                },
+            }],
+        }
+    }
+
+    fn replay_source_read_count() -> usize {
+        REPLAY_SOURCE_READS.with(|reads| reads.get())
+    }
+
+    fn reset_replay_source_read_count() {
+        REPLAY_SOURCE_READS.with(|reads| reads.set(0));
+    }
+
+    #[test]
+    fn static_rejections_do_not_reach_the_replay_source_reader() {
+        reset_replay_source_read_count();
+        assert!(
+            validate_report_mutation(static_test_report(".git/config", vec!["true".into()]), 1)
+                .is_err()
+        );
+        assert_eq!(replay_source_read_count(), 0);
+
+        reset_replay_source_read_count();
+        assert!(validate_report_mutation(static_test_report("src/lib.rs", vec![]), 1).is_err());
+        assert_eq!(replay_source_read_count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolved_control_aliases_are_rejected_before_reading_source() -> anyhow::Result<()> {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        let repo = tempfile::tempdir()?;
+        let root = repo.path();
+        for args in [
+            &["init"][..],
+            &["config", "user.email", "test@example.com"],
+            &["config", "user.name", "Togi Test"],
+        ] {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()?;
+            assert!(output.status.success());
+        }
+        std::fs::write(root.join("README"), b"fixture")?;
+        for args in [&["add", "."][..], &["commit", "-m", "initial"]] {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()?;
+            assert!(output.status.success());
+        }
+
+        let cached_source = root.join(".togi-cache/alias-target");
+        std::fs::create_dir_all(cached_source.parent().unwrap())?;
+        std::fs::write(&cached_source, b"x")?;
+        std::os::unix::fs::symlink(&cached_source, root.join("alias"))?;
+        let mut replay =
+            validate_report_mutation(static_test_report("alias", vec!["true".into()]), 1)?;
+        replay.source_revision = git_head(root)?;
+        replay.source_fingerprint = source_fingerprint(b"x");
+
+        reset_replay_source_read_count();
+        let error = validate_project_and_source(root, &replay).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("resolved replay source path targets a Togi or Git control path"),
+            "{error:#}"
+        );
+        assert_eq!(replay_source_read_count(), 0);
+        std::fs::remove_file(root.join("alias"))?;
+        std::fs::hard_link(&cached_source, root.join("alias"))?;
+        reset_replay_source_read_count();
+        let error = validate_project_and_source(root, &replay).unwrap_err();
+        assert!(
+            error.to_string().contains("multiple hard links"),
+            "{error:#}"
+        );
+        assert_eq!(replay_source_read_count(), 0);
+        Ok(())
+    }
+    #[test]
+    fn direct_recipe_origin_requires_matching_execution() {
+        assert!(DirectRecipeOrigin::Executed.matches_execution(MutationExecution::Executed));
+        assert!(!DirectRecipeOrigin::Executed.matches_execution(MutationExecution::ExactCache));
+    }
+
+    #[test]
+    fn command_validation_rejects_empty_commands() {
+        assert!(validate_command(&[], "test").is_err());
+        assert!(validate_command(&[String::new()], "test").is_err());
+    }
+}

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -1,3 +1,7 @@
+use crate::replay::{
+    REPORT_KIND, REPORT_SCHEMA_VERSION, RegularDirectRecipe, ReplayReportCapture,
+    replay_unavailable_reason,
+};
 use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
 use crate::{Mutation, MutationReport, MutationResult};
 use anyhow::Result;
@@ -6,6 +10,14 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize)]
 struct JsonReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_revision: Option<String>,
     total: usize,
     planned_total: usize,
     tested: usize,
@@ -110,6 +122,18 @@ struct JsonMutation {
     build_error_fingerprint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    byte_start: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    byte_end: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_fingerprint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replay: Option<JsonMutationReplay>,
 }
 
 #[derive(Serialize)]
@@ -117,6 +141,82 @@ struct JsonMutationExecution {
     state: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum JsonMutationReplay {
+    RegularDirect {
+        test_command: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        build_command: Option<Vec<String>>,
+        timeout_ms: u64,
+        env: BTreeMap<String, String>,
+        respect_workspace_ignores: bool,
+        origin: crate::replay::DirectRecipeOrigin,
+    },
+    Unavailable {
+        reason: &'static str,
+    },
+}
+
+struct JsonReplayMutationFields {
+    language: String,
+    source_path: String,
+    byte_start: usize,
+    byte_end: usize,
+    source_fingerprint: String,
+    replay: JsonMutationReplay,
+}
+
+fn json_replay_mutation_fields(
+    capture: &ReplayReportCapture,
+    direct_recipe: Option<&RegularDirectRecipe>,
+    mutation: &Mutation,
+    result: MutationResult,
+    execution: crate::MutationExecution,
+    schemata_enabled: bool,
+) -> JsonReplayMutationFields {
+    let source = capture.source_for(mutation.id);
+    let replay = match replay_unavailable_reason(
+        capture,
+        mutation.id,
+        result,
+        direct_recipe,
+        execution,
+        schemata_enabled,
+    ) {
+        Some(reason) => JsonMutationReplay::Unavailable {
+            reason: reason.as_str(),
+        },
+        None => {
+            let recipe = direct_recipe.expect("validated direct replay recipe must be present");
+            JsonMutationReplay::RegularDirect {
+                test_command: recipe.test_command.clone(),
+                build_command: recipe.build_command.clone(),
+                timeout_ms: recipe.timeout_ms,
+                env: recipe.env.clone(),
+                respect_workspace_ignores: recipe.respect_workspace_ignores,
+                origin: recipe.origin.clone(),
+            }
+        }
+    };
+    JsonReplayMutationFields {
+        language: source
+            .map(|source| source.language.clone())
+            .unwrap_or_else(|| mutation.language.clone()),
+        source_path: source.map(|source| source.path.clone()).unwrap_or_default(),
+        byte_start: source
+            .map(|source| source.byte_start)
+            .unwrap_or(mutation.byte_range.start),
+        byte_end: source
+            .map(|source| source.byte_end)
+            .unwrap_or(mutation.byte_range.end),
+        source_fingerprint: source
+            .map(|source| source.source_fingerprint.clone())
+            .unwrap_or_default(),
+        replay,
+    }
 }
 
 #[derive(Serialize)]
@@ -162,6 +262,22 @@ pub fn print_report_with_baseline(
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> Result<()> {
     println!("{}", to_json_string_with_baseline(report, comparison)?);
+    Ok(())
+}
+
+/// Print a versioned replay-aware mutation report. Only normal JSON reports
+/// receive this additive metadata; dry-run and suite-failure documents retain
+/// their distinct schemas.
+pub fn print_report_with_baseline_and_replay(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+    capture: &ReplayReportCapture,
+    direct_recipes: &BTreeMap<u32, RegularDirectRecipe>,
+) -> Result<()> {
+    println!(
+        "{}",
+        to_json_string_with_baseline_and_replay(report, comparison, capture, direct_recipes)?
+    );
     Ok(())
 }
 
@@ -238,6 +354,27 @@ pub fn to_json_string_with_baseline(
     report: &MutationReport,
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> Result<String> {
+    to_json_string_with_baseline_and_replay_optional(report, comparison, None)
+}
+/// Serialize a versioned replay-aware mutation report.
+pub fn to_json_string_with_baseline_and_replay(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+    capture: &ReplayReportCapture,
+    direct_recipes: &BTreeMap<u32, RegularDirectRecipe>,
+) -> Result<String> {
+    to_json_string_with_baseline_and_replay_optional(
+        report,
+        comparison,
+        Some((capture, direct_recipes)),
+    )
+}
+
+fn to_json_string_with_baseline_and_replay_optional(
+    report: &MutationReport,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+    replay_capture: Option<(&ReplayReportCapture, &BTreeMap<u32, RegularDirectRecipe>)>,
+) -> Result<String> {
     let diagnostic_by_id: BTreeMap<_, _> = report
         .build_error_diagnostics
         .iter()
@@ -248,6 +385,16 @@ pub fn to_json_string_with_baseline(
         .iter()
         .map(|(m, r)| {
             let execution = report.execution_for(m.id, *r);
+            let replay_fields = replay_capture.map(|(capture, recipes)| {
+                json_replay_mutation_fields(
+                    capture,
+                    recipes.get(&m.id),
+                    m,
+                    *r,
+                    execution,
+                    report.schemata.is_some(),
+                )
+            });
             JsonMutation {
                 id: m.id + 1,
                 file: m.file.display().to_string(),
@@ -281,6 +428,16 @@ pub fn to_json_string_with_baseline(
                     .then(|| comparison.and_then(|comparison| comparison.status_for(m.id)))
                     .flatten()
                     .map(|status| status.as_str()),
+                language: replay_fields.as_ref().map(|fields| fields.language.clone()),
+                source_path: replay_fields
+                    .as_ref()
+                    .map(|fields| fields.source_path.clone()),
+                byte_start: replay_fields.as_ref().map(|fields| fields.byte_start),
+                byte_end: replay_fields.as_ref().map(|fields| fields.byte_end),
+                source_fingerprint: replay_fields
+                    .as_ref()
+                    .map(|fields| fields.source_fingerprint.clone()),
+                replay: replay_fields.map(|fields| fields.replay),
             }
         })
         .collect();
@@ -316,7 +473,21 @@ pub fn to_json_string_with_baseline(
         .collect();
 
     let execution_counts = report.execution_counts();
+    let (kind, schema_version, generator, source_revision) = replay_capture
+        .map(|(capture, _)| {
+            (
+                Some(REPORT_KIND),
+                Some(REPORT_SCHEMA_VERSION),
+                Some(format!("togi/{}", env!("CARGO_PKG_VERSION"))),
+                capture.source_revision().map(str::to_owned),
+            )
+        })
+        .unwrap_or((None, None, None, None));
     let json_report = JsonReport {
+        kind,
+        schema_version,
+        generator,
+        source_revision,
         total: report.total,
         planned_total: report.planned_total,
         tested: execution_counts.executed,
@@ -371,11 +542,13 @@ mod tests {
     use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
     use crate::test_helpers::sample_report;
     use crate::{
-        BaselineTiming, BuildErrorDiagnostic, Mutation, SchemataFallbackReasonCount, SchemataReport,
+        BaselineTiming, BuildErrorDiagnostic, Mutation, MutationExecution,
+        SchemataFallbackReasonCount, SchemataReport,
     };
     use serde_json::Value;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+    use std::process::Command;
     use std::time::Duration;
 
     fn assert_object_keys(value: &Value, expected: &[&str]) {
@@ -844,6 +1017,157 @@ mod tests {
         assert_eq!(mutations[1]["replacement"], "!=");
         // diff is None because the test file doesn't exist on disk
         assert!(mutations[1]["diff"].is_null());
+    }
+
+    #[test]
+    fn replay_json_keeps_baseline_status_and_marks_unavailable_records() {
+        let project = tempfile::tempdir().unwrap();
+        let source_dir = project.path().join("src");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::write(source_dir.join("lib.rs"), "fn f() { a < b; }\n").unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Togi Test"],
+            vec!["add", "."],
+            vec!["commit", "-m", "initial"],
+        ] {
+            assert!(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(project.path())
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+        let mutation = Mutation {
+            id: 0,
+            file: PathBuf::from("src/lib.rs"),
+            language: "rust".into(),
+            line: 1,
+            column: 12,
+            operator: "lt_to_lte".into(),
+            description: "replace < with <=".into(),
+            original: "<".into(),
+            replacement: "<=".into(),
+            byte_range: 11..12,
+        };
+        let capture = ReplayReportCapture::capture(project.path(), std::slice::from_ref(&mutation));
+        let mut report = MutationReport {
+            results: vec![(mutation.clone(), MutationResult::Survived)],
+            execution_provenance: BTreeMap::from([(0, MutationExecution::Executed)]),
+            build_error_diagnostics: vec![],
+            schemata: Some(SchemataReport {
+                fast_path: 0,
+                fallback: 1,
+                fallback_reasons: vec![],
+            }),
+            baseline_timing: None,
+            duration: Duration::ZERO,
+            test_command: Some(vec!["cargo".into(), "test".into()]),
+            build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
+            total: 1,
+            killed: 0,
+            survived: 1,
+            timeout: 0,
+            build_errors: 0,
+        };
+        let recipe = RegularDirectRecipe {
+            test_command: vec!["cargo".into(), "test".into()],
+            build_command: None,
+            timeout_ms: 1_000,
+            env: BTreeMap::new(),
+            respect_workspace_ignores: true,
+            origin: crate::replay::DirectRecipeOrigin::Executed,
+        };
+        let comparison = crate::baseline::SurvivorBaselineComparison::from_statuses(
+            BTreeMap::from([(0, crate::baseline::SurvivorBaselineStatus::New)]),
+        );
+        let replayable: Value = serde_json::from_str(
+            &to_json_string_with_baseline_and_replay(
+                &report,
+                Some(&comparison),
+                &capture,
+                &BTreeMap::from([(0, recipe)]),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(replayable["kind"], REPORT_KIND);
+        assert_eq!(replayable["schema_version"], REPORT_SCHEMA_VERSION);
+        assert_eq!(replayable["mutations"][0]["baseline_status"], "new");
+        assert_eq!(replayable["mutations"][0]["source_path"], "src/lib.rs");
+        assert_eq!(
+            replayable["mutations"][0]["replay"]["kind"],
+            "regular_direct"
+        );
+
+        let schema: Value = serde_json::from_str(
+            &to_json_string_with_baseline_and_replay(&report, None, &capture, &BTreeMap::new())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(schema["mutations"][0]["replay"]["reason"], "schemata");
+
+        report.results[0].1 = MutationResult::BuildError;
+        report.execution_provenance.clear();
+        report.survived = 0;
+        report.build_errors = 1;
+        let not_executed: Value = serde_json::from_str(
+            &to_json_string_with_baseline_and_replay(&report, None, &capture, &BTreeMap::new())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            not_executed["mutations"][0]["replay"]["reason"],
+            "not_executed"
+        );
+
+        let mut missing = mutation;
+        missing.file = PathBuf::from("src/missing.rs");
+        let failed_capture =
+            ReplayReportCapture::capture(project.path(), std::slice::from_ref(&missing));
+        report.results[0].0 = missing;
+        let capture_failed: Value = serde_json::from_str(
+            &to_json_string_with_baseline_and_replay(
+                &report,
+                None,
+                &failed_capture,
+                &BTreeMap::new(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(capture_failed["mutations"][0]["file"], "src/missing.rs");
+        assert_eq!(
+            capture_failed["mutations"][0]["replay"]["reason"],
+            "capture_failed"
+        );
+    }
+
+    #[test]
+    fn replay_json_omits_source_revision_without_git_head() {
+        let project = tempfile::tempdir().unwrap();
+        let capture = ReplayReportCapture::capture(project.path(), &[]);
+        assert!(capture.source_revision().is_none());
+
+        let value: Value = serde_json::from_str(
+            &to_json_string_with_baseline_and_replay(
+                &sample_report(),
+                None,
+                &capture,
+                &BTreeMap::new(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(value["kind"], REPORT_KIND);
+        assert_eq!(value["schema_version"], REPORT_SCHEMA_VERSION);
+        assert!(value.get("source_revision").is_none());
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -192,9 +192,34 @@ pub fn print_report_with_baseline(
     format: crate::cli::OutputFormat,
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> anyhow::Result<()> {
+    print_report_with_baseline_and_replay(report, format, comparison, None)
+}
+
+/// Render a report, adding replay metadata only to JSON when source evidence
+/// and regular direct recipes were captured.
+pub fn print_report_with_baseline_and_replay(
+    report: &crate::MutationReport,
+    format: crate::cli::OutputFormat,
+    comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
+    replay: Option<(
+        &crate::replay::ReplayReportCapture,
+        &std::collections::BTreeMap<u32, crate::replay::RegularDirectRecipe>,
+    )>,
+) -> anyhow::Result<()> {
     use crate::cli::OutputFormat;
     match format {
-        OutputFormat::Json => json::print_report_with_baseline(report, comparison)?,
+        OutputFormat::Json => {
+            if let Some((capture, direct_recipes)) = replay {
+                json::print_report_with_baseline_and_replay(
+                    report,
+                    comparison,
+                    capture,
+                    direct_recipes,
+                )?;
+            } else {
+                json::print_report_with_baseline(report, comparison)?;
+            }
+        }
         OutputFormat::Github => github::print_report_with_baseline(report, comparison),
         OutputFormat::Html => {
             let path = std::path::Path::new("togi-report.html");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,12 +1,24 @@
 // Parallel test execution with timeouts
 
 use crate::cache::{self, CacheKey};
+use crate::replay::{DirectRecipeOrigin, RegularDirectRecipe};
+use crate::source_identity::{
+    normalized_project_relative_path, range_matches, resolve_normalized_project_relative_path,
+    source_fingerprint,
+};
 use crate::{
     BuildErrorDiagnostic, Mutation, MutationExecution, MutationReport, MutationResult,
     SchemataFallbackReasonCount, SchemataReport,
 };
 use anyhow::{Context, bail};
+#[cfg(not(windows))]
+use cap_fs_ext::MetadataExt as CapMetadataExt;
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir as CapDir, OpenOptions as CapOpenOptions};
+use cap_tempfile::TempFile;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::ffi::OsString;
 use std::fs;
 use std::hash::Hasher;
 use std::io::{IsTerminal, Read, Write};
@@ -195,6 +207,10 @@ pub struct TestRunner {
 #[derive(Debug)]
 pub struct RunOutcome {
     pub report: MutationReport,
+    /// Captured direct recipes for regular one-mutation paths only. These are
+    /// kept separate from the general report so non-JSON renderers never grow
+    /// replay-specific data.
+    pub replay_recipes: BTreeMap<u32, RegularDirectRecipe>,
     pub cancelled: bool,
 }
 
@@ -213,6 +229,27 @@ pub struct BaselineTimingConfig<'a> {
     pub env: &'a HashMap<String, String>,
     pub cancelled: &'a AtomicBool,
     pub respect_workspace_ignores: bool,
+}
+
+/// A deliberately narrow replay invocation. It never reaches normal runner
+/// cache/history/selection/schemata paths.
+pub struct ReplayRunConfig<'a> {
+    pub test_command: Vec<String>,
+    pub build_command: Option<Vec<String>>,
+    pub timeout: Duration,
+    pub env: HashMap<String, String>,
+    pub respect_workspace_ignores: bool,
+    pub source_revision: &'a str,
+    pub source_fingerprint: &'a str,
+    pub show_output: bool,
+    pub cancelled: &'a AtomicBool,
+}
+
+#[derive(Debug)]
+pub struct ReplayRunOutcome {
+    pub result: MutationResult,
+    pub test_output: Option<String>,
+    pub cancelled: bool,
 }
 /// Configuration for validating unmutated test suites before mutation execution.
 pub struct BaselineHealthConfig<'a> {
@@ -694,6 +731,24 @@ impl GitWorktreeOverlay {
         }
         Ok(())
     }
+
+    fn apply_replay(
+        &self,
+        source_root: &CapDir,
+        workspace: &ReplayWorkspace,
+    ) -> std::io::Result<()> {
+        for relative in &self.remove_paths {
+            workspace.remove_relative(relative)?;
+        }
+        for relative in &self.copy_paths {
+            if cap_relative_file_is_regular(source_root, relative)? {
+                workspace.copy_regular_source(source_root, relative)?;
+            } else {
+                workspace.remove_relative(relative)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl WorkspaceCopy {
@@ -714,6 +769,280 @@ impl WorkspaceCopy {
     }
 }
 
+/// Replay's capability-bounded view of its disposable clone.
+///
+/// `root` deliberately precedes `workspace` so its capability handle is
+/// dropped before the `WorkspaceCopy` closes its TempDir, which matters on
+/// Windows.
+struct ReplayWorkspace {
+    root: CapDir,
+    workspace: WorkspaceCopy,
+}
+
+impl ReplayWorkspace {
+    fn open(workspace: WorkspaceCopy) -> std::io::Result<Self> {
+        let root = CapDir::open_ambient_dir(workspace.root(), ambient_authority())?;
+        Ok(Self { root, workspace })
+    }
+
+    /// This path is only for external Git and user-command working directories.
+    fn root(&self) -> &Path {
+        self.workspace.root()
+    }
+
+    fn ensure_directory(&self, relative: &Path) -> std::io::Result<()> {
+        let (parents, leaf) = split_replay_relative_path(relative)?;
+        let mut current = self.root.try_clone()?;
+        for component in parents.into_iter().chain(std::iter::once(leaf)) {
+            current = ensure_cap_directory_child(&current, &component)?;
+        }
+        Ok(())
+    }
+
+    fn remove_relative(&self, relative: &Path) -> std::io::Result<()> {
+        let (parents, leaf) = split_replay_relative_path(relative)?;
+        let mut current = self.root.try_clone()?;
+        for component in parents {
+            match current.symlink_metadata(&component) {
+                Ok(metadata) if metadata.file_type().is_dir() => {
+                    current = current.open_dir_nofollow(&component)?;
+                }
+                Ok(_) => {
+                    remove_cap_entry(&current, &component)?;
+                    return Ok(());
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(error),
+            }
+        }
+        remove_cap_entry(&current, &leaf)
+    }
+
+    fn read_regular(&self, relative: &Path) -> std::io::Result<Vec<u8>> {
+        let (parent, leaf) = open_cap_existing_parent(&self.root, relative)?;
+        let metadata = parent.symlink_metadata(&leaf)?;
+        if !metadata.file_type().is_file() {
+            return Err(std::io::Error::other(format!(
+                "replay workspace entry {} is not a regular file",
+                relative.display()
+            )));
+        }
+        let mut options = CapOpenOptions::new();
+        options.read(true).follow(FollowSymlinks::No);
+        let mut file = parent.open_with(&leaf, &options)?;
+        if !file.metadata()?.file_type().is_file() {
+            return Err(std::io::Error::other(format!(
+                "replay workspace entry {} changed from a regular file",
+                relative.display()
+            )));
+        }
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents)?;
+        Ok(contents)
+    }
+
+    fn copy_regular_source(&self, source_root: &CapDir, relative: &Path) -> std::io::Result<()> {
+        let (source_parent, source_leaf) = open_cap_existing_parent(source_root, relative)?;
+        let source_metadata = source_parent.symlink_metadata(&source_leaf)?;
+        if !source_metadata.file_type().is_file() {
+            return Err(std::io::Error::other(format!(
+                "replay source entry {} is not a regular file",
+                relative.display()
+            )));
+        }
+        let mut options = CapOpenOptions::new();
+        options.read(true).follow(FollowSymlinks::No);
+        let mut source_file = source_parent.open_with(&source_leaf, &options)?;
+        // Permissions and bytes come from this same held capability file.
+        let source_metadata = source_file.metadata()?;
+        if !source_metadata.file_type().is_file() {
+            return Err(std::io::Error::other(format!(
+                "replay source entry {} changed from a regular file",
+                relative.display()
+            )));
+        }
+        let permissions = source_metadata.permissions();
+        #[cfg(not(windows))]
+        if CapMetadataExt::nlink(&source_metadata) > 1 {
+            // Recheck the opened inode before copying it into the replay clone.
+            return Err(std::io::Error::other(format!(
+                "replay source entry {} has multiple hard links",
+                relative.display()
+            )));
+        }
+
+        let (destination_parent, destination_leaf) = ensure_cap_parent(&self.root, relative)?;
+        let mut staged = TempFile::new(&destination_parent)?;
+        std::io::copy(&mut source_file, staged.as_file_mut())?;
+        staged.as_file_mut().flush()?;
+        staged.as_file().set_permissions(permissions)?;
+        staged.replace(destination_leaf)
+    }
+
+    fn replace_regular(&self, relative: &Path, contents: &[u8]) -> std::io::Result<()> {
+        let (parent, leaf) = ensure_cap_parent(&self.root, relative)?;
+        let permissions = parent
+            .symlink_metadata(&leaf)
+            .ok()
+            .filter(|metadata| metadata.file_type().is_file())
+            .map(|metadata| metadata.permissions());
+        let mut staged = TempFile::new(&parent)?;
+        staged.as_file_mut().write_all(contents)?;
+        staged.as_file_mut().flush()?;
+        if let Some(permissions) = permissions {
+            staged.as_file().set_permissions(permissions)?;
+        }
+        run_replay_publish_hook();
+        staged.replace(leaf)
+    }
+}
+
+fn split_replay_relative_path(relative: &Path) -> std::io::Result<(Vec<OsString>, OsString)> {
+    if !is_safe_relative_path(relative) {
+        return Err(invalid_workspace_relative_path(relative));
+    }
+    let mut components = relative
+        .components()
+        .map(|component| match component {
+            std::path::Component::Normal(component) => Ok(component.to_os_string()),
+            _ => Err(invalid_workspace_relative_path(relative)),
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    let leaf = components
+        .pop()
+        .ok_or_else(|| invalid_workspace_relative_path(relative))?;
+    Ok((components, leaf))
+}
+
+fn remove_cap_entry(parent: &CapDir, name: &OsString) -> std::io::Result<()> {
+    match parent.symlink_metadata(name) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            #[cfg(windows)]
+            {
+                Err(std::io::Error::other(
+                    "replay cannot safely remove a directory on Windows",
+                ))
+            }
+            #[cfg(not(windows))]
+            {
+                // Unix removal remains rooted in the held parent capability.
+                parent.remove_dir_all(name)
+            }
+        }
+        Ok(_) => parent.remove_file_or_symlink(name),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn ensure_cap_directory_child(parent: &CapDir, name: &OsString) -> std::io::Result<CapDir> {
+    loop {
+        match parent.symlink_metadata(name) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                return parent.open_dir_nofollow(name);
+            }
+            Ok(_) => remove_cap_entry(parent, name)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        match parent.create_dir(name) {
+            Ok(()) => return parent.open_dir_nofollow(name),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn ensure_cap_parent(root: &CapDir, relative: &Path) -> std::io::Result<(CapDir, OsString)> {
+    let (parents, leaf) = split_replay_relative_path(relative)?;
+    let mut current = root.try_clone()?;
+    for component in parents {
+        current = ensure_cap_directory_child(&current, &component)?;
+    }
+    Ok((current, leaf))
+}
+
+fn open_cap_existing_parent(root: &CapDir, relative: &Path) -> std::io::Result<(CapDir, OsString)> {
+    let (parents, leaf) = split_replay_relative_path(relative)?;
+    let mut current = root.try_clone()?;
+    for component in parents {
+        let metadata = current.symlink_metadata(&component)?;
+        if !metadata.file_type().is_dir() {
+            return Err(std::io::Error::other(format!(
+                "capability path parent {} is not a directory",
+                component.to_string_lossy()
+            )));
+        }
+        current = current.open_dir_nofollow(&component)?;
+    }
+    Ok((current, leaf))
+}
+
+fn cap_relative_file_is_regular(root: &CapDir, relative: &Path) -> std::io::Result<bool> {
+    let (parents, leaf) = match split_replay_relative_path(relative) {
+        Ok(parts) => parts,
+        Err(_) => return Ok(false),
+    };
+    let mut current = root.try_clone()?;
+    for component in parents {
+        let metadata = match current.symlink_metadata(&component) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        if !metadata.file_type().is_dir() {
+            return Ok(false);
+        }
+        current = current.open_dir_nofollow(&component)?;
+    }
+    match current.symlink_metadata(&leaf) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static REPLAY_PUBLISH_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_replay_publish_hook(hook: Option<Box<dyn FnOnce()>>) {
+    REPLAY_PUBLISH_HOOK.with(|slot| *slot.borrow_mut() = hook);
+}
+
+fn run_replay_publish_hook() {
+    #[cfg(test)]
+    REPLAY_PUBLISH_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+/// Replay-only RAII restoration through the capability writer.
+struct ReplayFileGuard<'a> {
+    workspace: &'a ReplayWorkspace,
+    relative: PathBuf,
+    original: Vec<u8>,
+}
+
+impl Drop for ReplayFileGuard<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = self
+            .workspace
+            .replace_regular(&self.relative, &self.original)
+        {
+            eprintln!(
+                "error: failed to restore replay workspace {}: {error}",
+                self.relative.display()
+            );
+        }
+    }
+}
+
 impl Drop for WorkspaceCopy {
     fn drop(&mut self) {
         let WorkspaceResetStrategy::GitWorktree { project_root, .. } = &self.reset_strategy else {
@@ -728,6 +1057,8 @@ impl Drop for WorkspaceCopy {
     }
 }
 
+/// Normal workspace-copy exclusions. Keep this compatible with ordinary
+/// `togi check` workspace behavior.
 pub(crate) fn should_skip_workspace_entry(relative: &Path) -> bool {
     relative.components().any(|component| {
         component.as_os_str().to_str().is_some_and(|name| {
@@ -754,6 +1085,38 @@ fn should_copy_workspace_entry(project_root: &Path, path: &Path) -> bool {
         || path
             .strip_prefix(project_root)
             .is_ok_and(|relative| !should_skip_workspace_entry(relative))
+}
+
+/// Replay excludes control aliases case-insensitively in addition to normal
+/// disposable-workspace artifacts.
+fn should_skip_replay_workspace_entry(relative: &Path) -> bool {
+    relative.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            let name = name.to_ascii_lowercase();
+            matches!(
+                name.as_str(),
+                ".git"
+                    | ".togi"
+                    | ".togi-cache"
+                    | ".togi.lock"
+                    | ".togi-baseline"
+                    | ".codex"
+                    | ".claude"
+                    | "target"
+                    | "node_modules"
+                    | ".venv"
+                    | "dist"
+                    | "build"
+            ) || name.starts_with(".togi-")
+        })
+    })
+}
+
+fn should_copy_replay_workspace_entry(project_root: &Path, path: &Path) -> bool {
+    path == project_root
+        || path
+            .strip_prefix(project_root)
+            .is_ok_and(|relative| !should_skip_replay_workspace_entry(relative))
 }
 
 /// Workspace directories kept across resets.
@@ -1262,9 +1625,147 @@ fn copy_workspace_with_options(
         }
     }
 
+    finish_copy_workspace(project_root, tempdir, root, respect_ignores)
+}
+
+/// Create an independent Git snapshot for replay without registering a
+/// worktree in the source repository. The source working tree is then overlaid
+/// so dirty, untracked, and deleted paths retain normal workspace semantics.
+fn copy_workspace_for_replay(
+    project_root: &Path,
+    expected_source_revision: &str,
+    respect_ignores: bool,
+) -> std::io::Result<ReplayWorkspace> {
+    ensure_replay_snapshot_revision(project_root, expected_source_revision)?;
+    let tempdir = tempfile::tempdir()?;
+    let root = tempdir.path().join("workspace");
+    clone_replay_snapshot(project_root, &root, expected_source_revision)?;
+
+    let workspace = ReplayWorkspace::open(WorkspaceCopy {
+        _tempdir: tempdir,
+        root,
+        reset_strategy: WorkspaceResetStrategy::Copy,
+    })?;
+    let source_root = CapDir::open_ambient_dir(project_root, ambient_authority())?;
+    ensure_replay_snapshot_revision(project_root, expected_source_revision)?;
+    let overlay = collect_replay_git_worktree_overlay(project_root)?;
+    remove_replay_snapshot_exclusions(&workspace)?;
+    populate_replay_workspace(project_root, &source_root, &workspace, respect_ignores)?;
+    overlay.apply_replay(&source_root, &workspace)?;
+    ensure_replay_snapshot_revision(project_root, expected_source_revision)?;
+    Ok(workspace)
+}
+
+fn git_snapshot_revision(project_root: &Path) -> std::io::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "HEAD"])
+        .current_dir(project_root)
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "could not resolve Git HEAD for replay snapshot in {}\nstderr:\n{}",
+            project_root.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if revision.is_empty() {
+        return Err(std::io::Error::other(
+            "could not resolve a non-empty Git HEAD for replay snapshot",
+        ));
+    }
+    Ok(revision)
+}
+
+fn ensure_replay_snapshot_revision(
+    project_root: &Path,
+    expected_source_revision: &str,
+) -> std::io::Result<()> {
+    let current = git_snapshot_revision(project_root)?;
+    if current != expected_source_revision {
+        return Err(std::io::Error::other(format!(
+            "replay source Git HEAD changed: expected {expected_source_revision}, found {current}"
+        )));
+    }
+    Ok(())
+}
+
+fn clone_replay_snapshot(
+    project_root: &Path,
+    root: &Path,
+    source_revision: &str,
+) -> std::io::Result<()> {
+    let clone = std::process::Command::new("git")
+        .args(["clone", "--no-local", "--quiet", "--no-checkout"])
+        .arg(project_root)
+        .arg(root)
+        .output()?;
+    if !clone.status.success() {
+        return Err(std::io::Error::other(format!(
+            "could not create isolated Git replay snapshot from {}\nstderr:\n{}",
+            project_root.display(),
+            String::from_utf8_lossy(&clone.stderr)
+        )));
+    }
+
+    let checkout = std::process::Command::new("git")
+        .args(["checkout", "--detach", "--quiet", source_revision])
+        .current_dir(root)
+        .output()?;
+    if !checkout.status.success() {
+        return Err(std::io::Error::other(format!(
+            "could not check out replay snapshot revision {source_revision}\nstderr:\n{}",
+            String::from_utf8_lossy(&checkout.stderr)
+        )));
+    }
+
+    let git_dir = root.join(".git");
+    let metadata = fs::symlink_metadata(&git_dir)?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(std::io::Error::other(
+            "isolated replay snapshot has a non-directory .git entry",
+        ));
+    }
+    Ok(())
+}
+
+fn remove_replay_snapshot_exclusions(workspace: &ReplayWorkspace) -> std::io::Result<()> {
+    fn remove_entries(
+        workspace: &ReplayWorkspace,
+        current: &CapDir,
+        current_relative: &Path,
+    ) -> std::io::Result<()> {
+        for entry in current.entries()? {
+            let entry = entry?;
+            let relative = current_relative.join(entry.file_name());
+            // The clone's own independent Git directory is the one excluded
+            // entry that must remain for Git-dependent replay commands.
+            if relative == Path::new(".git") {
+                continue;
+            }
+            if should_skip_replay_workspace_entry(&relative) {
+                workspace.remove_relative(&relative)?;
+                continue;
+            }
+            if entry.file_type()?.is_dir() {
+                let child = current.open_dir_nofollow(entry.file_name())?;
+                remove_entries(workspace, &child, &relative)?;
+            }
+        }
+        Ok(())
+    }
+
+    remove_entries(workspace, &workspace.root, Path::new(""))
+}
+
+fn finish_copy_workspace(
+    project_root: &Path,
+    tempdir: tempfile::TempDir,
+    root: PathBuf,
+    respect_ignores: bool,
+) -> std::io::Result<WorkspaceCopy> {
     fs::create_dir(&root)?;
     populate_workspace(project_root, &root, respect_ignores)?;
-
     Ok(WorkspaceCopy {
         _tempdir: tempdir,
         root,
@@ -1578,8 +2079,7 @@ fn collect_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorkt
         if !should_overlay_workspace_entry(&relative) {
             continue;
         }
-        let source = project_root.join(&relative);
-        if source.is_file() {
+        if project_root.join(&relative).is_file() {
             copy_paths.insert(relative);
         } else {
             remove_paths.insert(relative);
@@ -1603,6 +2103,80 @@ fn collect_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorkt
         copy_paths: copy_paths.into_iter().collect(),
         remove_paths: remove_paths.into_iter().collect(),
     })
+}
+
+fn collect_replay_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorktreeOverlay> {
+    let changed_paths = git_z_output_paths(
+        project_root,
+        &["diff", "--name-only", "-z", "--no-renames", "HEAD", "--"],
+    )?;
+    let untracked_paths = git_z_output_paths(
+        project_root,
+        &["ls-files", "-z", "--others", "--exclude-standard", "--"],
+    )?;
+
+    let mut copy_paths = BTreeSet::new();
+    let mut remove_paths = BTreeSet::new();
+
+    for relative in changed_paths {
+        if !should_overlay_replay_workspace_entry(&relative) {
+            continue;
+        }
+        if replay_source_relative_file_is_regular(project_root, &relative)? {
+            copy_paths.insert(relative);
+        } else {
+            remove_paths.insert(relative);
+        }
+    }
+
+    for relative in untracked_paths {
+        if !should_overlay_replay_workspace_entry(&relative) {
+            continue;
+        }
+        if replay_source_relative_file_is_regular(project_root, &relative)? {
+            copy_paths.insert(relative);
+        }
+    }
+
+    for copied in &copy_paths {
+        remove_paths.remove(copied);
+    }
+
+    Ok(GitWorktreeOverlay {
+        copy_paths: copy_paths.into_iter().collect(),
+        remove_paths: remove_paths.into_iter().collect(),
+    })
+}
+
+/// Replay-only source classification without following symlinked parents into
+/// source-root control state.
+fn replay_source_relative_file_is_regular(
+    project_root: &Path,
+    relative: &Path,
+) -> std::io::Result<bool> {
+    if !is_safe_relative_path(relative) {
+        return Ok(false);
+    }
+    let mut current = project_root.to_path_buf();
+    let mut components = relative.components().peekable();
+    while let Some(component) = components.next() {
+        let std::path::Component::Normal(component) = component else {
+            return Ok(false);
+        };
+        current.push(component);
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        if components.peek().is_none() {
+            return Ok(metadata.file_type().is_file());
+        }
+        if !metadata.file_type().is_dir() {
+            return Ok(false);
+        }
+    }
+    Ok(false)
 }
 
 fn git_z_output_paths(project_root: &Path, args: &[&str]) -> std::io::Result<Vec<PathBuf>> {
@@ -1629,6 +2203,10 @@ fn git_z_output_paths(project_root: &Path, args: &[&str]) -> std::io::Result<Vec
 
 fn should_overlay_workspace_entry(relative: &Path) -> bool {
     is_safe_relative_path(relative) && !should_skip_workspace_entry(relative)
+}
+
+fn should_overlay_replay_workspace_entry(relative: &Path) -> bool {
+    is_safe_relative_path(relative) && !should_skip_replay_workspace_entry(relative)
 }
 
 fn safe_git_relative_path(raw: &[u8]) -> Option<PathBuf> {
@@ -1737,20 +2315,170 @@ fn remove_workspace_path(path: &Path) -> std::io::Result<()> {
     }
 }
 
+fn ensure_workspace_root(workspace_root: &Path) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(workspace_root)?;
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "workspace root {} is not a directory",
+            workspace_root.display()
+        )))
+    }
+}
+
+fn invalid_workspace_relative_path(relative: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "workspace destination path {} is not a safe relative path",
+            relative.display()
+        ),
+    )
+}
+
+/// Create one directory after replacing any non-directory entry at its leaf.
+/// Callers first materialize all ancestor directories, so this never follows a
+/// symlink while preparing a workspace destination.
+fn materialize_workspace_directory(path: &Path) -> std::io::Result<()> {
+    loop {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_dir() => return Ok(()),
+            Ok(_) => remove_workspace_path(path)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        match fs::create_dir(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn materialize_workspace_directory_at(
+    workspace_root: &Path,
+    relative: &Path,
+) -> std::io::Result<()> {
+    if !is_safe_relative_path(relative) {
+        return Err(invalid_workspace_relative_path(relative));
+    }
+    ensure_workspace_root(workspace_root)?;
+    let mut current = workspace_root.to_path_buf();
+    for component in relative.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err(invalid_workspace_relative_path(relative));
+        };
+        current.push(component);
+        materialize_workspace_directory(&current)?;
+    }
+    Ok(())
+}
+
+fn materialize_workspace_parent(workspace_root: &Path, relative: &Path) -> std::io::Result<()> {
+    if !is_safe_relative_path(relative) {
+        return Err(invalid_workspace_relative_path(relative));
+    }
+    ensure_workspace_root(workspace_root)?;
+    if let Some(parent) = relative
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        materialize_workspace_directory_at(workspace_root, parent)?;
+    }
+    Ok(())
+}
+
+/// Prepare a destination below a workspace without retaining a leaf symlink.
+fn prepare_workspace_destination(
+    workspace_root: &Path,
+    relative: &Path,
+) -> std::io::Result<PathBuf> {
+    materialize_workspace_parent(workspace_root, relative)?;
+    let destination = workspace_root.join(relative);
+    remove_workspace_path(&destination)?;
+    Ok(destination)
+}
+
+fn copy_regular_source_file_to_workspace(
+    source: &Path,
+    workspace_root: &Path,
+    relative: &Path,
+) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if !metadata.file_type().is_file() {
+        return Err(std::io::Error::other(format!(
+            "source entry {} is not a regular file",
+            source.display()
+        )));
+    }
+    let destination = prepare_workspace_destination(workspace_root, relative)?;
+    fs::copy(source, destination)?;
+    Ok(())
+}
+
+fn normal_overlay_source_is_control_path(relative: &Path) -> bool {
+    relative.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            let name = name.to_ascii_lowercase();
+            name == ".git" || name == ".togi" || name == ".togi.lock" || name.starts_with(".togi-")
+        })
+    })
+}
+
+fn resolve_normal_overlay_source(
+    project_root: &Path,
+    relative: &Path,
+) -> std::io::Result<Option<PathBuf>> {
+    if !is_safe_relative_path(relative) {
+        return Err(invalid_workspace_relative_path(relative));
+    }
+    let source = project_root.join(relative);
+    if !source.is_file() {
+        return Ok(None);
+    }
+    let normalized = normalized_project_relative_path(project_root, relative).ok_or_else(|| {
+        std::io::Error::other(format!(
+            "workspace overlay source {} is not project-relative",
+            source.display()
+        ))
+    })?;
+    let resolved =
+        resolve_normalized_project_relative_path(project_root, &normalized).ok_or_else(|| {
+            std::io::Error::other(format!(
+                "workspace overlay source {} does not resolve within the project root",
+                source.display()
+            ))
+        })?;
+    let root = project_root.canonicalize()?;
+    let resolved_relative = resolved.strip_prefix(root).map_err(|_| {
+        std::io::Error::other(format!(
+            "workspace overlay source {} does not resolve within the project root",
+            source.display()
+        ))
+    })?;
+    if normal_overlay_source_is_control_path(resolved_relative) {
+        return Err(std::io::Error::other(format!(
+            "workspace overlay source {} resolves into Togi or Git control state",
+            source.display()
+        )));
+    }
+    if !fs::metadata(&resolved)?.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(resolved))
+}
+
 fn copy_overlay_file(
     project_root: &Path,
     workspace_root: &Path,
     relative: &Path,
 ) -> std::io::Result<()> {
-    let source = project_root.join(relative);
-    let destination = workspace_root.join(relative);
-    if !source.is_file() {
-        remove_workspace_path(&destination)?;
+    let Some(source) = resolve_normal_overlay_source(project_root, relative)? else {
+        remove_workspace_path(&workspace_root.join(relative))?;
         return Ok(());
-    }
-    if let Some(parent) = destination.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    };
+    let destination = prepare_workspace_destination(workspace_root, relative)?;
     fs::copy(source, destination)?;
     Ok(())
 }
@@ -1786,10 +2514,7 @@ fn restore_workspace_dirs(
     preserved_dirs: Vec<(PathBuf, PathBuf)>,
 ) -> std::io::Result<()> {
     for (relative, stash) in preserved_dirs {
-        let destination = workspace_root.join(relative);
-        if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent)?;
-        }
+        let destination = prepare_workspace_destination(workspace_root, &relative)?;
         fs::rename(stash, destination)?;
     }
     Ok(())
@@ -1830,17 +2555,62 @@ fn populate_workspace(
             Err(_) => continue,
         };
 
-        let dest = root.join(relative);
         if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            fs::create_dir_all(&dest)?;
+            materialize_workspace_directory_at(root, relative)?;
         } else if entry.file_type().is_some_and(|ft| ft.is_file()) {
-            if let Some(parent) = dest.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::copy(path, dest)?;
+            copy_regular_source_file_to_workspace(path, root, relative)?;
         }
     }
 
+    Ok(())
+}
+
+/// Populate a replay clone through capabilities rather than destination paths.
+fn populate_replay_workspace(
+    project_root: &Path,
+    source_root: &CapDir,
+    workspace: &ReplayWorkspace,
+    respect_ignores: bool,
+) -> std::io::Result<()> {
+    let project_root_for_filter = project_root.to_path_buf();
+    let mut builder = ignore::WalkBuilder::new(project_root);
+    builder
+        .hidden(false)
+        .ignore(respect_ignores)
+        .git_ignore(respect_ignores)
+        .git_exclude(respect_ignores)
+        .git_global(respect_ignores)
+        .parents(respect_ignores)
+        .filter_entry(move |entry| {
+            should_copy_replay_workspace_entry(&project_root_for_filter, entry.path())
+        });
+
+    for entry in builder.build() {
+        let entry = entry.map_err(std::io::Error::other)?;
+        let path = entry.path();
+        if path == project_root {
+            continue;
+        }
+        let relative = match path.strip_prefix(project_root) {
+            Ok(relative) if is_safe_relative_path(relative) => relative,
+            _ => continue,
+        };
+        if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_dir())
+        {
+            workspace.ensure_directory(relative)?;
+        } else if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+        {
+            if cap_relative_file_is_regular(source_root, relative)? {
+                workspace.copy_regular_source(source_root, relative)?;
+            } else {
+                workspace.remove_relative(relative)?;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1958,6 +2728,7 @@ struct MutationRunRecord {
     result: MutationResult,
     execution: MutationExecution,
     build_error_diagnostic: Option<BuildErrorDiagnostic>,
+    replay_recipe: Option<RegularDirectRecipe>,
 }
 
 impl MutationRunRecord {
@@ -1971,11 +2742,17 @@ impl MutationRunRecord {
             result,
             execution: MutationExecution::for_result(result),
             build_error_diagnostic,
+            replay_recipe: None,
         }
     }
 
     fn with_execution(mut self, execution: MutationExecution) -> Self {
         self.execution = execution;
+        self
+    }
+
+    fn with_replay_recipe(mut self, replay_recipe: RegularDirectRecipe) -> Self {
+        self.replay_recipe = Some(replay_recipe);
         self
     }
 }
@@ -2357,6 +3134,30 @@ impl PreparedMutationRun {
         }
     }
 
+    /// Capture the final direct argv before cache/history lookup. The recipe
+    /// deliberately contains no configuration lookup inputs: replay must not
+    /// resolve current routes, selection, or sandbox settings again.
+    fn direct_recipe(
+        &self,
+        commands: &CommandConfig,
+        env: &HashMap<String, String>,
+        respect_workspace_ignores: bool,
+        origin: DirectRecipeOrigin,
+    ) -> RegularDirectRecipe {
+        RegularDirectRecipe {
+            test_command: sandboxed_command(&commands.sandbox_command, &self.selected_test.argv),
+            build_command: (commands.build_command_explicit && !commands.build_command.is_empty())
+                .then(|| sandboxed_command(&commands.sandbox_command, &commands.build_command)),
+            timeout_ms: u64::try_from(self.selected_test.timeout.as_millis()).unwrap_or(u64::MAX),
+            env: env
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+            respect_workspace_ignores,
+            origin,
+        }
+    }
+
     fn restore_result(
         &self,
         project_root: &Path,
@@ -2446,6 +3247,13 @@ fn run_queued_mutation(
             env: shared.env,
         },
     );
+    // Capture the exact direct recipe before any cache/history lookup.
+    let direct_recipe = prepared.direct_recipe(
+        shared.commands,
+        shared.env,
+        shared.respect_workspace_ignores,
+        DirectRecipeOrigin::Executed,
+    );
 
     // Normal runs retain lazy cache lookup; early-stop runs preclassify every
     // candidate before scheduling and mark fresh entries as already checked.
@@ -2456,11 +3264,19 @@ fn run_queued_mutation(
             reservation.release();
             exclude_restored_from_early_stop(shared.early_stop, restored.execution);
             record_progress(&shared, &mutation, restored.result, None, true);
-            return Some((
-                index,
-                MutationRunRecord::new(mutation, restored.result, None)
-                    .with_execution(restored.execution),
-            ));
+            let mut record = MutationRunRecord::new(mutation, restored.result, None)
+                .with_execution(restored.execution);
+            if matches!(
+                restored.result,
+                MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
+            ) {
+                if let Some(origin) = DirectRecipeOrigin::from_execution(restored.execution) {
+                    let mut recipe = direct_recipe.clone();
+                    recipe.origin = origin;
+                    record = record.with_replay_recipe(recipe);
+                }
+            }
+            return Some((index, record));
         }
     }
 
@@ -2538,7 +3354,14 @@ fn run_queued_mutation(
     );
     record_early_stop(&shared, result);
     let diagnostic = build_error_diagnostic_from_outcome(&mutation, "regular", &outcome);
-    Some((index, MutationRunRecord::new(mutation, result, diagnostic)))
+    let mut record = MutationRunRecord::new(mutation, result, diagnostic);
+    if matches!(
+        result,
+        MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
+    ) {
+        record = record.with_replay_recipe(direct_recipe);
+    }
+    Some((index, record))
 }
 
 struct TestSlotReservation {
@@ -2714,14 +3537,33 @@ impl TestRunner {
                     env: &self.env,
                 },
             );
+            // Capture before cache/history lookup even when early-stop
+            // preclassification restores the verdict.
+            let direct_recipe = prepared.direct_recipe(
+                &self.commands,
+                &self.env,
+                self.respect_workspace_ignores,
+                DirectRecipeOrigin::Executed,
+            );
             if let Some(restored_result) =
                 prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
             {
-                restored.push((
-                    index,
+                let mut record =
                     MutationRunRecord::new(mutation.clone(), restored_result.result, None)
-                        .with_execution(restored_result.execution),
-                ));
+                        .with_execution(restored_result.execution);
+                if matches!(
+                    restored_result.result,
+                    MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
+                ) {
+                    if let Some(origin) =
+                        DirectRecipeOrigin::from_execution(restored_result.execution)
+                    {
+                        let mut recipe = direct_recipe;
+                        recipe.origin = origin;
+                        record = record.with_replay_recipe(recipe);
+                    }
+                }
+                restored.push((index, record));
             } else {
                 fresh.push(QueuedMutation {
                     index,
@@ -2826,6 +3668,17 @@ impl TestRunner {
             .map(|(index, mutation)| (mutation.id, index))
             .collect();
         let plan = crate::schemata::plan(&self.project_root, mutations);
+        let schema_candidate_ids: HashSet<u32> = plan
+            .selected
+            .iter()
+            .filter(|schema_mutation| {
+                matches!(
+                    schema_mutation.mutation.language.as_str(),
+                    "c" | "cpp" | "go" | "java" | "rust"
+                )
+            })
+            .map(|schema_mutation| schema_mutation.mutation.id)
+            .collect();
         let mut schema_by_language = HashMap::<String, Vec<crate::schemata::SchemaMutation>>::new();
         let mut fallback_mutations = Vec::new();
         let mut schemata_summary = SchemataRunSummary::default();
@@ -2834,6 +3687,14 @@ impl TestRunner {
             .into_iter()
             .map(|(_, record)| record)
             .collect::<Vec<_>>();
+        // Cache/history restoration before schema planning is not enough
+        // evidence to publish a direct replay recipe for a schema candidate.
+        // Known regular fallbacks keep their captured direct recipe.
+        for record in &mut all_records {
+            if schema_candidate_ids.contains(&record.mutation.id) {
+                record.replay_recipe = None;
+            }
+        }
 
         for schema_mutation in plan.selected {
             match schema_mutation.mutation.language.as_str() {
@@ -2913,7 +3774,10 @@ impl TestRunner {
                 planned_total,
                 tested_counter,
             );
-            all_records.extend(records_from_report(fallback.report));
+            all_records.extend(records_from_report(
+                fallback.report,
+                fallback.replay_recipes,
+            ));
         }
 
         all_records.sort_by_key(|record| {
@@ -3535,13 +4399,11 @@ impl TestRunner {
         planned_total: usize,
         early_stop_reason: Option<String>,
     ) -> RunOutcome {
+        let (report, replay_recipes) =
+            self.report_from_records(all_records, duration, planned_total, early_stop_reason);
         RunOutcome {
-            report: self.report_from_records(
-                all_records,
-                duration,
-                planned_total,
-                early_stop_reason,
-            ),
+            report,
+            replay_recipes,
             cancelled: self.cancelled.load(Ordering::Acquire),
         }
     }
@@ -3552,10 +4414,11 @@ impl TestRunner {
         duration: Duration,
         planned_total: usize,
         early_stop_reason: Option<String>,
-    ) -> MutationReport {
+    ) -> (MutationReport, BTreeMap<u32, RegularDirectRecipe>) {
         let mut results = Vec::with_capacity(all_records.len());
         let mut build_error_diagnostics = Vec::new();
         let mut execution_provenance = BTreeMap::new();
+        let mut replay_recipes = BTreeMap::new();
         let mut total = 0;
         let mut killed = 0;
         let mut survived = 0;
@@ -3568,6 +4431,7 @@ impl TestRunner {
                 result,
                 execution,
                 build_error_diagnostic,
+                replay_recipe,
             } = record;
             total += 1;
             match result {
@@ -3588,39 +4452,50 @@ impl TestRunner {
                 debug_assert_eq!(result, MutationResult::BuildError);
                 build_error_diagnostics.push(diagnostic);
             }
+            if let Some(recipe) = replay_recipe {
+                if matches!(
+                    result,
+                    MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
+                ) {
+                    replay_recipes.insert(mutation.id, recipe);
+                }
+            }
             results.push((mutation, result));
         }
 
-        MutationReport {
-            results,
-            execution_provenance,
-            build_error_diagnostics,
-            schemata: None,
-            baseline_timing: None,
-            duration,
-            test_command: if self.commands.language_commands.is_empty()
-                && self.commands.project_commands.is_empty()
-            {
-                Some(sandboxed_command(
-                    &self.commands.sandbox_command,
-                    &self.commands.command,
-                ))
-            } else {
-                None
+        (
+            MutationReport {
+                results,
+                execution_provenance,
+                build_error_diagnostics,
+                schemata: None,
+                baseline_timing: None,
+                duration,
+                test_command: if self.commands.language_commands.is_empty()
+                    && self.commands.project_commands.is_empty()
+                {
+                    Some(sandboxed_command(
+                        &self.commands.sandbox_command,
+                        &self.commands.command,
+                    ))
+                } else {
+                    None
+                },
+                build_command: if self.commands.build_command_explicit {
+                    sandboxed_command(&self.commands.sandbox_command, &self.commands.build_command)
+                } else {
+                    vec![]
+                },
+                planned_total,
+                early_stop_reason,
+                total,
+                killed,
+                survived,
+                timeout: timeout_count,
+                build_errors,
             },
-            build_command: if self.commands.build_command_explicit {
-                sandboxed_command(&self.commands.sandbox_command, &self.commands.build_command)
-            } else {
-                vec![]
-            },
-            planned_total,
-            early_stop_reason,
-            total,
-            killed,
-            survived,
-            timeout: timeout_count,
-            build_errors,
-        }
+            replay_recipes,
+        )
     }
 }
 
@@ -3729,7 +4604,10 @@ fn run_schema_workspace_mutation(
     )
 }
 
-fn records_from_report(report: MutationReport) -> Vec<MutationRunRecord> {
+fn records_from_report(
+    report: MutationReport,
+    mut replay_recipes: BTreeMap<u32, RegularDirectRecipe>,
+) -> Vec<MutationRunRecord> {
     let MutationReport {
         results,
         execution_provenance,
@@ -3748,7 +4626,12 @@ fn records_from_report(report: MutationReport) -> Vec<MutationRunRecord> {
                 .copied()
                 .unwrap_or_else(|| MutationExecution::for_result(result));
             let diagnostic = diagnostics.remove(&mutation.id);
-            MutationRunRecord::new(mutation, result, diagnostic).with_execution(execution)
+            let mut record =
+                MutationRunRecord::new(mutation, result, diagnostic).with_execution(execution);
+            if let Some(recipe) = replay_recipes.remove(&record.mutation.id) {
+                record = record.with_replay_recipe(recipe);
+            }
+            record
         })
         .collect()
 }
@@ -3984,6 +4867,7 @@ fn validate_and_resolve_mutation_path(
 struct ResolvedMutation<'a> {
     mutation: &'a Mutation,
     file_path: Result<PathBuf, ()>,
+    relative_path: Result<PathBuf, ()>,
 }
 
 impl<'a> ResolvedMutation<'a> {
@@ -3992,6 +4876,13 @@ impl<'a> ResolvedMutation<'a> {
         Self {
             mutation,
             file_path: validate_and_resolve_mutation_path(project_root, &mutation.file),
+            relative_path: project_relative_path(project_root, &mutation.file).and_then(
+                |relative| {
+                    is_safe_relative_path(&relative)
+                        .then_some(relative)
+                        .ok_or(())
+                },
+            ),
         }
     }
 
@@ -4000,30 +4891,124 @@ impl<'a> ResolvedMutation<'a> {
         execution_root: &Path,
         mutation: &'a Mutation,
     ) -> Self {
-        let file_path = if mutation.file.is_absolute() {
-            mutation
-                .file
-                .canonicalize()
-                .ok()
-                .and_then(|canonical| {
-                    original_root
-                        .canonicalize()
-                        .ok()
-                        .and_then(|root| canonical.strip_prefix(root).ok().map(PathBuf::from))
-                })
-                .and_then(|relative| {
-                    validate_and_resolve_mutation_path(execution_root, &relative).ok()
-                })
-                .ok_or(())
+        let relative_path = if mutation.file.is_absolute() {
+            mutation.file.canonicalize().ok().and_then(|canonical| {
+                original_root
+                    .canonicalize()
+                    .ok()
+                    .and_then(|root| canonical.strip_prefix(root).ok().map(PathBuf::from))
+            })
         } else {
-            validate_and_resolve_mutation_path(execution_root, &mutation.file)
-        };
+            Some(mutation.file.clone())
+        }
+        .filter(|relative| is_safe_relative_path(relative))
+        .ok_or(());
+        let file_path = relative_path
+            .as_ref()
+            .map_err(|_| ())
+            .and_then(|relative| validate_and_resolve_mutation_path(execution_root, relative));
 
         Self {
             mutation,
             file_path,
+            relative_path,
         }
     }
+
+    fn new_for_replay(source_root: &Path, workspace_root: &Path, mutation: &'a Mutation) -> Self {
+        let relative_path =
+            project_relative_path(source_root, &mutation.file).and_then(|relative| {
+                is_safe_relative_path(&relative)
+                    .then_some(relative)
+                    .ok_or(())
+            });
+        let file_path = relative_path
+            .as_ref()
+            .map(|relative| workspace_root.join(relative))
+            .map_err(|_| ());
+        Self {
+            mutation,
+            file_path,
+            relative_path,
+        }
+    }
+}
+
+fn validate_replay_snapshot_target(
+    workspace: &ReplayWorkspace,
+    target: &ResolvedMutation<'_>,
+    expected_source_fingerprint: &str,
+) -> anyhow::Result<()> {
+    let relative = target.relative_path.as_ref().map_err(|()| {
+        anyhow::anyhow!(
+            "could not derive a safe replay source path for {}",
+            target.mutation.file.display()
+        )
+    })?;
+    let source = workspace.read_regular(relative).with_context(|| {
+        format!(
+            "could not read replay source {} in isolated snapshot",
+            target.mutation.file.display()
+        )
+    })?;
+    if source_fingerprint(&source) != expected_source_fingerprint {
+        anyhow::bail!("replay snapshot source fingerprint does not match the report");
+    }
+    if !range_matches(
+        &source,
+        target.mutation.byte_range.start,
+        target.mutation.byte_range.end,
+        &target.mutation.original,
+    ) {
+        anyhow::bail!("replay snapshot mutation byte range and original bytes do not match");
+    }
+    Ok(())
+}
+
+/// Execute one validated replay in a disposable workspace without consulting
+/// or updating any normal-run cache/history state.
+pub fn run_replay_mutation(
+    project_root: &Path,
+    mutation: &Mutation,
+    config: ReplayRunConfig<'_>,
+) -> anyhow::Result<ReplayRunOutcome> {
+    // cap-primitives 4.0.2 cannot atomically remove an opened directory on
+    // Windows. Reject before clone setup rather than risk a path-based
+    // directory-replacement window in replay's mutable workspace.
+    #[cfg(windows)]
+    anyhow::bail!(
+        "replay is unavailable on Windows: safe disposable workspace setup requires race-free directory removal"
+    );
+
+    let workspace = copy_workspace_for_replay(
+        project_root,
+        config.source_revision,
+        config.respect_workspace_ignores,
+    )
+    .with_context(|| "could not create replay workspace")?;
+    let target = ResolvedMutation::new_for_replay(project_root, workspace.root(), mutation);
+    validate_replay_snapshot_target(&workspace, &target, config.source_fingerprint)?;
+    let build_command = config.build_command.as_deref().unwrap_or(&[]);
+    let outcome = run_single_mutation_with_replay_access(
+        &config.test_command,
+        &[],
+        BuildCommand {
+            argv: build_command,
+            explicit: config.build_command.is_some(),
+        },
+        config.timeout,
+        workspace.root(),
+        target,
+        config.show_output,
+        &config.env,
+        config.cancelled,
+        Some(&workspace),
+    );
+    Ok(ReplayRunOutcome {
+        result: outcome.result,
+        test_output: outcome.test_output,
+        cancelled: outcome.cancelled,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4038,11 +5023,49 @@ fn run_single_mutation(
     env: &HashMap<String, String>,
     cancelled: &AtomicBool,
 ) -> MutationOutcome {
+    run_single_mutation_with_replay_access(
+        command,
+        sandbox_command,
+        build_command,
+        timeout,
+        project_root,
+        target,
+        capture_output,
+        env,
+        cancelled,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_single_mutation_with_replay_access(
+    command: &[String],
+    sandbox_command: &[String],
+    build_command: BuildCommand<'_>,
+    timeout: Duration,
+    project_root: &Path,
+    target: ResolvedMutation<'_>,
+    capture_output: bool,
+    env: &HashMap<String, String>,
+    cancelled: &AtomicBool,
+    replay_workspace: Option<&ReplayWorkspace>,
+) -> MutationOutcome {
     if cancelled.load(Ordering::Acquire) {
         return MutationOutcome::cancelled();
     }
 
     let mutation = target.mutation;
+    let replay_relative = target.relative_path.as_ref().ok().cloned();
+    if replay_workspace.is_some() && replay_relative.is_none() {
+        return MutationOutcome::build_error_with(
+            "resolve_mutation_path",
+            vec![],
+            format!(
+                "could not derive a safe mutation path {} in replay workspace",
+                mutation.file.display()
+            ),
+        );
+    }
     let file_path = match target.file_path {
         Ok(path) => path,
         Err(()) => {
@@ -4058,23 +5081,49 @@ fn run_single_mutation(
         }
     };
 
-    // Read original content
-    let original = match std::fs::read(&file_path) {
-        Ok(content) => content,
-        Err(e) => {
-            eprintln!("warning: could not read {}: {e}", file_path.display());
-            return MutationOutcome::build_error_with(
-                "read_source",
-                vec![],
-                format!("could not read {}: {e}", file_path.display()),
-            );
+    // Replay reads and restores through its clone capability; normal runs keep
+    // their established ambient-path behavior.
+    let (original, _normal_guard, _replay_guard): (
+        Vec<u8>,
+        Option<FileGuard>,
+        Option<ReplayFileGuard<'_>>,
+    ) = if let (Some(workspace), Some(relative)) = (replay_workspace, replay_relative.as_deref()) {
+        match workspace.read_regular(relative) {
+            Ok(content) => {
+                let guard = ReplayFileGuard {
+                    workspace,
+                    relative: relative.to_path_buf(),
+                    original: content.clone(),
+                };
+                (content, None, Some(guard))
+            }
+            Err(error) => {
+                eprintln!("warning: could not read {}: {error}", file_path.display());
+                return MutationOutcome::build_error_with(
+                    "read_source",
+                    vec![],
+                    format!("could not read {}: {error}", file_path.display()),
+                );
+            }
         }
-    };
-
-    // Set up file guard for guaranteed restoration
-    let _guard = FileGuard {
-        path: file_path.clone(),
-        original: original.clone(),
+    } else {
+        match std::fs::read(&file_path) {
+            Ok(content) => {
+                let guard = FileGuard {
+                    path: file_path.clone(),
+                    original: content.clone(),
+                };
+                (content, Some(guard), None)
+            }
+            Err(error) => {
+                eprintln!("warning: could not read {}: {error}", file_path.display());
+                return MutationOutcome::build_error_with(
+                    "read_source",
+                    vec![],
+                    format!("could not read {}: {error}", file_path.display()),
+                );
+            }
+        }
     };
 
     // Apply mutation
@@ -4093,14 +5142,34 @@ fn run_single_mutation(
             ),
         );
     }
+    if !crate::source_identity::range_matches(&original, range.start, range.end, &mutation.original)
+    {
+        return MutationOutcome::build_error_with(
+            "apply_mutation",
+            vec![],
+            format!(
+                "mutation original bytes do not match {}..{} in {}",
+                range.start,
+                range.end,
+                file_path.display()
+            ),
+        );
+    }
     mutated.splice(range, mutation.replacement.as_bytes().iter().copied());
 
-    if let Err(e) = write_workspace_file(&file_path, &mutated) {
-        eprintln!("warning: could not write {}: {e}", file_path.display());
+    let write_result = match (replay_workspace, replay_relative.as_deref()) {
+        (Some(workspace), Some(relative)) => workspace.replace_regular(relative, &mutated),
+        (Some(_), None) => Err(std::io::Error::other(
+            "missing replay mutation path after validation",
+        )),
+        (None, _) => write_workspace_file(&file_path, &mutated),
+    };
+    if let Err(error) = write_result {
+        eprintln!("warning: could not write {}: {error}", file_path.display());
         return MutationOutcome::build_error_with(
             "write_source",
             vec![],
-            format!("could not write {}: {e}", file_path.display()),
+            format!("could not write {}: {error}", file_path.display()),
         );
     }
 
@@ -4832,6 +5901,608 @@ mod tests {
         std::fs::write(&file, b"hello world").unwrap();
         let mutation = make_test_mutation(Path::new("test.txt"));
         (dir, file, mutation)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_snapshot_target_rejects_fifo_before_reading() -> anyhow::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let root = tempdir.path().to_path_buf();
+        let fifo = root.join("target");
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status()?;
+        assert!(status.success());
+
+        let mutation = make_test_mutation(&fifo);
+        let target = ResolvedMutation::new(&root, &mutation);
+        let workspace = ReplayWorkspace::open(WorkspaceCopy {
+            _tempdir: tempdir,
+            root,
+            reset_strategy: WorkspaceResetStrategy::Copy,
+        })?;
+        let error =
+            validate_replay_snapshot_target(&workspace, &target, "sha256:expected").unwrap_err();
+        assert!(format!("{error:#}").contains("not a regular file"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_workspace_publish_does_not_follow_replaced_leaf_symlink() -> anyhow::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let root = tempdir.path().to_path_buf();
+        let target = root.join("target");
+        std::fs::write(&target, b"original")?;
+        let sentinel_dir = tempfile::tempdir()?;
+        let sentinel = sentinel_dir.path().join("sentinel");
+        std::fs::write(&sentinel, b"outside")?;
+        let replacement_target = target.clone();
+        let replacement_sentinel = sentinel.clone();
+        let workspace = ReplayWorkspace::open(WorkspaceCopy {
+            _tempdir: tempdir,
+            root,
+            reset_strategy: WorkspaceResetStrategy::Copy,
+        })?;
+
+        set_replay_publish_hook(Some(Box::new(move || {
+            std::fs::remove_file(&replacement_target).unwrap();
+            std::os::unix::fs::symlink(&replacement_sentinel, &replacement_target).unwrap();
+        })));
+        workspace.replace_regular(Path::new("target"), b"mutated")?;
+
+        assert_eq!(std::fs::read(&sentinel)?, b"outside");
+        assert_eq!(workspace.read_regular(Path::new("target"))?, b"mutated");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_workspace_publish_does_not_write_hardlink_target() -> anyhow::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let root = tempdir.path().to_path_buf();
+        let sentinel_dir = tempfile::tempdir()?;
+        let sentinel = sentinel_dir.path().join("sentinel");
+        std::fs::write(&sentinel, b"outside")?;
+        std::fs::hard_link(&sentinel, root.join("target"))?;
+        let workspace = ReplayWorkspace::open(WorkspaceCopy {
+            _tempdir: tempdir,
+            root,
+            reset_strategy: WorkspaceResetStrategy::Copy,
+        })?;
+
+        workspace.replace_regular(Path::new("target"), b"mutated")?;
+
+        assert_eq!(std::fs::read(&sentinel)?, b"outside");
+        assert_eq!(workspace.read_regular(Path::new("target"))?, b"mutated");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_workspace_copies_only_regular_sources_and_preserves_permissions() -> anyhow::Result<()>
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source_tempdir = tempfile::tempdir()?;
+        let source_root = CapDir::open_ambient_dir(source_tempdir.path(), ambient_authority())?;
+        let source = source_tempdir.path().join("source");
+        std::fs::write(&source, b"source bytes")?;
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o640))?;
+        let workspace_tempdir = tempfile::tempdir()?;
+        let root = workspace_tempdir.path().to_path_buf();
+        let workspace = ReplayWorkspace::open(WorkspaceCopy {
+            _tempdir: workspace_tempdir,
+            root,
+            reset_strategy: WorkspaceResetStrategy::Copy,
+        })?;
+
+        workspace.copy_regular_source(&source_root, Path::new("source"))?;
+        let copied = workspace.read_regular(Path::new("source"))?;
+        assert_eq!(copied, b"source bytes");
+        let copied_mode = std::fs::metadata(workspace.root().join("source"))?
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(copied_mode, 0o640);
+
+        let sentinel = source_tempdir.path().join("sentinel");
+        std::fs::write(&sentinel, b"outside")?;
+        let source_link = source_tempdir.path().join("link");
+        std::os::unix::fs::symlink(&sentinel, &source_link)?;
+        assert!(
+            workspace
+                .copy_regular_source(&source_root, Path::new("link"))
+                .is_err()
+        );
+        let source_hardlink = source_tempdir.path().join("hardlink");
+        std::fs::hard_link(&sentinel, &source_hardlink)?;
+        assert!(
+            workspace
+                .copy_regular_source(&source_root, Path::new("hardlink"))
+                .is_err()
+        );
+        assert_eq!(std::fs::read(&sentinel)?, b"outside");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_workspace_replaces_parent_symlink_inside_clone() -> anyhow::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let root = tempdir.path().to_path_buf();
+        let sentinel_dir = tempfile::tempdir()?;
+        let sentinel = sentinel_dir.path().join("sentinel");
+        std::fs::write(&sentinel, b"outside")?;
+        std::os::unix::fs::symlink(sentinel_dir.path(), root.join("alias"))?;
+        let workspace = ReplayWorkspace::open(WorkspaceCopy {
+            _tempdir: tempdir,
+            root,
+            reset_strategy: WorkspaceResetStrategy::Copy,
+        })?;
+
+        workspace.replace_regular(Path::new("alias/sentinel"), b"mutated")?;
+
+        assert_eq!(std::fs::read(&sentinel)?, b"outside");
+        assert_eq!(
+            workspace.read_regular(Path::new("alias/sentinel"))?,
+            b"mutated"
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn replay_is_rejected_on_windows_before_workspace_setup() {
+        let (dir, file, mutation) = make_relative_test_setup();
+        let cancelled = AtomicBool::new(false);
+        let error = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: successful_command(),
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: "expected",
+                source_fingerprint: "sha256:expected",
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unavailable on Windows"));
+        assert_eq!(std::fs::read(file).unwrap(), b"hello world");
+    }
+    #[cfg(not(windows))]
+    #[test]
+    fn replay_runner_uses_only_workspace_and_validates_original_bytes() -> anyhow::Result<()> {
+        let (dir, file, mutation) = make_relative_test_setup();
+        if !git_available() {
+            return Ok(());
+        }
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Togi Test"]);
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "initial"]);
+        let source_revision = git_snapshot_revision(dir.path())?;
+        let expected_source_fingerprint = source_fingerprint(&std::fs::read(&file)?);
+        let cache_dir = dir.path().join(".togi-cache");
+        std::fs::create_dir_all(&cache_dir)?;
+        let history_path = cache_dir.join("history.json");
+        std::fs::write(&history_path, "sentinel history")?;
+        let cache_before = std::fs::read(&history_path)?;
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+        let config = ReplayRunConfig {
+            test_command: vec![
+                "sh".into(),
+                "-c".into(),
+                "printf invoked >> \"$1\"".into(),
+                "replay".into(),
+                log_path.display().to_string(),
+            ],
+            build_command: None,
+            timeout: Duration::from_secs(1),
+            env: HashMap::new(),
+            respect_workspace_ignores: true,
+            source_revision: &source_revision,
+            source_fingerprint: &expected_source_fingerprint,
+            show_output: false,
+            cancelled: &cancelled,
+        };
+
+        let outcome = run_replay_mutation(dir.path(), &mutation, config)?;
+        assert_eq!(outcome.result, MutationResult::Survived);
+        assert_eq!(std::fs::read(&log_path)?, b"invoked");
+        assert_eq!(std::fs::read(&file)?, b"hello world");
+        assert_eq!(std::fs::read(&history_path)?, cache_before);
+        assert!(!dir.path().join(".togi.lock").exists());
+
+        let mut mismatched = mutation;
+        mismatched.original = "nope".into();
+        let rejected_log = log_dir.path().join("rejected.log");
+        let rejected = run_replay_mutation(
+            dir.path(),
+            &mismatched,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    rejected_log.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: &source_revision,
+                source_fingerprint: &expected_source_fingerprint,
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        );
+        assert!(rejected.is_err());
+        assert!(!rejected_log.exists());
+        assert_eq!(std::fs::read(&file)?, b"hello world");
+        assert_eq!(std::fs::read(&history_path)?, cache_before);
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn replay_runner_requires_git_snapshot_before_spawning_commands() -> anyhow::Result<()> {
+        let (dir, _file, mutation) = make_relative_test_setup();
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+
+        let result = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    log_path.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: "expected",
+                source_fingerprint: "expected",
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        );
+        assert!(result.is_err());
+        assert!(!log_path.exists());
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn replay_runner_rejects_snapshot_fingerprint_mismatch_before_spawning_commands()
+    -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let (dir, file, mutation) = make_relative_test_setup();
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Togi Test"]);
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "initial"]);
+        let source_revision = git_snapshot_revision(dir.path())?;
+        let expected_source_fingerprint = source_fingerprint(&std::fs::read(&file)?);
+        std::fs::write(&file, b"changed source")?;
+
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+        let result = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    log_path.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: &source_revision,
+                source_fingerprint: &expected_source_fingerprint,
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        );
+        assert!(result.is_err());
+        assert!(!log_path.exists());
+        assert_eq!(std::fs::read(&file)?, b"changed source");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_overlay_replaces_tracked_symlink_without_touching_source_target() -> anyhow::Result<()>
+    {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let (dir, file, mutation) = make_relative_test_setup();
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Togi Test"]);
+        let victim = dir.path().join(".togi-cache/history.json");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&victim, &link)?;
+        let nested = dir.path().join("nested");
+        std::os::unix::fs::symlink(victim.parent().unwrap(), &nested)?;
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "initial"]);
+        let source_revision = git_snapshot_revision(dir.path())?;
+        let expected_source_fingerprint = source_fingerprint(&std::fs::read(&file)?);
+
+        std::fs::create_dir_all(victim.parent().unwrap())?;
+        std::fs::write(&victim, b"source cache sentinel")?;
+        std::fs::remove_file(&link)?;
+        std::fs::write(&link, b"dirty payload")?;
+        std::fs::remove_file(&nested)?;
+        std::fs::create_dir(&nested)?;
+        std::fs::write(nested.join("payload"), b"nested dirty payload")?;
+
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+        let outcome = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    log_path.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: &source_revision,
+                source_fingerprint: &expected_source_fingerprint,
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        )?;
+        assert_eq!(outcome.result, MutationResult::Survived);
+        assert_eq!(std::fs::read(&log_path)?, b"invoked");
+        assert_eq!(std::fs::read(&victim)?, b"source cache sentinel");
+        assert_eq!(std::fs::read(&link)?, b"dirty payload");
+        assert_eq!(
+            std::fs::read(nested.join("payload"))?,
+            b"nested dirty payload"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_overlay_skips_untracked_source_symlink_to_cache() -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let (dir, file, mutation) = make_relative_test_setup();
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Togi Test"]);
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "initial"]);
+        let source_revision = git_snapshot_revision(dir.path())?;
+        let expected_source_fingerprint = source_fingerprint(&std::fs::read(&file)?);
+
+        let cached_source = dir.path().join(".togi-cache/history.json");
+        std::fs::create_dir_all(cached_source.parent().unwrap())?;
+        std::fs::write(&cached_source, b"source cache sentinel")?;
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&cached_source, &alias)?;
+        let replay_overlay = collect_replay_git_worktree_overlay(dir.path())?;
+        assert!(
+            replay_overlay
+                .copy_paths
+                .iter()
+                .all(|relative| relative != Path::new("alias"))
+        );
+
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+        let outcome = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "test ! -e alias && printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    log_path.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: &source_revision,
+                source_fingerprint: &expected_source_fingerprint,
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        )?;
+        assert_eq!(outcome.result, MutationResult::Survived);
+        assert_eq!(std::fs::read(&log_path)?, b"invoked");
+        assert_eq!(std::fs::read(&cached_source)?, b"source cache sentinel");
+        assert!(std::fs::symlink_metadata(&alias)?.file_type().is_symlink());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replay_overlay_skips_source_parent_symlink_to_cache() -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let (dir, file, mutation) = make_relative_test_setup();
+        let replaced_dir = dir.path().join("dir");
+        std::fs::create_dir(&replaced_dir)?;
+        std::fs::write(replaced_dir.join("file"), b"tracked source")?;
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "test@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Togi Test"]);
+        run_git(dir.path(), &["add", "."]);
+        run_git(dir.path(), &["commit", "-m", "initial"]);
+        let source_revision = git_snapshot_revision(dir.path())?;
+        let expected_source_fingerprint = source_fingerprint(&std::fs::read(&file)?);
+
+        let cached_source = dir.path().join(".togi-cache/file");
+        std::fs::create_dir_all(cached_source.parent().unwrap())?;
+        std::fs::write(&cached_source, b"source cache sentinel")?;
+        std::fs::remove_dir_all(&replaced_dir)?;
+        std::os::unix::fs::symlink(".togi-cache", &replaced_dir)?;
+        assert!(!replay_source_relative_file_is_regular(
+            dir.path(),
+            Path::new("dir/file")
+        )?);
+        let overlay = collect_replay_git_worktree_overlay(dir.path())?;
+        assert!(
+            overlay
+                .copy_paths
+                .iter()
+                .all(|relative| !relative.starts_with("dir"))
+        );
+
+        let log_dir = tempfile::tempdir()?;
+        let log_path = log_dir.path().join("replay.log");
+        let cancelled = AtomicBool::new(false);
+        let outcome = run_replay_mutation(
+            dir.path(),
+            &mutation,
+            ReplayRunConfig {
+                test_command: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "test ! -e dir/file && printf invoked >> \"$1\"".into(),
+                    "replay".into(),
+                    log_path.display().to_string(),
+                ],
+                build_command: None,
+                timeout: Duration::from_secs(1),
+                env: HashMap::new(),
+                respect_workspace_ignores: true,
+                source_revision: &source_revision,
+                source_fingerprint: &expected_source_fingerprint,
+                show_output: false,
+                cancelled: &cancelled,
+            },
+        )?;
+        assert_eq!(outcome.result, MutationResult::Survived);
+        assert_eq!(std::fs::read(&log_path)?, b"invoked");
+        assert_eq!(std::fs::read(&cached_source)?, b"source cache sentinel");
+        assert!(
+            std::fs::symlink_metadata(&replaced_dir)?
+                .file_type()
+                .is_symlink()
+        );
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn regular_direct_recipes_cover_fresh_cache_history_and_schema_fallback() -> anyhow::Result<()>
+    {
+        for (reuse, expected_origin) in [
+            (None, DirectRecipeOrigin::Executed),
+            (
+                Some(ReuseSource::ExactCache),
+                DirectRecipeOrigin::ExactCache,
+            ),
+            (
+                Some(ReuseSource::IncrementalHistory),
+                DirectRecipeOrigin::IncrementalHistory,
+            ),
+        ] {
+            let (dir, _file, mutation) = make_relative_test_setup();
+            let mut commands = test_command_config();
+            commands.command = successful_command();
+            if let Some(reuse) = reuse {
+                seed_reused_survivor(dir.path(), &commands, &mutation, reuse)?;
+            }
+            let runner = TestRunner {
+                commands,
+                parallelism: 1,
+                project_root: dir.path().to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: EarlyStopConfig::default(),
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun: false,
+                learned_selection: false,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            let outcome = runner.run(vec![mutation.clone()]);
+            let recipe = outcome
+                .replay_recipes
+                .get(&mutation.id)
+                .expect("regular result should capture a direct replay recipe");
+            assert_eq!(recipe.origin, expected_origin);
+            assert_eq!(recipe.test_command, successful_command());
+        }
+
+        let (dir, _file, mut mutation) = make_relative_test_setup();
+        mutation.language = "unsupported".into();
+        let mut commands = test_command_config();
+        commands.command = successful_command();
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: EarlyStopConfig::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: true,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let outcome = runner.run_with_schemata(vec![mutation.clone()]);
+        assert!(outcome.report.schemata.is_some());
+        assert_eq!(
+            outcome
+                .replay_recipes
+                .get(&mutation.id)
+                .map(|recipe| &recipe.origin),
+            Some(&DirectRecipeOrigin::Executed)
+        );
+        Ok(())
     }
 
     fn go_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
@@ -6433,6 +8104,30 @@ test "$runs" -eq 1
     }
 
     #[test]
+    fn replay_workspace_control_exclusions_are_ascii_case_insensitive() {
+        for path in [
+            ".GIT/config",
+            ".TOGI/state",
+            ".TOGI-CACHE/history.json",
+            ".TOGI.LOCK",
+            ".TOGI-BASELINE",
+            ".TOGI-OTHER/state",
+        ] {
+            assert!(
+                should_skip_replay_workspace_entry(Path::new(path)),
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    fn normal_workspace_exclusions_remain_case_sensitive() {
+        for path in ["Target/cache", "Build/artifact", ".Togi-Custom/state"] {
+            assert!(!should_skip_workspace_entry(Path::new(path)), "{path}");
+        }
+    }
+
+    #[test]
     fn copy_workspace_copies_regular_files_and_skips_internal_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -6498,6 +8193,36 @@ test "$runs" -eq 1
         assert!(!copy.root().join(".togi.lock").exists());
         assert!(!copy.root().join(".codex").exists());
         assert!(!copy.root().join(".claude").exists());
+    }
+
+    #[test]
+    fn normal_workspace_copy_retains_mixed_case_unrelated_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for (relative, contents) in [
+            ("Target/cache", b"target" as &[u8]),
+            ("Build/artifact", b"build"),
+            (".Togi-Custom/state", b"custom"),
+        ] {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, contents).unwrap();
+        }
+
+        let copy = copy_workspace_with_options(root, false).unwrap();
+
+        assert_eq!(
+            std::fs::read(copy.root().join("Target/cache")).unwrap(),
+            b"target"
+        );
+        assert_eq!(
+            std::fs::read(copy.root().join("Build/artifact")).unwrap(),
+            b"build"
+        );
+        assert_eq!(
+            std::fs::read(copy.root().join(".Togi-Custom/state")).unwrap(),
+            b"custom"
+        );
     }
 
     #[test]
@@ -6597,6 +8322,64 @@ test "$runs" -eq 1
     }
 
     #[test]
+    fn replay_workspace_is_independent_git_snapshot_without_source_admin_residue() {
+        if !git_available() {
+            return;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_clean_git_fixture(root);
+        std::fs::write(root.join(".TOGI-BASELINE"), b"control").unwrap();
+        std::fs::write(root.join("src/deleted.rs"), b"stale").unwrap();
+        run_git(root, &["add", ".TOGI-BASELINE", "src/deleted.rs"]);
+        run_git(root, &["commit", "-m", "add snapshot controls"]);
+        let source_revision = git_snapshot_revision(root).unwrap();
+        std::fs::remove_file(root.join("src/deleted.rs")).unwrap();
+        std::fs::create_dir_all(root.join(".TOGI-CACHE")).unwrap();
+        std::fs::write(root.join(".TOGI-CACHE/cache"), b"control").unwrap();
+        let worktrees = root.join(".git/worktrees");
+        assert!(!worktrees.exists());
+
+        let workspace_root;
+        {
+            let copy = copy_workspace_for_replay(root, &source_revision, true).unwrap();
+            workspace_root = copy.root().to_path_buf();
+            let git_dir = copy.root().join(".git");
+            let metadata = std::fs::symlink_metadata(&git_dir).unwrap();
+            assert!(metadata.file_type().is_dir());
+            assert!(!metadata.file_type().is_symlink());
+            assert_eq!(
+                std::fs::read(copy.root().join("src/lib.rs")).unwrap(),
+                b"pub fn f() {}\n"
+            );
+            assert!(!copy.root().join(".TOGI-BASELINE").exists());
+            assert!(!copy.root().join(".TOGI-CACHE").exists());
+            assert!(!copy.root().join("src/deleted.rs").exists());
+            assert!(!worktrees.exists());
+        }
+
+        assert!(!workspace_root.exists());
+        assert!(!worktrees.exists());
+    }
+
+    #[test]
+    fn replay_snapshot_rejects_mismatched_expected_revision() {
+        if !git_available() {
+            return;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_clean_git_fixture(root);
+        let actual = git_snapshot_revision(root).unwrap();
+        let expected = "0".repeat(actual.len());
+        assert_ne!(actual, expected);
+        assert!(copy_workspace_for_replay(root, &expected, true).is_err());
+        assert!(!root.join(".git/worktrees").exists());
+    }
+
+    #[test]
     fn copy_workspace_uses_git_worktree_with_dirty_overlay() -> std::io::Result<()> {
         if !git_available() {
             return Ok(());
@@ -6648,6 +8431,7 @@ test "$runs" -eq 1
         );
         assert_eq!(std::fs::read(copy.root().join("local.txt"))?, b"copy me");
         assert!(!copy.root().join("src/old.rs").exists());
+
         assert_eq!(
             std::fs::read(copy.root().join("src/replaced/nested.rs"))?,
             b"pub fn nested() {}\n"
@@ -6657,6 +8441,139 @@ test "$runs" -eq 1
             std::fs::read(copy.root().join("target/debug/cache"))?,
             b"keep"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_git_worktree_overlay_follows_dirty_and_untracked_regular_source_symlinks()
+    -> std::io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+        init_clean_git_fixture(root);
+        std::fs::write(root.join("target.txt"), b"linked contents")?;
+        std::fs::write(root.join("tracked.txt"), b"original contents")?;
+        run_git(root, &["add", "target.txt", "tracked.txt"]);
+        run_git(root, &["commit", "-m", "add overlay files"]);
+
+        std::fs::remove_file(root.join("tracked.txt"))?;
+        symlink("target.txt", root.join("tracked.txt"))?;
+        symlink("target.txt", root.join("untracked-link.txt"))?;
+
+        let copy = copy_workspace(root)?;
+
+        for relative in ["tracked.txt", "untracked-link.txt"] {
+            let destination = copy.root().join(relative);
+            assert_eq!(std::fs::read(&destination)?, b"linked contents");
+            assert!(
+                !std::fs::symlink_metadata(destination)?
+                    .file_type()
+                    .is_symlink(),
+                "{relative} should retain normal overlay copy semantics"
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_workspace_falls_back_for_escaping_untracked_symlink() -> std::io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().join("repo");
+        std::fs::create_dir(&root)?;
+        init_clean_git_fixture(&root);
+        let outside = tmp.path().join("outside.rs");
+        let link = root.join("untracked-link.rs");
+        std::fs::write(&outside, b"outside")?;
+        symlink(&outside, &link)?;
+
+        let copy = copy_workspace(&root)?;
+
+        assert!(matches!(&copy.reset_strategy, WorkspaceResetStrategy::Copy));
+        assert!(!copy.root().join("untracked-link.rs").exists());
+        assert_eq!(std::fs::read(&outside)?, b"outside");
+        assert!(std::fs::symlink_metadata(&link)?.file_type().is_symlink());
+        assert!(!root.join(".git/worktrees").exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_git_worktree_overlay_replaces_destination_symlink() -> std::io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().join("repo");
+        std::fs::create_dir(&root)?;
+        init_clean_git_fixture(&root);
+        let sentinel = tmp.path().join("outside");
+        std::fs::write(&sentinel, b"outside sentinel")?;
+        let link = root.join("link.txt");
+        symlink(&sentinel, &link)?;
+        run_git(&root, &["add", "link.txt"]);
+        run_git(&root, &["commit", "-m", "add linked file"]);
+
+        std::fs::remove_file(&link)?;
+        std::fs::write(&link, b"overlay contents")?;
+
+        let copy = copy_workspace(&root)?;
+        let destination = copy.root().join("link.txt");
+        assert_eq!(std::fs::read(&sentinel)?, b"outside sentinel");
+        assert!(
+            std::fs::symlink_metadata(&destination)?
+                .file_type()
+                .is_file()
+        );
+        assert_eq!(std::fs::read(destination)?, b"overlay contents");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_overlay_rejects_escaping_and_control_symlink_sources() -> std::io::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().join("project");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir(&root)?;
+        std::fs::create_dir(&workspace)?;
+        let outside = tmp.path().join("outside");
+        std::fs::write(&outside, b"outside sentinel")?;
+        symlink(&outside, root.join("outside-link"))?;
+
+        let error = copy_overlay_file(&root, &workspace, Path::new("outside-link")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not resolve within the project root")
+        );
+        assert_eq!(std::fs::read(&outside)?, b"outside sentinel");
+
+        let control = root.join(".TOGI-CACHE/cache");
+        std::fs::create_dir_all(control.parent().unwrap())?;
+        std::fs::write(&control, b"control sentinel")?;
+        symlink(".TOGI-CACHE/cache", root.join("control-link"))?;
+
+        let error = copy_overlay_file(&root, &workspace, Path::new("control-link")).unwrap_err();
+        assert!(error.to_string().contains("Togi or Git control state"));
+        assert_eq!(std::fs::read(control)?, b"control sentinel");
         Ok(())
     }
 

--- a/src/source_identity.rs
+++ b/src/source_identity.rs
@@ -1,0 +1,116 @@
+use sha2::{Digest, Sha256};
+use std::path::{Component, Path, PathBuf};
+
+/// Normalize a source path to Togi's canonical project-relative slash form.
+///
+/// This is intentionally shared by baseline comparison and replay so both
+/// features agree on source identity.
+pub(crate) fn normalized_project_relative_path(project_root: &Path, file: &Path) -> Option<String> {
+    let relative = if file.is_absolute() {
+        file.strip_prefix(project_root).ok()?
+    } else {
+        file
+    };
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part.to_str()?;
+                if part.contains('\\') {
+                    return None;
+                }
+                parts.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+/// Return whether a stored path is already a canonical project-relative path.
+pub(crate) fn is_normalized_project_relative_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|part| !part.is_empty() && part != "." && part != "..")
+}
+
+/// Resolve a stored canonical path without permitting traversal or symlink
+/// escape from the project root.
+pub(crate) fn resolve_normalized_project_relative_path(
+    project_root: &Path,
+    path: &str,
+) -> Option<PathBuf> {
+    if !is_normalized_project_relative_path(path) {
+        return None;
+    }
+    let root = project_root.canonicalize().ok()?;
+    let candidate = root.join(path);
+    let resolved = candidate.canonicalize().ok()?;
+    resolved.strip_prefix(&root).ok()?;
+    Some(resolved)
+}
+
+/// SHA-256 of the exact on-disk source bytes, including a stable algorithm tag.
+pub(crate) fn source_fingerprint(source: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(source))
+}
+
+/// Verify that a stored byte range is in bounds and still names the original
+/// UTF-8 mutation bytes exactly.
+pub(crate) fn range_matches(source: &[u8], start: usize, end: usize, original: &str) -> bool {
+    start <= end
+        && end <= source.len()
+        && source
+            .get(start..end)
+            .is_some_and(|bytes| bytes == original.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized_path_rejects_escape_and_normalizes_dot_components() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            normalized_project_relative_path(root, Path::new("./src/../src/lib.rs")),
+            Some("src/lib.rs".into())
+        );
+        assert_eq!(
+            normalized_project_relative_path(root, Path::new("../outside.rs")),
+            None
+        );
+        assert!(!is_normalized_project_relative_path("src/../lib.rs"));
+    }
+
+    #[test]
+    fn fingerprint_is_raw_sha256_and_ranges_are_byte_exact() {
+        assert_eq!(
+            source_fingerprint(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert!(range_matches("aé".as_bytes(), 1, 3, "é"));
+        assert!(!range_matches("aé".as_bytes(), 1, 2, "é"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolved_path_rejects_symlink_escape_from_project_root() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path().join("project");
+        let outside = tempdir.path().join("outside.rs");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&outside, b"outside").unwrap();
+        symlink(&outside, root.join("alias.rs")).unwrap();
+
+        assert!(resolve_normalized_project_relative_path(&root, "alias.rs").is_none());
+    }
+}

--- a/tests/replay.rs
+++ b/tests/replay.rs
@@ -1,0 +1,395 @@
+#![cfg(not(windows))]
+
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn togi() -> Command {
+    Command::cargo_bin("togi").unwrap()
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_status(root: &Path) -> Vec<u8> {
+    std::process::Command::new("git")
+        .args(["status", "--porcelain=v1", "-z"])
+        .current_dir(root)
+        .output()
+        .unwrap()
+        .stdout
+}
+
+fn snapshot_tree(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    fn visit(root: &Path, current: &Path, entries: &mut Vec<(PathBuf, Vec<u8>)>) {
+        let Ok(read_dir) = fs::read_dir(current) else {
+            return;
+        };
+        let mut paths = read_dir
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>();
+        paths.sort();
+        for path in paths {
+            if path.is_dir() {
+                visit(root, &path, entries);
+            } else if path.is_file() {
+                entries.push((
+                    path.strip_prefix(root).unwrap().to_path_buf(),
+                    fs::read(&path).unwrap(),
+                ));
+            }
+        }
+    }
+
+    if !root.exists() {
+        return Vec::new();
+    }
+    let mut entries = Vec::new();
+    visit(root, root, &mut entries);
+    entries
+}
+
+struct ReplayFixture {
+    repo: TempDir,
+    report_dir: TempDir,
+    report_path: PathBuf,
+    log_path: PathBuf,
+    source_path: PathBuf,
+    report: Value,
+}
+
+fn setup_replay_fixture() -> ReplayFixture {
+    let repo = TempDir::new().unwrap();
+    let root = repo.path();
+    git(root, &["init"]);
+    git(root, &["config", "user.email", "test@example.com"]);
+    git(root, &["config", "user.name", "Togi Test"]);
+
+    let source_path = root.join("main.go");
+    fs::write(
+        &source_path,
+        "package main\n\nfunc add(a, b int) int {\n\treturn a + b\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("go.mod"),
+        "module example.com/replay\n\ngo 1.21\n",
+    )
+    .unwrap();
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", "initial"]);
+
+    // Keep the target dirty: matching exact target bytes, rather than a clean
+    // worktree, are the replay source identity contract.
+    fs::write(
+        &source_path,
+        "package main\n\nfunc add(a, b int) int {\n\tif a > b {\n\t\treturn a\n\t}\n\treturn a + b\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("test.sh"),
+        "#!/bin/sh\ntest \"$(git rev-parse --is-inside-work-tree)\" = true || exit 1\nprintf x >> \"$TOGI_REPLAY_LOG\"\nexit 0\n",
+    )
+    .unwrap();
+
+    // Both report and command-log paths intentionally live outside the repo.
+    let report_dir = TempDir::new().unwrap();
+    let log_path = report_dir.path().join("invocations.log");
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--format",
+            "json",
+            "--test-cmd",
+            "sh test.sh",
+            "--no-schemata",
+            "--max-per-run",
+            "1",
+        ])
+        .current_dir(root)
+        .env("TOGI_REPLAY_LOG", &log_path)
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "surviving fixture should leave a JSON report\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "check did not emit one JSON report: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(report["kind"], "mutation_report");
+    assert_eq!(report["schema_version"], 1);
+    assert!(report["source_revision"].as_str().is_some());
+    assert_eq!(report["mutations"][0]["source_path"], "main.go");
+    assert!(
+        report["mutations"][0]["source_fingerprint"]
+            .as_str()
+            .is_some_and(|fingerprint| fingerprint.starts_with("sha256:"))
+    );
+    assert_eq!(report["mutations"][0]["replay"]["kind"], "regular_direct");
+
+    let report_path = report_dir.path().join("report.json");
+    fs::write(&report_path, &output.stdout).unwrap();
+    ReplayFixture {
+        repo,
+        report_dir,
+        report_path,
+        log_path,
+        source_path,
+        report,
+    }
+}
+
+fn write_json(path: &Path, value: &Value) {
+    fs::write(path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
+}
+
+fn assert_rejected_without_invocation(fixture: &ReplayFixture, contents: &[u8], id: &str) {
+    fs::write(&fixture.report_path, contents).unwrap();
+    fs::write(&fixture.log_path, []).unwrap();
+    let output = togi()
+        .args([
+            "replay",
+            id,
+            "--report",
+            fixture.report_path.to_str().unwrap(),
+        ])
+        .current_dir(fixture.repo.path())
+        .env("TOGI_REPLAY_LOG", &fixture.log_path)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "malformed/non-replayable report unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        fs::read(&fixture.log_path).unwrap().is_empty(),
+        "replay spawned the test command before rejecting the report"
+    );
+}
+
+#[test]
+fn replay_forces_a_real_direct_execution_without_source_or_cache_residue() {
+    let fixture = setup_replay_fixture();
+    let id = fixture.report["mutations"][0]["id"]
+        .as_u64()
+        .unwrap()
+        .to_string();
+    let source_before = fs::read(&fixture.source_path).unwrap();
+    let status_before = git_status(fixture.repo.path());
+    let git_worktrees_before = snapshot_tree(&fixture.repo.path().join(".git/worktrees"));
+    let cache_before = snapshot_tree(&fixture.repo.path().join(".togi-cache"));
+    let lock_before = fs::read(fixture.repo.path().join(".togi.lock")).unwrap_or_default();
+    let log_before = fs::read(&fixture.log_path).unwrap();
+
+    let output = togi()
+        .args([
+            "replay",
+            &id,
+            "--report",
+            fixture.report_path.to_str().unwrap(),
+        ])
+        .current_dir(fixture.repo.path())
+        .env("TOGI_REPLAY_LOG", &fixture.log_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "replay failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Expected historical result: survived"));
+    assert!(stdout.contains("Fresh result: survived"));
+    assert!(stdout.contains("forced fresh direct execution"));
+    assert!(stdout.contains("Effective command: [\"sh\",\"test.sh\"]"));
+    assert_ne!(fs::read(&fixture.log_path).unwrap(), log_before);
+    assert_eq!(fs::read(&fixture.source_path).unwrap(), source_before);
+    assert_eq!(git_status(fixture.repo.path()), status_before);
+    assert_eq!(
+        snapshot_tree(&fixture.repo.path().join(".git/worktrees")),
+        git_worktrees_before
+    );
+    assert_eq!(
+        snapshot_tree(&fixture.repo.path().join(".togi-cache")),
+        cache_before
+    );
+    assert_eq!(
+        fs::read(fixture.repo.path().join(".togi.lock")).unwrap_or_default(),
+        lock_before
+    );
+    assert!(fixture.report_dir.path().exists());
+}
+
+#[test]
+fn replay_rejects_invalid_or_mismatched_reports_before_running_tests() {
+    let fixture = setup_replay_fixture();
+    let id = fixture.report["mutations"][0]["id"]
+        .as_u64()
+        .unwrap()
+        .to_string();
+
+    assert_rejected_without_invocation(&fixture, b"{not json", &id);
+    assert_rejected_without_invocation(&fixture, br#"{"mutations":[]}"#, &id);
+
+    let mut unsupported_version = fixture.report.clone();
+    unsupported_version["schema_version"] = json!(2);
+    write_json(&fixture.report_path, &unsupported_version);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut wrong_kind = fixture.report.clone();
+    wrong_kind["kind"] = json!("dry_run");
+    write_json(&fixture.report_path, &wrong_kind);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    assert_rejected_without_invocation(
+        &fixture,
+        &serde_json::to_vec(&fixture.report).unwrap(),
+        "999",
+    );
+
+    for replay in [
+        json!({"kind": "unavailable", "reason": "schemata"}),
+        json!({"kind": "unavailable", "reason": "not_executed"}),
+    ] {
+        let mut unavailable = fixture.report.clone();
+        unavailable["mutations"][0]["replay"] = replay;
+        write_json(&fixture.report_path, &unavailable);
+        assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+    }
+
+    let mut non_executed_result = fixture.report.clone();
+    non_executed_result["mutations"][0]["result"] = json!("build_error");
+    write_json(&fixture.report_path, &non_executed_result);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut not_executed = fixture.report.clone();
+    not_executed["mutations"][0]["execution"] =
+        json!({"state": "not_executed", "reason": "build_error"});
+    write_json(&fixture.report_path, &not_executed);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut mismatched_origin = fixture.report.clone();
+    mismatched_origin["mutations"][0]["replay"]["origin"] = json!("exact_cache");
+    write_json(&fixture.report_path, &mismatched_origin);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut missing_execution = fixture.report.clone();
+    missing_execution["mutations"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("execution");
+    write_json(&fixture.report_path, &missing_execution);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut control_path = fixture.report.clone();
+    control_path["mutations"][0]["source_path"] = json!(".git/config");
+    write_json(&fixture.report_path, &control_path);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let mut uppercase_control_path = fixture.report.clone();
+    uppercase_control_path["mutations"][0]["source_path"] = json!(".GIT/config");
+    write_json(&fixture.report_path, &uppercase_control_path);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let tampered_values = [
+        ("source_path", json!("../test.sh")),
+        ("byte_start", json!(999_999)),
+        ("original", json!("tampered")),
+        (
+            "source_fingerprint",
+            json!("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+        ),
+    ];
+    for (field, value) in tampered_values {
+        let mut tampered = fixture.report.clone();
+        tampered["mutations"][0][field] = value;
+        write_json(&fixture.report_path, &tampered);
+        assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+    }
+
+    let mut empty_command = fixture.report.clone();
+    empty_command["mutations"][0]["replay"]["test_command"] = json!([]);
+    write_json(&fixture.report_path, &empty_command);
+    assert_rejected_without_invocation(&fixture, &fs::read(&fixture.report_path).unwrap(), &id);
+
+    let source_before = fs::read(&fixture.source_path).unwrap();
+    fs::write(&fixture.source_path, b"package main\n// target changed\n").unwrap();
+    assert_rejected_without_invocation(
+        &fixture,
+        &serde_json::to_vec(&fixture.report).unwrap(),
+        &id,
+    );
+    fs::write(&fixture.source_path, source_before).unwrap();
+
+    git(fixture.repo.path(), &["add", "main.go"]);
+    git(fixture.repo.path(), &["commit", "-m", "different head"]);
+    assert_rejected_without_invocation(
+        &fixture,
+        &serde_json::to_vec(&fixture.report).unwrap(),
+        &id,
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn replay_rejects_symlink_alias_to_control_path_before_spawning() {
+    let fixture = setup_replay_fixture();
+    let id = fixture.report["mutations"][0]["id"]
+        .as_u64()
+        .unwrap()
+        .to_string();
+    let cached_source = fixture.repo.path().join(".togi-cache/alias-target.go");
+    let source_bytes = fs::read(&fixture.source_path).unwrap();
+    fs::create_dir_all(cached_source.parent().unwrap()).unwrap();
+    fs::write(&cached_source, &source_bytes).unwrap();
+    std::os::unix::fs::symlink(&cached_source, fixture.repo.path().join("alias.go")).unwrap();
+
+    let mut alias_report = fixture.report.clone();
+    alias_report["mutations"][0]["source_path"] = json!("alias.go");
+    write_json(&fixture.report_path, &alias_report);
+    fs::write(&fixture.log_path, []).unwrap();
+    let output = togi()
+        .args([
+            "replay",
+            &id,
+            "--report",
+            fixture.report_path.to_str().unwrap(),
+        ])
+        .current_dir(fixture.repo.path())
+        .env("TOGI_REPLAY_LOG", &fixture.log_path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("resolved replay source path targets a Togi or Git control path")
+    );
+    assert!(fs::read(&fixture.log_path).unwrap().is_empty());
+    assert_eq!(fs::read(&cached_source).unwrap(), source_bytes);
+}


### PR DESCRIPTION
Closes #439.

- Isolated replay: re-execute one mutation in a disposable HEAD-pinned clone; live tree never mutated.
- Versioned JSON provenance: kind/schema_version/generator/source_revision envelope plus per-mutation source_path/byte range/fingerprint and direct recipes.
- Source/report validation: revision match, project-relative confinement, control-path/hardlink rejection, fingerprint and byte-range checks, recipe-origin provenance.
- No source residue: capability-bounded staged writes, guard-restored bytes, tempdir cleanup.
- Windows fail-closed: replay bails explicitly where race-free replacement is unavailable.
- Tests/gates: `cargo test --locked` (721 passed; 11 ignored), `cargo fmt --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`.