### PR TITLE
fix(action): defer unset inputs to repository config

### DIFF
--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-args=(
-  check
-  --base "${TOGI_BASE:-origin/main}"
-  --timeout "${TOGI_TIMEOUT:-30}"
-  --format "${TOGI_FORMAT:-terminal}"
-)
+args=(check)
+
+if [[ -n "${TOGI_BASE:-}" ]]; then
+  args+=(--base "$TOGI_BASE")
+fi
+
+if [[ -n "${TOGI_TIMEOUT:-}" ]]; then
+  args+=(--timeout "$TOGI_TIMEOUT")
+fi
+
+if [[ -n "${TOGI_FORMAT:-}" ]]; then
+  args+=(--format "$TOGI_FORMAT")
+fi
 
 if [[ -n "${TOGI_TEST_CMD:-}" ]]; then
   args+=(--test-cmd "$TOGI_TEST_CMD")

--- a/README.md
+++ b/README.md
@@ -627,6 +627,38 @@ jobs:
       - run: togi check --base origin/main --format github --fail-under 80
 ```
 
+### GitHub Action
+
+The composite Action (`Darkroom4364/togi`) wraps the install-and-run steps
+above. Use it when your project already has a `togi.toml`:
+
+```yaml
+- uses: Darkroom4364/togi@<version>
+```
+
+The Action passes `--base`, `--timeout`, and `--format` to togi **only when
+you supply a non-empty value for the corresponding input**. If you omit them,
+the flags are not passed to the CLI. Omitted `base` and `timeout` then defer
+to your repository `togi.toml` — respecting `[diff].base` and `[test].timeout`
+(including per-language and per-project overrides). Output format is CLI-only:
+`togi.toml` has no format setting, so an omitted `format` falls back to the
+CLI default `terminal`, while a non-empty `format` explicitly selects the CLI
+output format.
+
+Explicitly supplied values still take precedence over `togi.toml` (standard
+CLI-override semantics):
+
+```yaml
+- uses: Darkroom4364/togi@<version>
+  with:
+    base: origin/develop
+    timeout: '120'
+    format: json
+```
+
+The `test-cmd` input has always followed this pattern and is unchanged.
+The `version` input and its `latest` default are also unchanged.
+
 ## Code scanning (SARIF)
 
 `togi check --format sarif` emits a [SARIF 2.1.0](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report: one result per surviving mutant with its file and line, plus the mutation score in the run's invocation properties. Upload it to GitHub code scanning to see surviving mutants as annotations on the PR diff:

--- a/action.yml
+++ b/action.yml
@@ -8,18 +8,15 @@ inputs:
   base:
     description: 'Base branch to diff against'
     required: false
-    default: 'origin/main'
   timeout:
     description: 'Per-mutation timeout in seconds'
     required: false
-    default: '30'
   test-cmd:
     description: 'Test command override'
     required: false
   format:
     description: 'Output format (terminal, json, github, html, or sarif)'
     required: false
-    default: 'terminal'
   version:
     description: 'togi version to use'
     required: false

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2923,6 +2923,99 @@ fn assert_action_helper_test_cmd(test_cmd: &str) {
 }
 
 #[test]
+fn github_action_run_helper_omits_flags_for_unset_inputs() {
+    if !bash_available() {
+        eprintln!("skipping action helper test because bash is unavailable");
+        return;
+    }
+
+    let dir = TempDir::new().unwrap();
+    let fake_togi = dir.path().join("fake-togi.sh");
+    fs::write(&fake_togi, "#!/usr/bin/env bash\nprintf '<%s>\\n' \"$@\"\n").unwrap();
+    std::process::Command::new("bash")
+        .args(["-c", "chmod +x \"$1\"", "--"])
+        .arg(&fake_togi)
+        .output()
+        .unwrap();
+
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
+    let output = std::process::Command::new("bash")
+        .arg(helper)
+        .env("TOGI_BIN", &fake_togi)
+        .env_remove("TOGI_BASE")
+        .env_remove("TOGI_TIMEOUT")
+        .env_remove("TOGI_FORMAT")
+        .env_remove("TOGI_TEST_CMD")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let args: Vec<String> = stdout.lines().map(String::from).collect();
+    assert_eq!(args, vec!["<check>".to_string()]);
+}
+
+#[test]
+fn github_action_inputs_have_no_baked_in_defaults() {
+    let action_yml =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml")).unwrap();
+
+    // Split the inputs: mapping into per-input blocks keyed by name.
+    let mut blocks: Vec<(&str, Vec<&str>)> = Vec::new();
+    let mut in_inputs = false;
+    for line in action_yml.lines() {
+        if line == "inputs:" {
+            in_inputs = true;
+            continue;
+        }
+        if in_inputs {
+            if !line.starts_with("  ") {
+                break;
+            }
+            if let Some(name) = line.strip_prefix("  ") {
+                if !name.starts_with(' ') && name.ends_with(':') {
+                    blocks.push((name.trim_end_matches(':'), Vec::new()));
+                    continue;
+                }
+            }
+            if let Some((_, body)) = blocks.last_mut() {
+                body.push(line);
+            }
+        }
+    }
+
+    for name in ["base", "timeout", "format"] {
+        let (_, body) = blocks
+            .iter()
+            .find(|(block, _)| *block == name)
+            .unwrap_or_else(|| panic!("action.yml is missing the `{name}` input"));
+        assert!(
+            !body
+                .iter()
+                .any(|line| line.trim_start().starts_with("default:")),
+            "action.yml input `{name}` must not bake in a default; unset inputs defer to togi.toml"
+        );
+    }
+
+    let (_, version_body) = blocks
+        .iter()
+        .find(|(block, _)| *block == "version")
+        .expect("action.yml is missing the `version` input");
+    assert!(
+        version_body
+            .iter()
+            .any(|line| line.trim() == "default: 'latest'"),
+        "action.yml input `version` must keep its 'latest' default"
+    );
+}
+
+#[test]
 fn github_action_asset_resolver_matches_release_assets() {
     if !bash_available() {
         eprintln!("skipping action asset resolver test because bash is unavailable");


### PR DESCRIPTION
Closes #452.

- Unset `base`/`timeout`/`format` inputs no longer pass CLI flags (mirroring `test-cmd`). Omitted `base`/`timeout` defer to the consumer's `togi.toml` (`[diff].base`, `[test].timeout` incl. per-language/per-project overrides); non-empty values remain CLI overrides. `togi.toml` has no format setting, so an omitted `format` sends no flag and uses the CLI default `terminal`; a non-empty `format` explicitly selects the CLI output format. `version` and its `latest` default are unchanged.
- README documents this exact behavior: TOML defer for `base`/`timeout`, CLI-only `terminal` default for `format`.

Verification: `bash -n` clean; `cargo test --test cli github_action` 5/5 pass (new regression tests prove unset inputs omit all three flags, explicit values pass them, and action.yml carries no baked-in defaults); `cargo fmt --check` clean; full `cargo test` 722 passed, 0 failed. CI 13/13 pass on head `a8a241c`.