### PR TITLE
fix: prevent cache writes after interrupted mutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1025,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shell-words",
+ "signal-hook",
  "tempfile",
  "toml",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ctrlc = "3"
 # Platform
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+signal-hook = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,18 +32,32 @@ struct ResolvedCheckConfig {
 
 fn main() {
     let cancelled = Arc::new(AtomicBool::new(false));
-    let cancelled_handler = cancelled.clone();
 
     // First Ctrl+C sets the flag so the runner can stop gracefully.
     // Second Ctrl+C force-exits for impatient users.
-    ctrlc::set_handler(move || {
-        if cancelled_handler.swap(true, Ordering::SeqCst) {
-            eprintln!("\nForce exit — files may need manual restoration (check git status)");
-            process::exit(130);
-        }
-        eprintln!("\nInterrupted — finishing current mutation and cleaning up...");
-    })
-    .expect("failed to set Ctrl+C handler");
+    #[cfg(unix)]
+    {
+        use signal_hook::consts::SIGINT;
+        // Conditional shutdown MUST precede flag registration: if the flag
+        // were registered first, the first SIGINT would both set the flag
+        // AND immediately terminate.
+        signal_hook::flag::register_conditional_shutdown(SIGINT, 130, cancelled.clone())
+            .expect("failed to register SIGINT conditional shutdown");
+        signal_hook::flag::register(SIGINT, cancelled.clone())
+            .expect("failed to register SIGINT flag handler");
+    }
+    #[cfg(windows)]
+    {
+        let cancelled_handler = cancelled.clone();
+        ctrlc::set_handler(move || {
+            if cancelled_handler.swap(true, Ordering::SeqCst) {
+                eprintln!("\nForce exit — files may need manual restoration (check git status)");
+                process::exit(130);
+            }
+            eprintln!("\nInterrupted — finishing current mutation and cleaning up...");
+        })
+        .expect("failed to set Ctrl+C handler");
+    }
 
     let cli = togi::cli::Cli::parse();
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5385,6 +5385,19 @@ fn run_command(
         }
     };
 
+    // Defense-in-depth: the child was reaped but process-group
+    // descendants may still hold pipes open. Check the cancellation
+    // flag before any result or side-effect propagation.
+    if cancelled.load(Ordering::Acquire) {
+        process_tree.terminate(child.id());
+        finish_capture_threads(
+            &mut stdout_capture,
+            &mut stderr_capture,
+            capture_cleanup_deadline(),
+        );
+        return MutationOutcome::cancelled();
+    }
+
     process_tree.terminate(child.id());
 
     let result = if status.success() {


### PR DESCRIPTION
## Summary

Prevents cache writes after interrupted mutation via two complementary mechanisms:

1. **Unix SIGINT flag registration**: Uses `signal_hook::flag::register_conditional_shutdown(SIGINT, 130, ...)` before `register(SIGINT, ...)` so the first SIGINT sets the flag (graceful shutdown), and a second triggers the conditional 130 exit. Windows retains the existing `ctrlc` handler.

2. **Post-child cancellation guard**: After reaping the child process, the runner checks the cancellation flag before propagating results or writing to cache. When set, it terminates the process tree, cleans capture threads, and returns `cancelled`.

## Verification

- `cargo fmt --check` — passed
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — passed
- `cargo check --locked --target x86_64-pc-windows-gnu --tests` — passed (no errors)
- `cargo test --locked --test cli interrupted_mutation_exits_130_without_a_report_or_side_effects` — 20/20 passed
- `cargo test --locked --test cli` — 62/62 passed
- `cargo test --locked` — 723 passed, 11 ignored, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ctrl+C handling on Unix systems so the first interrupt cancels the current operation gracefully.
  * Ensured cancellation is recognized immediately after a process exits, preventing incorrect success, termination, or timeout results.
  * Preserved the existing behavior where a second interrupt forcefully exits the application on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->