### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,13 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: stable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.14.1
+          package-manager-cache: false
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 8.0.x
       - name: Integration tests
         run: cargo test --locked -- --ignored
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"


### PR DESCRIPTION
Part of #447

Aligns the tag-triggered release Integration Tests job with `ci.yml` by provisioning Node 24.14.1 and .NET 8.0.x after Go, so the ignored polyglot suite has identical runtime provisioning. Explicitly disables setup-node package-manager caching to avoid deriving cache behavior from future root package metadata. Bumps the package and lockfile version from 0.2.0 to 0.3.0.

Validation gates:
- `cargo fmt --check`
- `cargo test --locked`
- `cargo test --locked -- --ignored`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo check --locked --target x86_64-pc-windows-gnu --tests`

The ignored integration suite could not complete locally because the C# fixture requires `dotnet`, which is unavailable in this environment; its other 10 ignored tests passed. Tagging and release occur only after merge and a full main CI run is green.