### PR TITLE
Add replayable Action report artifact

### DIFF
--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -6,7 +6,8 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
-report_path="${TOGI_REPORT_PATH:-${RUNNER_TEMP:-.}/togi-report.json}"
+report_output_path="${TOGI_REPORT_PATH:-${RUNNER_TEMP:-.}/togi-report.json}"
+report_path="$report_output_path"
 if command -v cygpath >/dev/null 2>&1; then
   report_path=$(cygpath -u "$report_path")
 fi
@@ -111,7 +112,7 @@ if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
   exit 2
 fi
 if ! {
-  printf 'report-path=%s\n' "$report_path"
+  printf 'report-path=%s\n' "$report_output_path"
   printf 'mutation-score=%s\n' "$mutation_score"
   printf 'survivor-count=%s\n' "$survivor_count"
 } >>"$GITHUB_OUTPUT"; then

--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -1,22 +1,123 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-args=(check)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to generate Action report outputs" >&2
+  exit 2
+fi
+
+report_path="${TOGI_REPORT_PATH:-${RUNNER_TEMP:-.}/togi-report.json}"
+if command -v cygpath >/dev/null 2>&1; then
+  report_path=$(cygpath -u "$report_path")
+fi
+if ! mkdir -p "$(dirname "$report_path")"; then
+  echo "Could not create report directory for ${report_path}" >&2
+  exit 2
+fi
+if ! rm -f "$report_path"; then
+  echo "Could not remove stale report at ${report_path}" >&2
+  exit 2
+fi
+
+review_args=(check)
+json_args=(check)
 
 if [[ -n "${TOGI_BASE:-}" ]]; then
-  args+=(--base "$TOGI_BASE")
+  review_args+=(--base "$TOGI_BASE")
+  json_args+=(--base "$TOGI_BASE")
 fi
 
 if [[ -n "${TOGI_TIMEOUT:-}" ]]; then
-  args+=(--timeout "$TOGI_TIMEOUT")
+  review_args+=(--timeout "$TOGI_TIMEOUT")
+  json_args+=(--timeout "$TOGI_TIMEOUT")
 fi
 
 if [[ -n "${TOGI_FORMAT:-}" ]]; then
-  args+=(--format "$TOGI_FORMAT")
+  review_args+=(--format "$TOGI_FORMAT")
 fi
+json_args+=(--format json)
 
 if [[ -n "${TOGI_TEST_CMD:-}" ]]; then
-  args+=(--test-cmd "$TOGI_TEST_CMD")
+  review_args+=(--test-cmd "$TOGI_TEST_CMD")
+  json_args+=(--test-cmd "$TOGI_TEST_CMD")
 fi
 
-"${TOGI_BIN:-togi}" "${args[@]}"
+togi_bin="${TOGI_BIN:-togi}"
+
+if [[ "${TOGI_FORMAT:-}" == "json" ]]; then
+  "$togi_bin" "${review_args[@]}" | tee "$report_path"
+  statuses=("${PIPESTATUS[@]}")
+  review_status=${statuses[0]}
+  tee_status=${statuses[1]}
+  if (( tee_status != 0 )); then
+    echo "Could not write report to ${report_path}" >&2
+    rm -f "$report_path"
+    exit 2
+  fi
+  json_status=$review_status
+else
+  "$togi_bin" "${review_args[@]}"
+  review_status=$?
+  case "$review_status" in
+    0|1)
+      ;;
+    *)
+      rm -f "$report_path"
+      exit "$review_status"
+      ;;
+  esac
+
+  "$togi_bin" "${json_args[@]}" >"$report_path"
+  json_status=$?
+fi
+
+case "$json_status" in
+  0|1)
+    ;;
+  *)
+    rm -f "$report_path"
+    exit "$json_status"
+    ;;
+esac
+
+summary=$(
+  jq -er '
+    if .kind != "mutation_report" then
+      error("expected a normal mutation report")
+    elif (.schema_version | type) != "number" then
+      error("report schema version is missing or invalid")
+    elif (.schema_version < 1 or (.schema_version | floor) != .schema_version) then
+      error("report schema version is missing or invalid")
+    elif (.mutation_score | type) != "number" then
+      error("report mutation score is missing or invalid")
+    elif (.survived | type) != "number" then
+      error("report survivor count is missing or invalid")
+    elif (.survived < 0 or (.survived | floor) != .survived) then
+      error("report survivor count is missing or invalid")
+    else
+      [.mutation_score, .survived] | @tsv
+    end
+  ' "$report_path"
+) || {
+  echo "Togi did not produce a valid replayable mutation report" >&2
+  rm -f "$report_path"
+  exit 2
+}
+
+IFS=$'\t' read -r mutation_score survivor_count <<<"$summary"
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "GITHUB_OUTPUT is required to publish Action outputs" >&2
+  rm -f "$report_path"
+  exit 2
+fi
+if ! {
+  printf 'report-path=%s\n' "$report_path"
+  printf 'mutation-score=%s\n' "$mutation_score"
+  printf 'survivor-count=%s\n' "$survivor_count"
+} >>"$GITHUB_OUTPUT"; then
+  echo "Could not write Action outputs" >&2
+  rm -f "$report_path"
+  exit 2
+fi
+
+exit "$review_status"

--- a/README.md
+++ b/README.md
@@ -676,6 +676,53 @@ CLI-override semantics):
 The `test-cmd` input has always followed this pattern and is unchanged.
 The `version` input and its `latest` default are also unchanged.
 
+For a normal mutation report, every Action run also creates a replayable
+`togi-report.json`. When `format` is not `json`, the Action preserves the
+selected review run and then runs the same binary with `--format json` to
+capture the report. When `format: json` is selected, that one JSON stream is
+saved without a second run. The selected review run remains the PR gate:
+survivors still make the Action exit 1.
+
+By default, the Action uploads the report as the `togi-report` artifact for
+14 days. Configure retention with `report-retention-days`, or set
+`upload-report: 'false'` to keep the report local to the job without uploading
+it:
+
+```yaml
+- id: togi
+  uses: Darkroom4364/togi@<version>
+  with:
+    format: github
+    report-retention-days: '14'
+    # upload-report: 'false'
+```
+
+The Action exposes `report-path`, `mutation-score`, and `survivor-count` as
+step outputs. Because a survivor intentionally fails the Action, later steps
+that consume the artifact or outputs must use `if: always()`.
+
+Download and replay a report in a checkout at the report's recorded source
+revision:
+
+```yaml
+- uses: actions/download-artifact@v8
+  if: ${{ always() }}
+  with:
+    name: togi-report
+    path: togi-artifact
+- name: Replay a recorded mutant
+  if: ${{ always() }}
+  run: togi replay <mutant-id> --report togi-artifact/togi-report.json
+```
+
+Choose an ID whose report has `replay.kind` set to `regular_direct`; records
+explicitly marked unavailable by togi's existing replay contract cannot be
+replayed.
+
+Replay executes commands recorded in the report. Download and replay only
+trusted artifacts, and retain them only as long as their source and command
+metadata are appropriate for your repository.
+
 ## Code scanning (SARIF)
 
 `togi check --format sarif` emits a [SARIF 2.1.0](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report: one result per surviving mutant with its file and line, plus the mutation score in the run's invocation properties. Upload it to GitHub code scanning to see surviving mutants as annotations on the PR diff:

--- a/README.md
+++ b/README.md
@@ -683,16 +683,19 @@ capture the report. When `format: json` is selected, that one JSON stream is
 saved without a second run. The selected review run remains the PR gate:
 survivors still make the Action exit 1.
 
-By default, the Action uploads the report as the `togi-report` artifact for
-14 days. Configure retention with `report-retention-days`, or set
-`upload-report: 'false'` to keep the report local to the job without uploading
-it:
+By default, the Action uploads the report as the `togi-report` artifact
+(`report-artifact-name: 'togi-report'`) for 14 days. Configure retention with
+`report-retention-days`, or set `upload-report: 'false'` to keep the report
+local to the job without uploading it. In a matrix or when invoking the Action
+more than once in a job, set a unique `report-artifact-name`, such as
+`togi-report-${{ matrix.shard }}`, to avoid artifact-name conflicts:
 
 ```yaml
 - id: togi
   uses: Darkroom4364/togi@<version>
   with:
     format: github
+    report-artifact-name: togi-report-${{ matrix.shard }}
     report-retention-days: '14'
     # upload-report: 'false'
 ```
@@ -708,7 +711,7 @@ revision:
 - uses: actions/download-artifact@v8
   if: ${{ always() }}
   with:
-    name: togi-report
+    name: togi-report-${{ matrix.shard }}
     path: togi-artifact
 - name: Replay a recorded mutant
   if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -688,14 +688,14 @@ By default, the Action uploads the report as the `togi-report` artifact
 `report-retention-days`, or set `upload-report: 'false'` to keep the report
 local to the job without uploading it. In a matrix or when invoking the Action
 more than once in a job, set a unique `report-artifact-name`, such as
-`togi-report-${{ matrix.shard }}`, to avoid artifact-name conflicts:
+`togi-report-${{ matrix.shard }}`, to avoid artifact-name conflicts. A
+matching download step must use the same custom name.
 
 ```yaml
 - id: togi
   uses: Darkroom4364/togi@<version>
   with:
     format: github
-    report-artifact-name: togi-report-${{ matrix.shard }}
     report-retention-days: '14'
     # upload-report: 'false'
 ```
@@ -711,7 +711,7 @@ revision:
 - uses: actions/download-artifact@v8
   if: ${{ always() }}
   with:
-    name: togi-report-${{ matrix.shard }}
+    name: togi-report
     path: togi-artifact
 - name: Replay a recorded mutant
   if: ${{ always() }}

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,29 @@ inputs:
   format:
     description: 'Output format (terminal, json, github, html, or sarif)'
     required: false
+  upload-report:
+    description: 'Upload the replayable JSON report artifact'
+    required: false
+    default: 'true'
+  report-retention-days:
+    description: 'Retention in days for the replayable JSON report artifact'
+    required: false
+    default: '14'
   version:
     description: 'togi version to use'
     required: false
     default: 'latest'
+
+outputs:
+  report-path:
+    description: 'Path to the generated replayable JSON report'
+    value: ${{ steps.run-togi.outputs.report-path }}
+  mutation-score:
+    description: 'Mutation score from the replayable JSON report'
+    value: ${{ steps.run-togi.outputs.mutation-score }}
+  survivor-count:
+    description: 'Survivor count from the replayable JSON report'
+    value: ${{ steps.run-togi.outputs.survivor-count }}
 
 runs:
   using: 'composite'
@@ -93,11 +112,22 @@ runs:
         TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"
 
     - name: Run togi
+      id: run-togi
       shell: bash
       env:
         TOGI_BASE: ${{ inputs.base }}
         TOGI_TIMEOUT: ${{ inputs.timeout }}
         TOGI_FORMAT: ${{ inputs.format }}
         TOGI_TEST_CMD: ${{ inputs.test-cmd }}
+        TOGI_REPORT_PATH: ${{ runner.temp }}/togi-report.json
       run: |
         bash "${{ github.action_path }}/.github/scripts/run-togi.sh"
+
+    - name: Upload replayable report
+      if: ${{ always() && inputs.upload-report == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: togi-report
+        path: ${{ runner.temp }}/togi-report.json
+        retention-days: ${{ inputs.report-retention-days }}
+        if-no-files-found: warn

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Retention in days for the replayable JSON report artifact'
     required: false
     default: '14'
+  report-artifact-name:
+    description: 'Name for the replayable JSON report artifact'
+    required: false
+    default: 'togi-report'
   version:
     description: 'togi version to use'
     required: false
@@ -127,7 +131,7 @@ runs:
       if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}
       uses: actions/upload-artifact@v7
       with:
-        name: togi-report
+        name: ${{ inputs.report-artifact-name }}
         path: ${{ runner.temp }}/togi-report.json
         retention-days: ${{ inputs.report-retention-days }}
         if-no-files-found: warn

--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
         bash "${{ github.action_path }}/.github/scripts/run-togi.sh"
 
     - name: Upload replayable report
-      if: ${{ always() && inputs.upload-report == 'true' }}
+      if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}
       uses: actions/upload-artifact@v7
       with:
         name: togi-report

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3418,8 +3418,9 @@ fn github_action_inputs_have_no_baked_in_defaults() {
 
 #[test]
 fn github_action_declares_replay_report_contract() {
-    let action_yml =
-        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml")).unwrap();
+    let action_yml = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml"))
+        .unwrap()
+        .replace("\r\n", "\n");
 
     for expected in [
         "outputs:\n  report-path:",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3403,6 +3403,7 @@ fn github_action_inputs_have_no_baked_in_defaults() {
         ("version", "'latest'"),
         ("upload-report", "'true'"),
         ("report-retention-days", "'14'"),
+        ("report-artifact-name", "'togi-report'"),
     ] {
         let (_, body) = blocks
             .iter()
@@ -3429,9 +3430,10 @@ fn github_action_declares_replay_report_contract() {
         "value: ${{ steps.run-togi.outputs.survivor-count }}",
         "id: run-togi",
         "TOGI_REPORT_PATH: ${{ runner.temp }}/togi-report.json",
+        "report-artifact-name:",
         "if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}",
         "uses: actions/upload-artifact@v7",
-        "name: togi-report",
+        "name: ${{ inputs.report-artifact-name }}",
         "path: ${{ runner.temp }}/togi-report.json",
         "retention-days: ${{ inputs.report-retention-days }}",
         "if-no-files-found: warn",
@@ -3441,10 +3443,6 @@ fn github_action_declares_replay_report_contract() {
             "action.yml is missing `{expected}`"
         );
     }
-    assert!(
-        !action_yml.contains("report-artifact-name"),
-        "the Action report contract must not add an artifact-name input"
-    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3116,6 +3116,67 @@ fn github_action_run_helper_reuses_selected_json_stdout_once() {
     assert_action_outputs(&fixture);
 }
 
+#[cfg(not(windows))]
+#[test]
+fn github_action_run_helper_keeps_native_report_output_path() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    let cygpath_dir = fixture.dir.path().join("fake-bin");
+    fs::create_dir(&cygpath_dir).unwrap();
+    let cygpath = cygpath_dir.join("cygpath");
+    fs::write(
+        &cygpath,
+        "#!/usr/bin/env bash\n[[ \"$1\" == \"-u\" ]] || exit 2\nprintf '%s\\n' \"$FAKE_CYGPATH_RESULT\"\n",
+    )
+    .unwrap();
+    let output = std::process::Command::new("bash")
+        .args(["-c", "chmod +x \"$1\"", "--"])
+        .arg(&cygpath)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let inherited_path = std::env::var("PATH").expect("PATH must be set");
+    let path = format!("{}:{inherited_path}", cygpath_dir.display());
+    let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
+    let output = std::process::Command::new("bash")
+        .arg(helper)
+        .current_dir(fixture.dir.path())
+        .env("PATH", path)
+        .env("TOGI_BIN", &fixture.fake_togi)
+        .env("TOGI_REPORT_PATH", r"C:\runner\temp\togi-report.json")
+        .env("RUNNER_TEMP", fixture.dir.path())
+        .env("GITHUB_OUTPUT", &fixture.github_output)
+        .env("FAKE_TOGI_LOG", &fixture.invocation_log)
+        .env("FAKE_TOGI_REVIEW_STATUS", "0")
+        .env("FAKE_TOGI_JSON_STATUS", "0")
+        .env("FAKE_TOGI_JSON", NORMAL_ACTION_REPORT)
+        .env("FAKE_CYGPATH_RESULT", &fixture.report_path)
+        .env_remove("TOGI_BASE")
+        .env_remove("TOGI_TIMEOUT")
+        .env_remove("TOGI_TEST_CMD")
+        .env("TOGI_FORMAT", "github")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(fixture.report_path.exists());
+    assert_eq!(
+        action_helper_invocations(&fixture),
+        vec![
+            action_args(&["check", "--format", "github"]),
+            action_args(&["check", "--format", "json"]),
+        ]
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.github_output).unwrap(),
+        "report-path=C:\\runner\\temp\\togi-report.json\nmutation-score=75.5\nsurvivor-count=1\n"
+    );
+}
+
 #[test]
 fn github_action_run_helper_omits_unset_review_flags() {
     if !bash_available() || !jq_available() {
@@ -3367,7 +3428,7 @@ fn github_action_declares_replay_report_contract() {
         "value: ${{ steps.run-togi.outputs.survivor-count }}",
         "id: run-togi",
         "TOGI_REPORT_PATH: ${{ runner.temp }}/togi-report.json",
-        "if: ${{ always() && inputs.upload-report == 'true' }}",
+        "if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}",
         "uses: actions/upload-artifact@v7",
         "name: togi-report",
         "path: ${{ runner.temp }}/togi-report.json",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3284,7 +3284,7 @@ fn github_action_report_replays_a_direct_mutation() {
     assert!(output_values.contains("mutation-score="));
     assert!(output_values.contains("survivor-count="));
 
-    std::process::Command::new(assert_cmd::cargo::cargo_bin("togi"))
+    togi()
         .args([
             "replay",
             &mutation_id,
@@ -3292,12 +3292,8 @@ fn github_action_report_replays_a_direct_mutation() {
             report_path.to_str().unwrap(),
         ])
         .current_dir(repo.path())
-        .output()
-        .unwrap()
-        .status
-        .success()
-        .then_some(())
-        .expect("replay should accept the Action report");
+        .assert()
+        .success();
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,7 @@ use predicates::prelude::*;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::{fs::PermissionsExt, process::CommandExt};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -2865,100 +2865,439 @@ fn check_help_lists_test_selection_file_flag() {
         .stdout(predicate::str::contains("--test-selection-file"));
 }
 
-#[test]
-fn github_action_run_helper_preserves_multiword_test_cmd() {
-    if !bash_available() {
-        eprintln!("skipping action helper test because bash is unavailable");
-        return;
-    }
-
-    assert_action_helper_test_cmd("go test ./...");
-    assert_action_helper_test_cmd("cargo test --workspace --all-features");
+fn jq_available() -> bool {
+    std::process::Command::new("jq")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
-fn assert_action_helper_test_cmd(test_cmd: &str) {
+struct ActionHelperFixture {
+    dir: TempDir,
+    fake_togi: PathBuf,
+    invocation_log: PathBuf,
+    github_output: PathBuf,
+    report_path: PathBuf,
+}
+
+fn action_helper_fixture() -> ActionHelperFixture {
     let dir = TempDir::new().unwrap();
     let fake_togi = dir.path().join("fake-togi.sh");
-    fs::write(&fake_togi, "#!/usr/bin/env bash\nprintf '<%s>\\n' \"$@\"\n").unwrap();
-    std::process::Command::new("bash")
+    let invocation_log = dir.path().join("invocations.log");
+    let github_output = dir.path().join("github-output");
+    let report_path = dir.path().join("togi-report.json");
+    fs::write(
+        &fake_togi,
+        r#"#!/usr/bin/env bash
+set -u
+args=("$@")
+format=terminal
+for ((index = 0; index < ${#args[@]}; index++)); do
+  if [[ "${args[index]}" == "--format" ]]; then
+    format="${args[$((index + 1))]}"
+    break
+  fi
+done
+for arg in "${args[@]}"; do
+  printf '<%s>\n' "$arg" >> "$FAKE_TOGI_LOG"
+done
+printf '%s\n' '--' >> "$FAKE_TOGI_LOG"
+if [[ "$format" == "json" ]]; then
+  printf '%s\n' "${FAKE_TOGI_JSON:?}"
+  exit "${FAKE_TOGI_JSON_STATUS:-0}"
+fi
+printf 'review-format=%s\n' "$format"
+exit "${FAKE_TOGI_REVIEW_STATUS:-0}"
+"#,
+    )
+    .unwrap();
+    let output = std::process::Command::new("bash")
         .args(["-c", "chmod +x \"$1\"", "--"])
         .arg(&fake_togi)
         .output()
         .unwrap();
+    assert!(output.status.success());
 
+    ActionHelperFixture {
+        dir,
+        fake_togi,
+        invocation_log,
+        github_output,
+        report_path,
+    }
+}
+
+struct ActionHelperRun<'a> {
+    base: Option<&'a str>,
+    timeout: Option<&'a str>,
+    format: Option<&'a str>,
+    test_cmd: Option<&'a str>,
+    review_status: i32,
+    json_status: i32,
+    json: &'a str,
+}
+
+fn run_action_helper(
+    fixture: &ActionHelperFixture,
+    run: ActionHelperRun<'_>,
+) -> std::process::Output {
     let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
-    let output = std::process::Command::new("bash")
+    let mut command = std::process::Command::new("bash");
+    command
         .arg(helper)
-        .env("TOGI_BIN", &fake_togi)
-        .env("TOGI_BASE", "HEAD~1")
-        .env("TOGI_TIMEOUT", "45")
-        .env("TOGI_FORMAT", "json")
-        .env("TOGI_TEST_CMD", test_cmd)
-        .output()
-        .unwrap();
+        .current_dir(fixture.dir.path())
+        .env("TOGI_BIN", &fixture.fake_togi)
+        .env("RUNNER_TEMP", fixture.dir.path())
+        .env("GITHUB_OUTPUT", &fixture.github_output)
+        .env("FAKE_TOGI_LOG", &fixture.invocation_log)
+        .env("FAKE_TOGI_REVIEW_STATUS", run.review_status.to_string())
+        .env("FAKE_TOGI_JSON_STATUS", run.json_status.to_string())
+        .env("FAKE_TOGI_JSON", run.json);
+    for (name, value) in [
+        ("TOGI_BASE", run.base),
+        ("TOGI_TIMEOUT", run.timeout),
+        ("TOGI_FORMAT", run.format),
+        ("TOGI_TEST_CMD", run.test_cmd),
+    ] {
+        if let Some(value) = value {
+            command.env(name, value);
+        } else {
+            command.env_remove(name);
+        }
+    }
+    command.output().unwrap()
+}
 
-    assert!(
-        output.status.success(),
-        "helper failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+fn action_helper_invocations(fixture: &ActionHelperFixture) -> Vec<Vec<String>> {
+    let mut invocations = Vec::new();
+    let mut invocation = Vec::new();
+    for line in fs::read_to_string(&fixture.invocation_log).unwrap().lines() {
+        if line == "--" {
+            invocations.push(std::mem::take(&mut invocation));
+        } else {
+            assert!(
+                line.starts_with('<') && line.ends_with('>'),
+                "unexpected fake invocation log line: {line}"
+            );
+            invocation.push(line[1..line.len() - 1].to_string());
+        }
+    }
+    assert!(invocation.is_empty(), "unterminated fake invocation");
+    invocations
+}
+
+fn action_args(args: &[&str]) -> Vec<String> {
+    args.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+fn assert_action_outputs(fixture: &ActionHelperFixture) {
+    assert_eq!(
+        fs::read_to_string(&fixture.github_output).unwrap(),
+        format!(
+            "report-path={}\nmutation-score=75.5\nsurvivor-count=1\n",
+            fixture.report_path.display()
+        )
+    );
+}
+
+const NORMAL_ACTION_REPORT: &str =
+    r#"{"kind":"mutation_report","schema_version":1,"mutation_score":75.5,"survived":1}"#;
+
+#[test]
+fn github_action_run_helper_preserves_selected_format_and_exit_one() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    let output = run_action_helper(
+        &fixture,
+        ActionHelperRun {
+            base: Some("HEAD~1"),
+            timeout: Some("45"),
+            format: Some("github"),
+            test_cmd: Some("cargo test --workspace --all-features"),
+            review_status: 1,
+            json_status: 1,
+            json: NORMAL_ACTION_REPORT,
+        },
     );
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let args: Vec<String> = stdout.lines().map(String::from).collect();
     assert_eq!(
-        args,
+        output.status.code(),
+        Some(1),
+        "helper failed with stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "review-format=github\n"
+    );
+    assert_eq!(
+        action_helper_invocations(&fixture),
         vec![
-            "<check>".to_string(),
-            "<--base>".to_string(),
-            "<HEAD~1>".to_string(),
-            "<--timeout>".to_string(),
-            "<45>".to_string(),
-            "<--format>".to_string(),
-            "<json>".to_string(),
-            "<--test-cmd>".to_string(),
-            format!("<{test_cmd}>"),
+            action_args(&[
+                "check",
+                "--base",
+                "HEAD~1",
+                "--timeout",
+                "45",
+                "--format",
+                "github",
+                "--test-cmd",
+                "cargo test --workspace --all-features",
+            ]),
+            action_args(&[
+                "check",
+                "--base",
+                "HEAD~1",
+                "--timeout",
+                "45",
+                "--format",
+                "json",
+                "--test-cmd",
+                "cargo test --workspace --all-features",
+            ]),
         ]
     );
+    assert_eq!(
+        fs::read_to_string(&fixture.report_path).unwrap(),
+        format!("{NORMAL_ACTION_REPORT}\n")
+    );
+    assert_action_outputs(&fixture);
 }
 
 #[test]
-fn github_action_run_helper_omits_flags_for_unset_inputs() {
-    if !bash_available() {
-        eprintln!("skipping action helper test because bash is unavailable");
+fn github_action_run_helper_reuses_selected_json_stdout_once() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
         return;
     }
 
-    let dir = TempDir::new().unwrap();
-    let fake_togi = dir.path().join("fake-togi.sh");
-    fs::write(&fake_togi, "#!/usr/bin/env bash\nprintf '<%s>\\n' \"$@\"\n").unwrap();
-    std::process::Command::new("bash")
-        .args(["-c", "chmod +x \"$1\"", "--"])
-        .arg(&fake_togi)
-        .output()
-        .unwrap();
+    let fixture = action_helper_fixture();
+    let output = run_action_helper(
+        &fixture,
+        ActionHelperRun {
+            base: Some("HEAD~1"),
+            timeout: Some("45"),
+            format: Some("json"),
+            test_cmd: Some("go test ./..."),
+            review_status: 1,
+            json_status: 1,
+            json: NORMAL_ACTION_REPORT,
+        },
+    );
 
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("{NORMAL_ACTION_REPORT}\n")
+    );
+    assert_eq!(
+        action_helper_invocations(&fixture),
+        vec![action_args(&[
+            "check",
+            "--base",
+            "HEAD~1",
+            "--timeout",
+            "45",
+            "--format",
+            "json",
+            "--test-cmd",
+            "go test ./...",
+        ])]
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.report_path).unwrap(),
+        format!("{NORMAL_ACTION_REPORT}\n")
+    );
+    assert_action_outputs(&fixture);
+}
+
+#[test]
+fn github_action_run_helper_omits_unset_review_flags() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    let output = run_action_helper(
+        &fixture,
+        ActionHelperRun {
+            base: None,
+            timeout: None,
+            format: None,
+            test_cmd: None,
+            review_status: 0,
+            json_status: 0,
+            json: NORMAL_ACTION_REPORT,
+        },
+    );
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "review-format=terminal\n"
+    );
+    assert_eq!(
+        action_helper_invocations(&fixture),
+        vec![
+            action_args(&["check"]),
+            action_args(&["check", "--format", "json"]),
+        ]
+    );
+    assert_action_outputs(&fixture);
+}
+
+#[test]
+fn github_action_run_helper_removes_invalid_or_fatal_sidecar_reports() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    for (json_status, json) in [(1, "not json"), (2, NORMAL_ACTION_REPORT)] {
+        let fixture = action_helper_fixture();
+        let output = run_action_helper(
+            &fixture,
+            ActionHelperRun {
+                base: Some("HEAD~1"),
+                timeout: None,
+                format: Some("github"),
+                test_cmd: None,
+                review_status: 1,
+                json_status,
+                json,
+            },
+        );
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "unexpected status for JSON sidecar status {json_status}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!fixture.report_path.exists());
+        assert!(
+            !fixture.github_output.exists()
+                || fs::read_to_string(&fixture.github_output)
+                    .unwrap()
+                    .is_empty()
+        );
+    }
+}
+
+#[test]
+fn github_action_run_helper_propagates_fatal_review_and_cleans_stale_report() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    fs::write(&fixture.report_path, "stale report").unwrap();
+    let output = run_action_helper(
+        &fixture,
+        ActionHelperRun {
+            base: Some("HEAD~1"),
+            timeout: None,
+            format: Some("github"),
+            test_cmd: None,
+            review_status: 2,
+            json_status: 0,
+            json: NORMAL_ACTION_REPORT,
+        },
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        action_helper_invocations(&fixture),
+        vec![action_args(&[
+            "check", "--base", "HEAD~1", "--format", "github",
+        ])]
+    );
+    assert!(!fixture.report_path.exists());
+    assert!(
+        !fixture.github_output.exists()
+            || fs::read_to_string(&fixture.github_output)
+                .unwrap()
+                .is_empty()
+    );
+}
+
+#[test]
+fn github_action_report_replays_a_direct_mutation() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action replay test because bash or jq is unavailable");
+        return;
+    }
+
+    let repo = setup_git_repo();
+    fs::write(
+        repo.path().join("togi.toml"),
+        "[mutations]\nschemata = false\nmax_per_run = 1\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join("test.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+    let report_dir = TempDir::new().unwrap();
+    let report_path = report_dir.path().join("togi-report.json");
+    let github_output = report_dir.path().join("github-output");
     let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
     let output = std::process::Command::new("bash")
         .arg(helper)
-        .env("TOGI_BIN", &fake_togi)
-        .env_remove("TOGI_BASE")
-        .env_remove("TOGI_TIMEOUT")
-        .env_remove("TOGI_FORMAT")
-        .env_remove("TOGI_TEST_CMD")
+        .current_dir(repo.path())
+        .env("TOGI_BIN", assert_cmd::cargo::cargo_bin("togi"))
+        .env("RUNNER_TEMP", report_dir.path())
+        .env("GITHUB_OUTPUT", &github_output)
+        .env("TOGI_BASE", "HEAD")
+        .env("TOGI_FORMAT", "github")
+        .env("TOGI_TEST_CMD", "sh test.sh")
         .output()
         .unwrap();
 
-    assert!(
-        output.status.success(),
-        "helper failed\nstdout:\n{}\nstderr:\n{}",
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Action helper did not preserve the surviving review failure\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("::warning"));
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let args: Vec<String> = stdout.lines().map(String::from).collect();
-    assert_eq!(args, vec!["<check>".to_string()]);
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(&report_path).unwrap()).unwrap();
+    assert_eq!(report["kind"], "mutation_report");
+    assert!(report["schema_version"].as_u64().is_some());
+    let mutation = report["mutations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|mutation| mutation["replay"]["kind"] == "regular_direct")
+        .expect("report should contain a directly replayable mutation");
+    let mutation_id = mutation["id"].as_u64().unwrap().to_string();
+    let output_values = fs::read_to_string(&github_output).unwrap();
+    assert!(output_values.contains(&format!("report-path={}", report_path.display())));
+    assert!(output_values.contains("mutation-score="));
+    assert!(output_values.contains("survivor-count="));
+
+    std::process::Command::new(assert_cmd::cargo::cargo_bin("togi"))
+        .args([
+            "replay",
+            &mutation_id,
+            "--report",
+            report_path.to_str().unwrap(),
+        ])
+        .current_dir(repo.path())
+        .output()
+        .unwrap()
+        .status
+        .success()
+        .then_some(())
+        .expect("replay should accept the Action report");
 }
 
 #[test]
@@ -3003,15 +3342,50 @@ fn github_action_inputs_have_no_baked_in_defaults() {
         );
     }
 
-    let (_, version_body) = blocks
-        .iter()
-        .find(|(block, _)| *block == "version")
-        .expect("action.yml is missing the `version` input");
-    assert!(
-        version_body
+    for (name, default) in [
+        ("version", "'latest'"),
+        ("upload-report", "'true'"),
+        ("report-retention-days", "'14'"),
+    ] {
+        let (_, body) = blocks
             .iter()
-            .any(|line| line.trim() == "default: 'latest'"),
-        "action.yml input `version` must keep its 'latest' default"
+            .find(|(block, _)| *block == name)
+            .unwrap_or_else(|| panic!("action.yml is missing the `{name}` input"));
+        assert!(
+            body.iter()
+                .any(|line| line.trim() == format!("default: {default}")),
+            "action.yml input `{name}` must keep its {default} default"
+        );
+    }
+}
+
+#[test]
+fn github_action_declares_replay_report_contract() {
+    let action_yml =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml")).unwrap();
+
+    for expected in [
+        "outputs:\n  report-path:",
+        "value: ${{ steps.run-togi.outputs.report-path }}",
+        "value: ${{ steps.run-togi.outputs.mutation-score }}",
+        "value: ${{ steps.run-togi.outputs.survivor-count }}",
+        "id: run-togi",
+        "TOGI_REPORT_PATH: ${{ runner.temp }}/togi-report.json",
+        "if: ${{ always() && inputs.upload-report == 'true' }}",
+        "uses: actions/upload-artifact@v7",
+        "name: togi-report",
+        "path: ${{ runner.temp }}/togi-report.json",
+        "retention-days: ${{ inputs.report-retention-days }}",
+        "if-no-files-found: warn",
+    ] {
+        assert!(
+            action_yml.contains(expected),
+            "action.yml is missing `{expected}`"
+        );
+    }
+    assert!(
+        !action_yml.contains("report-artifact-name"),
+        "the Action report contract must not add an artifact-name input"
     );
 }
 


### PR DESCRIPTION
## Summary
- preserve the selected Action review output and blocking status while generating a replayable JSON sidecar
- upload the report with opt-out, retention, and step outputs
- document download/replay and cover the Action contract deterministically

Closes #453

## Verification
- `cargo test --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `./.github/scripts/check-pinned-actions.sh`
- Action shell smoke scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions now produce replayable JSON mutation reports.
  * Reports can be uploaded as artifacts with configurable retention or disabled.
  * Exposes report path, mutation score, and survivor count as Action outputs.
  * Supports downloading and replaying eligible reports.

* **Documentation**
  * Added configuration guidance, artifact handling details, and replay instructions.

* **Tests**
  * Expanded coverage for report generation, validation, outputs, uploads, and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->