### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"


### PR DESCRIPTION
## Release prep

v0.4.0 ships the already-merged composite-Action replay artifact contract from [#462](https://github.com/Darkroom4364/togi/pull/462), which closes [#453](https://github.com/Darkroom4364/togi/issues/453).

This PR changes only the root package version in `Cargo.toml` and the matching root `togi` entry in `Cargo.lock` from `0.3.0` to `0.4.0`.

## Local gates

- PASS — `cargo fmt --check`
- PASS — `cargo test --locked` (730 passed; 11 ignored)
- UNAVAILABLE LOCAL RUNTIME — `cargo test --locked -- --ignored`: 10/11 passed; the C# fixture stopped because `dotnet` is not installed locally (`dotnet: command not found`). This is not a code failure; tag CI provisions .NET.
- PASS — `cargo clippy --locked --all-targets --all-features -- -D warnings`
- PASS — `cargo check --locked --target x86_64-pc-windows-gnu`
- UNAVAILABLE LOCAL TARGET — the established release target `x86_64-pc-windows-msvc` is not installed locally; Windows CI remains required.
- PASS — `.github/scripts/check-pinned-actions.sh`

Tagging and release occur only after this PR merges and main CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.3.0 to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->