### PR TITLE
ci: add advisory Togi Action dogfood

### DIFF
--- a/.github/workflows/togi-action-advisory.yml
+++ b/.github/workflows/togi-action-advisory.yml
@@ -1,0 +1,43 @@
+name: Togi Action Advisory
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: togi-action-advisory-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  mutation-test:
+    name: Togi Action Advisory
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          cache-bin: false
+      - name: Run Togi action (advisory)
+        id: togi
+        uses: Darkroom4364/togi@05560884c9faf6e438e158245d7f19b4a28f63df # v0.4.0 release action source
+        with:
+          version: v0.4.0
+          base: origin/${{ github.base_ref }}
+          test-cmd: cargo test --locked
+          timeout: '120'
+          format: json
+          upload-report: 'true'
+          report-artifact-name: togi-action-advisory-report
+          report-retention-days: '14'


### PR DESCRIPTION
## Summary
- add a read-only, non-blocking PR workflow that dogfoods the released v0.4.0 Action
- upload the Action-owned replayable report artifact without PR comments or SARIF

## Verification
- `.github/scripts/check-pinned-actions.sh`
- `cargo fmt --check`
- `cargo test --locked github_action_declares_replay_report_contract`

The first source-changing #454 PR will provide the meaningful diff, artifact, and trusted replay dogfood run.