### PR TITLE
Confirm narrowed mutation survivors

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,12 +403,14 @@ fail the run when LCOV coverage is below a threshold:
 - `--fail-on-uncovered-diff` fails when any changed line is uncovered
 - `togi test-map` generates a Go line-to-test map from per-test coverage
 - `--test-selection-file coverage/test-selection.json` narrows each mutant to tests that cover that line when the configured runner supports test selection
+- `--confirm-survivors` re-runs only narrowed survivors through their original full route; a full-suite kill is reported as `killed`, not as an actionable survivor.
 
 ```bash
 togi check --coverage auto
 togi check --coverage-cmd ./scripts/collect-coverage.sh --coverage-file coverage/lcov.info
 togi test-map --path . --output coverage/test-selection.json
 togi check --coverage-file coverage/lcov.info --test-selection-file coverage/test-selection.json
+togi check --test-selection-file coverage/test-selection.json --confirm-survivors
 togi check --coverage-file coverage/lcov.info --min-line-coverage 80 --min-diff-coverage 90
 ```
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -583,6 +583,7 @@ mod tests {
     fn fixture_report(results: Vec<(Mutation, MutationResult)>) -> MutationReport {
         let total = results.len();
         MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             killed: results
                 .iter()
                 .filter(|(_, result)| *result == MutationResult::Killed)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,9 @@ pub struct CheckArgs {
     /// JSON source-line to test-name map for targeted test runs
     #[arg(long)]
     pub test_selection_file: Option<PathBuf>,
+    /// Re-run narrowed survivors with their full test route before reporting them
+    #[arg(long)]
+    pub confirm_survivors: bool,
 
     /// Disable structured incremental history reuse
     #[arg(long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,8 @@ pub struct MutationConfig {
     pub coverage_command: Vec<String>,
     pub test_selection_file: Option<PathBuf>,
     #[serde(default)]
+    pub confirm_survivors: bool,
+    #[serde(default)]
     pub min_line_coverage: Option<f64>,
     #[serde(default)]
     pub min_diff_coverage: Option<f64>,
@@ -543,6 +545,7 @@ impl Default for MutationConfig {
             coverage_file: None,
             coverage_command: vec![],
             test_selection_file: None,
+            confirm_survivors: false,
             min_line_coverage: None,
             min_diff_coverage: None,
             fail_on_uncovered_diff: false,
@@ -836,6 +839,7 @@ base = "origin/develop"
 [mutations]
 max_per_run = 50
 schemata = true
+confirm_survivors = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.test.profile, Some(ResourceProfile::Ci));
@@ -850,6 +854,7 @@ schemata = true
         assert_eq!(config.diff.base, "origin/develop");
         assert_eq!(config.mutations.max_per_run, 50);
         assert!(config.mutations.schemata);
+        assert!(config.mutations.confirm_survivors);
     }
 
     #[test]
@@ -901,6 +906,7 @@ commnad = ["cargo", "test"]
             config.mutations.test_selection_file,
             Some("coverage/test-selection.json".into())
         );
+        assert!(!config.mutations.confirm_survivors);
         assert!(config.mutations.min_line_coverage.is_none());
         assert!(config.mutations.min_diff_coverage.is_none());
         assert!(!config.mutations.fail_on_uncovered_diff);
@@ -934,6 +940,7 @@ commnad = ["cargo", "test"]
         assert!(config.mutations.operators.is_empty());
         assert!(config.mutations.coverage_file.is_none());
         assert!(config.mutations.test_selection_file.is_none());
+        assert!(!config.mutations.confirm_survivors);
         assert!(config.mutations.min_line_coverage.is_none());
         assert!(config.mutations.min_diff_coverage.is_none());
         assert!(!config.mutations.fail_on_uncovered_diff);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,72 @@ impl fmt::Display for MutationExecution {
     }
 }
 
+/// How the test command for a mutation was selected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestSelectionProvenance {
+    /// The configured full test route ran unchanged.
+    Full,
+    /// A test-selection map narrowed the primary route.
+    Narrowed { confirmation: SurvivorConfirmation },
+}
+
+impl TestSelectionProvenance {
+    pub fn mode_name(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Narrowed { .. } => "narrowed",
+        }
+    }
+
+    pub fn confirmation(self) -> Option<SurvivorConfirmation> {
+        match self {
+            Self::Full => None,
+            Self::Narrowed { confirmation } => Some(confirmation),
+        }
+    }
+}
+
+impl fmt::Display for TestSelectionProvenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full => write!(f, "full suite"),
+            Self::Narrowed { confirmation } => {
+                write!(f, "narrowed; confirmation: {confirmation}")
+            }
+        }
+    }
+}
+
+/// Outcome of the full-suite check requested for a narrowed survivor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurvivorConfirmation {
+    NotRequested,
+    NotNeeded,
+    ConfirmedSurvived,
+    Killed,
+    TimedOut,
+    BuildError,
+}
+
+impl SurvivorConfirmation {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::NotRequested => "not_requested",
+            Self::NotNeeded => "not_needed",
+            Self::ConfirmedSurvived => "confirmed_survived",
+            Self::Killed => "killed",
+            Self::TimedOut => "timed_out",
+            Self::BuildError => "build_error",
+        }
+    }
+}
+
+impl fmt::Display for SurvivorConfirmation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 /// Why a mutation did not run its mutated test suite.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MutationNonExecutionReason {
@@ -264,6 +330,8 @@ pub struct MutationReport {
     /// by mutation id. Verdicts absent here derive their canonical execution
     /// state from `MutationResult`.
     pub execution_provenance: BTreeMap<u32, MutationExecution>,
+    /// Sparse test-selection provenance for runs with a configured selection map.
+    pub selection_provenance: BTreeMap<u32, TestSelectionProvenance>,
     /// Diagnostics for mutations classified as `BuildError`.
     pub build_error_diagnostics: Vec<BuildErrorDiagnostic>,
     pub schemata: Option<SchemataReport>,
@@ -310,6 +378,11 @@ impl MutationReport {
             .get(&mutation_id)
             .copied()
             .unwrap_or_else(|| MutationExecution::for_result(result))
+    }
+
+    /// Return test-selection provenance when a selection map was configured.
+    pub fn selection_for(&self, mutation_id: u32) -> Option<TestSelectionProvenance> {
+        self.selection_provenance.get(&mutation_id).copied()
     }
 
     /// Count fresh executions, restored verdicts, and non-executed outcomes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ struct ExplainMutation {
     description: String,
     result: String,
     execution: Option<ExplainMutationExecution>,
+    test_selection: Option<ExplainTestSelection>,
     original: Option<String>,
     replacement: Option<String>,
     diff: Option<String>,
@@ -148,6 +149,12 @@ struct ExplainMutation {
 struct ExplainMutationExecution {
     state: String,
     reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ExplainTestSelection {
+    mode: String,
+    confirmation: Option<String>,
 }
 
 fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
@@ -204,6 +211,12 @@ fn explain_mutation(mutant_id: u32, report_path: &Path) -> anyhow::Result<()> {
 
     println!();
     println!("Execution: {execution_detail}");
+    if let Some(selection) = &mutation.test_selection {
+        println!("Test selection: {}", selection.mode);
+        if let Some(confirmation) = &selection.confirmation {
+            println!("Full-suite confirmation: {confirmation}");
+        }
+    }
     if test_executed {
         if let Some(command) = report.test_command.as_ref().filter(|cmd| !cmd.is_empty()) {
             println!("Test command: {}", serde_json::to_string(command)?);
@@ -768,6 +781,9 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
     }
     if let Some(path) = cfg.test_selection_file {
         config.mutations.test_selection_file = Some(path);
+    }
+    if cfg.confirm_survivors {
+        config.mutations.confirm_survivors = true;
     }
     if cfg.no_incremental_history {
         config.mutations.incremental_history = false;
@@ -1417,6 +1433,7 @@ fn coverage_only_report(
     togi::MutationReport {
         results: Vec::new(),
         execution_provenance: BTreeMap::new(),
+        selection_provenance: BTreeMap::new(),
         build_error_diagnostics: Vec::new(),
         schemata: None,
         baseline_timing: None,
@@ -1536,6 +1553,7 @@ fn command_config(
             config.mutations.test_selection_file.as_deref(),
             project_root,
         ),
+        confirm_survivors: config.mutations.confirm_survivors,
     }
 }
 
@@ -1981,6 +1999,7 @@ mod tests {
             min_diff_coverage: None,
             fail_on_uncovered_diff: false,
             test_selection_file: None,
+            confirm_survivors: false,
             no_incremental_history: false,
             learned_selection: false,
             force_rerun: false,
@@ -2009,6 +2028,21 @@ mod tests {
 
         assert_eq!(resolved.config.test.jobs, 1);
         assert!(resolved.fail_fast);
+    }
+
+    #[test]
+    fn resolve_config_cli_confirmation_enables_survivor_confirmation() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = dir.path().join("togi.toml");
+        std::fs::write(&config_path, "[mutations]\nconfirm_survivors = false\n")
+            .expect("config should be written");
+        let mut cfg = check_config();
+        cfg.config = Some(config_path);
+        cfg.confirm_survivors = true;
+
+        let resolved = resolve_config(cfg).expect("config should resolve");
+
+        assert!(resolved.config.mutations.confirm_survivors);
     }
 
     #[test]

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -1,10 +1,11 @@
-use crate::{Mutation, MutationExecution, MutationReport, MutationResult};
+use crate::{Mutation, MutationExecution, MutationReport, MutationResult, TestSelectionProvenance};
 
 /// Format a GitHub Actions warning annotation for a survived mutation.
 fn format_annotation_with_baseline(
     mutation: &Mutation,
     execution: MutationExecution,
     status: Option<crate::baseline::SurvivorBaselineStatus>,
+    selection: Option<TestSelectionProvenance>,
 ) -> String {
     let provenance = match execution {
         MutationExecution::Executed => String::new(),
@@ -15,8 +16,11 @@ fn format_annotation_with_baseline(
     let baseline = status
         .map(|status| format!(" [baseline: {}]", status.as_str()))
         .unwrap_or_default();
+    let selection = selection
+        .map(|selection| format!(" [selection: {selection}]"))
+        .unwrap_or_default();
     let message = format!(
-        "Survived mutation: {} ({}){provenance}{baseline}",
+        "Survived mutation: {} ({}){provenance}{baseline}{selection}",
         mutation.operator, mutation.description
     );
     format!(
@@ -52,6 +56,7 @@ fn annotations_with_baseline(
                 mutation,
                 report.execution_for(mutation.id, *result),
                 comparison.and_then(|comparison| comparison.status_for(mutation.id)),
+                report.selection_for(mutation.id),
             )
         })
         .collect()
@@ -152,6 +157,7 @@ mod tests {
             .filter(|(_, r)| *r == MutationResult::Survived)
             .count();
         MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             planned_total: results.len(),
             early_stop_reason: None,
             total: results.len(),
@@ -173,7 +179,7 @@ mod tests {
     #[test]
     fn annotation_format_for_survived_mutation() {
         let m = mutation("src/auth.rs", 47, "lt_to_lte", "changed < to <=");
-        let line = format_annotation_with_baseline(&m, MutationExecution::Executed, None);
+        let line = format_annotation_with_baseline(&m, MutationExecution::Executed, None, None);
         assert_eq!(
             line,
             "::warning file=src/auth.rs,line=47::Survived mutation: lt_to_lte (changed < to <=)"
@@ -280,6 +286,7 @@ mod tests {
             &m,
             MutationExecution::Executed,
             Some(crate::baseline::SurvivorBaselineStatus::Historic),
+            None,
         );
         assert_eq!(
             line,

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -52,6 +52,7 @@ pub fn generate_report_with_baseline(
     for (mutation, result) in &report.results {
         let file_path = mutation.file.display().to_string();
         let execution = report.execution_for(mutation.id, *result);
+        let selection = report.selection_for(mutation.id);
         let result_str = match result {
             MutationResult::Killed => "killed",
             MutationResult::Survived => "survived",
@@ -92,7 +93,9 @@ pub fn generate_report_with_baseline(
             original: mutation.original.clone(),
             replacement: mutation.replacement.clone(),
             result: result_str,
-            execution: execution.to_string(),
+            execution: selection
+                .map(|selection| format!("{execution}; {selection}"))
+                .unwrap_or_else(|| execution.to_string()),
             baseline_status: (*result == MutationResult::Survived)
                 .then(|| comparison.and_then(|comparison| comparison.status_for(mutation.id)))
                 .flatten()
@@ -535,6 +538,7 @@ mod tests {
     #[test]
     fn html_contains_build_error_diagnostics() {
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 1,
@@ -609,6 +613,7 @@ mod tests {
             ));
         }
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results,
             execution_provenance: BTreeMap::new(),
             build_error_diagnostics,
@@ -633,6 +638,7 @@ mod tests {
     #[test]
     fn html_escapes_special_chars() {
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 1,
@@ -689,6 +695,7 @@ mod tests {
         }
 
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results,
             execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -111,6 +111,8 @@ struct JsonMutation {
     result: String,
     execution: JsonMutationExecution,
     #[serde(skip_serializing_if = "Option::is_none")]
+    test_selection: Option<JsonTestSelection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     column: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     original: Option<String>,
@@ -141,6 +143,13 @@ struct JsonMutationExecution {
     state: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct JsonTestSelection {
+    mode: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confirmation: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -385,6 +394,14 @@ fn to_json_string_with_baseline_and_replay_optional(
         .iter()
         .map(|(m, r)| {
             let execution = report.execution_for(m.id, *r);
+            let test_selection = report
+                .selection_for(m.id)
+                .map(|selection| JsonTestSelection {
+                    mode: selection.mode_name(),
+                    confirmation: selection
+                        .confirmation()
+                        .map(|confirmation| confirmation.name()),
+                });
             let replay_fields = replay_capture.map(|(capture, recipes)| {
                 json_replay_mutation_fields(
                     capture,
@@ -413,6 +430,7 @@ fn to_json_string_with_baseline_and_replay_optional(
                     state: execution.state_name(),
                     reason: execution.reason().map(|reason| reason.name()),
                 },
+                test_selection,
                 column: Some(m.column),
                 original: Some(m.original.clone()),
                 replacement: Some(m.replacement.clone()),
@@ -543,7 +561,7 @@ mod tests {
     use crate::test_helpers::sample_report;
     use crate::{
         BaselineTiming, BuildErrorDiagnostic, Mutation, MutationExecution,
-        SchemataFallbackReasonCount, SchemataReport,
+        SchemataFallbackReasonCount, SchemataReport, SurvivorConfirmation, TestSelectionProvenance,
     };
     use serde_json::Value;
     use std::collections::BTreeMap;
@@ -702,6 +720,34 @@ mod tests {
     }
 
     #[test]
+    fn json_output_records_selection_mode_and_confirmation() {
+        let mut report = sample_report();
+        report.selection_provenance.insert(
+            0,
+            TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::Killed,
+            },
+        );
+        report
+            .selection_provenance
+            .insert(1, TestSelectionProvenance::Full);
+
+        let value: Value = serde_json::from_str(&to_json_string(&report).unwrap()).unwrap();
+
+        assert_eq!(value["mutations"][0]["test_selection"]["mode"], "narrowed");
+        assert_eq!(
+            value["mutations"][0]["test_selection"]["confirmation"],
+            "killed"
+        );
+        assert_eq!(value["mutations"][1]["test_selection"]["mode"], "full");
+        assert!(
+            value["mutations"][1]["test_selection"]
+                .get("confirmation")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn json_output_reports_reuse_and_nonexecution_reasons() {
         let mut report = sample_report();
         report
@@ -850,6 +896,7 @@ mod tests {
     #[test]
     fn json_score_zero_when_all_build_errors() {
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 1,
@@ -897,6 +944,7 @@ mod tests {
         );
         let fingerprint = diagnostic.fingerprint.clone();
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 1,
@@ -952,6 +1000,7 @@ mod tests {
     #[test]
     fn json_score_100_when_empty_report() {
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![],
             execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
@@ -1055,6 +1104,7 @@ mod tests {
         };
         let capture = ReplayReportCapture::capture(project.path(), std::slice::from_ref(&mutation));
         let mut report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(mutation.clone(), MutationResult::Survived)],
             execution_provenance: BTreeMap::from([(0, MutationExecution::Executed)]),
             build_error_diagnostics: vec![],

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -379,6 +379,11 @@ pub fn format_pr_comment_with_baseline(
                 }
                 MutationExecution::NotExecuted(reason) => format!(" (not executed: {reason})"),
             };
+            let selection = report
+                .selection_for(mutation.id)
+                .map(|selection| format!(" (selection: {selection})"))
+                .unwrap_or_default();
+            let provenance = format!("{provenance}{selection}");
             if let Some(comparison) = comparison {
                 let baseline_status = comparison
                     .status_for(mutation.id)
@@ -552,6 +557,7 @@ mod tests {
     #[test]
     fn build_error_groups_deduplicate_by_diagnostic_fingerprint() {
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![
                 report_mutation(0, "src/a.rs", MutationResult::BuildError),
                 report_mutation(1, "src/b.rs", MutationResult::BuildError),
@@ -773,6 +779,7 @@ mod tests {
         use crate::{MutationReport, MutationResult};
         use std::time::Duration;
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 0,
@@ -813,6 +820,7 @@ mod tests {
         use crate::{MutationReport, MutationResult};
         use std::time::Duration;
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 0,
@@ -854,6 +862,7 @@ mod tests {
         use crate::{MutationReport, MutationResult};
         use std::time::Duration;
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![(
                 Mutation {
                     id: 0,
@@ -898,6 +907,7 @@ mod tests {
         use crate::{MutationReport, MutationResult};
         use std::time::Duration;
         let report = MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results: vec![
                 (
                     Mutation {
@@ -970,6 +980,7 @@ mod tests {
             .filter(|(_, r)| *r == MutationResult::Killed)
             .count();
         MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results,
             execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -1,4 +1,7 @@
-use crate::{Mutation, MutationExecution, MutationReport, MutationResult};
+use crate::{
+    Mutation, MutationExecution, MutationReport, MutationResult, SurvivorConfirmation,
+    TestSelectionProvenance,
+};
 use anyhow::Result;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -72,6 +75,60 @@ struct SarifInvocationProperties {
     #[serde(skip_serializing_if = "super::is_zero")]
     subsumed: usize,
     mutation_score: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selection_confirmation: Option<SarifSelectionConfirmationSummary>,
+}
+
+#[derive(Serialize)]
+struct SarifSelectionConfirmationSummary {
+    full: usize,
+    narrowed: usize,
+    confirmation_not_requested: usize,
+    confirmation_not_needed: usize,
+    confirmation_confirmed_survived: usize,
+    confirmation_killed: usize,
+    confirmation_timed_out: usize,
+    confirmation_build_error: usize,
+}
+
+impl SarifSelectionConfirmationSummary {
+    fn from_report(report: &MutationReport) -> Option<Self> {
+        if report.selection_provenance.is_empty() {
+            return None;
+        }
+
+        let mut summary = Self {
+            full: 0,
+            narrowed: 0,
+            confirmation_not_requested: 0,
+            confirmation_not_needed: 0,
+            confirmation_confirmed_survived: 0,
+            confirmation_killed: 0,
+            confirmation_timed_out: 0,
+            confirmation_build_error: 0,
+        };
+        for selection in report.selection_provenance.values() {
+            match selection {
+                TestSelectionProvenance::Full => summary.full += 1,
+                TestSelectionProvenance::Narrowed { confirmation } => {
+                    summary.narrowed += 1;
+                    match confirmation {
+                        SurvivorConfirmation::NotRequested => {
+                            summary.confirmation_not_requested += 1
+                        }
+                        SurvivorConfirmation::NotNeeded => summary.confirmation_not_needed += 1,
+                        SurvivorConfirmation::ConfirmedSurvived => {
+                            summary.confirmation_confirmed_survived += 1
+                        }
+                        SurvivorConfirmation::Killed => summary.confirmation_killed += 1,
+                        SurvivorConfirmation::TimedOut => summary.confirmation_timed_out += 1,
+                        SurvivorConfirmation::BuildError => summary.confirmation_build_error += 1,
+                    }
+                }
+            }
+        }
+        Some(summary)
+    }
 }
 
 #[derive(Serialize)]
@@ -92,6 +149,10 @@ struct SarifResultProperties {
     nonexecution_reason: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    test_selection_mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selection_confirmation: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -133,6 +194,7 @@ fn result_for_with_baseline(
     mutation: &Mutation,
     execution: MutationExecution,
     status: Option<crate::baseline::SurvivorBaselineStatus>,
+    selection: Option<TestSelectionProvenance>,
 ) -> SarifResult {
     SarifResult {
         rule_id: mutation.operator.clone(),
@@ -156,11 +218,17 @@ fn result_for_with_baseline(
                 },
             },
         }],
-        properties: (!execution.is_tested() || status.is_some()).then(|| SarifResultProperties {
-            execution: execution.state_name(),
-            nonexecution_reason: execution.reason().map(|reason| reason.name()),
-            baseline_status: status.map(|status| status.as_str()),
-        }),
+        properties: (!execution.is_tested() || status.is_some() || selection.is_some()).then(
+            || SarifResultProperties {
+                execution: execution.state_name(),
+                nonexecution_reason: execution.reason().map(|reason| reason.name()),
+                baseline_status: status.map(|status| status.as_str()),
+                test_selection_mode: selection.map(|selection| selection.mode_name()),
+                selection_confirmation: selection
+                    .and_then(|selection| selection.confirmation())
+                    .map(|confirmation| confirmation.name()),
+            },
+        ),
     }
 }
 
@@ -251,6 +319,7 @@ pub fn to_sarif_string_with_baseline(
                     uncovered: report.uncovered_count(),
                     subsumed: report.subsumed_count(),
                     mutation_score: super::mutation_score(report),
+                    selection_confirmation: SarifSelectionConfirmationSummary::from_report(report),
                 },
             }],
             results: surviving
@@ -260,6 +329,7 @@ pub fn to_sarif_string_with_baseline(
                         mutation,
                         *execution,
                         comparison.and_then(|comparison| comparison.status_for(mutation.id)),
+                        report.selection_for(mutation.id),
                     )
                 })
                 .collect(),
@@ -273,6 +343,7 @@ pub fn to_sarif_string_with_baseline(
 mod tests {
     use super::*;
     use crate::test_helpers::sample_report;
+    use crate::{SurvivorConfirmation, TestSelectionProvenance};
     use serde_json::Value;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
@@ -311,6 +382,7 @@ mod tests {
             .filter(|(_, r)| *r == MutationResult::BuildError)
             .count();
         MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             planned_total: results.len(),
             early_stop_reason: None,
             total: results.len(),
@@ -388,6 +460,62 @@ mod tests {
         let results = value["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0]["ruleId"], "op_b");
+    }
+
+    #[test]
+    fn sarif_keeps_confirmation_outcomes_in_invocation_properties() {
+        let mut report = report_with(vec![
+            (
+                mutation(0, "src/killed.rs", 1, "op", "killed by confirmation"),
+                MutationResult::Killed,
+            ),
+            (
+                mutation(1, "src/survived.rs", 2, "op", "confirmed survivor"),
+                MutationResult::Survived,
+            ),
+        ]);
+        report.selection_provenance.insert(
+            0,
+            TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::Killed,
+            },
+        );
+        report.selection_provenance.insert(
+            1,
+            TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::ConfirmedSurvived,
+            },
+        );
+
+        let value = parse(&report);
+
+        assert_eq!(value["runs"][0]["results"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            value["runs"][0]["results"][0]["properties"]["test_selection_mode"],
+            "narrowed"
+        );
+        assert_eq!(
+            value["runs"][0]["results"][0]["properties"]["selection_confirmation"],
+            "confirmed_survived"
+        );
+        assert_eq!(
+            value["runs"][0]["invocations"][0]["properties"]["selection_confirmation"],
+            serde_json::json!({
+                "full": 0,
+                "narrowed": 2,
+                "confirmation_not_requested": 0,
+                "confirmation_not_needed": 0,
+                "confirmation_confirmed_survived": 1,
+                "confirmation_killed": 1,
+                "confirmation_timed_out": 0,
+                "confirmation_build_error": 0
+            })
+        );
+        assert!(
+            parse(&sample_report())["runs"][0]["invocations"][0]["properties"]
+                .get("selection_confirmation")
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -78,6 +78,10 @@ fn format_report(
         let desc = &mutation.description;
         let execution = report.execution_for(mutation.id, *result);
         let execution_text = execution.to_string();
+        let selection_text = report
+            .selection_for(mutation.id)
+            .map(|selection| format!("; {selection}"))
+            .unwrap_or_default();
 
         let (tag, extra) = match result {
             MutationResult::Killed => ("✓ KILLED", None),
@@ -157,20 +161,21 @@ fn format_report(
             };
             writeln!(
                 out,
-                "  {} {}:{}  {} {}: {} [{}]",
+                "  {} {}:{}  {} {}: {} [{}{}]",
                 tag_colored,
                 file,
                 line,
                 dim("—"),
                 dim(operator),
                 desc,
-                dim(&execution_text)
+                dim(&execution_text),
+                dim(&selection_text)
             )
         } else {
             writeln!(
                 out,
-                "  {:<14}{}:{} — {}: {} [{}]",
-                tag, file, line, operator, desc, execution_text
+                "  {:<14}{}:{} — {}: {} [{}{}]",
+                tag, file, line, operator, desc, execution_text, selection_text
             )
         }
         .unwrap();
@@ -390,7 +395,7 @@ fn all_build_error_guidance(report: &MutationReport) -> Option<String> {
 mod tests {
     use super::*;
     use crate::runner::{RunSuiteFailure, RunSuiteFailureOutcome, SuiteFailurePhase};
-    use crate::{BuildErrorDiagnostic, Mutation};
+    use crate::{BuildErrorDiagnostic, Mutation, SurvivorConfirmation, TestSelectionProvenance};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -430,6 +435,7 @@ mod tests {
             .count();
 
         MutationReport {
+            selection_provenance: std::collections::BTreeMap::new(),
             results,
             execution_provenance: BTreeMap::new(),
             build_error_diagnostics: vec![],
@@ -464,6 +470,24 @@ mod tests {
         assert!(annotated.contains("Baseline: new"));
         assert_eq!(annotated.matches("Baseline:").count(), 1);
         assert!(!format_report_plain(&report).contains("Baseline:"));
+    }
+
+    #[test]
+    fn terminal_output_records_selection_confirmation() {
+        let mut report = report(vec![(
+            mutation(0, "src/survived.rs", 1),
+            MutationResult::Survived,
+        )]);
+        report.selection_provenance.insert(
+            0,
+            TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::ConfirmedSurvived,
+            },
+        );
+
+        let output = format_report_plain(&report);
+
+        assert!(output.contains("narrowed; confirmation: confirmed_survived"));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8,7 +8,7 @@ use crate::source_identity::{
 };
 use crate::{
     BuildErrorDiagnostic, Mutation, MutationExecution, MutationReport, MutationResult,
-    SchemataFallbackReasonCount, SchemataReport,
+    SchemataFallbackReasonCount, SchemataReport, SurvivorConfirmation, TestSelectionProvenance,
 };
 use anyhow::{Context, bail};
 #[cfg(not(windows))]
@@ -68,6 +68,8 @@ pub struct CommandConfig {
     pub language_timeouts: HashMap<String, Duration>,
     /// Optional source-line to test-name map used to narrow test commands.
     pub test_selection: Option<TestSelectionConfig>,
+    /// Confirm actual narrowed survivors against their original full route.
+    pub confirm_survivors: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -353,9 +355,12 @@ pub fn run_suite_failure(error: &anyhow::Error) -> Option<&RunSuiteFailure> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SelectedTestCommand {
     argv: Vec<String>,
+    /// Original route argv retained only when test selection changed it.
+    unnarrowed_argv: Option<Vec<String>>,
     timeout: Duration,
     uses_default_timeout: bool,
     selected_tests: Vec<String>,
+    selection_active: bool,
 }
 
 impl SelectedTestCommand {
@@ -387,6 +392,26 @@ impl SelectedTestCommand {
             env_parts.join(",")
         )
     }
+    fn is_narrowed(&self) -> bool {
+        self.unnarrowed_argv.is_some()
+    }
+
+    fn unnarrowed_argv(&self) -> Option<&[String]> {
+        self.unnarrowed_argv.as_deref()
+    }
+
+    fn selection_provenance(
+        &self,
+        confirmation: SurvivorConfirmation,
+    ) -> Option<TestSelectionProvenance> {
+        if !self.selection_active {
+            None
+        } else if self.is_narrowed() {
+            Some(TestSelectionProvenance::Narrowed { confirmation })
+        } else {
+            Some(TestSelectionProvenance::Full)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -405,6 +430,7 @@ fn select_test_command_with_history(
     history: Option<&cache::IncrementalHistoryStore>,
 ) -> SelectedTestCommand {
     let mut selected = select_unnarrowed_test_command(project_root, commands, mutation);
+    selected.selection_active = commands.test_selection.is_some();
 
     if let Some(test_selection) = &commands.test_selection {
         if let Some(mut tests) = test_selection.tests_for(project_root, mutation) {
@@ -417,7 +443,10 @@ fn select_test_command_with_history(
             }) {
                 tests.sort_by_key(|test| if *test == preferred { 0 } else { 1 });
             }
-            selected.argv = narrow_test_command(selected.argv, &tests);
+            let narrowed = narrow_test_command(selected.argv.clone(), &tests);
+            if narrowed != selected.argv {
+                selected.unnarrowed_argv = Some(std::mem::replace(&mut selected.argv, narrowed));
+            }
             selected.selected_tests = tests;
         }
     }
@@ -458,9 +487,11 @@ fn select_unnarrowed_test_command(
 
     SelectedTestCommand {
         argv,
+        unnarrowed_argv: None,
         timeout,
         uses_default_timeout,
         selected_tests: Vec::new(),
+        selection_active: false,
     }
 }
 
@@ -3066,6 +3097,7 @@ struct QueuedMutation {
     index: usize,
     mutation: Mutation,
     restore_checked: bool,
+    primary_restore: Option<RestoredMutationResult>,
 }
 
 #[derive(Debug)]
@@ -3073,6 +3105,7 @@ struct MutationRunRecord {
     mutation: Mutation,
     result: MutationResult,
     execution: MutationExecution,
+    selection: Option<TestSelectionProvenance>,
     build_error_diagnostic: Option<BuildErrorDiagnostic>,
     replay_recipe: Option<RegularDirectRecipe>,
 }
@@ -3088,12 +3121,18 @@ impl MutationRunRecord {
             result,
             execution: MutationExecution::for_result(result),
             build_error_diagnostic,
+            selection: None,
             replay_recipe: None,
         }
     }
 
     fn with_execution(mut self, execution: MutationExecution) -> Self {
         self.execution = execution;
+        self
+    }
+
+    fn with_selection(mut self, selection: Option<TestSelectionProvenance>) -> Self {
+        self.selection = selection;
         self
     }
 
@@ -3490,8 +3529,25 @@ impl PreparedMutationRun {
         respect_workspace_ignores: bool,
         origin: DirectRecipeOrigin,
     ) -> RegularDirectRecipe {
+        self.direct_recipe_for(
+            &self.selected_test.argv,
+            commands,
+            env,
+            respect_workspace_ignores,
+            origin,
+        )
+    }
+
+    fn direct_recipe_for(
+        &self,
+        test_command: &[String],
+        commands: &CommandConfig,
+        env: &HashMap<String, String>,
+        respect_workspace_ignores: bool,
+        origin: DirectRecipeOrigin,
+    ) -> RegularDirectRecipe {
         RegularDirectRecipe {
-            test_command: sandboxed_command(&commands.sandbox_command, &self.selected_test.argv),
+            test_command: sandboxed_command(&commands.sandbox_command, test_command),
             build_command: (commands.build_command_explicit && !commands.build_command.is_empty())
                 .then(|| sandboxed_command(&commands.sandbox_command, &commands.build_command)),
             timeout_ms: u64::try_from(self.selected_test.timeout.as_millis()).unwrap_or(u64::MAX),
@@ -3565,6 +3621,38 @@ impl PreparedMutationRun {
     }
 }
 
+fn needs_survivor_confirmation(
+    commands: &CommandConfig,
+    selected: &SelectedTestCommand,
+    result: MutationResult,
+) -> bool {
+    commands.confirm_survivors && selected.is_narrowed() && result == MutationResult::Survived
+}
+
+fn confirmation_from_result(result: MutationResult) -> SurvivorConfirmation {
+    match result {
+        MutationResult::Survived => SurvivorConfirmation::ConfirmedSurvived,
+        MutationResult::Killed => SurvivorConfirmation::Killed,
+        MutationResult::Timeout => SurvivorConfirmation::TimedOut,
+        MutationResult::BuildError => SurvivorConfirmation::BuildError,
+        MutationResult::Uncovered | MutationResult::Subsumed => SurvivorConfirmation::BuildError,
+    }
+}
+
+fn confirmation_workspace_reset_error(
+    workspace_root: &Path,
+    error: std::io::Error,
+) -> MutationOutcome {
+    MutationOutcome::build_error_with(
+        "confirmation_workspace_reset",
+        vec![],
+        format!(
+            "could not reset isolated mutation workspace {} before full-suite confirmation: {error}",
+            workspace_root.display()
+        ),
+    )
+}
+
 fn run_queued_mutation(
     queued: QueuedMutation,
     reservation: TestSlotReservation,
@@ -3574,9 +3662,9 @@ fn run_queued_mutation(
         index,
         mutation,
         restore_checked,
+        primary_restore,
     } = queued;
 
-    // Stop if cancelled (Ctrl+C).
     if shared.cancelled.load(Ordering::Relaxed) {
         return None;
     }
@@ -3593,31 +3681,41 @@ fn run_queued_mutation(
             env: shared.env,
         },
     );
-    // Capture the exact direct recipe before any cache/history lookup.
-    let direct_recipe = prepared.direct_recipe(
+    let primary_direct_recipe = prepared.direct_recipe(
         shared.commands,
         shared.env,
         shared.respect_workspace_ignores,
         DirectRecipeOrigin::Executed,
     );
+    let restored = primary_restore.or_else(|| {
+        (!restore_checked)
+            .then(|| {
+                prepared.restore_result(shared.project_root, shared.history, shared.force_rerun)
+            })
+            .flatten()
+    });
 
-    // Normal runs retain lazy cache lookup; early-stop runs preclassify every
-    // candidate before scheduling and mark fresh entries as already checked.
-    if !restore_checked {
-        if let Some(restored) =
-            prepared.restore_result(shared.project_root, shared.history, shared.force_rerun)
-        {
+    if let Some(restored) = restored {
+        if !needs_survivor_confirmation(shared.commands, &prepared.selected_test, restored.result) {
             reservation.release();
             exclude_restored_from_early_stop(shared.early_stop, restored.execution);
             record_progress(&shared, &mutation, restored.result, None, true);
+            let confirmation = if prepared.selected_test.is_narrowed()
+                && restored.result == MutationResult::Survived
+            {
+                SurvivorConfirmation::NotRequested
+            } else {
+                SurvivorConfirmation::NotNeeded
+            };
             let mut record = MutationRunRecord::new(mutation, restored.result, None)
-                .with_execution(restored.execution);
+                .with_execution(restored.execution)
+                .with_selection(prepared.selected_test.selection_provenance(confirmation));
             if matches!(
                 restored.result,
                 MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
             ) {
                 if let Some(origin) = DirectRecipeOrigin::from_execution(restored.execution) {
-                    let mut recipe = direct_recipe.clone();
+                    let mut recipe = primary_direct_recipe.clone();
                     recipe.origin = origin;
                     record = record.with_replay_recipe(recipe);
                 }
@@ -3626,9 +3724,12 @@ fn run_queued_mutation(
         }
     }
 
-    let outcome = {
-        let workspace_slot = shared.workspace_pool.acquire();
-        let workspace_root = workspace_slot.root().to_path_buf();
+    let primary_was_restored = restored.is_some();
+    let workspace_slot = shared.workspace_pool.acquire();
+    let workspace_root = workspace_slot.root().to_path_buf();
+    let primary_outcome = if let Some(restored) = restored {
+        MutationOutcome::new(restored.result, None)
+    } else {
         if workspace_slot.needs_reset() {
             if let Err(e) =
                 workspace_slot.reset(shared.project_root, shared.respect_workspace_ignores)
@@ -3652,7 +3753,12 @@ fn run_queued_mutation(
                 );
                 return Some((
                     index,
-                    MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic)),
+                    MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic))
+                        .with_selection(
+                            prepared
+                                .selected_test
+                                .selection_provenance(SurvivorConfirmation::NotNeeded),
+                        ),
                 ));
             }
         }
@@ -3674,21 +3780,87 @@ fn run_queued_mutation(
         )
     };
 
-    if outcome.cancelled {
+    if primary_outcome.cancelled {
         return None;
     }
-    if outcome.result == MutationResult::BuildError {
-        reservation.release();
-    } else {
-        reservation.commit();
+    if !primary_was_restored {
+        prepared.store_cache(shared.project_root, primary_outcome.result);
+        prepared.record_history(
+            shared.history,
+            primary_outcome.result,
+            primary_outcome.test_output.as_deref(),
+        );
     }
 
-    prepared.store_cache(shared.project_root, outcome.result);
-    prepared.record_history(
-        shared.history,
-        outcome.result,
-        outcome.test_output.as_deref(),
-    );
+    let primary_result = primary_outcome.result;
+    let mut outcome = primary_outcome;
+    let mut execution = restored
+        .map(|restored| restored.execution)
+        .unwrap_or_else(|| MutationExecution::for_result(outcome.result));
+    let mut direct_recipe = primary_direct_recipe;
+    let confirmation =
+        if needs_survivor_confirmation(shared.commands, &prepared.selected_test, primary_result) {
+            let full_argv = prepared
+                .selected_test
+                .unnarrowed_argv()
+                .expect("narrowed test command must retain its full route");
+            outcome =
+                match workspace_slot.reset(shared.project_root, shared.respect_workspace_ignores) {
+                    Ok(()) => {
+                        let workspace_target = ResolvedMutation::new_for_execution(
+                            shared.project_root,
+                            &workspace_root,
+                            &mutation,
+                        );
+                        run_single_mutation(
+                            full_argv,
+                            shared.commands.sandbox_command.as_slice(),
+                            BuildCommand {
+                                argv: shared.build_command,
+                                explicit: shared.build_command_explicit,
+                            },
+                            prepared.selected_test.timeout,
+                            &workspace_root,
+                            workspace_target,
+                            shared.show_output,
+                            shared.env,
+                            shared.cancelled,
+                        )
+                    }
+                    Err(error) => confirmation_workspace_reset_error(&workspace_root, error),
+                };
+            if outcome.cancelled {
+                return None;
+            }
+            execution = MutationExecution::for_result(outcome.result);
+            direct_recipe = prepared.direct_recipe_for(
+                full_argv,
+                shared.commands,
+                shared.env,
+                shared.respect_workspace_ignores,
+                DirectRecipeOrigin::Executed,
+            );
+            confirmation_from_result(outcome.result)
+        } else if prepared.selected_test.is_narrowed() && primary_result == MutationResult::Survived
+        {
+            SurvivorConfirmation::NotRequested
+        } else {
+            SurvivorConfirmation::NotNeeded
+        };
+
+    if primary_was_restored {
+        if outcome.result == MutationResult::BuildError {
+            reservation.release();
+        } else {
+            reservation.commit();
+        }
+    } else if primary_result == MutationResult::BuildError {
+        reservation.release();
+    } else {
+        // A primary test already consumed this candidate's slot even if the
+        // full confirmation later cannot run.
+        reservation.commit();
+    }
 
     let result = outcome.result;
     record_progress(
@@ -3700,7 +3872,9 @@ fn run_queued_mutation(
     );
     record_early_stop(&shared, result);
     let diagnostic = build_error_diagnostic_from_outcome(&mutation, "regular", &outcome);
-    let mut record = MutationRunRecord::new(mutation, result, diagnostic);
+    let mut record = MutationRunRecord::new(mutation, result, diagnostic)
+        .with_execution(execution)
+        .with_selection(prepared.selected_test.selection_provenance(confirmation));
     if matches!(
         result,
         MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
@@ -3844,6 +4018,7 @@ impl TestRunner {
                         index,
                         mutation,
                         restore_checked: false,
+                        primary_restore: None,
                     })
                     .collect(),
                 restored: Vec::new(),
@@ -3867,6 +4042,7 @@ impl TestRunner {
                     index,
                     mutation: mutation.clone(),
                     restore_checked: false,
+                    primary_restore: None,
                 });
                 continue;
             }
@@ -3894,9 +4070,30 @@ impl TestRunner {
             if let Some(restored_result) =
                 prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
             {
+                if needs_survivor_confirmation(
+                    &self.commands,
+                    &prepared.selected_test,
+                    restored_result.result,
+                ) {
+                    fresh.push(QueuedMutation {
+                        index,
+                        mutation: mutation.clone(),
+                        restore_checked: true,
+                        primary_restore: Some(restored_result),
+                    });
+                    continue;
+                }
+                let confirmation = if prepared.selected_test.is_narrowed()
+                    && restored_result.result == MutationResult::Survived
+                {
+                    SurvivorConfirmation::NotRequested
+                } else {
+                    SurvivorConfirmation::NotNeeded
+                };
                 let mut record =
                     MutationRunRecord::new(mutation.clone(), restored_result.result, None)
-                        .with_execution(restored_result.execution);
+                        .with_execution(restored_result.execution)
+                        .with_selection(prepared.selected_test.selection_provenance(confirmation));
                 if matches!(
                     restored_result.result,
                     MutationResult::Killed | MutationResult::Survived | MutationResult::Timeout
@@ -3915,6 +4112,7 @@ impl TestRunner {
                     index,
                     mutation: mutation.clone(),
                     restore_checked: true,
+                    primary_restore: None,
                 });
             }
         }
@@ -3998,6 +4196,15 @@ impl TestRunner {
         }
         let planned_total = mutations.len();
         let preclassified = self.preclassify_for_early_stop(&mutations);
+        let pending_restores: HashMap<u32, RestoredMutationResult> = preclassified
+            .fresh
+            .iter()
+            .filter_map(|queued| {
+                queued
+                    .primary_restore
+                    .map(|restored| (queued.mutation.id, restored))
+            })
+            .collect();
         let restored_ids: HashSet<u32> = preclassified
             .restored
             .iter()
@@ -4077,6 +4284,7 @@ impl TestRunner {
                 early_stop.clone(),
                 tested_counter.clone(),
                 restore_checked,
+                &pending_restores,
             ) {
                 Ok((records, demoted)) => {
                     schemata_summary.fast_path += records
@@ -4111,6 +4319,7 @@ impl TestRunner {
                     .enumerate()
                     .map(|(index, mutation)| QueuedMutation {
                         index,
+                        primary_restore: pending_restores.get(&mutation.id).copied(),
                         mutation,
                         restore_checked,
                     })
@@ -4339,6 +4548,7 @@ impl TestRunner {
         early_stop: Option<Arc<EarlyStopState>>,
         tested_counter: Arc<AtomicUsize>,
         restore_checked: bool,
+        pending_restores: &HashMap<u32, RestoredMutationResult>,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
         self.run_schema_mutations_inner(
             language,
@@ -4346,10 +4556,12 @@ impl TestRunner {
             early_stop,
             tested_counter,
             restore_checked,
+            pending_restores,
             true,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn run_schema_mutations_inner(
         &self,
         language: &str,
@@ -4357,6 +4569,7 @@ impl TestRunner {
         early_stop: Option<Arc<EarlyStopState>>,
         tested_counter: Arc<AtomicUsize>,
         restore_checked: bool,
+        pending_restores: &HashMap<u32, RestoredMutationResult>,
         allow_build_bisection: bool,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
         let rewrites =
@@ -4414,10 +4627,19 @@ impl TestRunner {
             } else {
                 prepared.selected_test.argv.clone()
             };
-            if !restore_checked {
-                if let Some(restored) =
+            let primary_restore = pending_restores.get(&mutation.id).copied().or_else(|| {
+                if restore_checked {
+                    None
+                } else {
                     prepared.restore_result(&self.project_root, history.as_ref(), self.force_rerun)
-                {
+                }
+            });
+            if let Some(restored) = primary_restore {
+                if !needs_survivor_confirmation(
+                    &self.commands,
+                    &prepared.selected_test,
+                    restored.result,
+                ) {
                     reservation.release();
                     exclude_restored_from_early_stop(early_stop.as_ref(), restored.execution);
                     if self.verbose {
@@ -4428,16 +4650,29 @@ impl TestRunner {
                             mutation.operator
                         );
                     }
+                    let confirmation = if prepared.selected_test.is_narrowed()
+                        && restored.result == MutationResult::Survived
+                    {
+                        SurvivorConfirmation::NotRequested
+                    } else {
+                        SurvivorConfirmation::NotNeeded
+                    };
                     results.push(
                         MutationRunRecord::new(mutation.clone(), restored.result, None)
-                            .with_execution(restored.execution),
+                            .with_execution(restored.execution)
+                            .with_selection(
+                                prepared.selected_test.selection_provenance(confirmation),
+                            ),
                     );
                     continue;
                 }
             }
 
+            let primary_was_restored = primary_restore.is_some();
             let mut cacheable = true;
-            let outcome = if workspace_needs_reset {
+            let outcome = if let Some(restored) = primary_restore {
+                MutationOutcome::new(restored.result, None)
+            } else if workspace_needs_reset {
                 if let Err(e) = workspace.reset(&self.project_root, self.respect_workspace_ignores)
                 {
                     cacheable = false;
@@ -4518,6 +4753,7 @@ impl TestRunner {
                                     early_stop.clone(),
                                     tested_counter.clone(),
                                     restore_checked,
+                                    pending_restores,
                                     false,
                                 ) {
                                     Ok((batch_records, batch_demoted)) => {
@@ -4563,24 +4799,91 @@ impl TestRunner {
                 }
                 break;
             }
-            if outcome.result == MutationResult::BuildError {
+            if !primary_was_restored {
+                if cacheable {
+                    prepared.store_cache(&self.project_root, outcome.result);
+                }
+                prepared.record_history(
+                    history.as_ref(),
+                    outcome.result,
+                    outcome.test_output.as_deref(),
+                );
+            }
+
+            let primary_result = outcome.result;
+            let mut final_outcome = outcome;
+            let mut execution = primary_restore
+                .map(|restored| restored.execution)
+                .unwrap_or(MutationExecution::Executed);
+            let confirmation = if needs_survivor_confirmation(
+                &self.commands,
+                &prepared.selected_test,
+                primary_result,
+            ) {
+                let full_argv = prepared
+                    .selected_test
+                    .unnarrowed_argv()
+                    .expect("narrowed test command must retain its full argv");
+                let full_argv = if language == "go" {
+                    force_go_no_test_cache(full_argv.to_vec())
+                } else {
+                    full_argv.to_vec()
+                };
+                let mut confirmation_cacheable = true;
+                let confirmed = match workspace
+                    .reset(&self.project_root, self.respect_workspace_ignores)
+                {
+                    Ok(()) => {
+                        workspace_needs_reset = true;
+                        run_schema_workspace_mutation(
+                            self,
+                            workspace.root(),
+                            &rewrites,
+                            &full_argv,
+                            prepared.selected_test.timeout,
+                            &env,
+                            &mut confirmation_cacheable,
+                        )
+                    }
+                    Err(error) => MutationOutcome::build_error_with(
+                        "confirmation_workspace_reset",
+                        vec![],
+                        format!(
+                            "could not reset schema workspace {} before full-suite confirmation: {error}",
+                            workspace.root().display()
+                        ),
+                    ),
+                };
+                if confirmed.cancelled {
+                    break;
+                }
+                execution = MutationExecution::Executed;
+                final_outcome = confirmed;
+                confirmation_from_result(final_outcome.result)
+            } else if prepared.selected_test.is_narrowed()
+                && primary_result == MutationResult::Survived
+            {
+                SurvivorConfirmation::NotRequested
+            } else {
+                SurvivorConfirmation::NotNeeded
+            };
+
+            if primary_was_restored {
+                if final_outcome.result == MutationResult::BuildError {
+                    reservation.release();
+                } else {
+                    reservation.commit();
+                }
+            } else if primary_result == MutationResult::BuildError {
                 reservation.release();
             } else {
                 reservation.commit();
             }
             if let Some(early_stop) = &early_stop {
-                early_stop.record(outcome.result);
+                early_stop.record(final_outcome.result);
             }
-            if cacheable {
-                prepared.store_cache(&self.project_root, outcome.result);
-            }
-            prepared.record_history(
-                history.as_ref(),
-                outcome.result,
-                outcome.test_output.as_deref(),
-            );
             if self.verbose {
-                let symbol = match outcome.result {
+                let symbol = match final_outcome.result {
                     MutationResult::Killed => "✓ killed",
                     MutationResult::Survived => "✗ survived",
                     MutationResult::Timeout => "⧖ timeout",
@@ -4596,8 +4899,8 @@ impl TestRunner {
                     mutation.operator
                 );
             }
-            if self.show_output && outcome.result == MutationResult::Survived {
-                if let Some(output) = outcome.test_output.as_deref() {
+            if self.show_output && final_outcome.result == MutationResult::Survived {
+                if let Some(output) = final_outcome.test_output.as_deref() {
                     eprintln!(
                         "  ┌─ test output for {}:{} ({})",
                         mutation.file.display(),
@@ -4610,12 +4913,13 @@ impl TestRunner {
                     eprintln!("  └─");
                 }
             }
-            let diagnostic = build_error_diagnostic_from_outcome(mutation, "schemata", &outcome);
-            results.push(MutationRunRecord::new(
-                mutation.clone(),
-                outcome.result,
-                diagnostic,
-            ));
+            let diagnostic =
+                build_error_diagnostic_from_outcome(mutation, "schemata", &final_outcome);
+            results.push(
+                MutationRunRecord::new(mutation.clone(), final_outcome.result, diagnostic)
+                    .with_execution(execution)
+                    .with_selection(prepared.selected_test.selection_provenance(confirmation)),
+            );
         }
 
         Ok((results, demoted))
@@ -4764,6 +5068,7 @@ impl TestRunner {
         let mut results = Vec::with_capacity(all_records.len());
         let mut build_error_diagnostics = Vec::new();
         let mut execution_provenance = BTreeMap::new();
+        let mut selection_provenance = BTreeMap::new();
         let mut replay_recipes = BTreeMap::new();
         let mut total = 0;
         let mut killed = 0;
@@ -4777,6 +5082,7 @@ impl TestRunner {
                 result,
                 execution,
                 build_error_diagnostic,
+                selection,
                 replay_recipe,
             } = record;
             total += 1;
@@ -4793,6 +5099,9 @@ impl TestRunner {
             }
             if execution != MutationExecution::for_result(result) {
                 execution_provenance.insert(mutation.id, execution);
+            }
+            if let Some(selection) = selection {
+                selection_provenance.insert(mutation.id, selection);
             }
             if let Some(diagnostic) = build_error_diagnostic {
                 debug_assert_eq!(result, MutationResult::BuildError);
@@ -4813,6 +5122,7 @@ impl TestRunner {
             MutationReport {
                 results,
                 execution_provenance,
+                selection_provenance,
                 build_error_diagnostics,
                 schemata: None,
                 baseline_timing: None,
@@ -4957,6 +5267,7 @@ fn records_from_report(
     let MutationReport {
         results,
         execution_provenance,
+        selection_provenance,
         build_error_diagnostics,
         ..
     } = report;
@@ -4972,8 +5283,10 @@ fn records_from_report(
                 .copied()
                 .unwrap_or_else(|| MutationExecution::for_result(result));
             let diagnostic = diagnostics.remove(&mutation.id);
-            let mut record =
-                MutationRunRecord::new(mutation, result, diagnostic).with_execution(execution);
+            let selection = selection_provenance.get(&mutation.id).copied();
+            let mut record = MutationRunRecord::new(mutation, result, diagnostic)
+                .with_execution(execution)
+                .with_selection(selection);
             if let Some(recipe) = replay_recipes.remove(&record.mutation.id) {
                 record = record.with_replay_recipe(recipe);
             }
@@ -7570,13 +7883,28 @@ mod tests {
         mutation: &Mutation,
         reuse_source: ReuseSource,
     ) -> anyhow::Result<()> {
-        let env = HashMap::new();
+        seed_reused_survivor_with_env(
+            project_root,
+            commands,
+            mutation,
+            reuse_source,
+            &HashMap::new(),
+        )
+    }
+
+    fn seed_reused_survivor_with_env(
+        project_root: &Path,
+        commands: &CommandConfig,
+        mutation: &Mutation,
+        reuse_source: ReuseSource,
+        env: &HashMap<String, String>,
+    ) -> anyhow::Result<()> {
         let selected = select_test_command(project_root, commands, mutation);
         let command_context = selected.cache_context(
             &commands.build_command,
             commands.build_command_explicit,
             &commands.sandbox_command,
-            &env,
+            env,
         );
         let context_hash = cache_context_fingerprint(project_root);
         let source_path = if mutation.file.is_absolute() {
@@ -7641,6 +7969,66 @@ test "$runs" -eq 1
             "state".into(),
             state_dir.display().to_string(),
         ]
+    }
+
+    #[cfg(unix)]
+    fn fake_selection_command(
+        project_root: &Path,
+        command_name: &str,
+        narrowed_marker: &str,
+        full_status: i32,
+    ) -> (HashMap<String, String>, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let bin = project_root.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let command = bin.join(command_name);
+        let log = project_root.join("confirmation-command.log");
+        std::fs::write(
+            &command,
+            format!(
+                "#!/bin/sh\nprintf '<%s>\\n' \"$*\" >> \"$TOGI_CONFIRMATION_LOG\"\ncase \" $* \" in\n  *\" {narrowed_marker} \"*) exit 0 ;;\n  *) exit {full_status} ;;\nesac\n"
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&command).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&command, permissions).unwrap();
+
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".into(),
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+        env.insert("TOGI_CONFIRMATION_LOG".into(), log.display().to_string());
+        (env, log)
+    }
+
+    #[cfg(unix)]
+    fn confirmation_runner(
+        project_root: &Path,
+        commands: CommandConfig,
+        env: HashMap<String, String>,
+    ) -> TestRunner {
+        TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: project_root.to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: EarlyStopConfig::default(),
+            respect_workspace_ignores: true,
+            env,
+            incremental_history: false,
+            force_rerun: true,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     fn c_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
@@ -7863,6 +8251,7 @@ test "$runs" -eq 1
 
     fn test_command_config() -> CommandConfig {
         CommandConfig {
+            confirm_survivors: false,
             command: vec!["cargo".into(), "test".into()],
             force_default_command: false,
             force_default_timeout: false,
@@ -8062,12 +8451,16 @@ test "$runs" -eq 1
     fn selected_test_command_cache_context_preserves_argv_boundaries() {
         let selected = SelectedTestCommand {
             argv: vec!["cargo test".into()],
+            unnarrowed_argv: None,
+            selection_active: false,
             timeout: Duration::from_secs(2),
             uses_default_timeout: false,
             selected_tests: Vec::new(),
         };
         let ambiguous = SelectedTestCommand {
             argv: vec!["cargo".into(), "test".into()],
+            unnarrowed_argv: None,
+            selection_active: false,
             timeout: Duration::from_secs(2),
             uses_default_timeout: false,
             selected_tests: Vec::new(),
@@ -8375,6 +8768,196 @@ test "$runs" -eq 1
     }
 
     #[test]
+    fn narrowed_routes_retain_their_full_command_for_confirmation() {
+        for (path, command, test) in [
+            (
+                "src/calc.go",
+                vec!["go".into(), "test".into(), "./...".into()],
+                "TestAdd",
+            ),
+            ("src/calc.py", vec!["pytest".into()], "selected_test"),
+            (
+                "src/calc.test.ts",
+                vec!["vitest".into(), "run".into()],
+                "selected_test",
+            ),
+            (
+                "src/lib.rs",
+                vec!["cargo".into(), "test".into()],
+                "selected_test",
+            ),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let mut selection = TestSelectionConfig::new();
+            selection.insert(root.path(), Path::new(path), 1, vec![test.into()]);
+            let mut commands = test_command_config();
+            let full_command = command.clone();
+            commands.command = command;
+            commands.test_selection = Some(selection);
+            let mut mutation = make_test_mutation(Path::new(path));
+            mutation.line = 1;
+
+            let selected = select_test_command(root.path(), &commands, &mutation);
+
+            assert_eq!(
+                selected.unnarrowed_argv(),
+                Some(full_command.as_slice()),
+                "{path} must retain its original route"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confirmation_kills_a_narrowed_survivor_on_its_full_route() {
+        let (dir, _, mutation) = make_relative_test_setup();
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            dir.path(),
+            Path::new("test.txt"),
+            1,
+            vec!["selected_test".into()],
+        );
+        let (env, log) = fake_selection_command(dir.path(), "pytest", "-k selected_test", 1);
+        let mut commands = test_command_config();
+        commands.command = vec!["pytest".into()];
+        commands.test_selection = Some(selection);
+        commands.confirm_survivors = true;
+
+        let report = confirmation_runner(dir.path(), commands, env)
+            .run(vec![mutation.clone()])
+            .report;
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].0.id, mutation.id);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert_eq!(report.survived, 0);
+        assert_eq!(
+            report.selection_for(mutation.id),
+            Some(TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::Killed,
+            })
+        );
+        assert_eq!(
+            std::fs::read_to_string(log)
+                .unwrap()
+                .lines()
+                .collect::<Vec<_>>(),
+            ["<-k selected_test>", "<>"],
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn disabled_confirmation_leaves_narrowed_survivors_unchanged() {
+        let (dir, _, mutation) = make_relative_test_setup();
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            dir.path(),
+            Path::new("test.txt"),
+            1,
+            vec!["selected_test".into()],
+        );
+        let (env, log) = fake_selection_command(dir.path(), "pytest", "-k selected_test", 1);
+        let mut commands = test_command_config();
+        commands.command = vec!["pytest".into()];
+        commands.test_selection = Some(selection);
+
+        let report = confirmation_runner(dir.path(), commands, env)
+            .run(vec![mutation.clone()])
+            .report;
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].0.id, mutation.id);
+        assert_eq!(report.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            report.selection_for(mutation.id),
+            Some(TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::NotRequested,
+            })
+        );
+        assert_eq!(
+            std::fs::read_to_string(log)
+                .unwrap()
+                .lines()
+                .collect::<Vec<_>>(),
+            ["<-k selected_test>"],
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confirmation_rechecks_a_cached_narrowed_survivor_without_rewriting_its_cache() {
+        let (dir, _, mutation) = make_relative_test_setup();
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            dir.path(),
+            Path::new("test.txt"),
+            1,
+            vec!["selected_test".into()],
+        );
+        let (env, log) = fake_selection_command(dir.path(), "pytest", "-k selected_test", 1);
+        let mut commands = test_command_config();
+        commands.command = vec!["pytest".into()];
+        commands.test_selection = Some(selection);
+        commands.confirm_survivors = true;
+        seed_reused_survivor_with_env(
+            dir.path(),
+            &commands,
+            &mutation,
+            ReuseSource::ExactCache,
+            &env,
+        )
+        .unwrap();
+
+        let mut runner = confirmation_runner(dir.path(), commands, env);
+        runner.force_rerun = false;
+        let report = runner.run(vec![mutation.clone()]).report;
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].0.id, mutation.id);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert_eq!(
+            report.execution_for(mutation.id, MutationResult::Killed),
+            MutationExecution::Executed
+        );
+        assert_eq!(
+            report.selection_for(mutation.id),
+            Some(TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::Killed,
+            })
+        );
+        assert_eq!(
+            std::fs::read_to_string(log)
+                .unwrap()
+                .lines()
+                .collect::<Vec<_>>(),
+            ["<>"],
+        );
+        let selected = select_test_command(dir.path(), &runner.commands, &mutation);
+        let source = std::fs::read(dir.path().join("test.txt")).unwrap();
+        let key = CacheKey::new(
+            &source,
+            &cache_identity(dir.path(), &mutation),
+            &mutation.description,
+            &format!(
+                "{};context={:016x}",
+                selected.cache_context(
+                    &runner.commands.build_command,
+                    runner.commands.build_command_explicit,
+                    &runner.commands.sandbox_command,
+                    &runner.env,
+                ),
+                cache_context_fingerprint(dir.path())
+            ),
+        );
+        assert_eq!(
+            cache::lookup(dir.path(), &key),
+            Some(MutationResult::Survived)
+        );
+    }
+
+    #[test]
     fn select_test_command_falls_back_for_multiple_cargo_tests() -> anyhow::Result<()> {
         let tmp = tempfile::tempdir()?;
         let mut selection = TestSelectionConfig::new();
@@ -8534,6 +9117,7 @@ test "$runs" -eq 1
         let mut selection = TestSelectionConfig::new();
         selection.insert(dir.path(), &file, mutation.line, vec!["test_add".into()]);
         let commands = || CommandConfig {
+            confirm_survivors: false,
             command: failing_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -8649,6 +9233,7 @@ test "$runs" -eq 1
         std::fs::write(dir.path().join(&cached.file), "hello")?;
         std::fs::write(dir.path().join(&historical.file), "hello")?;
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: successful_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -8761,6 +9346,7 @@ test "$runs" -eq 1
         let (dir, file, mutation) = make_test_setup();
 
         let commands = || CommandConfig {
+            confirm_survivors: false,
             command: failing_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -8903,6 +9489,7 @@ test "$runs" -eq 1
                       echo 'test result: FAILED. 1 passed; 1 failed;'\n\
                       exit 1\n";
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: vec!["sh".into(), "-c".into(), script.into()],
             force_default_command: false,
             force_default_timeout: false,
@@ -8972,6 +9559,7 @@ test "$runs" -eq 1
     /// skipped execution observable in the report.
     fn seed_killer_cluster_history(dir: &Path, file: &Path, mutations: &[Mutation]) {
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: failing_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -9010,6 +9598,7 @@ test "$runs" -eq 1
     fn killer_cluster_runner(dir: &Path, learned_selection: bool) -> TestRunner {
         TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: failing_command(),
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10469,6 +11058,7 @@ sleep 10"#
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sleep".into(), "10".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10535,6 +11125,7 @@ sleep 10"#
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10606,6 +11197,7 @@ int main(void) {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["./calc".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10671,6 +11263,7 @@ int main() {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["./calc".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10735,6 +11328,7 @@ esac
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script.into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10784,6 +11378,7 @@ esac
         ];
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: successful_command(),
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10850,6 +11445,7 @@ touch side_effect
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script.into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -10909,6 +11505,7 @@ esac
         let mut env = HashMap::new();
         env.insert("STATE_DIR".to_string(), state.path().display().to_string());
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: vec!["sh".into(), "-c".into(), script.into()],
             force_default_command: false,
             force_default_timeout: false,
@@ -10927,6 +11524,8 @@ esac
         let selected = select_test_command(dir.path(), &commands, &first);
         let cache_selected = SelectedTestCommand {
             argv: selected.argv,
+            unnarrowed_argv: None,
+            selection_active: false,
             timeout: selected.timeout,
             uses_default_timeout: selected.uses_default_timeout,
             selected_tests: selected.selected_tests,
@@ -11004,6 +11603,7 @@ esac
         std::fs::write(dir.path().join("calc.go"), source)?;
         let mutation = go_operator_mutation(0, "calc.go", source, 0);
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: failing_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -11113,6 +11713,7 @@ func third(a, b int) bool { return a == b }
                     .map(|id| go_operator_mutation(id, "calc.go", source, id as usize))
                     .collect::<Vec<_>>();
                 let commands = CommandConfig {
+                    confirm_survivors: false,
                     command: failing_command(),
                     force_default_command: false,
                     force_default_timeout: false,
@@ -11181,6 +11782,7 @@ func third(a, b int) bool { return a == b }
                 .map(|id| go_operator_mutation(id, "calc.go", source, id as usize))
                 .collect::<Vec<_>>();
             let commands = CommandConfig {
+                confirm_survivors: false,
                 command: first_run_survives_second_kills_command(state.path()),
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11285,6 +11887,7 @@ def second(c, d):
         let python_cached = python(1, 0);
         let python_history = python(2, 1);
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: successful_command(),
             force_default_command: false,
             force_default_timeout: false,
@@ -11411,6 +12014,7 @@ func second(c, d int) bool { return c == d }
         // per-mutant runs (raw splice, no wraps) build fine (#412).
         let build = "if grep -rq __togi_active .; then exit 1; fi";
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: vec!["sh".into(), "-c".into(), "exit 1".into()],
             force_default_command: false,
             force_default_timeout: false,
@@ -11472,6 +12076,7 @@ func second(c, d int) bool { return c == d }
         // first mutation's schema batch compiles and should keep the fast path.
         let build = r#"if grep -rq '__togi_active("1")' .; then exit 1; fi"#;
         let commands = CommandConfig {
+            confirm_survivors: false,
             command: vec!["sh".into(), "-c".into(), "exit 1".into()],
             force_default_command: false,
             force_default_timeout: false,
@@ -11555,6 +12160,7 @@ class Calc {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["java".into(), "Calc".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11615,6 +12221,7 @@ mod tests {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["cargo".into(), "test".into(), "--quiet".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11654,6 +12261,46 @@ mod tests {
         assert_eq!(report.results[0].1, MutationResult::Killed);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn schemata_confirmation_rechecks_narrowed_rust_survivors_on_the_full_route() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let source = "pub fn same(a: i32, b: i32) -> bool { a == b }\n";
+        std::fs::write(dir.path().join("src/lib.rs"), source).unwrap();
+        let mutation = rust_operator_mutation(0, "src/lib.rs", source, 0);
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            dir.path(),
+            Path::new("src/lib.rs"),
+            1,
+            vec!["narrow_test".into()],
+        );
+        let (env, log) = fake_selection_command(dir.path(), "cargo", "narrow_test", 1);
+        let mut commands = test_command_config();
+        commands.command = vec!["cargo".into(), "test".into()];
+        commands.test_selection = Some(selection);
+        commands.confirm_survivors = true;
+
+        let report = confirmation_runner(dir.path(), commands, env)
+            .run_with_schemata(vec![mutation.clone()])
+            .report;
+
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert_eq!(
+            report.selection_for(mutation.id),
+            Some(TestSelectionProvenance::Narrowed {
+                confirmation: SurvivorConfirmation::Killed,
+            })
+        );
+        assert_eq!(
+            std::fs::read_to_string(log)
+                .unwrap()
+                .lines()
+                .collect::<Vec<_>>(),
+            ["<test narrow_test>", "<test>"],
+        );
+    }
     #[test]
     fn max_tested_limits_mutations() {
         let (dir, file, _) = make_test_setup();
@@ -11669,6 +12316,7 @@ mod tests {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11715,6 +12363,7 @@ mod tests {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11773,6 +12422,7 @@ mod tests {
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -11848,6 +12498,7 @@ mod tests {
                     })
                     .collect::<anyhow::Result<Vec<_>>>()?;
                 let commands = CommandConfig {
+                    confirm_survivors: false,
                     command: failing_command(),
                     force_default_command: false,
                     force_default_timeout: false,
@@ -11916,6 +12567,7 @@ mod tests {
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
             let commands = CommandConfig {
+                confirm_survivors: false,
                 command: first_run_survives_second_kills_command(state.path()),
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12012,6 +12664,7 @@ sleep 0.2
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script.into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12088,6 +12741,7 @@ sleep 0.2
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12155,6 +12809,7 @@ rmdir "$lock"
             let mut env = HashMap::new();
             env.insert("STATE_DIR".to_string(), state.path().display().to_string());
             let commands = CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script.into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12259,6 +12914,7 @@ rmdir "$lock"
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12337,6 +12993,7 @@ rmdir "$lock"
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script.into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12405,6 +13062,7 @@ rmdir "$lock"
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12453,6 +13111,7 @@ rmdir "$lock"
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["true".into()], // default would survive
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12526,6 +13185,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12607,6 +13267,7 @@ exit 1"#
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sh".into(), "-c".into(), script],
                 force_default_command: false,
                 force_default_timeout: false,
@@ -12660,6 +13321,7 @@ exit 1"#
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec![
                     "sh".into(),
                     "-c".into(),
@@ -12721,6 +13383,7 @@ exit 1"#
 
         let runner = TestRunner {
             commands: CommandConfig {
+                confirm_survivors: false,
                 command: vec!["sleep".into(), "1".into()],
                 force_default_command: false,
                 force_default_timeout: false,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 /// A standard two-mutation report for testing report formatters.
 pub fn sample_report() -> MutationReport {
     MutationReport {
+        selection_provenance: std::collections::BTreeMap::new(),
         results: vec![
             (
                 Mutation {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2857,12 +2857,13 @@ fn read_log(path: &Path) -> String {
 }
 
 #[test]
-fn check_help_lists_test_selection_file_flag() {
+fn check_help_lists_test_selection_confirmation_flags() {
     togi()
         .args(["check", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--test-selection-file"));
+        .stdout(predicate::str::contains("--test-selection-file"))
+        .stdout(predicate::str::contains("--confirm-survivors"));
 }
 
 fn jq_available() -> bool {

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -110,6 +110,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
+            confirm_survivors: false,
             command: vec!["go".into(), "test".into(), "./...".into()],
             force_default_command: false,
             force_default_timeout: false,

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -64,6 +64,7 @@ fn run_fixture(case: FixtureCase) -> togi::MutationReport {
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
+            confirm_survivors: false,
             command: vec!["bash".into(), "run-tests.sh".into()],
             force_default_command: false,
             force_default_timeout: false,

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -69,6 +69,7 @@ fn verify_mutation_outcomes_match_independent_replay() {
 
     let runner = togi::runner::TestRunner {
         commands: togi::runner::CommandConfig {
+            confirm_survivors: false,
             command: vec!["go".into(), "test".into(), "./...".into()],
             force_default_command: false,
             force_default_timeout: false,

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -109,6 +109,11 @@ coverage_file = "coverage/lcov.info"
 # Default: unset
 test_selection_file = "coverage/test-selection.json"
 
+# Re-run narrowed survivors against their original full test route before reporting them.
+# Type: boolean
+# Default: false
+confirm_survivors = false
+
 # Reuse structured incremental history when the mutant source, command context,
 # and relevant covering tests have not changed.
 # Type: boolean


### PR DESCRIPTION
## Summary
- add opt-in full-suite confirmation for actual narrowed survivors
- preserve primary cache/history semantics while recording selection confirmation provenance
- expose provenance in terminal, JSON, HTML, GitHub, SARIF, and explain output

## Verification
- `cargo fmt -- --check`
- `cargo test --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `./.github/scripts/check-pinned-actions.sh`
- `cargo test --locked -- --ignored` *(10 passed; C# fixture requires unavailable `dotnet`)*

Closes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--confirm-survivors` to re-run narrowed survivors using their full test route.
  * Full-suite results now distinguish killed, timed out, build-error, and confirmed-survived outcomes.
  * Added configuration support, disabled by default.

* **Reporting**
  * Terminal, HTML, pull request, GitHub Actions, JSON, and SARIF reports now show test-selection and confirmation details.
  * Mutation explanations include selection metadata when available.

* **Documentation**
  * Updated CLI usage documentation and the example configuration with survivor-confirmation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->