### PR TITLE
chore: prepare v0.4.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"


### PR DESCRIPTION
## Release prep

#466 fixes the released Action’s child-env leak revealed by #465 dogfood. v0.4.1 is required before the advisory workflow can be re-pinned.

This PR changes only the root package version in `Cargo.toml` and the matching root `togi` entry in `Cargo.lock` from 0.4.0 to 0.4.1.

## Release safeguard

Tag/release only after this PR is merged and main CI is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->