### PR TITLE
ci: dogfood released togi v0.4.1

### DIFF
--- a/.github/workflows/togi-action-advisory.yml
+++ b/.github/workflows/togi-action-advisory.yml
@@ -31,9 +31,9 @@ jobs:
           cache-bin: false
       - name: Run Togi action (advisory)
         id: togi
-        uses: Darkroom4364/togi@05560884c9faf6e438e158245d7f19b4a28f63df # v0.4.0 release action source
+        uses: Darkroom4364/togi@a1503b2ebac4c63d377b015c4825b97cab25ec68 # v0.4.1 release action source
         with:
-          version: v0.4.0
+          version: v0.4.1
           base: origin/${{ github.base_ref }}
           test-cmd: cargo test --locked
           timeout: '120'


### PR DESCRIPTION
## Summary
- move the permanent self-dogfood Action pin to the released v0.4.1 environment-isolation fix
- let #465 exercise the released Action behavior

## Verification
- `.github/scripts/check-pinned-actions.sh`
- Ruby YAML parse of `.github/workflows/togi-action-advisory.yml`
- `git diff --check`