### PR TITLE
docs: verify released-binary first success

### DIFF
--- a/.github/scripts/run-released-binary-smoke.sh
+++ b/.github/scripts/run-released-binary-smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Exercises the documented Linux x86_64 released-binary first-success path.
+set -euo pipefail
+
+: "${TOGI_VERSION:?TOGI_VERSION is required}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+case "$(uname -m)" in
+  x86_64 | amd64) ;;
+  *)
+    echo "Released-binary smoke requires x86_64, got $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if command -v togi >/dev/null 2>&1; then
+  echo "Released-binary smoke requires no preinstalled togi: $(command -v togi)" >&2
+  exit 1
+fi
+
+eval "$(TOGI_OS=Linux TOGI_ARCH=x86_64 bash "${GITHUB_WORKSPACE}/.github/scripts/resolve-togi-asset.sh")"
+if [ "$TOGI_ARCHIVE" != "togi-linux-x86_64.tar.gz" ] || [ "$TOGI_BINARY" != "togi" ]; then
+  echo "Unexpected Linux release asset: ${TOGI_ARCHIVE} (${TOGI_BINARY})" >&2
+  exit 1
+fi
+
+release_base="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
+archive_path="${RUNNER_TEMP}/${TOGI_ARCHIVE}"
+checksums_path="${RUNNER_TEMP}/togi-release-checksums.txt"
+curl -fsSLo "$archive_path" "${release_base}/${TOGI_ARCHIVE}"
+curl -fsSLo "$checksums_path" "${release_base}/checksums.txt"
+expected_sha=$(awk -v file="$TOGI_ARCHIVE" '$2 == file || $2 == "./" file { print $1 }' "$checksums_path")
+if [ -z "$expected_sha" ]; then
+  echo "No checksum found for ${TOGI_ARCHIVE}" >&2
+  exit 1
+fi
+actual_sha=$(sha256sum "$archive_path" | awk '{print $1}')
+if [ "$actual_sha" != "$expected_sha" ]; then
+  echo "Checksum mismatch for ${TOGI_ARCHIVE}" >&2
+  exit 1
+fi
+
+TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" TOGI_ARCHIVE_PATH="$archive_path" \
+  bash "${GITHUB_WORKSPACE}/.github/scripts/install-togi-archive.sh"
+install_dir="${RUNNER_TEMP}/togi-bin"
+export PATH="${install_dir}:${PATH}"
+if [ "$(command -v togi)" != "${install_dir}/togi" ]; then
+  echo "Released-binary smoke did not select the installed togi" >&2
+  exit 1
+fi
+version_output=$(togi --version)
+printf '%s\n' "$version_output"
+if [ "$version_output" != "togi ${TOGI_VERSION#v}" ]; then
+  echo "Unexpected togi version: ${version_output}" >&2
+  exit 1
+fi
+
+fixture_dir="${GITHUB_WORKSPACE}/tests/fixtures/go"
+project_root=$(mktemp -d "${RUNNER_TEMP}/togi-released-binary-fixture.XXXXXX")
+trap 'rm -rf "$project_root"' EXIT
+cp "$fixture_dir/go.mod" "$fixture_dir/calc.go" "$fixture_dir/calc_test.go" "$project_root/"
+git -C "$project_root" init -q
+git -C "$project_root" config user.name "Togi Released Binary Smoke"
+git -C "$project_root" config user.email "togi-smoke@example.invalid"
+sed -i 's/if n > 0/if n < 0/' "$project_root/calc.go"
+git -C "$project_root" add go.mod calc.go calc_test.go
+git -C "$project_root" commit -qm "Seed fixture"
+sed -i 's/if n < 0/if n > 0/' "$project_root/calc.go"
+git -C "$project_root" add calc.go
+git -C "$project_root" commit -qm "Restore positive comparison"
+git -C "$project_root" rev-parse --verify HEAD~1 >/dev/null
+
+export GOFLAGS=-count=1
+export GOCACHE="${RUNNER_TEMP}/togi-released-binary-go-cache"
+rm -rf "$GOCACHE"
+go -C "$project_root" test ./...
+
+run_output="${RUNNER_TEMP}/togi-released-binary-smoke-output.txt"
+set +e
+(
+  cd "$project_root"
+  togi check --base HEAD~1
+) >"$run_output" 2>&1
+status=$?
+set -e
+
+case "$status" in
+  1)
+    ;;
+  0)
+    echo "Expected the weak fixture to produce a surviving mutant" >&2
+    cat "$run_output" >&2
+    exit 1
+    ;;
+  *)
+    echo "Released-binary mutation run failed with exit code ${status}" >&2
+    cat "$run_output" >&2
+    exit "$status"
+    ;;
+esac
+
+if ! grep -Eq '^Results: [0-9]+ killed, [1-9][0-9]* survived, 0 timeout, 0 build errors$' "$run_output"; then
+  echo "Released-binary mutation run did not prove healthy survivor results" >&2
+  cat "$run_output" >&2
+  exit 1
+fi
+if ! grep -Eq '^Execution: [1-9][0-9]* freshly tested$' "$run_output"; then
+  echo "Released-binary mutation run did not prove fresh execution" >&2
+  cat "$run_output" >&2
+  exit 1
+fi
+if grep -q '^Partial:' "$run_output"; then
+  echo "Released-binary mutation run was partial" >&2
+  cat "$run_output" >&2
+  exit 1
+fi
+git -C "$project_root" diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,22 @@ jobs:
       - name: Integration tests
         run: cargo test --locked -- --ignored
 
+  released-binary-smoke:
+    name: Released Binary Smoke
+    runs-on: ubuntu-latest
+    env:
+      TOGI_VERSION: v0.4.1
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+          cache: false
+      - name: Run released-binary smoke test
+        run: bash ./.github/scripts/run-released-binary-smoke.sh
+
   dogfood:
     name: Dogfood (togi on togi)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -69,18 +69,53 @@ Try it: `examples/polyglot-demo.sh` runs a PR-sized Go + Rust + Python change th
 
 ## Install
 
-Prefer a versioned GitHub Release and verify the published checksums:
+### Linux x86_64 (Tier 1) first success
+
+This tested released-binary path is for Linux x86_64 only. See the
+[compatibility contract](docs/COMPATIBILITY.md) for other platforms and support
+tiers.
+
+You need Bash, `curl`, `tar`, `sha256sum`, and `git`, plus a project with a
+passing test command that togi can auto-detect or that you configure as
+described in [Configuration](#configuration). Run the check from a Git checkout
+with a parent commit and at least one changed supported source line.
 
 ```bash
-TOGI_VERSION=vX.Y.Z
-curl -fsSLo togi.tar.gz \
-  "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/togi-linux-x86_64.tar.gz"
-curl -fsSLo checksums.txt \
-  "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}/checksums.txt"
-sha256sum --ignore-missing -c checksums.txt
-tar xzf togi.tar.gz
-install -m 0755 ./togi "$HOME/.local/bin/togi"
+(
+  set -euo pipefail
+  TOGI_VERSION=v0.4.1
+  TOGI_ARCHIVE=togi-linux-x86_64.tar.gz
+  RELEASE_BASE="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
+  TEMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TEMP_DIR"' EXIT
+  cd "$TEMP_DIR"
+
+  curl -fsSLo "$TOGI_ARCHIVE" "${RELEASE_BASE}/${TOGI_ARCHIVE}"
+  curl -fsSLo checksums.txt "${RELEASE_BASE}/checksums.txt"
+  EXPECTED_SHA=$(awk -v file="$TOGI_ARCHIVE" '$2 == file || $2 == "./" file { print $1 }' checksums.txt)
+  [ -n "$EXPECTED_SHA" ] || { echo "No checksum found for ${TOGI_ARCHIVE}" >&2; exit 1; }
+  ACTUAL_SHA=$(sha256sum "$TOGI_ARCHIVE" | awk '{print $1}')
+  [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ] || { echo "Checksum mismatch for ${TOGI_ARCHIVE}" >&2; exit 1; }
+
+  tar xzf "$TOGI_ARCHIVE"
+  mkdir -p "$HOME/.local/bin"
+  install -m 0755 ./togi "$HOME/.local/bin/togi"
+)
+export PATH="$HOME/.local/bin:$PATH"
+togi --version
 ```
+
+In the checkout you want to check:
+
+```bash
+git rev-parse --verify HEAD~1
+togi check --base HEAD~1
+```
+
+Exit `0` means all mutations were killed. Exit `1` means the mutation run
+completed and found surviving mutants. Exit `2` means an execution error (for
+example configuration, Git, or parsing) that you should fix before relying on
+the result.
 
 If you intentionally want a source-based install tied to a reviewed revision:
 


### PR DESCRIPTION
Fixes #469

- Adds the pinned Linux x86_64 released-binary first-success path.
- Adds a blocking smoke that verifies download, checksum, version, a fresh `HEAD~1` mutation run with the expected survivor exit, and restoration.

Tests:
- `bash -n .github/scripts/run-released-binary-smoke.sh`
- `.github/scripts/check-pinned-actions.sh`
- `cargo fmt -- --check`
- `cargo test --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

The smoke itself requires GitHub-hosted Linux x86_64; local development host is arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux x86_64 released-binary smoke testing in CI.
  * Expanded Linux x86_64 installation instructions with checksum validation, cleanup, verification steps, prerequisites, and exit-code guidance.

* **Tests**
  * CI now verifies released binary installation, version reporting, PATH selection, and core command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->