### PR TITLE
ci: add external dogfood protocol

### DIFF
--- a/.github/scripts/run-external-dogfood.sh
+++ b/.github/scripts/run-external-dogfood.sh
@@ -140,6 +140,8 @@ jq -n -S \
     --arg workflow_source_revision "$EXPECTED_WORKFLOW_SHA" \
     --arg workflow_source_ref "$EXPECTED_WORKFLOW_REF" \
     --arg approval_url "$APPROVAL_URL" \
+    --argjson approval_id "$APPROVAL_COMMENT_ID" \
+    --arg approval_author "$APPROVAL_AUTHOR" \
     --arg approval_body "$APPROVAL_BODY" \
     --arg release_tag "$TOGI_VERSION" \
     --arg archive "$TOGI_ARCHIVE" \
@@ -165,7 +167,7 @@ jq -n -S \
       case: "mitigrid-v0.4.1-pack",
       workflow_source_revision: $workflow_source_revision,
       workflow_source_ref: $workflow_source_ref,
-      approval: {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body},
+      approval: {url: $approval_url, id: $approval_id, author: $approval_author, body: $approval_body},
       release: {tag: $release_tag, archive: $archive, archive_sha256: $archive_sha256},
       target: {repository: $repository, revision: $revision, base: $base, mutation_scope: $path,
                direct_parent_changed_paths: [".togi-baseline", $path, "docs/governance/mutation-baseline-v0.1.md",
@@ -223,7 +225,7 @@ jq -n -S \
       actual_sha256: $actual_sha256, version: $version}' >"$output_dir/release-verification.json"
 
 target_dir="$work_root/target"
-GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CLONE_TIMEOUT_SECONDS}s" git clone --no-checkout "$TARGET_REPOSITORY" "$target_dir"
+GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CLONE_TIMEOUT_SECONDS}s" git clone --filter=blob:none --no-checkout "$TARGET_REPOSITORY" "$target_dir"
 GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CHECKOUT_TIMEOUT_SECONDS}s" git -C "$target_dir" checkout --detach "$TARGET_REVISION"
 [[ "$(git -C "$target_dir" rev-parse HEAD)" == "$TARGET_REVISION" ]] || die "target checkout revision did not match"
 git -C "$target_dir" cat-file -e "${TARGET_BASE}^{commit}"
@@ -284,7 +286,7 @@ printf '%s\n' \
     "approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
     "release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
     "release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
-    "target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --no-checkout $TARGET_REPOSITORY" \
+    "target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY" \
     "target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION" \
     "dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked" \
     "preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace" \

--- a/.github/scripts/run-external-dogfood.sh
+++ b/.github/scripts/run-external-dogfood.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Runs exactly the approved Mitigrid external-dogfood case and preserves its evidence.
+set -euo pipefail
+
+readonly APPROVAL_COMMENT_ID=5150807894
+readonly APPROVAL_AUTHOR=Darkroom4364
+readonly APPROVAL_URL="https://github.com/Darkroom4364/Mitigrid/pull/125#issuecomment-5150807894"
+readonly APPROVAL_API_URL="https://api.github.com/repos/Darkroom4364/Mitigrid/issues/comments/${APPROVAL_COMMENT_ID}"
+readonly APPROVAL_BODY="$(cat <<'EOF'
+I authorize one no-secret, read-only external-dogfood run of released Darkroom4364/togi v0.4.1 on Darkroom4364/Mitigrid commit f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8, base 16e7c9e49f353fd7f4254276b3a7ece99c6dedf6, scoped to crates/opencem-cli/src/commands/pack.rs, using cargo test --locked --workspace and cargo check --locked --workspace. The run may publish its bounded raw stdout/stderr, JSON reports, environment metadata, and checksums in Darkroom4364/togi. It must use no secrets and must not modify Mitigrid.
+EOF
+)"
+readonly TOGI_VERSION=v0.4.1
+readonly TOGI_ARCHIVE=togi-linux-x86_64.tar.gz
+readonly TOGI_ARCHIVE_SHA256=6be7bf55d3c84a539cdaa4e60e5b5ef212ddb0e2575cd6b85ceae50218abce5c
+readonly TARGET_REPOSITORY=https://github.com/Darkroom4364/Mitigrid.git
+readonly TARGET_REVISION=f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8
+readonly TARGET_BASE=16e7c9e49f353fd7f4254276b3a7ece99c6dedf6
+readonly TARGET_PATH=crates/opencem-cli/src/commands/pack.rs
+readonly GENERATED_MUTANT_CEILING=20
+readonly MUTATION_TIMEOUT_SECONDS=120
+readonly MUTATION_JOBS=2
+readonly OUTER_TIMEOUT_SECONDS=2100
+
+usage() {
+    cat <<'EOF'
+Usage: run-external-dogfood.sh OUTPUT_DIRECTORY
+
+Runs the one approved external-dogfood case. OUTPUT_DIRECTORY must be absent or
+an empty absolute directory. EXPECTED_WORKFLOW_SHA, GITHUB_SHA, and
+GITHUB_WORKSPACE are required from the workflow environment.
+EOF
+}
+
+die() {
+    echo "external dogfood: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+validate_archive_entries() {
+    tar tzf "$1" | awk '
+        {
+            path = $0
+            gsub(/\\/, "/", path)
+            if (path == "" || path ~ /^\// || path ~ /(^|\/)\.\.($|\/)/) {
+                printf "unsafe archive entry: %s\n", $0 > "/dev/stderr"
+                exit 1
+            }
+        }
+    '
+}
+
+validate_tar_entry_types() {
+    tar tvzf "$1" | awk '
+        {
+            kind = substr($0, 1, 1)
+            if (kind == "l" || kind == "h") {
+                printf "unsafe archive link entry: %s\n", $0 > "/dev/stderr"
+                exit 1
+            }
+        }
+    '
+}
+
+validate_single_json_document() {
+    jq -e -s 'length == 1' "$1" >/dev/null
+}
+
+if [[ "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+output_dir=$1
+case "$output_dir" in
+    /*) ;;
+    *) die "output directory must be absolute" ;;
+esac
+if [[ -e "$output_dir" ]]; then
+    [[ -d "$output_dir" ]] || die "output path is not a directory"
+    [[ -z "$(find "$output_dir" -mindepth 1 -print -quit)" ]] || die "output directory is not empty"
+else
+    mkdir -p "$output_dir"
+fi
+
+: "${EXPECTED_WORKFLOW_SHA:?EXPECTED_WORKFLOW_SHA is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+[[ "$EXPECTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || die "EXPECTED_WORKFLOW_SHA is not a full lowercase commit SHA"
+[[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || die "GITHUB_SHA is not a full lowercase commit SHA"
+[[ "$EXPECTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || die "workflow dispatch SHA does not match GITHUB_SHA"
+workflow_head=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)
+[[ "$workflow_head" == "$EXPECTED_WORKFLOW_SHA" ]] || die "checked-out Togi revision does not match expected workflow SHA"
+
+for command in awk cargo curl find git jq nproc sha256sum sort tar timeout; do
+    require_command "$command"
+done
+[[ "$(uname -s)" == Linux ]] || die "this protocol requires Linux"
+[[ "$(uname -m)" == x86_64 ]] || die "this protocol requires x86_64"
+
+work_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/togi-external-dogfood.XXXXXX")
+cleanup() {
+    rm -rf "$work_root"
+}
+trap cleanup EXIT
+
+approval_response="$work_root/approval-response.json"
+curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    "$APPROVAL_API_URL" >"$approval_response"
+[[ "$(jq -r '.id' "$approval_response")" == "$APPROVAL_COMMENT_ID" ]] || die "approval comment id did not match"
+[[ "$(jq -r '.user.login' "$approval_response")" == "$APPROVAL_AUTHOR" ]] || die "approval comment author did not match"
+[[ "$(jq -r '.html_url' "$approval_response")" == "$APPROVAL_URL" ]] || die "approval comment URL did not match"
+[[ "$(jq -r '.body' "$approval_response")" == "$APPROVAL_BODY" ]] || die "approval comment body did not match"
+jq -S '{url: .html_url, id, author: .user.login, created_at, body}' "$approval_response" >"$output_dir/approval.json"
+
+jq -n -S \
+    --arg workflow_source_revision "$EXPECTED_WORKFLOW_SHA" \
+    --arg approval_url "$APPROVAL_URL" \
+    --arg approval_body "$APPROVAL_BODY" \
+    --arg release_tag "$TOGI_VERSION" \
+    --arg archive "$TOGI_ARCHIVE" \
+    --arg archive_sha256 "$TOGI_ARCHIVE_SHA256" \
+    --arg repository "$TARGET_REPOSITORY" \
+    --arg revision "$TARGET_REVISION" \
+    --arg base "$TARGET_BASE" \
+    --arg path "$TARGET_PATH" \
+    --argjson ceiling "$GENERATED_MUTANT_CEILING" \
+    --argjson mutation_timeout "$MUTATION_TIMEOUT_SECONDS" \
+    --argjson jobs "$MUTATION_JOBS" \
+    --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" \
+    '{schema_version: 1,
+      case: "mitigrid-v0.4.1-pack",
+      workflow_source_revision: $workflow_source_revision,
+      approval: {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body},
+      release: {tag: $release_tag, archive: $archive, archive_sha256: $archive_sha256},
+      target: {repository: $repository, revision: $revision, base: $base, path: $path,
+               test_command: ["cargo", "test", "--locked", "--workspace"],
+               build_command: ["cargo", "check", "--locked", "--workspace"],
+               togi_toml_max_per_run: 0},
+      limits: {generated_mutant_ceiling: $ceiling, per_mutation_timeout_seconds: $mutation_timeout,
+               jobs: $jobs, outer_timeout_seconds: $outer_timeout}}' >"$output_dir/case.json"
+
+release_dir="$work_root/release"
+extract_dir="$work_root/extract"
+install_dir="$work_root/bin"
+mkdir -p "$release_dir" "$extract_dir" "$install_dir"
+archive_path="$release_dir/$TOGI_ARCHIVE"
+release_base="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
+curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    -o "$archive_path" "$release_base/$TOGI_ARCHIVE"
+curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    -o "$output_dir/release-checksums.txt" "$release_base/checksums.txt"
+manifest_matches=()
+while IFS= read -r manifest_match; do
+    manifest_matches+=("$manifest_match")
+done < <(awk -v file="$TOGI_ARCHIVE" '$2 == file || $2 == "./" file { print $1 }' "$output_dir/release-checksums.txt")
+[[ ${#manifest_matches[@]} -eq 1 ]] || die "release manifest must contain exactly one archive entry"
+[[ "${manifest_matches[0]}" == "$TOGI_ARCHIVE_SHA256" ]] || die "release manifest checksum did not match the approved checksum"
+archive_sha256=$(sha256sum "$archive_path" | awk '{print $1}')
+[[ "$archive_sha256" == "$TOGI_ARCHIVE_SHA256" ]] || die "downloaded archive checksum did not match the approved checksum"
+validate_archive_entries "$archive_path"
+validate_tar_entry_types "$archive_path"
+tar xzf "$archive_path" -C "$extract_dir"
+binaries=()
+while IFS= read -r binary; do
+    binaries+=("$binary")
+done < <(find "$extract_dir" -type f -name togi -print)
+[[ ${#binaries[@]} -eq 1 ]] || die "release archive must contain exactly one togi binary"
+install -m 0755 "${binaries[0]}" "$install_dir/togi"
+togi_bin="$install_dir/togi"
+togi_version="$($togi_bin --version)"
+[[ "$togi_version" == "togi 0.4.1" ]] || die "released binary version did not match v0.4.1"
+printf '%s\n' "$togi_version" >"$output_dir/togi-version.txt"
+jq -n -S \
+    --arg tag "$TOGI_VERSION" \
+    --arg archive "$TOGI_ARCHIVE" \
+    --arg expected_sha256 "$TOGI_ARCHIVE_SHA256" \
+    --arg actual_sha256 "$archive_sha256" \
+    --arg version "$togi_version" \
+    '{tag: $tag, archive: $archive, expected_sha256: $expected_sha256,
+      actual_sha256: $actual_sha256, version: $version}' >"$output_dir/release-verification.json"
+
+target_dir="$work_root/target"
+GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none --no-checkout "$TARGET_REPOSITORY" "$target_dir"
+GIT_TERMINAL_PROMPT=0 git -C "$target_dir" checkout --detach "$TARGET_REVISION"
+[[ "$(git -C "$target_dir" rev-parse HEAD)" == "$TARGET_REVISION" ]] || die "target checkout revision did not match"
+git -C "$target_dir" cat-file -e "${TARGET_BASE}^{commit}"
+[[ "$(git -C "$target_dir" rev-parse "${TARGET_REVISION}^")" == "$TARGET_BASE" ]] || die "approved base is not the target revision's direct parent"
+git -C "$target_dir" merge-base --is-ancestor "$TARGET_BASE" "$TARGET_REVISION"
+[[ -f "$target_dir/$TARGET_PATH" ]] || die "approved target path is absent"
+git -C "$target_dir" diff --binary "$TARGET_BASE" "$TARGET_REVISION" -- "$TARGET_PATH" >"$output_dir/target.patch"
+[[ -s "$output_dir/target.patch" ]] || die "approved target path has no diff from its base"
+[[ -f "$target_dir/togi.toml" ]] || die "target togi.toml is absent"
+awk '
+    /^\[mutations\]/{ in_mutations = 1; next }
+    /^\[/{ in_mutations = 0 }
+    in_mutations && /^[[:space:]]*max_per_run[[:space:]]*=[[:space:]]*0[[:space:]]*(#.*)?$/ { matches++ }
+    END { exit matches == 1 ? 0 : 1 }
+' "$target_dir/togi.toml" || die "target togi.toml must set mutations.max_per_run = 0"
+cp "$target_dir/togi.toml" "$output_dir/target-togi.toml"
+git -C "$target_dir" status --porcelain --untracked-files=all >"$output_dir/target-before-status.txt"
+[[ ! -s "$output_dir/target-before-status.txt" ]] || die "target worktree was not clean before execution"
+
+original_home=${HOME:?HOME is required}
+toolchain_home=${RUSTUP_HOME:-"$original_home/.rustup"}
+[[ -d "$toolchain_home" ]] || die "Rust toolchain location is unavailable"
+mkdir -p "$work_root/home" "$work_root/cargo-home"
+runtime_env=(
+    "PATH=$PATH"
+    "HOME=$work_root/home"
+    "CARGO_HOME=$work_root/cargo-home"
+    "RUSTUP_HOME=$toolchain_home"
+    "TZ=UTC"
+    "LC_ALL=C"
+)
+
+set +e
+(
+    cd "$target_dir"
+    env -i "${runtime_env[@]}" cargo fetch --locked
+) >"$output_dir/cargo-fetch.stdout" 2>"$output_dir/cargo-fetch.stderr"
+fetch_status=$?
+set -e
+printf '%s\n' "$fetch_status" >"$output_dir/cargo-fetch-status.txt"
+[[ "$fetch_status" -eq 0 ]] || die "cargo fetch failed"
+
+set +e
+(
+    cd "$target_dir"
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true cargo test --locked --workspace
+) >"$output_dir/preflight.stdout" 2>"$output_dir/preflight.stderr"
+preflight_status=$?
+set -e
+printf '%s\n' "$preflight_status" >"$output_dir/preflight-status.txt"
+[[ "$preflight_status" -eq 0 ]] || die "target preflight failed"
+
+printf '%s\n' \
+    'preflight: cargo test --locked --workspace' \
+    "dry-run: togi check --dry-run --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
+    "execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
+    >"$output_dir/commands.txt"
+
+set +e
+(
+    cd "$target_dir"
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
+        --dry-run --format json --base "$TARGET_BASE" --path "$TARGET_PATH" \
+        --test-cmd "cargo test --locked --workspace" \
+        --build-cmd "cargo check --locked --workspace"
+) >"$output_dir/dry-run.stdout" 2>"$output_dir/dry-run.stderr"
+dry_run_status=$?
+set -e
+printf '%s\n' "$dry_run_status" >"$output_dir/dry-run-status.txt"
+[[ "$dry_run_status" -eq 0 ]] || die "dry run failed"
+validate_single_json_document "$output_dir/dry-run.stdout"
+cp "$output_dir/dry-run.stdout" "$output_dir/dry-run.json"
+jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" '
+    def natural: type == "number" and . >= 0 and floor == .;
+    type == "object" and .kind == "dry_run" and .schema_version == 1 and .generator == "togi/0.4.1" and
+    .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
+    .planned_total == (.mutations | length) and .planned_total >= 1 and .planned_total <= $ceiling
+' "$output_dir/dry-run.json" >/dev/null || die "dry run did not produce the approved bounded v0.4.1 plan"
+
+start_ns=$(date -u +%s%N)
+set +e
+(
+    cd "$target_dir"
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --preserve-status 35m "$togi_bin" check \
+        --format json --base "$TARGET_BASE" --path "$TARGET_PATH" \
+        --test-cmd "cargo test --locked --workspace" \
+        --build-cmd "cargo check --locked --workspace" \
+        --timeout "$MUTATION_TIMEOUT_SECONDS" --jobs "$MUTATION_JOBS" \
+        --force-rerun --no-incremental-history
+) >"$output_dir/togi.stdout" 2>"$output_dir/togi.stderr"
+togi_status=$?
+set -e
+end_ns=$(date -u +%s%N)
+printf '%s\n' "$togi_status" >"$output_dir/togi-exit-status.txt"
+case "$togi_status" in
+    0|1) ;;
+    *) die "Togi execution failed with nonpublishable status $togi_status" ;;
+esac
+validate_single_json_document "$output_dir/togi.stdout"
+cp "$output_dir/togi.stdout" "$output_dir/report.json"
+wall_time_ms=$(((end_ns - start_ns) / 1000000))
+jq -n -S --argjson wall_time_ms "$wall_time_ms" '{wall_time_ms: $wall_time_ms}' >"$output_dir/wall-time.json"
+
+set +e
+(
+    cd "$target_dir"
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" clean
+) >"$work_root/togi-clean.stdout" 2>"$work_root/togi-clean.stderr"
+clean_status=$?
+set -e
+[[ "$clean_status" -eq 0 ]] || die "Togi clean failed"
+git -C "$target_dir" status --porcelain --untracked-files=all >"$output_dir/target-after-status.txt"
+[[ ! -s "$output_dir/target-after-status.txt" ]] || die "target worktree was not clean after execution"
+
+jq -n -S \
+    --arg workflow_source_revision "$EXPECTED_WORKFLOW_SHA" \
+    --arg runner_os "${RUNNER_OS:-Linux}" \
+    --arg runner_image "${ImageOS:-unknown}" \
+    --arg runner_image_version "${ImageVersion:-unknown}" \
+    --arg uname "$(uname -srm)" \
+    --arg arch "$(uname -m)" \
+    --arg cpu_count "$(nproc)" \
+    --arg cargo_version "$(cargo --version)" \
+    --arg rustc_version "$(rustc --version)" \
+    --arg git_version "$(git --version)" \
+    --arg togi_version "$togi_version" \
+    --arg locale "C" \
+    --arg timezone "UTC" \
+    --arg cargo_lock_sha256 "$(sha256sum "$target_dir/Cargo.lock" | awk '{print $1}')" \
+    --arg togi_toml_sha256 "$(sha256sum "$target_dir/togi.toml" | awk '{print $1}')" \
+    '{schema_version: 1, workflow_source_revision: $workflow_source_revision,
+      runner: {os: $runner_os, image: $runner_image, image_version: $runner_image_version,
+               uname: $uname, arch: $arch, cpu_count: $cpu_count},
+      versions: {cargo: $cargo_version, rustc: $rustc_version, git: $git_version, togi: $togi_version},
+      locale: $locale, timezone: $timezone,
+      target: {cargo_lock_sha256: $cargo_lock_sha256, togi_toml_sha256: $togi_toml_sha256}}' \
+    >"$output_dir/environment.json"
+
+validator="$GITHUB_WORKSPACE/.github/scripts/verify-external-dogfood-evidence.sh"
+[[ -f "$validator" ]] || die "offline evidence validator is unavailable"
+bash "$validator" --generate "$output_dir" >"$output_dir/validation.txt"
+checksum_files=(
+    approval.json case.json cargo-fetch-status.txt cargo-fetch.stderr cargo-fetch.stdout commands.txt
+    dry-run-status.txt dry-run.json dry-run.stderr dry-run.stdout environment.json
+    preflight-status.txt preflight.stderr preflight.stdout release-checksums.txt release-verification.json
+    report.json target-after-status.txt target-before-status.txt target-togi.toml target.patch
+    togi-exit-status.txt togi-version.txt togi.stderr togi.stdout validation.txt wall-time.json metrics.json
+)
+(
+    cd "$output_dir"
+    printf '%s\n' "${checksum_files[@]}" | LC_ALL=C sort | while IFS= read -r file; do
+        sha256sum "$file"
+    done
+) >"$output_dir/SHA256SUMS"
+bash "$validator" --verify "$output_dir"

--- a/.github/scripts/run-external-dogfood.sh
+++ b/.github/scripts/run-external-dogfood.sh
@@ -22,6 +22,15 @@ readonly GENERATED_MUTANT_CEILING=20
 readonly MUTATION_TIMEOUT_SECONDS=120
 readonly MUTATION_JOBS=2
 readonly OUTER_TIMEOUT_SECONDS=2100
+readonly CURL_CONNECT_TIMEOUT_SECONDS=15
+readonly CURL_MAX_TIME_SECONDS=120
+readonly TARGET_CLONE_TIMEOUT_SECONDS=300
+readonly TARGET_CHECKOUT_TIMEOUT_SECONDS=120
+readonly DEPENDENCY_FETCH_TIMEOUT_SECONDS=480
+readonly PREFLIGHT_TIMEOUT_SECONDS=600
+readonly DRY_RUN_TIMEOUT_SECONDS=300
+readonly CLEANUP_TIMEOUT_SECONDS=120
+readonly WORKFLOW_TIMEOUT_MINUTES=90
 
 usage() {
     cat <<'EOF'
@@ -105,7 +114,7 @@ fi
 workflow_head=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)
 [[ "$workflow_head" == "$EXPECTED_WORKFLOW_SHA" ]] || die "checked-out Togi revision does not match expected workflow SHA"
 
-for command in awk cargo curl find git jq nproc sha256sum sort tar timeout; do
+for command in awk cargo curl find git install jq nproc rustc sha256sum sort tar timeout; do
     require_command "$command"
 done
 [[ "$(uname -s)" == Linux ]] || die "this protocol requires Linux"
@@ -119,6 +128,7 @@ trap cleanup EXIT
 
 approval_response="$work_root/approval-response.json"
 curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     "$APPROVAL_API_URL" >"$approval_response"
 [[ "$(jq -r '.id' "$approval_response")" == "$APPROVAL_COMMENT_ID" ]] || die "approval comment id did not match"
 [[ "$(jq -r '.user.login' "$approval_response")" == "$APPROVAL_AUTHOR" ]] || die "approval comment author did not match"
@@ -142,6 +152,15 @@ jq -n -S \
     --argjson mutation_timeout "$MUTATION_TIMEOUT_SECONDS" \
     --argjson jobs "$MUTATION_JOBS" \
     --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" \
+    --argjson curl_connect_timeout "$CURL_CONNECT_TIMEOUT_SECONDS" \
+    --argjson curl_max_time "$CURL_MAX_TIME_SECONDS" \
+    --argjson target_clone_timeout "$TARGET_CLONE_TIMEOUT_SECONDS" \
+    --argjson target_checkout_timeout "$TARGET_CHECKOUT_TIMEOUT_SECONDS" \
+    --argjson dependency_fetch_timeout "$DEPENDENCY_FETCH_TIMEOUT_SECONDS" \
+    --argjson preflight_timeout "$PREFLIGHT_TIMEOUT_SECONDS" \
+    --argjson dry_run_timeout "$DRY_RUN_TIMEOUT_SECONDS" \
+    --argjson cleanup_timeout "$CLEANUP_TIMEOUT_SECONDS" \
+    --argjson workflow_timeout_minutes "$WORKFLOW_TIMEOUT_MINUTES" \
     '{schema_version: 1,
       case: "mitigrid-v0.4.1-pack",
       workflow_source_revision: $workflow_source_revision,
@@ -155,7 +174,11 @@ jq -n -S \
                build_command: ["cargo", "check", "--locked", "--workspace"],
                togi_toml_max_per_run: 0},
       limits: {generated_mutant_ceiling: $ceiling, per_mutation_timeout_seconds: $mutation_timeout,
-               jobs: $jobs, outer_timeout_seconds: $outer_timeout}}' >"$output_dir/case.json"
+               jobs: $jobs, curl_connect_timeout_seconds: $curl_connect_timeout, curl_max_time_seconds: $curl_max_time,
+               target_clone_timeout_seconds: $target_clone_timeout, target_checkout_timeout_seconds: $target_checkout_timeout,
+               dependency_fetch_timeout_seconds: $dependency_fetch_timeout, preflight_timeout_seconds: $preflight_timeout,
+               dry_run_timeout_seconds: $dry_run_timeout, outer_timeout_seconds: $outer_timeout,
+               cleanup_timeout_seconds: $cleanup_timeout, workflow_timeout_minutes: $workflow_timeout_minutes}}' >"$output_dir/case.json"
 
 release_dir="$work_root/release"
 extract_dir="$work_root/extract"
@@ -164,8 +187,10 @@ mkdir -p "$release_dir" "$extract_dir" "$install_dir"
 archive_path="$release_dir/$TOGI_ARCHIVE"
 release_base="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
 curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     -o "$archive_path" "$release_base/$TOGI_ARCHIVE"
 curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     -o "$output_dir/release-checksums.txt" "$release_base/checksums.txt"
 manifest_matches=()
 while IFS= read -r manifest_match; do
@@ -198,8 +223,8 @@ jq -n -S \
       actual_sha256: $actual_sha256, version: $version}' >"$output_dir/release-verification.json"
 
 target_dir="$work_root/target"
-GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none --no-checkout "$TARGET_REPOSITORY" "$target_dir"
-GIT_TERMINAL_PROMPT=0 git -C "$target_dir" checkout --detach "$TARGET_REVISION"
+GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CLONE_TIMEOUT_SECONDS}s" git clone --no-checkout "$TARGET_REPOSITORY" "$target_dir"
+GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CHECKOUT_TIMEOUT_SECONDS}s" git -C "$target_dir" checkout --detach "$TARGET_REVISION"
 [[ "$(git -C "$target_dir" rev-parse HEAD)" == "$TARGET_REVISION" ]] || die "target checkout revision did not match"
 git -C "$target_dir" cat-file -e "${TARGET_BASE}^{commit}"
 [[ "$(git -C "$target_dir" rev-parse "${TARGET_REVISION}^")" == "$TARGET_BASE" ]] || die "approved base is not the target revision's direct parent"
@@ -237,7 +262,7 @@ runtime_env=(
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" cargo fetch --locked
+    timeout --preserve-status "${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" cargo fetch --locked
 ) >"$output_dir/cargo-fetch.stdout" 2>"$output_dir/cargo-fetch.stderr"
 fetch_status=$?
 set -e
@@ -247,7 +272,7 @@ printf '%s\n' "$fetch_status" >"$output_dir/cargo-fetch-status.txt"
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true cargo test --locked --workspace
+    timeout --preserve-status "${PREFLIGHT_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true cargo test --locked --workspace
 ) >"$output_dir/preflight.stdout" 2>"$output_dir/preflight.stderr"
 preflight_status=$?
 set -e
@@ -255,15 +280,23 @@ printf '%s\n' "$preflight_status" >"$output_dir/preflight-status.txt"
 [[ "$preflight_status" -eq 0 ]] || die "target preflight failed"
 
 printf '%s\n' \
-    'preflight: cargo test --locked --workspace' \
-    "dry-run: togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
-    "execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
+    "workflow-deadline: timeout-minutes $WORKFLOW_TIMEOUT_MINUTES" \
+    "approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --no-checkout $TARGET_REPOSITORY" \
+    "target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION" \
+    "dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked" \
+    "preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace" \
+    "dry-run: timeout --preserve-status ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
+    "execution: timeout --preserve-status ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
+    "cleanup: timeout --preserve-status ${CLEANUP_TIMEOUT_SECONDS}s togi clean" \
     >"$output_dir/commands.txt"
 
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
+    timeout --preserve-status "${DRY_RUN_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
         --dry-run --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace"
@@ -289,7 +322,7 @@ start_ns=$(date -u +%s%N)
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --preserve-status 35m "$togi_bin" check \
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --preserve-status "${OUTER_TIMEOUT_SECONDS}s" "$togi_bin" check \
         --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace" \
@@ -312,7 +345,7 @@ jq -n -S --argjson wall_time_ms "$wall_time_ms" '{wall_time_ms: $wall_time_ms}' 
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" clean
+    timeout --preserve-status "${CLEANUP_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" clean
 ) >"$work_root/togi-clean.stdout" 2>"$work_root/togi-clean.stderr"
 clean_status=$?
 set -e

--- a/.github/scripts/run-external-dogfood.sh
+++ b/.github/scripts/run-external-dogfood.sh
@@ -30,6 +30,7 @@ readonly DEPENDENCY_FETCH_TIMEOUT_SECONDS=480
 readonly PREFLIGHT_TIMEOUT_SECONDS=600
 readonly DRY_RUN_TIMEOUT_SECONDS=300
 readonly CLEANUP_TIMEOUT_SECONDS=120
+readonly PHASE_KILL_GRACE_SECONDS=10
 readonly WORKFLOW_TIMEOUT_MINUTES=90
 
 usage() {
@@ -127,7 +128,8 @@ cleanup() {
 trap cleanup EXIT
 
 approval_response="$work_root/approval-response.json"
-curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${CURL_MAX_TIME_SECONDS}s" \
+    curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
     --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     "$APPROVAL_API_URL" >"$approval_response"
 [[ "$(jq -r '.id' "$approval_response")" == "$APPROVAL_COMMENT_ID" ]] || die "approval comment id did not match"
@@ -162,6 +164,7 @@ jq -n -S \
     --argjson preflight_timeout "$PREFLIGHT_TIMEOUT_SECONDS" \
     --argjson dry_run_timeout "$DRY_RUN_TIMEOUT_SECONDS" \
     --argjson cleanup_timeout "$CLEANUP_TIMEOUT_SECONDS" \
+    --argjson phase_kill_grace "$PHASE_KILL_GRACE_SECONDS" \
     --argjson workflow_timeout_minutes "$WORKFLOW_TIMEOUT_MINUTES" \
     '{schema_version: 1,
       case: "mitigrid-v0.4.1-pack",
@@ -180,7 +183,8 @@ jq -n -S \
                target_clone_timeout_seconds: $target_clone_timeout, target_checkout_timeout_seconds: $target_checkout_timeout,
                dependency_fetch_timeout_seconds: $dependency_fetch_timeout, preflight_timeout_seconds: $preflight_timeout,
                dry_run_timeout_seconds: $dry_run_timeout, outer_timeout_seconds: $outer_timeout,
-               cleanup_timeout_seconds: $cleanup_timeout, workflow_timeout_minutes: $workflow_timeout_minutes}}' >"$output_dir/case.json"
+               cleanup_timeout_seconds: $cleanup_timeout, phase_kill_grace_seconds: $phase_kill_grace,
+               workflow_timeout_minutes: $workflow_timeout_minutes}}' >"$output_dir/case.json"
 
 release_dir="$work_root/release"
 extract_dir="$work_root/extract"
@@ -188,10 +192,12 @@ install_dir="$work_root/bin"
 mkdir -p "$release_dir" "$extract_dir" "$install_dir"
 archive_path="$release_dir/$TOGI_ARCHIVE"
 release_base="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
-curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${CURL_MAX_TIME_SECONDS}s" \
+    curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
     --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     -o "$archive_path" "$release_base/$TOGI_ARCHIVE"
-curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
+timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${CURL_MAX_TIME_SECONDS}s" \
+    curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 \
     --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" --max-time "$CURL_MAX_TIME_SECONDS" \
     -o "$output_dir/release-checksums.txt" "$release_base/checksums.txt"
 manifest_matches=()
@@ -225,8 +231,8 @@ jq -n -S \
       actual_sha256: $actual_sha256, version: $version}' >"$output_dir/release-verification.json"
 
 target_dir="$work_root/target"
-GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CLONE_TIMEOUT_SECONDS}s" git clone --filter=blob:none --no-checkout "$TARGET_REPOSITORY" "$target_dir"
-GIT_TERMINAL_PROMPT=0 timeout --preserve-status "${TARGET_CHECKOUT_TIMEOUT_SECONDS}s" git -C "$target_dir" checkout --detach "$TARGET_REVISION"
+GIT_TERMINAL_PROMPT=0 timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${TARGET_CLONE_TIMEOUT_SECONDS}s" git clone --filter=blob:none --no-checkout "$TARGET_REPOSITORY" "$target_dir"
+GIT_TERMINAL_PROMPT=0 timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${TARGET_CHECKOUT_TIMEOUT_SECONDS}s" git -C "$target_dir" checkout --detach "$TARGET_REVISION"
 [[ "$(git -C "$target_dir" rev-parse HEAD)" == "$TARGET_REVISION" ]] || die "target checkout revision did not match"
 git -C "$target_dir" cat-file -e "${TARGET_BASE}^{commit}"
 [[ "$(git -C "$target_dir" rev-parse "${TARGET_REVISION}^")" == "$TARGET_BASE" ]] || die "approved base is not the target revision's direct parent"
@@ -264,7 +270,7 @@ runtime_env=(
 set +e
 (
     cd "$target_dir"
-    timeout --preserve-status "${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" cargo fetch --locked
+    timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" cargo fetch --locked
 ) >"$output_dir/cargo-fetch.stdout" 2>"$output_dir/cargo-fetch.stderr"
 fetch_status=$?
 set -e
@@ -274,7 +280,7 @@ printf '%s\n' "$fetch_status" >"$output_dir/cargo-fetch-status.txt"
 set +e
 (
     cd "$target_dir"
-    timeout --preserve-status "${PREFLIGHT_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true cargo test --locked --workspace
+    timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${PREFLIGHT_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true cargo test --locked --workspace
 ) >"$output_dir/preflight.stdout" 2>"$output_dir/preflight.stderr"
 preflight_status=$?
 set -e
@@ -283,22 +289,22 @@ printf '%s\n' "$preflight_status" >"$output_dir/preflight-status.txt"
 
 printf '%s\n' \
     "workflow-deadline: timeout-minutes $WORKFLOW_TIMEOUT_MINUTES" \
-    "approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
-    "release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
-    "release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
-    "target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY" \
-    "target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION" \
-    "dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked" \
-    "preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace" \
-    "dry-run: timeout --preserve-status ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
-    "execution: timeout --preserve-status ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
-    "cleanup: timeout --preserve-status ${CLEANUP_TIMEOUT_SECONDS}s togi clean" \
+    "approval-fetch: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "release-archive-download: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "release-checksums-download: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS" \
+    "target-clone: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY" \
+    "target-checkout: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION" \
+    "dependency-fetch: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked" \
+    "preflight: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace" \
+    "dry-run: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
+    "execution: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
+    "cleanup: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CLEANUP_TIMEOUT_SECONDS}s togi clean" \
     >"$output_dir/commands.txt"
 
 set +e
 (
     cd "$target_dir"
-    timeout --preserve-status "${DRY_RUN_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
+    timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${DRY_RUN_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
         --dry-run --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace"
@@ -324,7 +330,7 @@ start_ns=$(date -u +%s%N)
 set +e
 (
     cd "$target_dir"
-    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --preserve-status "${OUTER_TIMEOUT_SECONDS}s" "$togi_bin" check \
+    env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${OUTER_TIMEOUT_SECONDS}s" "$togi_bin" check \
         --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace" \
@@ -347,7 +353,7 @@ jq -n -S --argjson wall_time_ms "$wall_time_ms" '{wall_time_ms: $wall_time_ms}' 
 set +e
 (
     cd "$target_dir"
-    timeout --preserve-status "${CLEANUP_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" clean
+    timeout --kill-after="${PHASE_KILL_GRACE_SECONDS}s" "${CLEANUP_TIMEOUT_SECONDS}s" env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" clean
 ) >"$work_root/togi-clean.stdout" 2>"$work_root/togi-clean.stderr"
 clean_status=$?
 set -e

--- a/.github/scripts/run-external-dogfood.sh
+++ b/.github/scripts/run-external-dogfood.sh
@@ -17,6 +17,7 @@ readonly TARGET_REPOSITORY=https://github.com/Darkroom4364/Mitigrid.git
 readonly TARGET_REVISION=f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8
 readonly TARGET_BASE=16e7c9e49f353fd7f4254276b3a7ece99c6dedf6
 readonly TARGET_PATH=crates/opencem-cli/src/commands/pack.rs
+readonly DEFAULT_WORKFLOW_REF=refs/heads/main
 readonly GENERATED_MUTANT_CEILING=20
 readonly MUTATION_TIMEOUT_SECONDS=120
 readonly MUTATION_JOBS=2
@@ -27,8 +28,8 @@ usage() {
 Usage: run-external-dogfood.sh OUTPUT_DIRECTORY
 
 Runs the one approved external-dogfood case. OUTPUT_DIRECTORY must be absent or
-an empty absolute directory. EXPECTED_WORKFLOW_SHA, GITHUB_SHA, and
-GITHUB_WORKSPACE are required from the workflow environment.
+an empty absolute directory. EXPECTED_WORKFLOW_SHA, EXPECTED_WORKFLOW_REF,
+GITHUB_REF, GITHUB_SHA, and GITHUB_WORKSPACE are required from the workflow environment.
 EOF
 }
 
@@ -92,10 +93,14 @@ else
 fi
 
 : "${EXPECTED_WORKFLOW_SHA:?EXPECTED_WORKFLOW_SHA is required}"
+: "${EXPECTED_WORKFLOW_REF:?EXPECTED_WORKFLOW_REF is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
 : "${GITHUB_SHA:?GITHUB_SHA is required}"
 : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
 [[ "$EXPECTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || die "EXPECTED_WORKFLOW_SHA is not a full lowercase commit SHA"
 [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || die "GITHUB_SHA is not a full lowercase commit SHA"
+[[ "$EXPECTED_WORKFLOW_REF" == "$DEFAULT_WORKFLOW_REF" ]] || die "expected workflow ref is not the reviewed default branch"
+[[ "$GITHUB_REF" == "$EXPECTED_WORKFLOW_REF" ]] || die "workflow ref does not match the reviewed default branch"
 [[ "$EXPECTED_WORKFLOW_SHA" == "$GITHUB_SHA" ]] || die "workflow dispatch SHA does not match GITHUB_SHA"
 workflow_head=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)
 [[ "$workflow_head" == "$EXPECTED_WORKFLOW_SHA" ]] || die "checked-out Togi revision does not match expected workflow SHA"
@@ -123,6 +128,7 @@ jq -S '{url: .html_url, id, author: .user.login, created_at, body}' "$approval_r
 
 jq -n -S \
     --arg workflow_source_revision "$EXPECTED_WORKFLOW_SHA" \
+    --arg workflow_source_ref "$EXPECTED_WORKFLOW_REF" \
     --arg approval_url "$APPROVAL_URL" \
     --arg approval_body "$APPROVAL_BODY" \
     --arg release_tag "$TOGI_VERSION" \
@@ -139,9 +145,12 @@ jq -n -S \
     '{schema_version: 1,
       case: "mitigrid-v0.4.1-pack",
       workflow_source_revision: $workflow_source_revision,
+      workflow_source_ref: $workflow_source_ref,
       approval: {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body},
       release: {tag: $release_tag, archive: $archive, archive_sha256: $archive_sha256},
-      target: {repository: $repository, revision: $revision, base: $base, path: $path,
+      target: {repository: $repository, revision: $revision, base: $base, mutation_scope: $path,
+               direct_parent_changed_paths: [".togi-baseline", $path, "docs/governance/mutation-baseline-v0.1.md",
+                                             "docs/governance/public-readiness.md", "docs/governance/release-policy.md"],
                test_command: ["cargo", "test", "--locked", "--workspace"],
                build_command: ["cargo", "check", "--locked", "--workspace"],
                togi_toml_max_per_run: 0},
@@ -196,8 +205,11 @@ git -C "$target_dir" cat-file -e "${TARGET_BASE}^{commit}"
 [[ "$(git -C "$target_dir" rev-parse "${TARGET_REVISION}^")" == "$TARGET_BASE" ]] || die "approved base is not the target revision's direct parent"
 git -C "$target_dir" merge-base --is-ancestor "$TARGET_BASE" "$TARGET_REVISION"
 [[ -f "$target_dir/$TARGET_PATH" ]] || die "approved target path is absent"
-git -C "$target_dir" diff --binary "$TARGET_BASE" "$TARGET_REVISION" -- "$TARGET_PATH" >"$output_dir/target.patch"
-[[ -s "$output_dir/target.patch" ]] || die "approved target path has no diff from its base"
+expected_changed_paths=$(printf '%s\n' ".togi-baseline" "$TARGET_PATH" "docs/governance/mutation-baseline-v0.1.md" "docs/governance/public-readiness.md" "docs/governance/release-policy.md")
+git -C "$target_dir" diff --no-ext-diff --name-only --no-renames "$TARGET_BASE" "$TARGET_REVISION" | LC_ALL=C sort >"$output_dir/target-changed-paths.txt"
+[[ "$(cat "$output_dir/target-changed-paths.txt")" == "$expected_changed_paths" ]] || die "direct-parent diff does not match the approved five-path boundary"
+git -C "$target_dir" diff --no-ext-diff --binary "$TARGET_BASE" "$TARGET_REVISION" >"$output_dir/target.patch"
+[[ -s "$output_dir/target.patch" ]] || die "approved direct-parent diff is empty"
 [[ -f "$target_dir/togi.toml" ]] || die "target togi.toml is absent"
 awk '
     /^\[mutations\]/{ in_mutations = 1; next }
@@ -244,15 +256,15 @@ printf '%s\n' "$preflight_status" >"$output_dir/preflight-status.txt"
 
 printf '%s\n' \
     'preflight: cargo test --locked --workspace' \
-    "dry-run: togi check --dry-run --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
-    "execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
+    "dry-run: togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'" \
+    "execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history" \
     >"$output_dir/commands.txt"
 
 set +e
 (
     cd "$target_dir"
     env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true "$togi_bin" check \
-        --dry-run --format json --base "$TARGET_BASE" --path "$TARGET_PATH" \
+        --dry-run --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace"
 ) >"$output_dir/dry-run.stdout" 2>"$output_dir/dry-run.stderr"
@@ -262,11 +274,15 @@ printf '%s\n' "$dry_run_status" >"$output_dir/dry-run-status.txt"
 [[ "$dry_run_status" -eq 0 ]] || die "dry run failed"
 validate_single_json_document "$output_dir/dry-run.stdout"
 cp "$output_dir/dry-run.stdout" "$output_dir/dry-run.json"
-jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" '
+jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" --arg target_path "$TARGET_PATH" '
     def natural: type == "number" and . >= 0 and floor == .;
-    type == "object" and .kind == "dry_run" and .schema_version == 1 and .generator == "togi/0.4.1" and
-    .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
-    .planned_total == (.mutations | length) and .planned_total >= 1 and .planned_total <= $ceiling
+    type == "object" and (keys | sort) == ["dry_run", "kind", "mutations", "planned_total"] and
+    .kind == "dry_run" and .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
+    .planned_total == (.mutations | length) and .planned_total >= 1 and .planned_total <= $ceiling and
+    (.mutations | all(.[]; (keys | sort) == ["column", "description", "file", "id", "line", "operator", "original", "replacement"] and
+        (.id | natural) and (.file == $target_path) and (.line | natural) and (.column | natural) and
+        (.operator | type == "string") and (.description | type == "string") and
+        (.original | type == "string") and (.replacement | type == "string")))
 ' "$output_dir/dry-run.json" >/dev/null || die "dry run did not produce the approved bounded v0.4.1 plan"
 
 start_ns=$(date -u +%s%N)
@@ -274,7 +290,7 @@ set +e
 (
     cd "$target_dir"
     env -i "${runtime_env[@]}" CARGO_NET_OFFLINE=true timeout --preserve-status 35m "$togi_bin" check \
-        --format json --base "$TARGET_BASE" --path "$TARGET_PATH" \
+        --format json --base "$TARGET_BASE" \
         --test-cmd "cargo test --locked --workspace" \
         --build-cmd "cargo check --locked --workspace" \
         --timeout "$MUTATION_TIMEOUT_SECONDS" --jobs "$MUTATION_JOBS" \
@@ -301,11 +317,15 @@ set +e
 clean_status=$?
 set -e
 [[ "$clean_status" -eq 0 ]] || die "Togi clean failed"
+rm -f -- "$target_dir/.togi.lock"
+[[ ! -e "$target_dir/.togi-cache" ]] || die "Togi cache remained after cleanup"
+[[ ! -e "$target_dir/.togi.lock" ]] || die "Togi lock remained after cleanup"
 git -C "$target_dir" status --porcelain --untracked-files=all >"$output_dir/target-after-status.txt"
 [[ ! -s "$output_dir/target-after-status.txt" ]] || die "target worktree was not clean after execution"
 
 jq -n -S \
     --arg workflow_source_revision "$EXPECTED_WORKFLOW_SHA" \
+    --arg workflow_source_ref "$EXPECTED_WORKFLOW_REF" \
     --arg runner_os "${RUNNER_OS:-Linux}" \
     --arg runner_image "${ImageOS:-unknown}" \
     --arg runner_image_version "${ImageVersion:-unknown}" \
@@ -320,7 +340,7 @@ jq -n -S \
     --arg timezone "UTC" \
     --arg cargo_lock_sha256 "$(sha256sum "$target_dir/Cargo.lock" | awk '{print $1}')" \
     --arg togi_toml_sha256 "$(sha256sum "$target_dir/togi.toml" | awk '{print $1}')" \
-    '{schema_version: 1, workflow_source_revision: $workflow_source_revision,
+    '{schema_version: 1, workflow_source_revision: $workflow_source_revision, workflow_source_ref: $workflow_source_ref,
       runner: {os: $runner_os, image: $runner_image, image_version: $runner_image_version,
                uname: $uname, arch: $arch, cpu_count: $cpu_count},
       versions: {cargo: $cargo_version, rustc: $rustc_version, git: $git_version, togi: $togi_version},
@@ -335,7 +355,7 @@ checksum_files=(
     approval.json case.json cargo-fetch-status.txt cargo-fetch.stderr cargo-fetch.stdout commands.txt
     dry-run-status.txt dry-run.json dry-run.stderr dry-run.stdout environment.json
     preflight-status.txt preflight.stderr preflight.stdout release-checksums.txt release-verification.json
-    report.json target-after-status.txt target-before-status.txt target-togi.toml target.patch
+    report.json target-after-status.txt target-before-status.txt target-changed-paths.txt target-togi.toml target.patch
     togi-exit-status.txt togi-version.txt togi.stderr togi.stdout validation.txt wall-time.json metrics.json
 )
 (

--- a/.github/scripts/verify-external-dogfood-evidence.sh
+++ b/.github/scripts/verify-external-dogfood-evidence.sh
@@ -195,7 +195,7 @@ workflow-deadline: timeout-minutes $WORKFLOW_TIMEOUT_MINUTES
 approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
 release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
 release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
-target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --no-checkout $TARGET_REPOSITORY
+target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY
 target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION
 dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked
 preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace

--- a/.github/scripts/verify-external-dogfood-evidence.sh
+++ b/.github/scripts/verify-external-dogfood-evidence.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Generates and verifies only the approved Mitigrid external-dogfood evidence directory.
+set -euo pipefail
+
+readonly APPROVAL_COMMENT_ID=5150807894
+readonly APPROVAL_AUTHOR=Darkroom4364
+readonly APPROVAL_URL="https://github.com/Darkroom4364/Mitigrid/pull/125#issuecomment-5150807894"
+readonly APPROVAL_BODY="$(cat <<'EOF'
+I authorize one no-secret, read-only external-dogfood run of released Darkroom4364/togi v0.4.1 on Darkroom4364/Mitigrid commit f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8, base 16e7c9e49f353fd7f4254276b3a7ece99c6dedf6, scoped to crates/opencem-cli/src/commands/pack.rs, using cargo test --locked --workspace and cargo check --locked --workspace. The run may publish its bounded raw stdout/stderr, JSON reports, environment metadata, and checksums in Darkroom4364/togi. It must use no secrets and must not modify Mitigrid.
+EOF
+)"
+readonly TOGI_ARCHIVE=togi-linux-x86_64.tar.gz
+readonly TOGI_ARCHIVE_SHA256=6be7bf55d3c84a539cdaa4e60e5b5ef212ddb0e2575cd6b85ceae50218abce5c
+readonly TARGET_REPOSITORY=https://github.com/Darkroom4364/Mitigrid.git
+readonly TARGET_REVISION=f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8
+readonly TARGET_BASE=16e7c9e49f353fd7f4254276b3a7ece99c6dedf6
+readonly TARGET_PATH=crates/opencem-cli/src/commands/pack.rs
+readonly GENERATED_MUTANT_CEILING=20
+readonly MUTATION_TIMEOUT_SECONDS=120
+readonly MUTATION_JOBS=2
+readonly OUTER_TIMEOUT_SECONDS=2100
+
+usage() {
+    cat <<'EOF'
+Usage: verify-external-dogfood-evidence.sh --generate CASE_DIRECTORY
+       verify-external-dogfood-evidence.sh --verify CASE_DIRECTORY
+
+--generate validates the complete run inputs and raw reports, then writes a
+canonical metrics.json. --verify is offline-only: it repeats the validation,
+checks metrics.json, and checks every required artifact digest in SHA256SUMS.
+EOF
+}
+
+die() {
+    echo "external dogfood evidence: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+require_file() {
+    [[ -f "$case_dir/$1" ]] || die "required artifact is missing: $1"
+}
+
+validate_single_json_document() {
+    jq -e -s 'length == 1' "$1" >/dev/null || die "not exactly one JSON document: $1"
+}
+
+validate_togi_config() {
+    awk '
+        /^\[mutations\]/{ in_mutations = 1; next }
+        /^\[/{ in_mutations = 0 }
+        in_mutations && /^[[:space:]]*max_per_run[[:space:]]*=[[:space:]]*0[[:space:]]*(#.*)?$/ { matches++ }
+        END { exit matches == 1 ? 0 : 1 }
+    ' "$case_dir/target-togi.toml" || die "target-togi.toml does not set mutations.max_per_run = 0"
+}
+
+core_files=(
+    approval.json case.json cargo-fetch-status.txt cargo-fetch.stderr cargo-fetch.stdout commands.txt
+    dry-run-status.txt dry-run.json dry-run.stderr dry-run.stdout environment.json
+    preflight-status.txt preflight.stderr preflight.stdout release-checksums.txt release-verification.json
+    report.json target-after-status.txt target-before-status.txt target-togi.toml target.patch
+    togi-exit-status.txt togi-version.txt togi.stderr togi.stdout wall-time.json
+)
+hashed_files=("${core_files[@]}" metrics.json validation.txt)
+
+if [[ "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+if [[ $# -ne 2 || ( "$1" != "--generate" && "$1" != "--verify" ) ]]; then
+    usage >&2
+    exit 2
+fi
+mode=$1
+case_dir=$2
+[[ -d "$case_dir" ]] || die "case directory does not exist"
+for command in awk cmp jq sha256sum sort; do
+    require_command "$command"
+done
+for file in "${core_files[@]}"; do
+    require_file "$file"
+done
+
+validate_single_json_document "$case_dir/approval.json"
+validate_single_json_document "$case_dir/case.json"
+validate_single_json_document "$case_dir/environment.json"
+validate_single_json_document "$case_dir/release-verification.json"
+validate_single_json_document "$case_dir/dry-run.stdout"
+validate_single_json_document "$case_dir/dry-run.json"
+validate_single_json_document "$case_dir/togi.stdout"
+validate_single_json_document "$case_dir/report.json"
+validate_single_json_document "$case_dir/wall-time.json"
+cmp -s "$case_dir/dry-run.stdout" "$case_dir/dry-run.json" || die "dry-run JSON is not a byte-for-byte copy of stdout"
+cmp -s "$case_dir/togi.stdout" "$case_dir/report.json" || die "report JSON is not a byte-for-byte copy of stdout"
+
+jq -e \
+    --arg workflow_sha "$(jq -r '.workflow_source_revision' "$case_dir/case.json")" \
+    --arg approval_url "$APPROVAL_URL" \
+    --arg approval_body "$APPROVAL_BODY" \
+    --arg archive "$TOGI_ARCHIVE" \
+    --arg archive_sha256 "$TOGI_ARCHIVE_SHA256" \
+    --arg repository "$TARGET_REPOSITORY" \
+    --arg revision "$TARGET_REVISION" \
+    --arg base "$TARGET_BASE" \
+    --arg path "$TARGET_PATH" \
+    --argjson ceiling "$GENERATED_MUTANT_CEILING" \
+    --argjson mutation_timeout "$MUTATION_TIMEOUT_SECONDS" \
+    --argjson jobs "$MUTATION_JOBS" \
+    --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" '
+    .schema_version == 1 and .case == "mitigrid-v0.4.1-pack" and
+    (.workflow_source_revision | test("^[0-9a-f]{40}$")) and .workflow_source_revision == $workflow_sha and
+    .approval == {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body} and
+    .release == {tag: "v0.4.1", archive: $archive, archive_sha256: $archive_sha256} and
+    .target == {repository: $repository, revision: $revision, base: $base, path: $path,
+                test_command: ["cargo", "test", "--locked", "--workspace"],
+                build_command: ["cargo", "check", "--locked", "--workspace"],
+                togi_toml_max_per_run: 0} and
+    .limits == {generated_mutant_ceiling: $ceiling, per_mutation_timeout_seconds: $mutation_timeout,
+                jobs: $jobs, outer_timeout_seconds: $outer_timeout}
+' "$case_dir/case.json" >/dev/null || die "case metadata does not describe the one approved case"
+workflow_sha=$(jq -r '.workflow_source_revision' "$case_dir/case.json")
+
+jq -e --arg url "$APPROVAL_URL" --arg body "$APPROVAL_BODY" '
+    .url == $url and .id == 5150807894 and .author == "Darkroom4364" and .body == $body and
+    (.created_at | type == "string" and length > 0)
+' "$case_dir/approval.json" >/dev/null || die "approval provenance is invalid"
+
+jq -e --arg workflow_sha "$workflow_sha" '
+    def sha256: type == "string" and test("^[0-9a-f]{64}$");
+    .schema_version == 1 and .workflow_source_revision == $workflow_sha and
+    .runner.os == "Linux" and .runner.arch == "x86_64" and
+    (.runner.image | type == "string") and (.runner.image_version | type == "string") and
+    (.runner.uname | type == "string") and (.runner.cpu_count | type == "string" and test("^[1-9][0-9]*$")) and
+    .versions.togi == "togi 0.4.1" and (.versions.cargo | type == "string") and
+    (.versions.rustc | type == "string") and (.versions.git | type == "string") and
+    .locale == "C" and .timezone == "UTC" and
+    (.target.cargo_lock_sha256 | sha256) and (.target.togi_toml_sha256 | sha256)
+' "$case_dir/environment.json" >/dev/null || die "environment metadata is invalid"
+
+[[ "$(cat "$case_dir/togi-version.txt")" == "togi 0.4.1" ]] || die "released Togi version evidence is invalid"
+jq -e --arg archive "$TOGI_ARCHIVE" --arg sha256 "$TOGI_ARCHIVE_SHA256" '
+    .tag == "v0.4.1" and .archive == $archive and .expected_sha256 == $sha256 and
+    .actual_sha256 == $sha256 and .version == "togi 0.4.1"
+' "$case_dir/release-verification.json" >/dev/null || die "released archive verification is invalid"
+manifest_matches=()
+while IFS= read -r manifest_match; do
+    manifest_matches+=("$manifest_match")
+done < <(awk -v file="$TOGI_ARCHIVE" '$2 == file || $2 == "./" file { print $1 }' "$case_dir/release-checksums.txt")
+[[ ${#manifest_matches[@]} -eq 1 && "${manifest_matches[0]}" == "$TOGI_ARCHIVE_SHA256" ]] || die "release manifest evidence is invalid"
+
+[[ "$(cat "$case_dir/cargo-fetch-status.txt")" == 0 ]] || die "cargo fetch did not succeed"
+[[ "$(cat "$case_dir/preflight-status.txt")" == 0 ]] || die "target preflight did not succeed"
+[[ "$(cat "$case_dir/dry-run-status.txt")" == 0 ]] || die "dry run did not succeed"
+togi_status=$(cat "$case_dir/togi-exit-status.txt")
+[[ "$togi_status" == 0 || "$togi_status" == 1 ]] || die "Togi execution status is not publishable"
+[[ ! -s "$case_dir/target-before-status.txt" ]] || die "target was dirty before execution"
+[[ ! -s "$case_dir/target-after-status.txt" ]] || die "target was dirty after execution"
+[[ -s "$case_dir/target.patch" ]] || die "target patch is empty"
+validate_togi_config
+
+expected_commands=$(cat <<EOF
+preflight: cargo test --locked --workspace
+dry-run: togi check --dry-run --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
+execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
+EOF
+)
+[[ "$(cat "$case_dir/commands.txt")" == "$expected_commands" ]] || die "recorded commands are not the approved commands"
+
+jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" '
+    def natural: type == "number" and . >= 0 and floor == .;
+    type == "object" and .kind == "dry_run" and .schema_version == 1 and .generator == "togi/0.4.1" and
+    .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
+    .planned_total == (.mutations | length) and .planned_total >= 1 and .planned_total <= $ceiling and
+    (.mutations | all(.[]; (.id | natural) and (.file | type == "string") and (.line | natural) and
+        (.operator | type == "string") and (.description | type == "string") and
+        (.original | type == "string") and (.replacement | type == "string")))
+' "$case_dir/dry-run.json" >/dev/null || die "dry run is not the approved bounded v0.4.1 plan"
+dry_run_planned_total=$(jq -r '.planned_total' "$case_dir/dry-run.json")
+
+jq -e \
+    --arg revision "$TARGET_REVISION" \
+    --argjson dry_run_planned_total "$dry_run_planned_total" '
+    def natural: type == "number" and . >= 0 and floor == .;
+    def result_count($result): [.mutations[] | select(.result == $result)] | length;
+    def execution_count($state): [.mutations[] | select(.execution.state == $state)] | length;
+    . as $report |
+    ($report.mutations | length) as $mutation_length |
+    ($report | result_count("killed")) as $killed |
+    ($report | result_count("survived")) as $survived |
+    ($report | result_count("timeout")) as $timeout |
+    ($report | result_count("build_error")) as $build_errors |
+    ($report | result_count("uncovered")) as $uncovered |
+    ($report | result_count("subsumed")) as $subsumed |
+    ($report | execution_count("executed")) as $executed |
+    type == "object" and .kind == "mutation_report" and .schema_version == 1 and .generator == "togi/0.4.1" and
+    .source_revision == $revision and .test_command == ["cargo", "test", "--locked", "--workspace"] and
+    .build_command == ["cargo", "check", "--locked", "--workspace"] and (.planned_total | natural) and
+    ([.total, .tested, .killed, .survived, .timeout, .build_errors, (.executed_killed // 0),
+      (.exact_cache_reused // 0), (.incremental_history_reused // 0), (.uncovered // 0), (.subsumed // 0),
+      .duration_ms] | all(.[]; natural)) and
+    (.mutation_score | type == "number" and . >= 0) and
+    .planned_total == $dry_run_planned_total and .total == .planned_total and .total == $mutation_length and
+    .tested == .total and .tested == $executed and .tested > 0 and
+    .killed == $killed and .survived == $survived and .timeout == $timeout and .build_errors == $build_errors and
+    (.uncovered // 0) == $uncovered and (.subsumed // 0) == $subsumed and
+    (.executed_killed // .killed) == .killed and (.exact_cache_reused // 0) == 0 and
+    (.incremental_history_reused // 0) == 0 and (.uncovered // 0) == 0 and (.subsumed // 0) == 0 and
+    .timeout == 0 and .build_errors == 0 and .partial == false and (.early_stop_reason? // null) == null and
+    (.mutations | all(.[]; (.id | natural) and (.result == "killed" or .result == "survived") and
+        (.execution | type == "object") and .execution.state == "executed")) and
+    (((.killed / .tested * 100) - .mutation_score) | fabs) < 0.000001
+' "$case_dir/report.json" >/dev/null || die "report does not contain a complete fresh v0.4.1 execution"
+
+jq -e '
+    .wall_time_ms | type == "number" and . >= 0 and floor == .
+' "$case_dir/wall-time.json" >/dev/null || die "wall-time evidence is invalid"
+
+generate_metrics() {
+    jq -S --argjson execution_exit_status "$togi_status" \
+        --slurpfile dry_run "$case_dir/dry-run.json" \
+        --slurpfile wall_time "$case_dir/wall-time.json" '
+        . as $report |
+        {schema_version: 1,
+         source_revision: $report.source_revision,
+         dry_run_planned_total: $dry_run[0].planned_total,
+         planned_total: $report.planned_total,
+         total: $report.total,
+         tested: $report.tested,
+         killed: $report.killed,
+         survived: $report.survived,
+         timeout: $report.timeout,
+         build_errors: $report.build_errors,
+         executed_killed: ($report.executed_killed // $report.killed),
+         exact_cache_reused: ($report.exact_cache_reused // 0),
+         incremental_history_reused: ($report.incremental_history_reused // 0),
+         uncovered: ($report.uncovered // 0),
+         subsumed: ($report.subsumed // 0),
+         partial: $report.partial,
+         early_stop_reason: ($report.early_stop_reason // null),
+         mutation_score: $report.mutation_score,
+         duration_ms: $report.duration_ms,
+         execution_exit_status: $execution_exit_status,
+         wall_time_ms: $wall_time[0].wall_time_ms}
+    ' "$case_dir/report.json"
+}
+
+if [[ "$mode" == "--generate" ]]; then
+    generate_metrics >"$case_dir/metrics.json"
+    echo "generated metrics.json from the validated v0.4.1 report"
+    exit 0
+fi
+
+require_file metrics.json
+require_file validation.txt
+require_file SHA256SUMS
+metrics_tmp=$(mktemp)
+trap 'rm -f "$metrics_tmp"' EXIT
+generate_metrics >"$metrics_tmp"
+cmp -s "$metrics_tmp" "$case_dir/metrics.json" || die "metrics.json is not the deterministic report-derived metrics"
+
+expected_hash_files=$(printf '%s\n' "${hashed_files[@]}" | LC_ALL=C sort)
+actual_hash_files=$(awk '{print $2}' "$case_dir/SHA256SUMS" | LC_ALL=C sort)
+[[ "$actual_hash_files" == "$expected_hash_files" ]] || die "SHA256SUMS does not cover exactly the required artifacts"
+(
+    cd "$case_dir"
+    sha256sum --check --status SHA256SUMS
+) || die "artifact checksum validation failed"
+echo "verified complete external-dogfood evidence offline"

--- a/.github/scripts/verify-external-dogfood-evidence.sh
+++ b/.github/scripts/verify-external-dogfood-evidence.sh
@@ -28,6 +28,7 @@ readonly DEPENDENCY_FETCH_TIMEOUT_SECONDS=480
 readonly PREFLIGHT_TIMEOUT_SECONDS=600
 readonly DRY_RUN_TIMEOUT_SECONDS=300
 readonly CLEANUP_TIMEOUT_SECONDS=120
+readonly PHASE_KILL_GRACE_SECONDS=10
 readonly WORKFLOW_TIMEOUT_MINUTES=90
 
 usage() {
@@ -130,6 +131,7 @@ jq -e \
     --argjson preflight_timeout "$PREFLIGHT_TIMEOUT_SECONDS" \
     --argjson dry_run_timeout "$DRY_RUN_TIMEOUT_SECONDS" \
     --argjson cleanup_timeout "$CLEANUP_TIMEOUT_SECONDS" \
+    --argjson phase_kill_grace "$PHASE_KILL_GRACE_SECONDS" \
     --argjson workflow_timeout_minutes "$WORKFLOW_TIMEOUT_MINUTES" '
     .schema_version == 1 and .case == "mitigrid-v0.4.1-pack" and
     (.workflow_source_revision | test("^[0-9a-f]{40}$")) and
@@ -147,7 +149,8 @@ jq -e \
                 target_clone_timeout_seconds: $target_clone_timeout, target_checkout_timeout_seconds: $target_checkout_timeout,
                 dependency_fetch_timeout_seconds: $dependency_fetch_timeout, preflight_timeout_seconds: $preflight_timeout,
                 dry_run_timeout_seconds: $dry_run_timeout, outer_timeout_seconds: $outer_timeout,
-                cleanup_timeout_seconds: $cleanup_timeout, workflow_timeout_minutes: $workflow_timeout_minutes}
+                cleanup_timeout_seconds: $cleanup_timeout, phase_kill_grace_seconds: $phase_kill_grace,
+                workflow_timeout_minutes: $workflow_timeout_minutes}
 ' "$case_dir/case.json" >/dev/null || die "case metadata does not describe the one approved case"
 workflow_sha=$(jq -r '.workflow_source_revision' "$case_dir/case.json")
 
@@ -192,16 +195,16 @@ expected_changed_paths=$(printf '%s\n' ".togi-baseline" "$TARGET_PATH" "docs/gov
 
 expected_commands=$(cat <<EOF
 workflow-deadline: timeout-minutes $WORKFLOW_TIMEOUT_MINUTES
-approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
-release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
-release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
-target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY
-target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION
-dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked
-preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace
-dry-run: timeout --preserve-status ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
-execution: timeout --preserve-status ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
-cleanup: timeout --preserve-status ${CLEANUP_TIMEOUT_SECONDS}s togi clean
+approval-fetch: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+release-archive-download: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+release-checksums-download: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CURL_MAX_TIME_SECONDS}s curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+target-clone: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --filter=blob:none --no-checkout $TARGET_REPOSITORY
+target-checkout: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION
+dependency-fetch: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked
+preflight: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace
+dry-run: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
+execution: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
+cleanup: timeout --kill-after=${PHASE_KILL_GRACE_SECONDS}s ${CLEANUP_TIMEOUT_SECONDS}s togi clean
 EOF
 )
 [[ "$(cat "$case_dir/commands.txt")" == "$expected_commands" ]] || die "recorded commands are not the approved commands"

--- a/.github/scripts/verify-external-dogfood-evidence.sh
+++ b/.github/scripts/verify-external-dogfood-evidence.sh
@@ -20,6 +20,15 @@ readonly GENERATED_MUTANT_CEILING=20
 readonly MUTATION_TIMEOUT_SECONDS=120
 readonly MUTATION_JOBS=2
 readonly OUTER_TIMEOUT_SECONDS=2100
+readonly CURL_CONNECT_TIMEOUT_SECONDS=15
+readonly CURL_MAX_TIME_SECONDS=120
+readonly TARGET_CLONE_TIMEOUT_SECONDS=300
+readonly TARGET_CHECKOUT_TIMEOUT_SECONDS=120
+readonly DEPENDENCY_FETCH_TIMEOUT_SECONDS=480
+readonly PREFLIGHT_TIMEOUT_SECONDS=600
+readonly DRY_RUN_TIMEOUT_SECONDS=300
+readonly CLEANUP_TIMEOUT_SECONDS=120
+readonly WORKFLOW_TIMEOUT_MINUTES=90
 
 usage() {
     cat <<'EOF'
@@ -98,9 +107,10 @@ cmp -s "$case_dir/dry-run.stdout" "$case_dir/dry-run.json" || die "dry-run JSON 
 cmp -s "$case_dir/togi.stdout" "$case_dir/report.json" || die "report JSON is not a byte-for-byte copy of stdout"
 
 jq -e \
-    --arg workflow_sha "$(jq -r '.workflow_source_revision' "$case_dir/case.json")" \
     --arg workflow_ref "$DEFAULT_WORKFLOW_REF" \
     --arg approval_url "$APPROVAL_URL" \
+    --argjson approval_id "$APPROVAL_COMMENT_ID" \
+    --arg approval_author "$APPROVAL_AUTHOR" \
     --arg approval_body "$APPROVAL_BODY" \
     --arg archive "$TOGI_ARCHIVE" \
     --arg archive_sha256 "$TOGI_ARCHIVE_SHA256" \
@@ -111,11 +121,20 @@ jq -e \
     --argjson ceiling "$GENERATED_MUTANT_CEILING" \
     --argjson mutation_timeout "$MUTATION_TIMEOUT_SECONDS" \
     --argjson jobs "$MUTATION_JOBS" \
-    --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" '
+    --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" \
+    --argjson curl_connect_timeout "$CURL_CONNECT_TIMEOUT_SECONDS" \
+    --argjson curl_max_time "$CURL_MAX_TIME_SECONDS" \
+    --argjson target_clone_timeout "$TARGET_CLONE_TIMEOUT_SECONDS" \
+    --argjson target_checkout_timeout "$TARGET_CHECKOUT_TIMEOUT_SECONDS" \
+    --argjson dependency_fetch_timeout "$DEPENDENCY_FETCH_TIMEOUT_SECONDS" \
+    --argjson preflight_timeout "$PREFLIGHT_TIMEOUT_SECONDS" \
+    --argjson dry_run_timeout "$DRY_RUN_TIMEOUT_SECONDS" \
+    --argjson cleanup_timeout "$CLEANUP_TIMEOUT_SECONDS" \
+    --argjson workflow_timeout_minutes "$WORKFLOW_TIMEOUT_MINUTES" '
     .schema_version == 1 and .case == "mitigrid-v0.4.1-pack" and
-    (.workflow_source_revision | test("^[0-9a-f]{40}$")) and .workflow_source_revision == $workflow_sha and
+    (.workflow_source_revision | test("^[0-9a-f]{40}$")) and
     .workflow_source_ref == $workflow_ref and
-    .approval == {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body} and
+    .approval == {url: $approval_url, id: $approval_id, author: $approval_author, body: $approval_body} and
     .release == {tag: "v0.4.1", archive: $archive, archive_sha256: $archive_sha256} and
     .target == {repository: $repository, revision: $revision, base: $base, mutation_scope: $path,
                 direct_parent_changed_paths: [".togi-baseline", $path, "docs/governance/mutation-baseline-v0.1.md",
@@ -124,12 +143,16 @@ jq -e \
                 build_command: ["cargo", "check", "--locked", "--workspace"],
                 togi_toml_max_per_run: 0} and
     .limits == {generated_mutant_ceiling: $ceiling, per_mutation_timeout_seconds: $mutation_timeout,
-                jobs: $jobs, outer_timeout_seconds: $outer_timeout}
+                jobs: $jobs, curl_connect_timeout_seconds: $curl_connect_timeout, curl_max_time_seconds: $curl_max_time,
+                target_clone_timeout_seconds: $target_clone_timeout, target_checkout_timeout_seconds: $target_checkout_timeout,
+                dependency_fetch_timeout_seconds: $dependency_fetch_timeout, preflight_timeout_seconds: $preflight_timeout,
+                dry_run_timeout_seconds: $dry_run_timeout, outer_timeout_seconds: $outer_timeout,
+                cleanup_timeout_seconds: $cleanup_timeout, workflow_timeout_minutes: $workflow_timeout_minutes}
 ' "$case_dir/case.json" >/dev/null || die "case metadata does not describe the one approved case"
 workflow_sha=$(jq -r '.workflow_source_revision' "$case_dir/case.json")
 
-jq -e --arg url "$APPROVAL_URL" --arg body "$APPROVAL_BODY" '
-    .url == $url and .id == 5150807894 and .author == "Darkroom4364" and .body == $body and
+jq -e --arg url "$APPROVAL_URL" --argjson id "$APPROVAL_COMMENT_ID" --arg author "$APPROVAL_AUTHOR" --arg body "$APPROVAL_BODY" '
+    .url == $url and .id == $id and .author == $author and .body == $body and
     (.created_at | type == "string" and length > 0)
 ' "$case_dir/approval.json" >/dev/null || die "approval provenance is invalid"
 
@@ -168,9 +191,17 @@ expected_changed_paths=$(printf '%s\n' ".togi-baseline" "$TARGET_PATH" "docs/gov
 [[ "$(cat "$case_dir/target-changed-paths.txt")" == "$expected_changed_paths" ]] || die "direct-parent changed paths are invalid"
 
 expected_commands=$(cat <<EOF
-preflight: cargo test --locked --workspace
-dry-run: togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
-execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
+workflow-deadline: timeout-minutes $WORKFLOW_TIMEOUT_MINUTES
+approval-fetch: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+release-archive-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+release-checksums-download: curl --connect-timeout $CURL_CONNECT_TIMEOUT_SECONDS --max-time $CURL_MAX_TIME_SECONDS
+target-clone: timeout --preserve-status ${TARGET_CLONE_TIMEOUT_SECONDS}s git clone --no-checkout $TARGET_REPOSITORY
+target-checkout: timeout --preserve-status ${TARGET_CHECKOUT_TIMEOUT_SECONDS}s git checkout --detach $TARGET_REVISION
+dependency-fetch: timeout --preserve-status ${DEPENDENCY_FETCH_TIMEOUT_SECONDS}s cargo fetch --locked
+preflight: timeout --preserve-status ${PREFLIGHT_TIMEOUT_SECONDS}s cargo test --locked --workspace
+dry-run: timeout --preserve-status ${DRY_RUN_TIMEOUT_SECONDS}s togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
+execution: timeout --preserve-status ${OUTER_TIMEOUT_SECONDS}s togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
+cleanup: timeout --preserve-status ${CLEANUP_TIMEOUT_SECONDS}s togi clean
 EOF
 )
 [[ "$(cat "$case_dir/commands.txt")" == "$expected_commands" ]] || die "recorded commands are not the approved commands"

--- a/.github/scripts/verify-external-dogfood-evidence.sh
+++ b/.github/scripts/verify-external-dogfood-evidence.sh
@@ -15,6 +15,7 @@ readonly TARGET_REPOSITORY=https://github.com/Darkroom4364/Mitigrid.git
 readonly TARGET_REVISION=f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8
 readonly TARGET_BASE=16e7c9e49f353fd7f4254276b3a7ece99c6dedf6
 readonly TARGET_PATH=crates/opencem-cli/src/commands/pack.rs
+readonly DEFAULT_WORKFLOW_REF=refs/heads/main
 readonly GENERATED_MUTANT_CEILING=20
 readonly MUTATION_TIMEOUT_SECONDS=120
 readonly MUTATION_JOBS=2
@@ -61,7 +62,7 @@ core_files=(
     approval.json case.json cargo-fetch-status.txt cargo-fetch.stderr cargo-fetch.stdout commands.txt
     dry-run-status.txt dry-run.json dry-run.stderr dry-run.stdout environment.json
     preflight-status.txt preflight.stderr preflight.stdout release-checksums.txt release-verification.json
-    report.json target-after-status.txt target-before-status.txt target-togi.toml target.patch
+    report.json target-after-status.txt target-before-status.txt target-changed-paths.txt target-togi.toml target.patch
     togi-exit-status.txt togi-version.txt togi.stderr togi.stdout wall-time.json
 )
 hashed_files=("${core_files[@]}" metrics.json validation.txt)
@@ -98,6 +99,7 @@ cmp -s "$case_dir/togi.stdout" "$case_dir/report.json" || die "report JSON is no
 
 jq -e \
     --arg workflow_sha "$(jq -r '.workflow_source_revision' "$case_dir/case.json")" \
+    --arg workflow_ref "$DEFAULT_WORKFLOW_REF" \
     --arg approval_url "$APPROVAL_URL" \
     --arg approval_body "$APPROVAL_BODY" \
     --arg archive "$TOGI_ARCHIVE" \
@@ -112,9 +114,12 @@ jq -e \
     --argjson outer_timeout "$OUTER_TIMEOUT_SECONDS" '
     .schema_version == 1 and .case == "mitigrid-v0.4.1-pack" and
     (.workflow_source_revision | test("^[0-9a-f]{40}$")) and .workflow_source_revision == $workflow_sha and
+    .workflow_source_ref == $workflow_ref and
     .approval == {url: $approval_url, id: 5150807894, author: "Darkroom4364", body: $approval_body} and
     .release == {tag: "v0.4.1", archive: $archive, archive_sha256: $archive_sha256} and
-    .target == {repository: $repository, revision: $revision, base: $base, path: $path,
+    .target == {repository: $repository, revision: $revision, base: $base, mutation_scope: $path,
+                direct_parent_changed_paths: [".togi-baseline", $path, "docs/governance/mutation-baseline-v0.1.md",
+                                              "docs/governance/public-readiness.md", "docs/governance/release-policy.md"],
                 test_command: ["cargo", "test", "--locked", "--workspace"],
                 build_command: ["cargo", "check", "--locked", "--workspace"],
                 togi_toml_max_per_run: 0} and
@@ -128,9 +133,9 @@ jq -e --arg url "$APPROVAL_URL" --arg body "$APPROVAL_BODY" '
     (.created_at | type == "string" and length > 0)
 ' "$case_dir/approval.json" >/dev/null || die "approval provenance is invalid"
 
-jq -e --arg workflow_sha "$workflow_sha" '
+jq -e --arg workflow_sha "$workflow_sha" --arg workflow_ref "$DEFAULT_WORKFLOW_REF" '
     def sha256: type == "string" and test("^[0-9a-f]{64}$");
-    .schema_version == 1 and .workflow_source_revision == $workflow_sha and
+    .schema_version == 1 and .workflow_source_revision == $workflow_sha and .workflow_source_ref == $workflow_ref and
     .runner.os == "Linux" and .runner.arch == "x86_64" and
     (.runner.image | type == "string") and (.runner.image_version | type == "string") and
     (.runner.uname | type == "string") and (.runner.cpu_count | type == "string" and test("^[1-9][0-9]*$")) and
@@ -159,22 +164,24 @@ togi_status=$(cat "$case_dir/togi-exit-status.txt")
 [[ ! -s "$case_dir/target-before-status.txt" ]] || die "target was dirty before execution"
 [[ ! -s "$case_dir/target-after-status.txt" ]] || die "target was dirty after execution"
 [[ -s "$case_dir/target.patch" ]] || die "target patch is empty"
-validate_togi_config
+expected_changed_paths=$(printf '%s\n' ".togi-baseline" "$TARGET_PATH" "docs/governance/mutation-baseline-v0.1.md" "docs/governance/public-readiness.md" "docs/governance/release-policy.md")
+[[ "$(cat "$case_dir/target-changed-paths.txt")" == "$expected_changed_paths" ]] || die "direct-parent changed paths are invalid"
 
 expected_commands=$(cat <<EOF
 preflight: cargo test --locked --workspace
-dry-run: togi check --dry-run --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
-execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --path $TARGET_PATH --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
+dry-run: togi check --dry-run --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace'
+execution: timeout --preserve-status 35m togi check --format json --base $TARGET_BASE --test-cmd 'cargo test --locked --workspace' --build-cmd 'cargo check --locked --workspace' --timeout $MUTATION_TIMEOUT_SECONDS --jobs $MUTATION_JOBS --force-rerun --no-incremental-history
 EOF
 )
 [[ "$(cat "$case_dir/commands.txt")" == "$expected_commands" ]] || die "recorded commands are not the approved commands"
 
-jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" '
+jq -e --argjson ceiling "$GENERATED_MUTANT_CEILING" --arg target_path "$TARGET_PATH" '
     def natural: type == "number" and . >= 0 and floor == .;
-    type == "object" and .kind == "dry_run" and .schema_version == 1 and .generator == "togi/0.4.1" and
-    .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
+    type == "object" and (keys | sort) == ["dry_run", "kind", "mutations", "planned_total"] and
+    .kind == "dry_run" and .dry_run == true and (.planned_total | natural) and (.mutations | type == "array") and
     .planned_total == (.mutations | length) and .planned_total >= 1 and .planned_total <= $ceiling and
-    (.mutations | all(.[]; (.id | natural) and (.file | type == "string") and (.line | natural) and
+    (.mutations | all(.[]; (keys | sort) == ["column", "description", "file", "id", "line", "operator", "original", "replacement"] and
+        (.id | natural) and (.file == $target_path) and (.line | natural) and (.column | natural) and
         (.operator | type == "string") and (.description | type == "string") and
         (.original | type == "string") and (.replacement | type == "string")))
 ' "$case_dir/dry-run.json" >/dev/null || die "dry run is not the approved bounded v0.4.1 plan"
@@ -182,6 +189,7 @@ dry_run_planned_total=$(jq -r '.planned_total' "$case_dir/dry-run.json")
 
 jq -e \
     --arg revision "$TARGET_REVISION" \
+    --arg target_path "$TARGET_PATH" \
     --argjson dry_run_planned_total "$dry_run_planned_total" '
     def natural: type == "number" and . >= 0 and floor == .;
     def result_count($result): [.mutations[] | select(.result == $result)] | length;
@@ -209,7 +217,8 @@ jq -e \
     (.executed_killed // .killed) == .killed and (.exact_cache_reused // 0) == 0 and
     (.incremental_history_reused // 0) == 0 and (.uncovered // 0) == 0 and (.subsumed // 0) == 0 and
     .timeout == 0 and .build_errors == 0 and .partial == false and (.early_stop_reason? // null) == null and
-    (.mutations | all(.[]; (.id | natural) and (.result == "killed" or .result == "survived") and
+    (.mutations | all(.[]; (.id | natural) and (.file == $target_path) and
+        (.result == "killed" or .result == "survived") and
         (.execution | type == "object") and .execution.state == "executed")) and
     (((.killed / .tested * 100) - .mutation_score) | fabs) < 0.000001
 ' "$case_dir/report.json" >/dev/null || die "report does not contain a complete fresh v0.4.1 execution"

--- a/.github/workflows/external-dogfood.yml
+++ b/.github/workflows/external-dogfood.yml
@@ -9,8 +9,9 @@ on:
         type: string
 
 concurrency:
-  group: external-dogfood
+  group: external-dogfood-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read

--- a/.github/workflows/external-dogfood.yml
+++ b/.github/workflows/external-dogfood.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   external-dogfood:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
@@ -25,6 +26,7 @@ jobs:
       - name: Run approved external-dogfood protocol
         env:
           EXPECTED_WORKFLOW_SHA: ${{ inputs.expected_workflow_sha }}
+          EXPECTED_WORKFLOW_REF: ${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
         run: |
           set -euo pipefail
           bash .github/scripts/run-external-dogfood.sh "$RUNNER_TEMP/togi-external-dogfood-evidence"

--- a/.github/workflows/external-dogfood.yml
+++ b/.github/workflows/external-dogfood.yml
@@ -1,0 +1,37 @@
+name: External Dogfood Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_workflow_sha:
+        description: Reviewed main commit that must run this protocol
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  external-dogfood:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - name: Run approved external-dogfood protocol
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.expected_workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/run-external-dogfood.sh "$RUNNER_TEMP/togi-external-dogfood-evidence"
+      - name: Upload external-dogfood evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: togi-external-dogfood-mitigrid-${{ github.run_id }}
+          path: ${{ runner.temp }}/togi-external-dogfood-evidence
+          if-no-files-found: warn

--- a/.github/workflows/external-dogfood.yml
+++ b/.github/workflows/external-dogfood.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: external-dogfood
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -15,7 +19,7 @@ jobs:
   external-dogfood:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/docs/external-dogfood/README.md
+++ b/docs/external-dogfood/README.md
@@ -11,28 +11,32 @@ contains no run result and no versioned case directory.
 A case is eligible only when its public owner has explicitly authorized that
 exact no-secret, read-only run. Ownership, a public repository, or a compatible
 license alone are not permission. The runner is purpose-built for the only
-currently approved case and refuses any changed target, revision, base, path,
-commands, release, or approval provenance:
+currently approved case and refuses any changed target, revision, base, mutation
+scope, commands, release, or approval provenance:
 
 - approval: [Mitigrid PR #125 comment 5150807894](https://github.com/Darkroom4364/Mitigrid/pull/125#issuecomment-5150807894), authored by `Darkroom4364`;
 - released binary: Togi `v0.4.1`, `togi-linux-x86_64.tar.gz`, SHA-256 `6be7bf55d3c84a539cdaa4e60e5b5ef212ddb0e2575cd6b85ceae50218abce5c`;
 - target: `https://github.com/Darkroom4364/Mitigrid.git` at `f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8`, whose direct parent is `16e7c9e49f353fd7f4254276b3a7ece99c6dedf6`;
-- diff scope: `crates/opencem-cli/src/commands/pack.rs`;
+- direct-parent diff: exactly `.togi-baseline`, `crates/opencem-cli/src/commands/pack.rs`, `docs/governance/mutation-baseline-v0.1.md`, `docs/governance/public-readiness.md`, and `docs/governance/release-policy.md`; mutation scope: `crates/opencem-cli/src/commands/pack.rs`;
 - preflight/test command: `cargo test --locked --workspace`; build command: `cargo check --locked --workspace`.
 
 The workflow fetches the public approval comment and requires its id, author,
 URL, and complete body to match before it clones the target. It uses no user
-inputs for a target or command, no secrets, no caches, and a fresh target clone.
-The target must be clean before and after the run; the runner removes Togi's
-local state before recording the final cleanliness check.
+inputs for a target or command, no secrets, no cache reuse, and a fresh target
+clone. The target must be clean before and after the run; after `togi clean`,
+the runner deletes only `.togi.lock` and requires both it and `.togi-cache` to
+be absent before recording final cleanliness.
 
 ## Dispatch and reproducibility
 
-`external-dogfood.yml` is `workflow_dispatch` only. Dispatch it from reviewed
-`main` with `expected_workflow_sha` equal to the full commit SHA being run. The
-runner also requires that value to equal both `GITHUB_SHA` and the checked-out
-Togi revision. It runs only on Linux x86_64 (`ubuntu-24.04`) with a 40-minute
-job deadline and a 35-minute outer execution deadline.
+`external-dogfood.yml` is `workflow_dispatch` only. Its job runs only when
+`github.ref` is the repository default branch; currently it requires
+`refs/heads/main`. Dispatch reviewed `main` with `expected_workflow_sha` equal
+to the full commit SHA being run. The runner requires the workflow-supplied
+default-branch ref to equal `GITHUB_REF`, and the SHA to equal both `GITHUB_SHA`
+and the checked-out Togi revision. It runs only on Linux x86_64
+(`ubuntu-24.04`) with a 40-minute job deadline and a 35-minute outer execution
+deadline.
 
 The runner downloads the published archive and `checksums.txt`, requires the
 archive's named manifest entry and its calculated SHA-256 to equal the fixed
@@ -48,22 +52,30 @@ OS, uname/architecture, CPU count, tool versions, locale/timezone, target
 lockfile and config digests, and protocol identities/limits. It does not dump
 the environment, home directory, credentials, or tokens.
 
-Before execution, the full workspace preflight must pass. The released binary
-then performs an uncapped JSON dry run with the approved explicit base and path;
-the target's checked-in `togi.toml` must set `max_per_run = 0`. The generated
-count—not a truncation cap—must be between 1 and 20 inclusive and equal the
-dry-run mutation array length. The actual run repeats the explicit base/path
-and test/build command under `timeout --preserve-status 35m`, with `--timeout
-120 --jobs 2 --force-rerun --no-incremental-history` and no `--max-per-run`.
-Only exit status 0 or 1 reaches validation; a survivor is an observed result,
-not a protocol failure.
+Before execution, the full workspace preflight must pass. Togi v0.4.1 cannot
+combine its diff `--base` mode with `--path`; the runner therefore uses the
+approved explicit base without `--path`. Before its dry run it proves and
+records the full direct-parent diff's exact five-path boundary in
+`target-changed-paths.txt`, preserves that full binary diff, and requires every
+dry-run and report mutation to name the approved mutation-scope path. The other
+four changed files are non-mutable to released v0.4.1: `.togi-baseline` and the
+three Markdown governance files have unsupported file types, which the mutator
+reports only on stderr. JSON stdout remains the single dry-run or report
+document. The target's
+checked-in `togi.toml` must set `max_per_run = 0`. The generated count—not a
+truncation cap—must be between 1 and 20 inclusive and equal the dry-run mutation
+array length. The actual run repeats the explicit base and test/build command
+under `timeout --preserve-status 35m`, with a per-mutation timeout of 120
+seconds, `--jobs 2 --force-rerun --no-incremental-history`, and no
+`--max-per-run`. Only exit status 0 or 1 reaches validation; a survivor is an
+observed result, not a protocol failure.
 
 ## Evidence artifact and validation
 
 The named workflow artifact contains:
 
-- immutable case, approval, release verification, environment, command, target
-  diff/config, and clean-worktree metadata;
+- immutable case, approval, release verification, environment, command, full
+  target diff, exact changed-path list/config, and clean-worktree metadata;
 - raw stdout/stderr and status files for dependency fetch, preflight, dry run,
   and execution;
 - `dry-run.json` and `report.json`, each a byte-for-byte copy of its raw stdout;
@@ -72,24 +84,26 @@ The named workflow artifact contains:
 - `validation.txt` and a final `SHA256SUMS` covering every expected artifact
   except itself.
 
-The offline verifier first validates the exact authorization, identities,
-commands, release, complete dry-run plan, report schema/count invariants, and
-clean/full execution. It permits survivors but rejects timeouts, build errors,
-uncovered or subsumed mutations, exact-cache/history reuse, partial or
-early-stopped reports, or a non-fresh execution. `--generate` derives canonical
-metrics for an initial artifact; `--verify` recomputes them and validates all
-checksums without network access.
+The offline verifier first validates the exact authorization, default-branch
+provenance, identities, commands, full direct-parent diff boundary, complete
+dry-run plan and mutation scope, report schema/count invariants, and clean/full
+execution. It permits survivors but rejects timeouts, build errors, uncovered
+or subsumed mutations, exact-cache/history reuse, partial or early-stopped
+reports, or a non-fresh execution. `--generate` derives canonical metrics for
+an initial artifact; `--verify` recomputes them and validates all checksums
+without network access.
 
 ```bash
 bash .github/scripts/verify-external-dogfood-evidence.sh --verify CASE_DIRECTORY
 ```
 
-For a rerun, dispatch reviewed main again with its exact SHA, preserve the new
-artifact, and run the offline verifier on both artifacts. Compare the recorded
-workflow revision, release digest, target/base/path, lockfile/config digests,
-runner image/OS/architecture, CPU, tool versions, locale/timezone, dry-run
-count, and generated metrics before treating outcomes as comparable. A changed
-environment or dependency resolution is recorded drift, not proof of a Togi
+For a rerun, dispatch reviewed default-branch `main` again with its exact SHA,
+preserve the new artifact, and run the offline verifier on both artifacts.
+Compare the recorded workflow revision/ref, release digest, target/base/direct
+diff boundary/mutation scope, lockfile/config digests, runner
+image/OS/architecture, CPU, tool versions, locale/timezone, dry-run count, and
+generated metrics before treating outcomes as comparable. Changed environment
+or dependency resolution is recorded drift, not proof of a Togi
 regression or improvement.
 
 ## Publication sequence

--- a/docs/external-dogfood/README.md
+++ b/docs/external-dogfood/README.md
@@ -34,8 +34,13 @@ be absent before recording final cleanliness.
 `refs/heads/main`. Dispatch reviewed `main` with `expected_workflow_sha` equal
 to the full commit SHA being run. The runner requires the workflow-supplied
 default-branch ref to equal `GITHUB_REF`, and the SHA to equal both `GITHUB_SHA`
-and the checked-out Togi revision. A top-level `external-dogfood` concurrency
-group queues rather than cancels runs. It runs only on Linux x86_64
+and the checked-out Togi revision. Its top-level ref-scoped
+`external-dogfood-${{ github.ref }}` concurrency group has
+`cancel-in-progress: false` and `queue: max`: it permits one running and up to
+100 pending runs per ref, then cancels additional submissions. Rejected
+feature-ref dispatches therefore cannot consume the approved-main queue.
+Runs are FIFO by when they begin waiting, not dispatch time; scheduling can
+still make ordering non-deterministic. It runs only on Linux x86_64
 (`ubuntu-24.04`) with a 90-minute job deadline and a 2,100-second outer
 execution deadline.
 
@@ -44,16 +49,19 @@ archive's named manifest entry and its calculated SHA-256 to equal the fixed
 release checksum, safely extracts it, and requires `togi --version` to be
 exactly `togi 0.4.1`. It never builds or executes Togi from the workflow source.
 
-Every network or expensive target phase has a declared bound recorded in both
-`case.json` and `commands.txt`: each of the approval/archive/checksum downloads
-uses a 15-second connect timeout and a 120-second total curl timeout; target
-clone and checkout use 300 and 120 seconds; locked dependency fetch, preflight,
-and dry run use 480, 600, and 300 seconds; the actual execution uses 2,100
-seconds; and cleanup uses 120 seconds. The three download maxima plus those
-seven bounded phases total 4,380 seconds (73 minutes), leaving 17 minutes of
-the 90-minute job deadline for checkout/setup, release inspection, validation,
-and upload. Target commands retain their approved arguments; the
-`timeout --preserve-status` wrappers are protocol bounds.
+Every network or expensive target phase has a declared wall limit and a common
+10-second kill grace recorded in both `case.json` and `commands.txt`. Each of
+the approval/archive/checksum downloads retains its 15-second curl connect
+timeout and 120-second curl maximum, but is also wrapped by
+`timeout --kill-after=10s 120s` so its retry envelope is physically bounded.
+Target clone and checkout use 300 and 120 seconds; locked dependency fetch,
+preflight, and dry run use 480, 600, and 300 seconds; the actual execution uses
+2,100 seconds; and cleanup uses 120 seconds. The ten watchdogs' command limits
+sum to 4,380 seconds; their ten finite kill-grace allowances add 100 seconds,
+for a 4,480-second maximum (74 minutes 40 seconds). The 90-minute job leaves
+920 seconds (15 minutes 20 seconds) for checkout/setup, release inspection,
+validation, and upload. Target commands retain their approved arguments; the
+watchdogs are protocol bounds.
 
 The target uses a new `HOME` and `CARGO_HOME`. It fetches
 locked dependencies once, then uses an allowlisted `env -i` environment with an
@@ -77,12 +85,13 @@ document. The target's
 checked-in `togi.toml` must set `max_per_run = 0`. The generated count—not a
 truncation cap—must be between 1 and 20 inclusive and equal the dry-run mutation
 array length. The actual run repeats the explicit base and test/build command
-under `timeout --preserve-status 2100s`, with a per-mutation timeout of 120
+under `timeout --kill-after=10s 2100s`, with a per-mutation timeout of 120
 seconds, `--jobs 2 --force-rerun --no-incremental-history`, and no
-`--max-per-run`. A timeout or other nonzero status in any prior phase aborts the
-run and is nonpublishable. For execution, only exit status 0 or 1 reaches
-validation; a timeout status is nonpublishable, and a survivor is an observed
-result, not a protocol failure.
+`--max-per-run`. These watchdogs do not use `--preserve-status`: GNU `timeout`
+returns 124 when its deadline fires, and a forced kill remains nonpublishable
+(normally 137). A timeout or other nonzero status in any prior phase aborts the
+run and is nonpublishable. For execution, only normal exit status 0 or 1 reaches
+validation; a survivor is an observed result, not a protocol failure.
 
 ## Evidence artifact and validation
 

--- a/docs/external-dogfood/README.md
+++ b/docs/external-dogfood/README.md
@@ -1,0 +1,105 @@
+# External dogfood protocol
+
+This protocol can create reproducible evidence that a **released** Togi binary
+ran one explicitly authorized, bounded mutation-testing case outside this
+repository. It is not an adoption claim, a comparative performance claim, or a
+recommendation about the target project. PR A adds only this protocol; it
+contains no run result and no versioned case directory.
+
+## Selection and permission boundary
+
+A case is eligible only when its public owner has explicitly authorized that
+exact no-secret, read-only run. Ownership, a public repository, or a compatible
+license alone are not permission. The runner is purpose-built for the only
+currently approved case and refuses any changed target, revision, base, path,
+commands, release, or approval provenance:
+
+- approval: [Mitigrid PR #125 comment 5150807894](https://github.com/Darkroom4364/Mitigrid/pull/125#issuecomment-5150807894), authored by `Darkroom4364`;
+- released binary: Togi `v0.4.1`, `togi-linux-x86_64.tar.gz`, SHA-256 `6be7bf55d3c84a539cdaa4e60e5b5ef212ddb0e2575cd6b85ceae50218abce5c`;
+- target: `https://github.com/Darkroom4364/Mitigrid.git` at `f5f3f57c92fdb3405b92eca7c9b6a6d3d704c1e8`, whose direct parent is `16e7c9e49f353fd7f4254276b3a7ece99c6dedf6`;
+- diff scope: `crates/opencem-cli/src/commands/pack.rs`;
+- preflight/test command: `cargo test --locked --workspace`; build command: `cargo check --locked --workspace`.
+
+The workflow fetches the public approval comment and requires its id, author,
+URL, and complete body to match before it clones the target. It uses no user
+inputs for a target or command, no secrets, no caches, and a fresh target clone.
+The target must be clean before and after the run; the runner removes Togi's
+local state before recording the final cleanliness check.
+
+## Dispatch and reproducibility
+
+`external-dogfood.yml` is `workflow_dispatch` only. Dispatch it from reviewed
+`main` with `expected_workflow_sha` equal to the full commit SHA being run. The
+runner also requires that value to equal both `GITHUB_SHA` and the checked-out
+Togi revision. It runs only on Linux x86_64 (`ubuntu-24.04`) with a 40-minute
+job deadline and a 35-minute outer execution deadline.
+
+The runner downloads the published archive and `checksums.txt`, requires the
+archive's named manifest entry and its calculated SHA-256 to equal the fixed
+release checksum, safely extracts it, and requires `togi --version` to be
+exactly `togi 0.4.1`. It never builds or executes Togi from the workflow source.
+
+The target uses a new `HOME` and `CARGO_HOME`. It fetches
+locked dependencies once, then uses an allowlisted `env -i` environment with an
+isolated home/Cargo home, installed Rust toolchain location, `PATH`,
+`CARGO_NET_OFFLINE=true`, `TZ=UTC`, and `LC_ALL=C` for preflight, dry run, and
+execution. It records only the allowlisted environment facts: runner image and
+OS, uname/architecture, CPU count, tool versions, locale/timezone, target
+lockfile and config digests, and protocol identities/limits. It does not dump
+the environment, home directory, credentials, or tokens.
+
+Before execution, the full workspace preflight must pass. The released binary
+then performs an uncapped JSON dry run with the approved explicit base and path;
+the target's checked-in `togi.toml` must set `max_per_run = 0`. The generated
+count—not a truncation cap—must be between 1 and 20 inclusive and equal the
+dry-run mutation array length. The actual run repeats the explicit base/path
+and test/build command under `timeout --preserve-status 35m`, with `--timeout
+120 --jobs 2 --force-rerun --no-incremental-history` and no `--max-per-run`.
+Only exit status 0 or 1 reaches validation; a survivor is an observed result,
+not a protocol failure.
+
+## Evidence artifact and validation
+
+The named workflow artifact contains:
+
+- immutable case, approval, release verification, environment, command, target
+  diff/config, and clean-worktree metadata;
+- raw stdout/stderr and status files for dependency fetch, preflight, dry run,
+  and execution;
+- `dry-run.json` and `report.json`, each a byte-for-byte copy of its raw stdout;
+- `metrics.json`, generated deterministically from the machine-readable
+  `report.json`, not transcribed into prose;
+- `validation.txt` and a final `SHA256SUMS` covering every expected artifact
+  except itself.
+
+The offline verifier first validates the exact authorization, identities,
+commands, release, complete dry-run plan, report schema/count invariants, and
+clean/full execution. It permits survivors but rejects timeouts, build errors,
+uncovered or subsumed mutations, exact-cache/history reuse, partial or
+early-stopped reports, or a non-fresh execution. `--generate` derives canonical
+metrics for an initial artifact; `--verify` recomputes them and validates all
+checksums without network access.
+
+```bash
+bash .github/scripts/verify-external-dogfood-evidence.sh --verify CASE_DIRECTORY
+```
+
+For a rerun, dispatch reviewed main again with its exact SHA, preserve the new
+artifact, and run the offline verifier on both artifacts. Compare the recorded
+workflow revision, release digest, target/base/path, lockfile/config digests,
+runner image/OS/architecture, CPU, tool versions, locale/timezone, dry-run
+count, and generated metrics before treating outcomes as comparable. A changed
+environment or dependency resolution is recorded drift, not proof of a Togi
+regression or improvement.
+
+## Publication sequence
+
+1. Review and merge PR A, then dispatch the protocol from reviewed `main`.
+2. Retain the uploaded artifact only if its offline verification passes and its
+   report is complete and fresh.
+3. Put that evidence in a separate, evidence-only PR B. Only then may a
+   reviewed document link the versioned evidence and its workflow artifact.
+
+A protocol, a successful command, or one result cannot prove target adoption,
+general performance, broad compatibility, or reproducibility on a different
+runner image or dependency set.

--- a/docs/external-dogfood/README.md
+++ b/docs/external-dogfood/README.md
@@ -34,14 +34,26 @@ be absent before recording final cleanliness.
 `refs/heads/main`. Dispatch reviewed `main` with `expected_workflow_sha` equal
 to the full commit SHA being run. The runner requires the workflow-supplied
 default-branch ref to equal `GITHUB_REF`, and the SHA to equal both `GITHUB_SHA`
-and the checked-out Togi revision. It runs only on Linux x86_64
-(`ubuntu-24.04`) with a 40-minute job deadline and a 35-minute outer execution
-deadline.
+and the checked-out Togi revision. A top-level `external-dogfood` concurrency
+group queues rather than cancels runs. It runs only on Linux x86_64
+(`ubuntu-24.04`) with a 90-minute job deadline and a 2,100-second outer
+execution deadline.
 
 The runner downloads the published archive and `checksums.txt`, requires the
 archive's named manifest entry and its calculated SHA-256 to equal the fixed
 release checksum, safely extracts it, and requires `togi --version` to be
 exactly `togi 0.4.1`. It never builds or executes Togi from the workflow source.
+
+Every network or expensive target phase has a declared bound recorded in both
+`case.json` and `commands.txt`: each of the approval/archive/checksum downloads
+uses a 15-second connect timeout and a 120-second total curl timeout; target
+clone and checkout use 300 and 120 seconds; locked dependency fetch, preflight,
+and dry run use 480, 600, and 300 seconds; the actual execution uses 2,100
+seconds; and cleanup uses 120 seconds. The three download maxima plus those
+seven bounded phases total 4,380 seconds (73 minutes), leaving 17 minutes of
+the 90-minute job deadline for checkout/setup, release inspection, validation,
+and upload. Target commands retain their approved arguments; the
+`timeout --preserve-status` wrappers are protocol bounds.
 
 The target uses a new `HOME` and `CARGO_HOME`. It fetches
 locked dependencies once, then uses an allowlisted `env -i` environment with an
@@ -65,10 +77,12 @@ document. The target's
 checked-in `togi.toml` must set `max_per_run = 0`. The generated count—not a
 truncation cap—must be between 1 and 20 inclusive and equal the dry-run mutation
 array length. The actual run repeats the explicit base and test/build command
-under `timeout --preserve-status 35m`, with a per-mutation timeout of 120
+under `timeout --preserve-status 2100s`, with a per-mutation timeout of 120
 seconds, `--jobs 2 --force-rerun --no-incremental-history`, and no
-`--max-per-run`. Only exit status 0 or 1 reaches validation; a survivor is an
-observed result, not a protocol failure.
+`--max-per-run`. A timeout or other nonzero status in any prior phase aborts the
+run and is nonpublishable. For execution, only exit status 0 or 1 reaches
+validation; a timeout status is nonpublishable, and a survivor is an observed
+result, not a protocol failure.
 
 ## Evidence artifact and validation
 


### PR DESCRIPTION
Part of #473.\n\nAdds the reviewed dispatch-only protocol and offline evidence validator; no evidence result is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for approved external dogfood runs.
  * Added automated collection of execution results, environment details, timing, and integrity checks.
  * Added offline verification for generated evidence and artifact checksums.

* **Documentation**
  * Documented the approval, execution, evidence, verification, and rerun process for external dogfood testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->