### PR TITLE
feat(init): generate runnable configs for supported repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,8 +777,8 @@ your configured `[test] command`, and remove `base` when your `[diff].base`
 should select it instead. Output format is CLI-only, so `togi.toml` has no
 format setting. For a polyglot repo, commit the `togi init`-generated
 `togi.toml` and omit the Action `test-cmd` input so language-specific routes
-apply; the example's explicit `test-cmd` is a single-language override. For
-example:
+apply; the example's explicit `test-cmd` is a single-language override. The
+following TOML is a single-language example:
 
 ```toml
 [diff]

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ mutant source, command context, and relevant covering tests are unchanged.
 
 Optional. togi auto-detects a test command where supported; see [Before first run](#before-first-run) for its exact scope, prerequisites, and support boundaries.
 
-Run `togi init` to auto-detect your language, test runner (including pnpm/yarn/bun), and generate a `togi.toml`. For polyglot repos it creates per-language sections automatically.
+Run `togi init` to auto-detect your language, test runner (including pnpm/yarn/bun), and generate a `togi.toml`. It uses a locally resolvable `[diff].base` when one is available, otherwise retains the `origin/main` fallback; review that setting for CI or your PR base. For polyglot repos with distinct root markers it creates per-language sections automatically; if two markers select different commands for one language, configure an explicit `[test]` command or `[projects.*.test]` routes.
 
 Create a `togi.toml` for customization:
 
@@ -775,7 +775,10 @@ The Action passes `--base`, `--timeout`, `--format`, and `--test-cmd` only for
 non-empty inputs. Those inputs override `togi.toml`; remove `test-cmd` to use
 your configured `[test] command`, and remove `base` when your `[diff].base`
 should select it instead. Output format is CLI-only, so `togi.toml` has no
-format setting. For example:
+format setting. For a polyglot repo, commit the `togi init`-generated
+`togi.toml` and omit the Action `test-cmd` input so language-specific routes
+apply; the example's explicit `test-cmd` is a single-language override. For
+example:
 
 ```toml
 [diff]

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,11 +244,17 @@ impl JavaScriptRunner {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DetectedTestRoute {
+    marker: &'static str,
+    command: Vec<String>,
+    languages: &'static [&'static str],
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct ProjectInspection {
     has_cargo_toml: bool,
     has_go_mod: bool,
-    has_python_project: bool,
     python_manifest: Option<&'static str>,
     javascript_runner: Option<JavaScriptRunner>,
     has_pom_xml: bool,
@@ -287,7 +293,6 @@ impl ProjectInspection {
         Self {
             has_cargo_toml: project_root.join("Cargo.toml").exists(),
             has_go_mod: project_root.join("go.mod").exists(),
-            has_python_project: python_manifest.is_some(),
             python_manifest,
             javascript_runner: JavaScriptRunner::detect(project_root),
             has_pom_xml: project_root.join("pom.xml").exists(),
@@ -301,37 +306,70 @@ impl ProjectInspection {
         }
     }
 
-    fn detected_test_commands(&self) -> Vec<(&'static str, Vec<String>)> {
+    fn detected_test_routes(&self) -> Vec<DetectedTestRoute> {
         let mut detected = Vec::new();
         if self.has_cargo_toml {
-            detected.push(("Cargo.toml", vec!["cargo".into(), "test".into()]));
+            detected.push(DetectedTestRoute {
+                marker: "Cargo.toml",
+                command: vec!["cargo".into(), "test".into()],
+                languages: &["rust"],
+            });
         }
         if self.has_go_mod {
-            detected.push(("go.mod", vec!["go".into(), "test".into(), "./...".into()]));
+            detected.push(DetectedTestRoute {
+                marker: "go.mod",
+                command: vec!["go".into(), "test".into(), "./...".into()],
+                languages: &["go"],
+            });
         }
-        if let Some(manifest) = self.python_manifest {
-            detected.push((manifest, vec!["pytest".into()]));
+        if let Some(marker) = self.python_manifest {
+            detected.push(DetectedTestRoute {
+                marker,
+                command: vec!["pytest".into()],
+                languages: &["python"],
+            });
         }
         if let Some(runner) = self.javascript_runner {
-            detected.push(("package.json", runner.test_command()));
+            detected.push(DetectedTestRoute {
+                marker: "package.json",
+                command: runner.test_command(),
+                languages: &["typescript"],
+            });
         }
         if self.has_pom_xml {
-            detected.push(("pom.xml", vec!["mvn".into(), "test".into()]));
+            detected.push(DetectedTestRoute {
+                marker: "pom.xml",
+                command: vec!["mvn".into(), "test".into()],
+                languages: &["java"],
+            });
         }
-        if let Some(manifest) = self.gradle_manifest {
-            detected.push((manifest, vec!["./gradlew".into(), "test".into()]));
+        if let Some(marker) = self.gradle_manifest {
+            detected.push(DetectedTestRoute {
+                marker,
+                command: vec!["./gradlew".into(), "test".into()],
+                languages: &["java"],
+            });
         }
         if self.has_gemfile {
-            detected.push((
-                "Gemfile",
-                vec!["bundle".into(), "exec".into(), "rspec".into()],
-            ));
+            detected.push(DetectedTestRoute {
+                marker: "Gemfile",
+                command: vec!["bundle".into(), "exec".into(), "rspec".into()],
+                languages: &["ruby"],
+            });
         }
         if self.has_cmake {
-            detected.push(("CMakeLists.txt", vec!["ctest".into()]));
+            detected.push(DetectedTestRoute {
+                marker: "CMakeLists.txt",
+                command: vec!["ctest".into()],
+                languages: &["c", "cpp"],
+            });
         }
         if self.has_dotnet_project {
-            detected.push((".sln/.csproj", vec!["dotnet".into(), "test".into()]));
+            detected.push(DetectedTestRoute {
+                marker: ".sln/.csproj",
+                command: vec!["dotnet".into(), "test".into()],
+                languages: &["c_sharp"],
+            });
         }
         detected
     }
@@ -367,20 +405,23 @@ impl ProjectInspection {
 }
 
 pub fn detect_test_command(project_root: &Path) -> Vec<String> {
-    let detected = ProjectInspection::scan(project_root).detected_test_commands();
+    let detected = ProjectInspection::scan(project_root).detected_test_routes();
+    select_test_command(&detected)
+}
 
+fn select_test_command(detected: &[DetectedTestRoute]) -> Vec<String> {
     if detected.len() > 1 {
-        let names: Vec<&str> = detected.iter().map(|(name, _)| *name).collect();
+        let names: Vec<&str> = detected.iter().map(|route| route.marker).collect();
         eprintln!(
             "warning: multiple build systems detected ({}). Using `{}`. \
              Set [test] command in togi.toml to override.",
             names.join(", "),
-            detected[0].1.join(" ")
+            detected[0].command.join(" ")
         );
     }
 
-    if let Some((_, cmd)) = detected.into_iter().next() {
-        cmd
+    if let Some(route) = detected.first() {
+        route.command.clone()
     } else {
         eprintln!(
             "warning: no known build system found. Falling back to `make test`. \
@@ -388,6 +429,27 @@ pub fn detect_test_command(project_root: &Path) -> Vec<String> {
         );
         vec!["make".into(), "test".into()]
     }
+}
+
+fn validate_init_language_routes(routes: &[DetectedTestRoute]) -> anyhow::Result<()> {
+    let mut routes_by_language = HashMap::new();
+
+    for route in routes {
+        for &language in route.languages {
+            if let Some(previous) = routes_by_language.insert(language, route) {
+                if previous.command != route.command {
+                    anyhow::bail!(
+                        "multiple test commands for {language} detected ({} and {}); \
+                         configure an explicit [test] command or [projects.*.test] routes",
+                        previous.marker,
+                        route.marker
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -485,7 +547,7 @@ fn default_jobs_for_available_parallelism(available: usize) -> usize {
 }
 
 fn default_base() -> String {
-    "origin/main".into()
+    crate::diff::DEFAULT_DIFF_BASE.into()
 }
 
 fn default_max_per_run() -> usize {
@@ -670,15 +732,15 @@ impl Config {
             return TestCommandResolution::Resolved;
         }
 
-        let detected = ProjectInspection::scan(project_root).detected_test_commands();
+        let detected = ProjectInspection::scan(project_root).detected_test_routes();
         if detected.len() > 1 {
             return TestCommandResolution::Ambiguous(AmbiguousTestCommand {
-                candidates: detected.iter().map(|(name, _)| *name).collect(),
+                candidates: detected.iter().map(|route| route.marker).collect(),
             });
         }
 
-        self.test.command = if let Some((_, command)) = detected.into_iter().next() {
-            command
+        self.test.command = if let Some(route) = detected.into_iter().next() {
+            route.command
         } else {
             eprintln!(
                 "warning: no known build system found. Falling back to `make test`. \
@@ -698,10 +760,16 @@ impl Config {
 
     /// Write a template togi.toml to the given path.
     pub fn write_template(path: &Path) -> anyhow::Result<()> {
-        let project_root = path.parent().unwrap_or(Path::new("."));
+        let project_root = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
         let inspection = ProjectInspection::scan(project_root);
-        let test_cmd = detect_test_command(project_root);
+        let routes = inspection.detected_test_routes();
+        validate_init_language_routes(&routes)?;
+        let test_cmd = select_test_command(&routes);
         let build_cmd = inspection.detect_build_command();
+        let base_toml = toml::Value::String(crate::diff::init_diff_base(project_root)).to_string();
 
         let test_cmd_toml: Vec<String> = test_cmd.iter().map(|s| format!("\"{}\"", s)).collect();
 
@@ -749,32 +817,15 @@ impl Config {
         ));
 
         let mut lang_sections: Vec<String> = Vec::new();
-        // Only add language sections for languages that aren't the primary test command
-        if inspection.has_python_project && test_cmd.first().map(|s| s.as_str()) != Some("pytest") {
-            lang_sections.push("[test.languages.python]\ncommand = [\"pytest\"]\n".to_string());
-        }
-        if inspection.javascript_runner.is_some()
-            && !matches!(
-                test_cmd.first().map(|s| s.as_str()),
-                Some("npm" | "pnpm" | "yarn" | "bun")
-            )
-        {
-            let runner = inspection
-                .javascript_runner
-                .map(JavaScriptRunner::binary)
-                .unwrap_or("npm");
-            lang_sections.push(format!(
-                "[test.languages.typescript]\ncommand = [\"{}\", \"test\"]\n",
-                runner
-            ));
-        }
-        if inspection.has_go_mod && test_cmd.first().map(|s| s.as_str()) != Some("go") {
-            lang_sections
-                .push("[test.languages.go]\ncommand = [\"go\", \"test\", \"./...\"]\n".to_string());
-        }
-        if inspection.has_cargo_toml && test_cmd.first().map(|s| s.as_str()) != Some("cargo") {
-            lang_sections
-                .push("[test.languages.rust]\ncommand = [\"cargo\", \"test\"]\n".to_string());
+        for route in routes.iter().skip(1) {
+            let command_toml: Vec<String> =
+                route.command.iter().map(|s| format!("\"{}\"", s)).collect();
+            for language in route.languages {
+                lang_sections.push(format!(
+                    "[test.languages.{language}]\ncommand = [{}]\n",
+                    command_toml.join(", ")
+                ));
+            }
         }
 
         if !lang_sections.is_empty() {
@@ -786,9 +837,9 @@ impl Config {
             template.push('\n');
         }
 
-        template.push_str(
+        template.push_str(&format!(
             "[diff]\n\
-             base = \"origin/main\"\n\
+             base = {base_toml}\n\
              \n\
              [mutations]\n\
              max_per_run = 20\n\
@@ -796,7 +847,7 @@ impl Config {
              # schemata = true  # use supported mutant schemata as the fast path\n\
              # incremental_history = true  # reuse safe results from previous runs\n\
              # respect_workspace_ignores = true  # honor .ignore/.gitignore in mutation workspaces\n",
-        );
+        ));
 
         std::fs::write(path, template)?;
         Ok(())
@@ -1054,6 +1105,117 @@ sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--"]
         let content = std::fs::read_to_string(&path).unwrap();
         // pytest wins as primary, so JS gets a language section
         assert!(content.contains("[test.languages.typescript]"));
+    }
+
+    #[test]
+    fn write_template_routes_all_supported_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        for file in [
+            "Cargo.toml",
+            "go.mod",
+            "pyproject.toml",
+            "package.json",
+            "pnpm-lock.yaml",
+            "pom.xml",
+            "Gemfile",
+            "CMakeLists.txt",
+            "example.csproj",
+        ] {
+            std::fs::write(dir.path().join(file), "").unwrap();
+        }
+        let path = dir.path().join("togi.toml");
+        Config::write_template(&path).unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
+        let config: Config = toml::from_str(&content).unwrap();
+
+        let primary: Vec<String> = vec!["cargo".to_owned(), "test".to_owned()];
+        assert_eq!(config.test.command, primary);
+        for (language, expected) in [
+            ("go", vec!["go", "test", "./..."]),
+            ("python", vec!["pytest"]),
+            ("typescript", vec!["pnpm", "test"]),
+            ("java", vec!["mvn", "test"]),
+            ("ruby", vec!["bundle", "exec", "rspec"]),
+            ("c", vec!["ctest"]),
+            ("cpp", vec!["ctest"]),
+            ("c_sharp", vec!["dotnet", "test"]),
+        ] {
+            let expected: Vec<String> = expected.into_iter().map(str::to_owned).collect();
+            assert_eq!(
+                config.test.languages[language].command, expected,
+                "unexpected command for {language}"
+            );
+        }
+
+        let mut previous = 0;
+        for language in [
+            "go",
+            "python",
+            "typescript",
+            "java",
+            "ruby",
+            "c",
+            "cpp",
+            "c_sharp",
+        ] {
+            let section = format!("[test.languages.{language}]");
+            let position = content.find(&section).unwrap();
+            assert!(position > previous, "{section} is out of order");
+            previous = position;
+        }
+    }
+
+    #[test]
+    fn write_template_rejects_conflicting_java_routes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pom.xml"), "").unwrap();
+        std::fs::write(dir.path().join("build.gradle"), "").unwrap();
+        let path = dir.path().join("togi.toml");
+
+        let err = Config::write_template(&path).unwrap_err();
+        assert!(err.to_string().contains("pom.xml"));
+        assert!(err.to_string().contains("build.gradle"));
+        assert!(!path.exists());
+        assert!(err.to_string().contains("[projects.*.test]"));
+    }
+
+    #[test]
+    fn write_template_escapes_quoted_origin_head_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let run = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run(&["init"]);
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "initial"]);
+        run(&["update-ref", "refs/remotes/origin/trunk\"quoted", "HEAD"]);
+        run(&[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/trunk\"quoted",
+        ]);
+
+        let path = root.join("togi.toml");
+        Config::write_template(&path).unwrap();
+        let content = std::fs::read_to_string(path).unwrap();
+        let config: Config = toml::from_str(&content).unwrap();
+        assert_eq!(config.diff.base, "origin/trunk\"quoted");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1186,6 +1186,7 @@ sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--"]
         assert!(err.to_string().contains("[projects.*.test]"));
     }
 
+    #[cfg(not(windows))] // Git cannot create quote-containing refs on Windows.
     #[test]
     fn write_template_escapes_quoted_origin_head_target() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -420,6 +420,10 @@ fn select_test_command(detected: &[DetectedTestRoute]) -> Vec<String> {
         );
     }
 
+    select_primary_test_command(detected)
+}
+
+fn select_primary_test_command(detected: &[DetectedTestRoute]) -> Vec<String> {
     if let Some(route) = detected.first() {
         route.command.clone()
     } else {
@@ -767,7 +771,7 @@ impl Config {
         let inspection = ProjectInspection::scan(project_root);
         let routes = inspection.detected_test_routes();
         validate_init_language_routes(&routes)?;
-        let test_cmd = select_test_command(&routes);
+        let test_cmd = select_primary_test_command(&routes);
         let build_cmd = inspection.detect_build_command();
         let base_toml = toml::Value::String(crate::diff::init_diff_base(project_root)).to_string();
 
@@ -818,8 +822,11 @@ impl Config {
 
         let mut lang_sections: Vec<String> = Vec::new();
         for route in routes.iter().skip(1) {
-            let command_toml: Vec<String> =
-                route.command.iter().map(|s| format!("\"{}\"", s)).collect();
+            let command_toml: Vec<String> = route
+                .command
+                .iter()
+                .map(|command| toml::Value::String(command.clone()).to_string())
+                .collect();
             for language in route.languages {
                 lang_sections.push(format!(
                     "[test.languages.{language}]\ncommand = [{}]\n",

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,6 +4,60 @@ use crate::{ChangedFile, LineRange};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub(crate) const DEFAULT_DIFF_BASE: &str = "origin/main";
+
+/// Select a locally resolvable base for a newly generated configuration.
+pub(crate) fn init_diff_base(project_root: &Path) -> String {
+    if let Some(reference) = origin_head(project_root) {
+        return reference;
+    }
+
+    for reference in [DEFAULT_DIFF_BASE, "HEAD~1", "HEAD"] {
+        if git_ref_is_commit(project_root, reference) {
+            return reference.into();
+        }
+    }
+
+    DEFAULT_DIFF_BASE.into()
+}
+
+fn origin_head(project_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let reference = String::from_utf8(output.stdout)
+        .ok()?
+        .trim_end_matches(&['\r', '\n'][..])
+        .to_owned();
+    (!reference.is_empty() && git_ref_is_commit(project_root, &reference)).then_some(reference)
+}
+
+/// Verifies a candidate resolves to a commit before it reaches `git diff`.
+fn git_ref_is_commit(project_root: &Path, reference: &str) -> bool {
+    Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{reference}^{{commit}}"),
+        ])
+        .current_dir(project_root)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 /// Build ChangedFile entries for every supported file in the project tree.
 /// Respects `.gitignore` rules. Skips test/migration/seed files by default.
 pub fn collect_all_supported_files(
@@ -100,14 +154,7 @@ pub fn collect_changed_since(
     skip_noisy: bool,
     exclude_globs: &[String],
 ) -> anyhow::Result<Vec<ChangedFile>> {
-    // Validate the ref before using it in git commands to prevent
-    // arbitrary strings from being passed to git diff.
-    let ref_valid = Command::new("git")
-        .args(["rev-parse", "--verify", &format!("{since}^{{commit}}")])
-        .current_dir(project_root)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    let ref_valid = git_ref_is_commit(project_root, since);
 
     // Try as a commit ref first (SHA, branch, tag).
     let output = if ref_valid {
@@ -414,6 +461,135 @@ index 1111111..2222222 100644
 +pub mod mapper;
  pub mod runner;
 "#;
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_base_test_repo(with_parent: bool) -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        git(root, &["init"]);
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        git(root, &["add", "."]);
+        git(root, &["commit", "-m", "initial"]);
+        if with_parent {
+            std::fs::write(root.join("main.rs"), "fn main() { println!(\"hi\"); }\n").unwrap();
+            git(root, &["add", "."]);
+            git(root, &["commit", "-m", "second"]);
+        }
+        repo
+    }
+
+    #[test]
+    fn init_diff_base_prefers_verified_origin_head() {
+        let repo = init_base_test_repo(true);
+        let root = repo.path();
+        git(root, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        git(
+            root,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+            ],
+        );
+        assert_eq!(init_diff_base(root), "origin/main");
+    }
+
+    #[test]
+    fn init_diff_base_prefers_non_main_origin_head_target() {
+        let repo = init_base_test_repo(true);
+        let root = repo.path();
+        git(root, &["update-ref", "refs/remotes/origin/trunk", "HEAD"]);
+        git(
+            root,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/trunk",
+            ],
+        );
+        assert_eq!(init_diff_base(root), "origin/trunk");
+    }
+
+    #[test]
+    fn init_diff_base_ignores_unresolved_origin_head() {
+        let repo = init_base_test_repo(true);
+        let root = repo.path();
+        git(
+            root,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/missing",
+            ],
+        );
+        assert_eq!(init_diff_base(root), "HEAD~1");
+    }
+
+    #[test]
+    fn init_diff_base_uses_origin_main_when_origin_head_is_stale() {
+        let repo = init_base_test_repo(true);
+        let root = repo.path();
+        git(root, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        git(
+            root,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/missing",
+            ],
+        );
+        assert_eq!(init_diff_base(root), "origin/main");
+    }
+
+    #[test]
+    fn init_diff_base_uses_origin_main_without_origin_head() {
+        let repo = init_base_test_repo(true);
+        let root = repo.path();
+        git(root, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        assert_eq!(init_diff_base(root), "origin/main");
+    }
+
+    #[test]
+    fn init_diff_base_uses_head_parent_without_remote() {
+        let repo = init_base_test_repo(true);
+        assert_eq!(init_diff_base(repo.path()), "HEAD~1");
+    }
+
+    #[test]
+    fn init_diff_base_uses_head_for_root_commit() {
+        let repo = init_base_test_repo(false);
+        assert_eq!(init_diff_base(repo.path()), "HEAD");
+    }
+
+    #[test]
+    fn init_diff_base_falls_back_outside_git() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(init_diff_base(dir.path()), DEFAULT_DIFF_BASE);
+    }
+
+    #[test]
+    fn init_diff_base_falls_back_for_unborn_git_repository() {
+        let repo = tempfile::tempdir().unwrap();
+        git(repo.path(), &["init"]);
+        assert_eq!(init_diff_base(repo.path()), DEFAULT_DIFF_BASE);
+    }
 
     #[test]
     fn parses_multiple_files() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -83,7 +83,279 @@ fn init_creates_config() {
         .success()
         .stdout(predicate::str::contains("Created togi.toml"));
 
-    assert!(dir.path().join("togi.toml").exists());
+    let config = fs::read_to_string(dir.path().join("togi.toml")).unwrap();
+    assert!(config.contains("base = \"origin/main\""));
+}
+
+#[test]
+fn init_uses_head_parent_in_no_remote_repo() {
+    let dir = setup_git_repo();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "second"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    assert!(
+        fs::read_to_string(dir.path().join("togi.toml"))
+            .unwrap()
+            .contains("base = \"HEAD~1\"")
+    );
+
+    togi()
+        .args(["check", "--dry-run", "--test-cmd", "true"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn init_uses_head_for_root_commit_in_no_remote_repo() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    for args in [
+        &["init"][..],
+        &["config", "user.email", "test@test.com"][..],
+        &["config", "user.name", "Test"][..],
+    ] {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+    fs::write(root.join("go.mod"), "module example.com/test\n\ngo 1.21\n").unwrap();
+    fs::write(root.join("main.go"), "package main\nfunc main() {}\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    togi().arg("init").current_dir(root).assert().success();
+    let config = fs::read_to_string(root.join("togi.toml")).unwrap();
+    assert!(config.contains("base = \"HEAD\""));
+
+    togi()
+        .args(["check", "--dry-run", "--test-cmd", "true"])
+        .current_dir(root)
+        .assert()
+        .success();
+}
+
+#[test]
+fn init_escapes_quoted_origin_head_target_in_relative_config() {
+    let dir = setup_git_repo();
+    let root = dir.path();
+    let update_ref = std::process::Command::new("git")
+        .args(["update-ref", "refs/remotes/origin/trunk\"quoted", "HEAD"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(update_ref.status.success());
+    let origin_head = std::process::Command::new("git")
+        .args([
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/trunk\"quoted",
+        ])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(origin_head.status.success());
+
+    togi().arg("init").current_dir(root).assert().success();
+    let config: toml::Value =
+        toml::from_str(&fs::read_to_string(root.join("togi.toml")).unwrap()).unwrap();
+    assert_eq!(
+        config["diff"]["base"].as_str(),
+        Some("origin/trunk\"quoted")
+    );
+}
+#[test]
+fn init_generates_all_supported_root_routes() {
+    let dir = TempDir::new().unwrap();
+    for file in [
+        "Cargo.toml",
+        "go.mod",
+        "pyproject.toml",
+        "package.json",
+        "pom.xml",
+        "Gemfile",
+        "CMakeLists.txt",
+        "example.csproj",
+    ] {
+        fs::write(dir.path().join(file), "").unwrap();
+    }
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let config = fs::read_to_string(dir.path().join("togi.toml")).unwrap();
+    for language in [
+        "go",
+        "python",
+        "typescript",
+        "java",
+        "ruby",
+        "c",
+        "cpp",
+        "c_sharp",
+    ] {
+        assert!(
+            config.contains(&format!("[test.languages.{language}]")),
+            "missing route for {language}"
+        );
+    }
+}
+
+#[test]
+fn init_rejects_conflicting_java_routes_without_writing_config() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("pom.xml"), "").unwrap();
+    fs::write(dir.path().join("build.gradle"), "").unwrap();
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("pom.xml"))
+        .stderr(predicate::str::contains("build.gradle"))
+        .stderr(predicate::str::contains("[projects.*.test]"));
+    assert!(!dir.path().join("togi.toml").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn init_routes_non_primary_languages_over_cargo() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    for (file, content) in [
+        (
+            "Cargo.toml",
+            "[package]\nname = \"example\"\nversion = \"0.1.0\"\n",
+        ),
+        ("Gemfile", ""),
+        ("pom.xml", ""),
+        ("CMakeLists.txt", ""),
+        ("example.csproj", ""),
+        ("calc.rb", "def is_big(x)\n  x + 1 > 3\nend\n"),
+        (
+            "Calc.java",
+            "public final class Calc {\n    public static boolean isBig(int x) {\n        return x + 1 > 3;\n    }\n}\n",
+        ),
+        ("calc.c", "int is_big(int x) {\n    return x + 1 > 3;\n}\n"),
+        (
+            "calc.cpp",
+            "bool is_big(int x) {\n    return x + 1 > 3;\n}\n",
+        ),
+        (
+            "Calc.cs",
+            "public static class Calc\n{\n    public static bool IsBig(int x)\n    {\n        return x + 1 > 3;\n    }\n}\n",
+        ),
+    ] {
+        fs::write(root.join(file), content).unwrap();
+    }
+    git(&["add", "."]);
+    git(&["commit", "-m", "initial"]);
+
+    togi().arg("init").current_dir(root).assert().success();
+    let bin = root.join("bin");
+    fs::create_dir(&bin).unwrap();
+    for command in ["bundle", "mvn", "ctest", "dotnet"] {
+        let executable = bin.join(command);
+        fs::write(
+            &executable,
+            "#!/bin/sh\nbasename \"$0\" >> \"$TOGI_TEST_LOG\"\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable, permissions).unwrap();
+    }
+    let log = root.join("route.log");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    for (source, expected_command) in [
+        ("calc.rb", "bundle"),
+        ("Calc.java", "mvn"),
+        ("calc.c", "ctest"),
+        ("calc.cpp", "ctest"),
+        ("Calc.cs", "dotnet"),
+    ] {
+        let changed = fs::read_to_string(root.join(source)).unwrap();
+        fs::write(root.join(source), changed.replace("> 3", "> 4")).unwrap();
+        git(&["add", source]);
+        git(&["commit", "-m", source]);
+
+        let _ = fs::remove_file(&log);
+        let output = togi()
+            .args([
+                "check",
+                "--base",
+                "HEAD~1",
+                "--max-per-run",
+                "1",
+                "--no-schemata",
+            ])
+            .current_dir(root)
+            .env("PATH", &path)
+            .env("TOGI_TEST_LOG", &log)
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let log_content = fs::read_to_string(&log).unwrap();
+        let commands: Vec<_> = log_content.lines().collect();
+        assert!(!commands.is_empty(), "{source} ran no test command");
+        assert!(
+            commands.iter().all(|command| *command == expected_command),
+            "{source} did not use {expected_command}: {commands:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -207,7 +207,8 @@ fn init_generates_all_supported_root_routes() {
         .arg("init")
         .current_dir(dir.path())
         .assert()
-        .success();
+        .success()
+        .stderr(predicate::str::contains("multiple build systems detected").not());
     let config = fs::read_to_string(dir.path().join("togi.toml")).unwrap();
     for language in [
         "go",
@@ -348,7 +349,7 @@ fn init_routes_non_primary_languages_over_cargo() {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-        let log_content = fs::read_to_string(&log).unwrap();
+        let log_content = fs::read_to_string(&log).unwrap_or_default();
         let commands: Vec<_> = log_content.lines().collect();
         assert!(!commands.is_empty(), "{source} ran no test command");
         assert!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -158,6 +158,7 @@ fn init_uses_head_for_root_commit_in_no_remote_repo() {
         .success();
 }
 
+#[cfg(not(windows))] // Git cannot create quote-containing refs on Windows.
 #[test]
 fn init_escapes_quoted_origin_head_target_in_relative_config() {
     let dir = setup_git_repo();


### PR DESCRIPTION
## Summary
- choose a locally resolvable diff base when `togi init` creates a config
- generate routes for every supported root-level language marker and reject ambiguous same-language commands
- clarify config-first polyglot Action use

## Verification
- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked
- fresh no-origin init → ordinary dry-run check
- mixed-root generated Ruby/Java/C/C++/C# route smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `togi init` now automatically selects an appropriate diff base from the repository, with fallback options when needed.
  * Projects with multiple languages now receive language-specific test routes based on detected project markers.
  * Added explicit routing guidance and improved GitHub Action configuration for polyglot repositories.

* **Bug Fixes**
  * Added validation for conflicting commands targeting the same language.
  * Improved handling of remote branches, missing references, and repositories without commit history.

* **Documentation**
  * Expanded setup guidance for generated configuration and language-specific test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->