### PR TITLE
feat(report): add likely-equivalent survivor advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ togi check --base origin/main --format github
 togi check --base origin/main --pr-comment togi-pr-comment.md
 ```
 
+Survivors can carry a **likely equivalent (advisory)** reason when a narrow Rust syntax rule
+matches: standard `Vec`/`String` capacity hints or a stricter `&&` bound that already excludes
+the changed endpoint. They remain `survived` and continue to count toward scores and gates; JSON
+uses `likely_equivalent`, and every report format displays the same advisory reason.
+
 ### Parallel CI shards
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -423,9 +423,9 @@ togi check --base origin/main --pr-comment togi-pr-comment.md
 ```
 
 Survivors can carry a **likely equivalent (advisory)** reason when a narrow Rust syntax rule
-matches: standard `Vec`/`String` capacity hints or a stricter `&&` bound that already excludes
-the changed endpoint. They remain `survived` and continue to count toward scores and gates; JSON
-uses `likely_equivalent`, and every report format displays the same advisory reason.
+matches: identical boolean literals or a stricter primitive-integer `&&` bound that already
+excludes the changed endpoint. They remain `survived` and continue to count toward scores and
+gates; JSON uses `likely_equivalent`, and every report format displays the same advisory reason.
 
 ### Parallel CI shards
 

--- a/src/equivalent.rs
+++ b/src/equivalent.rs
@@ -13,15 +13,15 @@ use tree_sitter::{Node, Tree};
 /// Why a surviving mutant is likely equivalent under a narrow syntax-only rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LikelyEquivalentReason {
-    CapacityHint,
+    SameBooleanLiterals,
     RedundantBoundary,
 }
 
 impl LikelyEquivalentReason {
     pub(crate) fn message(self) -> &'static str {
         match self {
-            Self::CapacityHint => {
-                "changes only a Vec/String preallocation capacity hint under normal allocation behavior"
+            Self::SameBooleanLiterals => {
+                "both operands are the same boolean literal, so either logical operator produces the same value"
             }
             Self::RedundantBoundary => {
                 "a stricter `&&` sibling check already excludes the changed boundary"
@@ -88,8 +88,8 @@ fn likely_equivalent_reason(
         return None;
     }
 
-    if changes_capacity_hint(mutation, parsed) {
-        return Some(LikelyEquivalentReason::CapacityHint);
+    if has_identical_boolean_literals(mutation, parsed) {
+        return Some(LikelyEquivalentReason::SameBooleanLiterals);
     }
     if has_redundant_boundary(mutation, parsed) {
         return Some(LikelyEquivalentReason::RedundantBoundary);
@@ -97,62 +97,37 @@ fn likely_equivalent_reason(
     None
 }
 
-fn changes_capacity_hint(mutation: &Mutation, parsed: &ParsedSource) -> bool {
-    if !matches!(
-        mutation.operator.as_str(),
-        "zero_to_one" | "increment_numeric" | "decrement_numeric"
-    ) || !is_unsigned_decimal(&mutation.original)
-        || !is_unsigned_decimal(&mutation.replacement)
-    {
+fn has_identical_boolean_literals(mutation: &Mutation, parsed: &ParsedSource) -> bool {
+    let expected_operator = match mutation.operator.as_str() {
+        "and_to_or" => "&&",
+        "or_to_and" => "||",
+        _ => return false,
+    };
+    if mutation.original != expected_operator {
         return false;
     }
 
-    let Some(mut node) = parsed
-        .tree
-        .root_node()
-        .descendant_for_byte_range(mutation.byte_range.start, mutation.byte_range.end)
-    else {
+    let Some(binary) = binary_mutation_node(mutation, parsed) else {
+        return false;
+    };
+    let source = parsed.source.as_bytes();
+    let Some((left, _, right)) = binary_parts(binary, source) else {
+        return false;
+    };
+    let (Some(left), Some(right)) = (
+        source
+            .get(left.byte_range())
+            .and_then(|value| std::str::from_utf8(value).ok())
+            .map(str::trim),
+        source
+            .get(right.byte_range())
+            .and_then(|value| std::str::from_utf8(value).ok())
+            .map(str::trim),
+    ) else {
         return false;
     };
 
-    loop {
-        if node.kind() == "call_expression"
-            && let (Some(function), Some(arguments)) = (
-                node.child_by_field_name("function"),
-                node.child_by_field_name("arguments"),
-            )
-            && function
-                .utf8_text(parsed.source.as_bytes())
-                .ok()
-                .is_some_and(is_standard_capacity_constructor)
-            && arguments.named_child_count() == 1
-            && arguments
-                .named_child(0)
-                .is_some_and(|argument| argument.byte_range() == mutation.byte_range)
-        {
-            return true;
-        }
-        let Some(parent) = node.parent() else {
-            return false;
-        };
-        node = parent;
-    }
-}
-
-fn is_standard_capacity_constructor(function: &str) -> bool {
-    matches!(
-        function,
-        "Vec::with_capacity"
-            | "String::with_capacity"
-            | "std::vec::Vec::with_capacity"
-            | "std::string::String::with_capacity"
-            | "alloc::vec::Vec::with_capacity"
-            | "alloc::string::String::with_capacity"
-    )
-}
-
-fn is_unsigned_decimal(value: &str) -> bool {
-    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+    left == right && matches!(left, "true" | "false")
 }
 
 fn has_redundant_boundary(mutation: &Mutation, parsed: &ParsedSource) -> bool {
@@ -208,7 +183,76 @@ fn has_redundant_boundary(mutation: &Mutation, parsed: &ParsedSource) -> bool {
         return false;
     };
 
-    mutated.subject == sibling.subject && sibling_excludes_changed_boundary(mutated, sibling)
+    mutated.subject == sibling.subject
+        && is_direct_primitive_parameter_bound(logical_and, mutated.subject, parsed)
+        && sibling_excludes_changed_boundary(mutated, sibling)
+}
+
+fn is_direct_primitive_parameter_bound(
+    logical_and: Node<'_>,
+    subject: &str,
+    parsed: &ParsedSource,
+) -> bool {
+    let Some(block) = logical_and.parent() else {
+        return false;
+    };
+    if block.kind() != "block"
+        || block.named_child_count() != 1
+        || block
+            .named_child(0)
+            .is_none_or(|child| child.byte_range() != logical_and.byte_range())
+    {
+        return false;
+    }
+    let Some(function) = block.parent() else {
+        return false;
+    };
+    if function.kind() != "function_item" {
+        return false;
+    }
+    let Some(parameters) = function.child_by_field_name("parameters") else {
+        return false;
+    };
+
+    let source = parsed.source.as_bytes();
+    let mut cursor = parameters.walk();
+    for parameter in parameters.named_children(&mut cursor) {
+        if parameter.kind() != "parameter" {
+            continue;
+        }
+        let (Some(pattern), Some(type_name)) = (
+            parameter.child_by_field_name("pattern"),
+            parameter.child_by_field_name("type"),
+        ) else {
+            continue;
+        };
+        if source.get(pattern.byte_range()) == Some(subject.as_bytes())
+            && source
+                .get(type_name.byte_range())
+                .and_then(|value| std::str::from_utf8(value).ok())
+                .is_some_and(is_primitive_integer)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_primitive_integer(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        "i8" | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+    )
 }
 
 fn binary_mutation_node<'tree>(
@@ -344,8 +388,9 @@ mod tests {
             replacement: match operator {
                 "lt_to_lte" => "<=".into(),
                 "gt_to_gte" => ">=".into(),
-                "decrement_numeric" => "15".into(),
-                _ => "17".into(),
+                "and_to_or" => "||".into(),
+                "or_to_and" => "&&".into(),
+                _ => String::new(),
             },
             byte_range: start..start + original.len(),
         }
@@ -364,18 +409,18 @@ mod tests {
     }
 
     #[test]
-    fn marks_standard_collection_capacity_literal_mutations() {
-        let source = "fn make() { let _items = Vec::with_capacity(16); }";
+    fn marks_identical_boolean_literals() {
+        let source = "fn always() -> bool { true && true }";
         assert_eq!(
-            reason(source, "increment_numeric", "16"),
-            Some(LikelyEquivalentReason::CapacityHint)
+            reason(source, "and_to_or", "&&"),
+            Some(LikelyEquivalentReason::SameBooleanLiterals)
         );
     }
 
     #[test]
-    fn leaves_nonstandard_capacity_calls_unannotated() {
-        let source = "fn make() { let _items = Buffer::with_capacity(16); }";
-        assert_eq!(reason(source, "increment_numeric", "16"), None);
+    fn leaves_different_boolean_literals_unannotated() {
+        let source = "fn sometimes() -> bool { true && false }";
+        assert_eq!(reason(source, "and_to_or", "&&"), None);
     }
 
     #[test]
@@ -390,6 +435,12 @@ mod tests {
     #[test]
     fn leaves_equal_sibling_bound_unannotated() {
         let source = "fn valid(value: i32) -> bool { value < 10 && value <= 10 }";
+        assert_eq!(reason(source, "lt_to_lte", "<"), None);
+    }
+
+    #[test]
+    fn leaves_custom_comparison_types_unannotated() {
+        let source = "fn valid(value: Wrapped) -> bool { value < 10 && value <= 9 }";
         assert_eq!(reason(source, "lt_to_lte", "<"), None);
     }
 }

--- a/src/equivalent.rs
+++ b/src/equivalent.rs
@@ -63,9 +63,10 @@ pub(crate) fn advisories_for(report: &MutationReport) -> BTreeMap<u32, LikelyEqu
         let parsed = sources
             .entry(mutation.file.clone())
             .or_insert_with(|| ParsedSource::load(&mutation.file));
-        if let Some(parsed) = parsed.as_ref()
-            && let Some(reason) = likely_equivalent_reason(mutation, parsed)
-        {
+        let Some(parsed) = parsed.as_ref() else {
+            continue;
+        };
+        if let Some(reason) = likely_equivalent_reason(mutation, parsed) {
             advisories.insert(mutation.id, reason);
         }
     }

--- a/src/equivalent.rs
+++ b/src/equivalent.rs
@@ -1,0 +1,395 @@
+//! Conservative, advisory hints for surviving mutants that are likely equivalent.
+//!
+//! These heuristics deliberately use only local syntax. They never alter a mutation verdict,
+//! score, or gate: a false negative is preferable to hiding a real test gap.
+
+use crate::languages::LanguageSupport;
+use crate::{Mutation, MutationReport, MutationResult};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tree_sitter::{Node, Tree};
+
+/// Why a surviving mutant is likely equivalent under a narrow syntax-only rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LikelyEquivalentReason {
+    CapacityHint,
+    RedundantBoundary,
+}
+
+impl LikelyEquivalentReason {
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            Self::CapacityHint => {
+                "changes only a Vec/String preallocation capacity hint under normal allocation behavior"
+            }
+            Self::RedundantBoundary => {
+                "a stricter `&&` sibling check already excludes the changed boundary"
+            }
+        }
+    }
+}
+
+struct ParsedSource {
+    source: String,
+    tree: Tree,
+    language: Box<dyn LanguageSupport>,
+}
+
+impl ParsedSource {
+    fn load(path: &Path) -> Option<Self> {
+        let source = fs::read_to_string(path).ok()?;
+        let (tree, language) = crate::parser::parse_file(path, source.as_bytes()).ok()?;
+        Some(Self {
+            source,
+            tree,
+            language,
+        })
+    }
+}
+
+/// Return advisory reasons for surviving mutations, keyed by mutation id.
+///
+/// Source files are read and parsed once per file. If the current source cannot be
+/// read or parsed, the mutation stays a plain survivor rather than receiving a hint.
+pub(crate) fn advisories_for(report: &MutationReport) -> BTreeMap<u32, LikelyEquivalentReason> {
+    let mut sources = BTreeMap::<PathBuf, Option<ParsedSource>>::new();
+    let mut advisories = BTreeMap::new();
+
+    for (mutation, result) in &report.results {
+        if *result != MutationResult::Survived {
+            continue;
+        }
+        let parsed = sources
+            .entry(mutation.file.clone())
+            .or_insert_with(|| ParsedSource::load(&mutation.file));
+        if let Some(parsed) = parsed.as_ref()
+            && let Some(reason) = likely_equivalent_reason(mutation, parsed)
+        {
+            advisories.insert(mutation.id, reason);
+        }
+    }
+
+    advisories
+}
+
+fn likely_equivalent_reason(
+    mutation: &Mutation,
+    parsed: &ParsedSource,
+) -> Option<LikelyEquivalentReason> {
+    // The first rules rely on Rust's exact AST shapes. Do not infer intent for
+    // other languages until they have equally narrow, tested rules.
+    if mutation.language != "rust" || parsed.language.name() != "rust" {
+        return None;
+    }
+    if parsed.source.as_bytes().get(mutation.byte_range.clone())
+        != Some(mutation.original.as_bytes())
+    {
+        return None;
+    }
+
+    if changes_capacity_hint(mutation, parsed) {
+        return Some(LikelyEquivalentReason::CapacityHint);
+    }
+    if has_redundant_boundary(mutation, parsed) {
+        return Some(LikelyEquivalentReason::RedundantBoundary);
+    }
+    None
+}
+
+fn changes_capacity_hint(mutation: &Mutation, parsed: &ParsedSource) -> bool {
+    if !matches!(
+        mutation.operator.as_str(),
+        "zero_to_one" | "increment_numeric" | "decrement_numeric"
+    ) || !is_unsigned_decimal(&mutation.original)
+        || !is_unsigned_decimal(&mutation.replacement)
+    {
+        return false;
+    }
+
+    let Some(mut node) = parsed
+        .tree
+        .root_node()
+        .descendant_for_byte_range(mutation.byte_range.start, mutation.byte_range.end)
+    else {
+        return false;
+    };
+
+    loop {
+        if node.kind() == "call_expression"
+            && let (Some(function), Some(arguments)) = (
+                node.child_by_field_name("function"),
+                node.child_by_field_name("arguments"),
+            )
+            && function
+                .utf8_text(parsed.source.as_bytes())
+                .ok()
+                .is_some_and(is_standard_capacity_constructor)
+            && arguments.named_child_count() == 1
+            && arguments
+                .named_child(0)
+                .is_some_and(|argument| argument.byte_range() == mutation.byte_range)
+        {
+            return true;
+        }
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        node = parent;
+    }
+}
+
+fn is_standard_capacity_constructor(function: &str) -> bool {
+    matches!(
+        function,
+        "Vec::with_capacity"
+            | "String::with_capacity"
+            | "std::vec::Vec::with_capacity"
+            | "std::string::String::with_capacity"
+            | "alloc::vec::Vec::with_capacity"
+            | "alloc::string::String::with_capacity"
+    )
+}
+
+fn is_unsigned_decimal(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn has_redundant_boundary(mutation: &Mutation, parsed: &ParsedSource) -> bool {
+    let expected_operator = match mutation.operator.as_str() {
+        "lt_to_lte" => "<",
+        "gt_to_gte" => ">",
+        _ => return false,
+    };
+    if mutation.original != expected_operator {
+        return false;
+    }
+
+    let Some(comparison) = binary_mutation_node(mutation, parsed) else {
+        return false;
+    };
+    let Some(mut logical_and) = comparison.parent() else {
+        return false;
+    };
+    while logical_and.kind() == "parenthesized_expression" {
+        let Some(parent) = logical_and.parent() else {
+            return false;
+        };
+        logical_and = parent;
+    }
+    if logical_and.kind() != parsed.language.binary_expression_node() {
+        return false;
+    }
+
+    let source = parsed.source.as_bytes();
+    let Some((left, and_range, right)) = binary_parts(logical_and, source) else {
+        return false;
+    };
+    if source.get(and_range.clone()) != Some(&b"&&"[..]) {
+        return false;
+    }
+    let comparison_range = comparison.byte_range();
+    let sibling_range = if comparison_range == left.byte_range() {
+        right.byte_range()
+    } else if comparison_range == right.byte_range() {
+        left.byte_range()
+    } else {
+        return false;
+    };
+
+    let Some(mutated) = bound_comparison(
+        source.get(comparison_range.start..mutation.byte_range.start),
+        expected_operator,
+        source.get(mutation.byte_range.end..comparison_range.end),
+    ) else {
+        return false;
+    };
+    let Some(sibling) = bound_from_source(source.get(sibling_range)) else {
+        return false;
+    };
+
+    mutated.subject == sibling.subject && sibling_excludes_changed_boundary(mutated, sibling)
+}
+
+fn binary_mutation_node<'tree>(
+    mutation: &Mutation,
+    parsed: &'tree ParsedSource,
+) -> Option<Node<'tree>> {
+    let source = parsed.source.as_bytes();
+    let mut node = parsed
+        .tree
+        .root_node()
+        .descendant_for_byte_range(mutation.byte_range.start, mutation.byte_range.end)?;
+    loop {
+        if node.kind() == parsed.language.binary_expression_node()
+            && binary_parts(node, source).is_some_and(|(_, operator_range, _)| {
+                operator_range == mutation.byte_range
+                    && source.get(operator_range) == Some(mutation.original.as_bytes())
+            })
+        {
+            return Some(node);
+        }
+        node = node.parent()?;
+    }
+}
+fn binary_parts<'tree>(
+    node: Node<'tree>,
+    source: &[u8],
+) -> Option<(Node<'tree>, std::ops::Range<usize>, Node<'tree>)> {
+    let left = node.child_by_field_name("left")?;
+    let right = node.child_by_field_name("right")?;
+    let mut start = left.end_byte();
+    let mut end = right.start_byte();
+    while start < end && source.get(start).is_some_and(u8::is_ascii_whitespace) {
+        start += 1;
+    }
+    while end > start && source.get(end - 1).is_some_and(u8::is_ascii_whitespace) {
+        end -= 1;
+    }
+    (start < end).then_some((left, start..end, right))
+}
+
+#[derive(Clone, Copy)]
+struct Bound<'a> {
+    subject: &'a str,
+    operator: BoundOperator,
+    value: i128,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BoundOperator {
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+}
+
+fn bound_from_source(source: Option<&[u8]>) -> Option<Bound<'_>> {
+    let source = std::str::from_utf8(source?).ok()?.trim();
+    for (token, operator) in [
+        ("<=", BoundOperator::LessEqual),
+        (">=", BoundOperator::GreaterEqual),
+        ("<", BoundOperator::Less),
+        (">", BoundOperator::Greater),
+    ] {
+        if let Some((subject, value)) = source.split_once(token) {
+            return bound_comparison(Some(subject.as_bytes()), token, Some(value.as_bytes())).map(
+                |mut bound| {
+                    bound.operator = operator;
+                    bound
+                },
+            );
+        }
+    }
+    None
+}
+
+fn bound_comparison<'a>(
+    subject: Option<&'a [u8]>,
+    operator: &str,
+    value: Option<&'a [u8]>,
+) -> Option<Bound<'a>> {
+    let subject = std::str::from_utf8(subject?).ok()?.trim();
+    let value = std::str::from_utf8(value?).ok()?.trim();
+    let operator = match operator {
+        "<" => BoundOperator::Less,
+        "<=" => BoundOperator::LessEqual,
+        ">" => BoundOperator::Greater,
+        ">=" => BoundOperator::GreaterEqual,
+        _ => return None,
+    };
+    is_simple_identifier(subject).then_some(Bound {
+        subject,
+        operator,
+        value: parse_i128(value)?,
+    })
+}
+
+fn is_simple_identifier(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    matches!(bytes.next(), Some(b'a'..=b'z' | b'A'..=b'Z' | b'_'))
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn parse_i128(value: &str) -> Option<i128> {
+    value.parse().ok()
+}
+
+fn sibling_excludes_changed_boundary(mutated: Bound<'_>, sibling: Bound<'_>) -> bool {
+    match (mutated.operator, sibling.operator) {
+        (BoundOperator::Less, BoundOperator::Less) => sibling.value <= mutated.value,
+        (BoundOperator::Less, BoundOperator::LessEqual) => sibling.value < mutated.value,
+        (BoundOperator::Greater, BoundOperator::Greater) => sibling.value >= mutated.value,
+        (BoundOperator::Greater, BoundOperator::GreaterEqual) => sibling.value > mutated.value,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn mutation(source: &str, operator: &str, original: &str) -> Mutation {
+        let start = source.find(original).unwrap();
+        Mutation {
+            id: 0,
+            file: PathBuf::from("fixture.rs"),
+            language: "rust".into(),
+            line: 1,
+            column: start + 1,
+            operator: operator.into(),
+            description: String::new(),
+            original: original.into(),
+            replacement: match operator {
+                "lt_to_lte" => "<=".into(),
+                "gt_to_gte" => ">=".into(),
+                "decrement_numeric" => "15".into(),
+                _ => "17".into(),
+            },
+            byte_range: start..start + original.len(),
+        }
+    }
+
+    fn reason(source: &str, operator: &str, original: &str) -> Option<LikelyEquivalentReason> {
+        let mutation = mutation(source, operator, original);
+        let (tree, language) =
+            crate::parser::parse_file(&mutation.file, source.as_bytes()).unwrap();
+        let parsed = ParsedSource {
+            source: source.into(),
+            tree,
+            language,
+        };
+        likely_equivalent_reason(&mutation, &parsed)
+    }
+
+    #[test]
+    fn marks_standard_collection_capacity_literal_mutations() {
+        let source = "fn make() { let _items = Vec::with_capacity(16); }";
+        assert_eq!(
+            reason(source, "increment_numeric", "16"),
+            Some(LikelyEquivalentReason::CapacityHint)
+        );
+    }
+
+    #[test]
+    fn leaves_nonstandard_capacity_calls_unannotated() {
+        let source = "fn make() { let _items = Buffer::with_capacity(16); }";
+        assert_eq!(reason(source, "increment_numeric", "16"), None);
+    }
+
+    #[test]
+    fn marks_weakened_bound_masked_by_stricter_conjunction() {
+        let source = "fn valid(value: i32) -> bool { value < 10 && value <= 9 }";
+        assert_eq!(
+            reason(source, "lt_to_lte", "<"),
+            Some(LikelyEquivalentReason::RedundantBoundary)
+        );
+    }
+
+    #[test]
+    fn leaves_equal_sibling_bound_unannotated() {
+        let source = "fn valid(value: i32) -> bool { value < 10 && value <= 10 }";
+        assert_eq!(reason(source, "lt_to_lte", "<"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod coverage;
 pub mod diff;
+mod equivalent;
 pub mod languages;
 pub mod learned;
 pub mod lock;

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -6,6 +6,7 @@ fn format_annotation_with_baseline(
     execution: MutationExecution,
     status: Option<crate::baseline::SurvivorBaselineStatus>,
     selection: Option<TestSelectionProvenance>,
+    advisory: Option<&str>,
 ) -> String {
     let provenance = match execution {
         MutationExecution::Executed => String::new(),
@@ -19,8 +20,11 @@ fn format_annotation_with_baseline(
     let selection = selection
         .map(|selection| format!(" [selection: {selection}]"))
         .unwrap_or_default();
+    let advisory = advisory
+        .map(|reason| format!(" [likely equivalent (advisory): {reason}]"))
+        .unwrap_or_default();
     let message = format!(
-        "Survived mutation: {} ({}){provenance}{baseline}{selection}",
+        "Survived mutation: {} ({}){provenance}{baseline}{selection}{advisory}",
         mutation.operator, mutation.description
     );
     format!(
@@ -47,6 +51,7 @@ fn annotations_with_baseline(
     report: &MutationReport,
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> Vec<String> {
+    let advisories = crate::equivalent::advisories_for(report);
     report
         .results
         .iter()
@@ -57,6 +62,7 @@ fn annotations_with_baseline(
                 report.execution_for(mutation.id, *result),
                 comparison.and_then(|comparison| comparison.status_for(mutation.id)),
                 report.selection_for(mutation.id),
+                advisories.get(&mutation.id).map(|reason| reason.message()),
             )
         })
         .collect()
@@ -131,6 +137,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
+    use tempfile::TempDir;
 
     fn mutation(file: &str, line: usize, operator: &str, description: &str) -> Mutation {
         Mutation {
@@ -179,11 +186,28 @@ mod tests {
     #[test]
     fn annotation_format_for_survived_mutation() {
         let m = mutation("src/auth.rs", 47, "lt_to_lte", "changed < to <=");
-        let line = format_annotation_with_baseline(&m, MutationExecution::Executed, None, None);
+        let line =
+            format_annotation_with_baseline(&m, MutationExecution::Executed, None, None, None);
         assert_eq!(
             line,
             "::warning file=src/auth.rs,line=47::Survived mutation: lt_to_lte (changed < to <=)"
         );
+    }
+
+    #[test]
+    fn annotation_marks_likely_equivalent_survivors_as_advisory() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fixture.rs");
+        std::fs::write(&path, crate::test_helpers::CAPACITY_HINT_SOURCE).unwrap();
+        let report = report_with(vec![(
+            crate::test_helpers::capacity_hint_mutation(path),
+            MutationResult::Survived,
+        )]);
+
+        let annotations = annotations_with_baseline(&report, None);
+
+        assert_eq!(annotations.len(), 1);
+        assert!(annotations[0].contains("likely equivalent (advisory): changes only a Vec/String preallocation capacity hint under normal allocation behavior"));
     }
 
     #[test]
@@ -286,6 +310,7 @@ mod tests {
             &m,
             MutationExecution::Executed,
             Some(crate::baseline::SurvivorBaselineStatus::Historic),
+            None,
             None,
         );
         assert_eq!(

--- a/src/report/github.rs
+++ b/src/report/github.rs
@@ -198,16 +198,16 @@ mod tests {
     fn annotation_marks_likely_equivalent_survivors_as_advisory() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("fixture.rs");
-        std::fs::write(&path, crate::test_helpers::CAPACITY_HINT_SOURCE).unwrap();
+        std::fs::write(&path, crate::test_helpers::BOOLEAN_LITERAL_SOURCE).unwrap();
         let report = report_with(vec![(
-            crate::test_helpers::capacity_hint_mutation(path),
+            crate::test_helpers::boolean_literal_mutation(path),
             MutationResult::Survived,
         )]);
 
         let annotations = annotations_with_baseline(&report, None);
 
         assert_eq!(annotations.len(), 1);
-        assert!(annotations[0].contains("likely equivalent (advisory): changes only a Vec/String preallocation capacity hint under normal allocation behavior"));
+        assert!(annotations[0].contains("likely equivalent (advisory): both operands are the same boolean literal, so either logical operator produces the same value"));
     }
 
     #[test]

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -37,6 +37,7 @@ struct MutationEntry {
     result: &'static str,
     execution: String,
     baseline_status: Option<&'static str>,
+    likely_equivalent: Option<&'static str>,
 }
 
 pub fn generate_report(report: &MutationReport) -> Result<String> {
@@ -47,6 +48,7 @@ pub fn generate_report_with_baseline(
     report: &MutationReport,
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> Result<String> {
+    let equivalent_advisories = crate::equivalent::advisories_for(report);
     let mut files: BTreeMap<String, FileStats> = BTreeMap::new();
 
     for (mutation, result) in &report.results {
@@ -100,6 +102,9 @@ pub fn generate_report_with_baseline(
                 .then(|| comparison.and_then(|comparison| comparison.status_for(mutation.id)))
                 .flatten()
                 .map(|status| status.as_str()),
+            likely_equivalent: equivalent_advisories
+                .get(&mutation.id)
+                .map(|reason| reason.message()),
         });
     }
 
@@ -293,6 +298,15 @@ pub fn generate_report_with_baseline(
                 "subsumed" => "result-subsumed",
                 _ => "result-build-error",
             };
+            let advisory = m
+                .likely_equivalent
+                .map(|reason| {
+                    format!(
+                        "<br><small>Likely equivalent (advisory): {}</small>",
+                        html_escape(reason)
+                    )
+                })
+                .unwrap_or_default();
             if comparison.is_some() {
                 let baseline_status = m.baseline_status.map(html_escape).unwrap_or_default();
                 write!(
@@ -300,7 +314,7 @@ pub fn generate_report_with_baseline(
                     "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
                      <td><code class=\"orig\">{}</code></td>\
                      <td><code class=\"repl\">{}</code></td>\
-                     <td>{}</td><td>{}</td><td>{}</td></tr>",
+                     <td>{}{}</td><td>{}</td><td>{}</td></tr>",
                     result_class,
                     m.line,
                     html_escape(&m.operator),
@@ -308,6 +322,7 @@ pub fn generate_report_with_baseline(
                     html_escape(&m.original),
                     html_escape(&m.replacement),
                     m.result,
+                    advisory,
                     baseline_status,
                     html_escape(&m.execution)
                 )?;
@@ -317,7 +332,7 @@ pub fn generate_report_with_baseline(
                     "<tr class=\"{}\"><td>{}</td><td><code>{}</code></td><td>{}</td>\
                      <td><code class=\"orig\">{}</code></td>\
                      <td><code class=\"repl\">{}</code></td>\
-                     <td>{}</td><td>{}</td></tr>",
+                     <td>{}{}</td><td>{}</td></tr>",
                     result_class,
                     m.line,
                     html_escape(&m.operator),
@@ -325,6 +340,7 @@ pub fn generate_report_with_baseline(
                     html_escape(&m.original),
                     html_escape(&m.replacement),
                     m.result,
+                    advisory,
                     html_escape(&m.execution)
                 )?;
             }

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -125,6 +125,8 @@ struct JsonMutation {
     #[serde(skip_serializing_if = "Option::is_none")]
     baseline_status: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    likely_equivalent: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source_path: Option<String>,
@@ -389,6 +391,7 @@ fn to_json_string_with_baseline_and_replay_optional(
         .iter()
         .map(|diagnostic| (diagnostic.mutation_id, diagnostic))
         .collect();
+    let equivalent_advisories = crate::equivalent::advisories_for(report);
     let mutations: Vec<JsonMutation> = report
         .results
         .iter()
@@ -446,6 +449,9 @@ fn to_json_string_with_baseline_and_replay_optional(
                     .then(|| comparison.and_then(|comparison| comparison.status_for(m.id)))
                     .flatten()
                     .map(|status| status.as_str()),
+                likely_equivalent: equivalent_advisories
+                    .get(&m.id)
+                    .map(|reason| reason.message()),
                 language: replay_fields.as_ref().map(|fields| fields.language.clone()),
                 source_path: replay_fields
                     .as_ref()

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -347,6 +347,7 @@ pub fn format_pr_comment_with_baseline(
     }
     writeln!(md).unwrap();
 
+    let equivalent_advisories = crate::equivalent::advisories_for(report);
     let survived: Vec<_> = report
         .results
         .iter()
@@ -384,6 +385,10 @@ pub fn format_pr_comment_with_baseline(
                 .map(|selection| format!(" (selection: {selection})"))
                 .unwrap_or_default();
             let provenance = format!("{provenance}{selection}");
+            let advisory = equivalent_advisories
+                .get(&mutation.id)
+                .map(|reason| format!(" Likely equivalent (advisory): {}", reason.message()))
+                .unwrap_or_default();
             if let Some(comparison) = comparison {
                 let baseline_status = comparison
                     .status_for(mutation.id)
@@ -391,23 +396,25 @@ pub fn format_pr_comment_with_baseline(
                     .unwrap_or_default();
                 let _ = writeln!(
                     md,
-                    "| `{}` | {} | `{}` | {}{} | {} |",
+                    "| `{}` | {} | `{}` | {}{}{} | {} |",
                     escape_md_cell(&mutation.file.display().to_string()),
                     mutation.line,
                     escape_md_cell(&mutation.operator),
                     escape_md_cell(&mutation.description),
                     provenance,
+                    advisory,
                     baseline_status,
                 );
             } else {
                 let _ = writeln!(
                     md,
-                    "| `{}` | {} | `{}` | {}{} |",
+                    "| `{}` | {} | `{}` | {}{}{} |",
                     escape_md_cell(&mutation.file.display().to_string()),
                     mutation.line,
                     escape_md_cell(&mutation.operator),
                     escape_md_cell(&mutation.description),
                     provenance,
+                    advisory,
                 );
             }
         }
@@ -552,6 +559,32 @@ mod tests {
             },
             result,
         )
+    }
+
+    #[test]
+    fn likely_equivalent_advisory_is_rendered_without_changing_survivor_semantics() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fixture.rs");
+        std::fs::write(&path, crate::test_helpers::CAPACITY_HINT_SOURCE).unwrap();
+        let mut mutation = crate::test_helpers::capacity_hint_mutation(path);
+        mutation.id = 1;
+        let mut report = crate::test_helpers::sample_report();
+        report.results[1] = (mutation, MutationResult::Survived);
+
+        let reason = "changes only a Vec/String preallocation capacity hint under normal allocation behavior";
+        let terminal = crate::report::terminal::format_report_plain(&report);
+        let json = crate::report::json::to_json_string(&report).unwrap();
+        let html = crate::report::html::generate_report(&report).unwrap();
+        let sarif = crate::report::sarif::to_sarif_string(&report).unwrap();
+        let comment = format_pr_comment(&report, None);
+
+        assert!(terminal.contains(&format!("Likely equivalent (advisory): {reason}")));
+        assert!(terminal.contains("SURVIVED"));
+        assert!(json.contains(&format!("\"likely_equivalent\": \"{reason}\"")));
+        assert!(html.contains(&format!("Likely equivalent (advisory): {reason}")));
+        assert!(sarif.contains(&format!("\"likely_equivalent\": \"{reason}\"")));
+        assert!(comment.contains(&format!("Likely equivalent (advisory): {reason}")));
+        assert_eq!(report.survived, 1);
     }
 
     #[test]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -565,13 +565,13 @@ mod tests {
     fn likely_equivalent_advisory_is_rendered_without_changing_survivor_semantics() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("fixture.rs");
-        std::fs::write(&path, crate::test_helpers::CAPACITY_HINT_SOURCE).unwrap();
-        let mut mutation = crate::test_helpers::capacity_hint_mutation(path);
+        std::fs::write(&path, crate::test_helpers::BOOLEAN_LITERAL_SOURCE).unwrap();
+        let mut mutation = crate::test_helpers::boolean_literal_mutation(path);
         mutation.id = 1;
         let mut report = crate::test_helpers::sample_report();
         report.results[1] = (mutation, MutationResult::Survived);
 
-        let reason = "changes only a Vec/String preallocation capacity hint under normal allocation behavior";
+        let reason = "both operands are the same boolean literal, so either logical operator produces the same value";
         let terminal = crate::report::terminal::format_report_plain(&report);
         let json = crate::report::json::to_json_string(&report).unwrap();
         let html = crate::report::html::generate_report(&report).unwrap();

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -153,6 +153,8 @@ struct SarifResultProperties {
     test_selection_mode: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     selection_confirmation: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    likely_equivalent: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -195,13 +197,17 @@ fn result_for_with_baseline(
     execution: MutationExecution,
     status: Option<crate::baseline::SurvivorBaselineStatus>,
     selection: Option<TestSelectionProvenance>,
+    advisory: Option<&'static str>,
 ) -> SarifResult {
+    let advisory_suffix = advisory
+        .map(|reason| format!(" Likely equivalent (advisory): {reason}."))
+        .unwrap_or_default();
     SarifResult {
         rule_id: mutation.operator.clone(),
         level: "warning",
         message: SarifMessage {
             text: format!(
-                "Survived mutation: {} ({} → {})",
+                "Survived mutation: {} ({} → {}){advisory_suffix}",
                 mutation.description, mutation.original, mutation.replacement
             ),
         },
@@ -218,17 +224,20 @@ fn result_for_with_baseline(
                 },
             },
         }],
-        properties: (!execution.is_tested() || status.is_some() || selection.is_some()).then(
-            || SarifResultProperties {
-                execution: execution.state_name(),
-                nonexecution_reason: execution.reason().map(|reason| reason.name()),
-                baseline_status: status.map(|status| status.as_str()),
-                test_selection_mode: selection.map(|selection| selection.mode_name()),
-                selection_confirmation: selection
-                    .and_then(|selection| selection.confirmation())
-                    .map(|confirmation| confirmation.name()),
-            },
-        ),
+        properties: (!execution.is_tested()
+            || status.is_some()
+            || selection.is_some()
+            || advisory.is_some())
+        .then(|| SarifResultProperties {
+            execution: execution.state_name(),
+            nonexecution_reason: execution.reason().map(|reason| reason.name()),
+            baseline_status: status.map(|status| status.as_str()),
+            test_selection_mode: selection.map(|selection| selection.mode_name()),
+            selection_confirmation: selection
+                .and_then(|selection| selection.confirmation())
+                .map(|confirmation| confirmation.name()),
+            likely_equivalent: advisory,
+        }),
     }
 }
 
@@ -270,6 +279,7 @@ pub fn to_sarif_string_with_baseline(
     comparison: Option<&crate::baseline::SurvivorBaselineComparison>,
 ) -> Result<String> {
     let registry = registry_descriptions();
+    let equivalent_advisories = crate::equivalent::advisories_for(report);
     let surviving: Vec<(&Mutation, MutationExecution)> = report
         .results
         .iter()
@@ -330,6 +340,9 @@ pub fn to_sarif_string_with_baseline(
                         *execution,
                         comparison.and_then(|comparison| comparison.status_for(mutation.id)),
                         report.selection_for(mutation.id),
+                        equivalent_advisories
+                            .get(&mutation.id)
+                            .map(|reason| reason.message()),
                     )
                 })
                 .collect(),

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -70,6 +70,7 @@ fn format_report(
     let mut out = String::new();
     writeln!(out).unwrap();
     let execution_counts = report.execution_counts();
+    let equivalent_advisories = crate::equivalent::advisories_for(report);
 
     for (mutation, result) in &report.results {
         let file = mutation.file.display().to_string();
@@ -97,6 +98,13 @@ fn format_report(
                     }
                 )
                 .unwrap();
+                if let Some(reason) = equivalent_advisories.get(&mutation.id) {
+                    let _ = writeln!(
+                        detail,
+                        "              Likely equivalent (advisory): {}",
+                        reason.message()
+                    );
+                }
                 if let Some(status) =
                     comparison.and_then(|comparison| comparison.status_for(mutation.id))
                 {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -59,22 +59,22 @@ pub fn sample_report() -> MutationReport {
 }
 
 /// Rust source and mutation used to exercise likely-equivalent report annotations.
-pub const CAPACITY_HINT_SOURCE: &str = "fn make() { let _items = Vec::with_capacity(16); }\n";
+pub const BOOLEAN_LITERAL_SOURCE: &str = "pub fn always() -> bool { true && true }\n";
 
-pub fn capacity_hint_mutation(path: PathBuf) -> Mutation {
-    let start = CAPACITY_HINT_SOURCE
-        .find("16")
-        .expect("capacity hint fixture contains its literal");
+pub fn boolean_literal_mutation(path: PathBuf) -> Mutation {
+    let start = BOOLEAN_LITERAL_SOURCE
+        .find("&&")
+        .expect("boolean literal fixture contains its operator");
     Mutation {
         id: 0,
         file: path,
         language: "rust".into(),
         line: 1,
         column: start + 1,
-        operator: "increment_numeric".into(),
-        description: "Replace n with n+1".into(),
-        original: "16".into(),
-        replacement: "17".into(),
+        operator: "and_to_or".into(),
+        description: "Replace && with ||".into(),
+        original: "&&".into(),
+        replacement: "||".into(),
         byte_range: start..start + 2,
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -58,6 +58,27 @@ pub fn sample_report() -> MutationReport {
     }
 }
 
+/// Rust source and mutation used to exercise likely-equivalent report annotations.
+pub const CAPACITY_HINT_SOURCE: &str = "fn make() { let _items = Vec::with_capacity(16); }\n";
+
+pub fn capacity_hint_mutation(path: PathBuf) -> Mutation {
+    let start = CAPACITY_HINT_SOURCE
+        .find("16")
+        .expect("capacity hint fixture contains its literal");
+    Mutation {
+        id: 0,
+        file: path,
+        language: "rust".into(),
+        line: 1,
+        column: start + 1,
+        operator: "increment_numeric".into(),
+        description: "Replace n with n+1".into(),
+        original: "16".into(),
+        replacement: "17".into(),
+        byte_range: start..start + 2,
+    }
+}
+
 /// Parse Go source code into a tree-sitter tree.
 pub fn parse_go(src: &str) -> tree_sitter::Tree {
     let mut parser = tree_sitter::Parser::new();


### PR DESCRIPTION
Closes #455

## Summary
- Flag only Rust survivors that are structurally value-preserving: identical boolean literals and redundant primitive-integer boundaries in direct function bodies.
- Render the advisory reason in terminal, JSON, GitHub, PR-comment, HTML, and SARIF output without changing score or gate semantics.

## Validation
- `cargo test --locked`
- `cargo +1.87 test --locked`
- `cargo test --locked --test integration -- --ignored --skip csharp_fixture_runs_end_to_end`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Real `togi check --all --path src/togi_455_smoke.rs --operators and_to_or --max-per-run 1 --jobs 1 --timeout 90 --test-cmd "cargo test --quiet" --format json` smoke: one surviving `true && true` → `true || true` mutant retained `survived` and emitted `likely_equivalent`.

The C# ignored fixture was skipped because `dotnet` is unavailable on this host.