### PR TITLE
chore(release): prepare v0.5.0 source package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "togi"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cap-fs-ext",


### PR DESCRIPTION
Updates package and lock metadata only for v0.5.0.

Public install documentation remains at verified v0.4.1 until publication, per `docs/PUBLISHING.md`.

Refs #450 and #489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->