### PR TITLE
feat(bench): add PR-loop calibration acquisition

### DIFF
--- a/.github/workflows/pr-loop-calibration.yml
+++ b/.github/workflows/pr-loop-calibration.yml
@@ -1,0 +1,80 @@
+name: PR-loop Calibration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    if: github.ref == 'refs/heads/main'
+    name: Acquire PR-loop calibration evidence
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Assert native Linux x86_64 runner
+        shell: bash
+        env:
+          TOGI_EXPECTED_TARGET: x86_64-unknown-linux-gnu
+          TOGI_EXPECTED_ARCH: x86_64
+        run: bash ./.github/scripts/assert-native-target.sh
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+      - name: Check benchmark prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          for tool in bash git go jq sed sha256sum python3; do
+            command -v "$tool" >/dev/null 2>&1 || {
+              echo "missing calibration prerequisite: $tool" >&2
+              exit 1
+            }
+          done
+      - name: Build release binary
+        run: cargo build --locked --release
+      - name: Acquire five independent samples
+        shell: bash
+        env:
+          TOGI_BIN: ${{ github.workspace }}/target/release/togi
+          BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
+          CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration
+        run: |
+          set -euo pipefail
+          mkdir -p "$CALIBRATION_OUTPUT"
+          for sample in 1 2 3 4 5; do
+            bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$CALIBRATION_OUTPUT/sample-$sample"
+          done
+      - name: Collect candidate calibration
+        shell: bash
+        env:
+          CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration
+        run: |
+          set -euo pipefail
+          python3 benchmarks/pr-loop/collect-calibration.py \
+            --output "$CALIBRATION_OUTPUT/pr-loop-calibration-candidate.json" \
+            --source-commit "${GITHUB_SHA}" \
+            --source-run "${GITHUB_RUN_ID}" \
+            --source-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --source-utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            "$CALIBRATION_OUTPUT/sample-1/pr-loop-benchmark-result.json" \
+            "$CALIBRATION_OUTPUT/sample-2/pr-loop-benchmark-result.json" \
+            "$CALIBRATION_OUTPUT/sample-3/pr-loop-benchmark-result.json" \
+            "$CALIBRATION_OUTPUT/sample-4/pr-loop-benchmark-result.json" \
+            "$CALIBRATION_OUTPUT/sample-5/pr-loop-benchmark-result.json"
+      - name: Upload calibration evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pr-loop-calibration-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/togi-pr-loop-calibration
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -290,6 +290,15 @@ matching older `.togi-cache` entries. Structured incremental history is stored
 under `.togi-cache/history.json`; it can reuse killed/survived results when the
 mutant source, command context, and relevant covering tests are unchanged.
 
+## PR-loop calibration acquisition
+
+Maintainers may manually dispatch **PR-loop Calibration** from `main`. It runs five
+independent, observational-only Linux x86_64 harness samples and uploads a
+14-day artifact containing raw outputs and a candidate calibration JSON. It does
+not create a baseline, compare results, or gate CI. A later, separately reviewed
+baseline-activation PR must inspect that artifact and explicitly define any
+comparison policy; do not copy or invent a candidate baseline by hand.
+
 ## Configuration
 
 Optional. togi auto-detects a test command where supported; see [Before first run](#before-first-run) for its exact scope, prerequisites, and support boundaries.

--- a/benchmarks/pr-loop/collect-calibration.py
+++ b/benchmarks/pr-loop/collect-calibration.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Fail-closed collector for five comparable PR-loop benchmark results."""
+import argparse
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+import statistics
+import sys
+
+EXPECTED_KIND = "togi_pr_loop_benchmark_result"
+EXPECTED_SCHEMA = 1
+SAMPLE_COUNT = 5
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "benchmarks/pr-loop/manifest.json"
+PATCH_PATH = ROOT / "benchmarks/pr-loop/fixture-change.patch"
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def exact_int(value):
+    return type(value) is int
+
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def require(value, predicate, message):
+    if not predicate(value):
+        fail(message)
+    return value
+
+
+def digest_file(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def digest_tree(path):
+    if not path.is_dir():
+        fail(f"fixture source directory is unavailable: {path}")
+    digest = hashlib.sha256()
+    for child in sorted(path.rglob("*")):
+        if child.is_file():
+            digest.update(child.relative_to(path).as_posix().encode() + b"\0")
+            digest.update(child.read_bytes())
+    return digest.hexdigest()
+
+
+def load_json(path):
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid JSON result {path}: {error}")
+    return require(value, lambda item: isinstance(item, dict), f"result {path} is not a JSON object")
+
+
+def normalized_workload(workload, path):
+    require(workload, lambda item: isinstance(item, dict), f"{path}: workload is not an object")
+    command = require(workload.get("command"), lambda item: isinstance(item, list) and item and all(nonempty_string(arg) for arg in item), f"{path}: workload command is invalid")
+    semantics = require(workload.get("semantics"), lambda item: isinstance(item, dict), f"{path}: workload semantics are invalid")
+    value = {key: item for key, item in workload.items() if key not in {"timing", "artifacts", "command"}}
+    value["command_args"] = command[1:]
+    value["semantics"] = {key: item for key, item in semantics.items() if key != "reported_duration_ms"}
+    return value
+
+
+def validate_fixture_path(value, manifest_fixture_dir):
+    require(value, lambda item: item == manifest_fixture_dir, "fixture source dir differs from manifest")
+    path = Path(value)
+    require(value, lambda item: not path.is_absolute() and ".." not in path.parts, "fixture source dir must be a repository-relative path")
+    resolved = (ROOT / path).resolve()
+    try:
+        resolved.relative_to(ROOT.resolve())
+    except ValueError:
+        fail("fixture source dir escapes repository root")
+    return resolved
+
+
+def validate_result(result, path, expected_workloads, manifest_fixture_dir):
+    require(result.get("kind"), lambda item: item == EXPECTED_KIND, f"{path}: wrong result kind")
+    require(result.get("schema_version"), lambda item: item == EXPECTED_SCHEMA, f"{path}: wrong result schema")
+    require(result.get("timing_policy"), lambda item: item == "observational-only", f"{path}: wrong timing policy")
+    require(result.get("ok"), lambda item: item is True, f"{path}: result is not ok")
+    require(result.get("failures"), lambda item: item == [], f"{path}: result has failures")
+    require(result.get("manifest"), lambda item: item == {"name": "togi-pr-loop-benchmarks", "schema_version": 1, "path": "benchmarks/pr-loop/manifest.json"}, f"{path}: manifest identity mismatch")
+    provenance = require(result.get("provenance"), lambda item: isinstance(item, dict), f"{path}: missing provenance")
+    for key in ("runner_label", "os", "arch", "kernel_release", "fixture_source_dir", "fixture_patch", "fixture_patch_sha256", "togi_version", "report_kind", "go_version", "git_version"):
+        require(provenance.get(key), nonempty_string, f"{path}: invalid provenance.{key}")
+    require(provenance.get("logical_cpu_count"), lambda item: exact_int(item) and item > 0, f"{path}: invalid provenance.logical_cpu_count")
+    require(provenance.get("report_schema_version"), exact_int, f"{path}: invalid provenance.report_schema_version")
+    for key in ("image_os", "image_version"):
+        require(provenance.get(key), lambda item: item is None or nonempty_string(item), f"{path}: invalid provenance.{key}")
+    fixture_dir = validate_fixture_path(provenance["fixture_source_dir"], manifest_fixture_dir)
+    cross_workload = require(result.get("cross_workload"), lambda item: isinstance(item, dict), f"{path}: missing cross-workload evidence")
+    require(cross_workload.get("mutation_identity_consistent"), lambda item: item is True, f"{path}: cross-workload mutation identity is invalid")
+    require(cross_workload.get("mutation_identity_sha256"), nonempty_string, f"{path}: missing mutation identity digest")
+    workloads = require(result.get("workloads"), lambda item: isinstance(item, list), f"{path}: missing workloads")
+    names = [item.get("name") if isinstance(item, dict) else None for item in workloads]
+    require(names, lambda item: item == expected_workloads, f"{path}: workload order mismatch")
+    for workload in workloads:
+        name = workload.get("name") if isinstance(workload, dict) else "unknown"
+        require(workload, lambda item: isinstance(item, dict), f"{path}: workload {name} is malformed")
+        require(workload.get("ok"), lambda item: item is True, f"{path}: workload {name} is not ok")
+        require(workload.get("invariants"), lambda item: isinstance(item, list) and item and all(isinstance(invariant, dict) and invariant.get("ok") is True for invariant in item), f"{path}: workload {name} has failed invariants")
+        timing = require(workload.get("timing"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks timing")
+        for key in ("wall_ms", "reported_duration_ms"):
+            require(timing.get(key), lambda item: exact_int(item) and item >= 0, f"{path}: workload {name} has invalid {key}")
+        normalized_workload(workload, path)
+    return provenance, workloads, fixture_dir
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path, help="new candidate JSON path")
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--source-run", required=True)
+    parser.add_argument("--source-attempt", required=True, type=int)
+    parser.add_argument("--source-utc", required=True, help="UTC timestamp in RFC 3339 Z form")
+    parser.add_argument("results", nargs="+", type=Path, help="exactly five normalized result files")
+    args = parser.parse_args(argv)
+    if len(args.results) != SAMPLE_COUNT:
+        fail(f"expected exactly {SAMPLE_COUNT} results, received {len(args.results)}")
+    resolved_results = [path.resolve() for path in args.results]
+    if len(set(resolved_results)) != SAMPLE_COUNT:
+        fail("result paths must name five independent files")
+    try:
+        result_digests = [digest_file(path) for path in resolved_results]
+    except OSError as error:
+        fail(f"cannot digest normalized result: {error}")
+    if len(set(result_digests)) != SAMPLE_COUNT:
+        fail("normalized results must have five distinct content digests")
+    if args.source_attempt < 1 or not nonempty_string(args.source_commit) or not nonempty_string(args.source_run):
+        fail("source commit, run, and positive attempt are required")
+    try:
+        datetime.strptime(args.source_utc, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        fail("source UTC must be RFC 3339 UTC (YYYY-MM-DDTHH:MM:SSZ)")
+    if args.output.exists():
+        fail(f"output already exists: {args.output}")
+    manifest = load_json(MANIFEST_PATH)
+    fixture = require(manifest.get("fixture"), lambda item: isinstance(item, dict), "manifest fixture is invalid")
+    manifest_fixture_dir = require(fixture.get("source_dir"), lambda item: nonempty_string(item) and not Path(item).is_absolute() and ".." not in Path(item).parts, "manifest fixture source dir is invalid")
+    fixture_dir = validate_fixture_path(manifest_fixture_dir, manifest_fixture_dir)
+    expected_workloads = [item.get("name") if isinstance(item, dict) else None for item in manifest.get("workloads", [])]
+    require(expected_workloads, lambda item: item and all(nonempty_string(name) for name in item), "manifest has no valid workloads")
+    parsed = [(path, load_json(path)) for path in resolved_results]
+    validated = [validate_result(value, path, expected_workloads, manifest_fixture_dir) for path, value in parsed]
+    first_provenance, first_workloads, _ = validated[0]
+    identity = {
+        "manifest": parsed[0][1]["manifest"],
+        "fixture_source_dir": first_provenance["fixture_source_dir"],
+        "fixture_patch": first_provenance["fixture_patch"],
+        "fixture_patch_sha256": first_provenance["fixture_patch_sha256"],
+        "mutation_identity_sha256": parsed[0][1]["cross_workload"]["mutation_identity_sha256"],
+        "workloads": [normalized_workload(item, parsed[0][0]) for item in first_workloads],
+    }
+    runner_class = {key: first_provenance[key] for key in ("runner_label", "os", "arch", "logical_cpu_count")}
+    execution_provenance = {key: first_provenance[key] for key in ("togi_version", "report_kind", "report_schema_version", "go_version", "git_version")}
+    diagnostics = []
+    for index, ((path, result), (provenance, workloads, _)) in enumerate(zip(parsed, validated), start=1):
+        candidate_identity = {
+            "manifest": result["manifest"], "fixture_source_dir": provenance["fixture_source_dir"],
+            "fixture_patch": provenance["fixture_patch"], "fixture_patch_sha256": provenance["fixture_patch_sha256"],
+            "mutation_identity_sha256": result["cross_workload"]["mutation_identity_sha256"],
+            "workloads": [normalized_workload(item, path) for item in workloads],
+        }
+        if candidate_identity != identity:
+            fail(f"{path}: semantic identity mismatch")
+        if {key: provenance[key] for key in runner_class} != runner_class:
+            fail(f"{path}: runner class mismatch")
+        if {key: provenance[key] for key in execution_provenance} != execution_provenance:
+            fail(f"{path}: execution provenance mismatch")
+        diagnostics.append({"sample": f"sample-{index}", "kernel_release": provenance["kernel_release"], "image_os": provenance["image_os"], "image_version": provenance["image_version"]})
+    if identity["fixture_patch"] != fixture.get("patch_file") or identity["fixture_patch_sha256"] != digest_file(PATCH_PATH):
+        fail("current fixture patch does not match result provenance")
+    samples = {}
+    for index, name in enumerate(expected_workloads):
+        wall = [workloads[index]["timing"]["wall_ms"] for _, workloads, _ in validated]
+        duration = [workloads[index]["timing"]["reported_duration_ms"] for _, workloads, _ in validated]
+        median = statistics.median(wall)
+        samples[name] = {"wall_ms": wall, "duration_ms": duration, "wall_ms_median": median, "wall_ms_mad": statistics.median([abs(value - median) for value in wall])}
+    candidate = {
+        "kind": "togi_pr_loop_calibration_candidate",
+        "schema_version": 1,
+        "comparison_policy": "not-a-baseline; no comparator or gate is defined",
+        "source": {"commit": args.source_commit, "run": args.source_run, "attempt": args.source_attempt, "utc": args.source_utc},
+        "runner_class": runner_class,
+        "runner_diagnostics": diagnostics,
+        "execution_provenance": execution_provenance,
+        "semantic_identity": identity,
+        "samples": samples,
+        "source_file_digests": {
+            "benchmarks/pr-loop/manifest.json": digest_file(MANIFEST_PATH),
+            "benchmarks/pr-loop/fixture-change.patch": digest_file(PATCH_PATH),
+            f"{manifest_fixture_dir.rstrip('/')}/": digest_tree(fixture_dir),
+            **{
+                f"sample-{index}/pr-loop-benchmark-result.json": digest
+                for index, digest in enumerate(result_digests, start=1)
+            },
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except ValueError as error:
+        print(f"calibration collection failed: {error}", file=sys.stderr)
+        sys.exit(2)

--- a/benchmarks/pr-loop/run-pr-loop-benchmarks.sh
+++ b/benchmarks/pr-loop/run-pr-loop-benchmarks.sh
@@ -268,6 +268,17 @@ GIT_VERSION=$(git --version)
 OS_NAME=$(uname -s)
 ARCH_NAME=$(uname -m)
 STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+BENCH_RUNNER_LABEL=${BENCH_RUNNER_LABEL:-local}
+if command -v getconf >/dev/null 2>&1; then
+  LOGICAL_CPU_COUNT=$(getconf _NPROCESSORS_ONLN)
+elif command -v sysctl >/dev/null 2>&1; then
+  LOGICAL_CPU_COUNT=$(sysctl -n hw.logicalcpu)
+else
+  LOGICAL_CPU_COUNT=$(nproc)
+fi
+KERNEL_RELEASE=$(uname -r)
+IMAGE_OS=${ImageOS:-}
+IMAGE_VERSION=${ImageVersion:-}
 
 # jq filter for each named invariant. Manifest values are injected as
 # $expected_mutations, $changed_file, $line_min, and $line_max.
@@ -518,6 +529,11 @@ jq -n \
   --arg git_version "$GIT_VERSION" \
   --arg os "$OS_NAME" \
   --arg arch "$ARCH_NAME" \
+  --arg runner_label "$BENCH_RUNNER_LABEL" \
+  --argjson logical_cpu_count "$LOGICAL_CPU_COUNT" \
+  --arg kernel_release "$KERNEL_RELEASE" \
+  --arg image_os "$IMAGE_OS" \
+  --arg image_version "$IMAGE_VERSION" \
   --arg started_at "$STARTED_AT" \
   --arg fixture_source "$FIXTURE_SOURCE_DIR" \
   --arg patch_sha "$ACTUAL_PATCH_SHA" \
@@ -539,6 +555,11 @@ jq -n \
       os: $os,
       arch: $arch,
       go_version: $go_version,
+      runner_label: $runner_label,
+      logical_cpu_count: $logical_cpu_count,
+      kernel_release: $kernel_release,
+      image_os: (if $image_os == "" then null else $image_os end),
+      image_version: (if $image_version == "" then null else $image_version end),
       git_version: $git_version,
       fixture_source_dir: $fixture_source,
       fixture_patch: "benchmarks/pr-loop/fixture-change.patch",

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -1152,3 +1152,234 @@ fn ci_pr_loop_benchmark_contract_rejects_missing_or_wrong_evidence_validation() 
         "the validation step must use the approved normalized-result and raw paths"
     );
 }
+
+fn collector_path() -> PathBuf {
+    repo_root().join("benchmarks/pr-loop/collect-calibration.py")
+}
+
+fn run_collector(output: &Path, results: &[PathBuf]) -> Output {
+    let mut command = Command::new("python3");
+    command
+        .arg(collector_path())
+        .arg("--output")
+        .arg(output)
+        .arg("--source-commit")
+        .arg("test-commit")
+        .arg("--source-run")
+        .arg("test-run")
+        .arg("--source-attempt")
+        .arg("1")
+        .arg("--source-utc")
+        .arg("2026-08-04T00:00:00Z");
+    for result in results {
+        command.arg(result);
+    }
+    command.output().expect("spawn collector")
+}
+
+#[test]
+fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
+    if !harness_tools_available() || !tool_on_path("python3") {
+        eprintln!("skipping: harness or Python tools unavailable");
+        return;
+    }
+    let tools = install_fake_tools();
+    let samples = tempfile::tempdir().expect("sample tempdir");
+    let mut results = Vec::new();
+    for sample in 1..=5 {
+        let output = samples.path().join(format!("sample-{sample}"));
+        assert!(run_harness(&tools, &output, None, &[]).status.success());
+        results.push(output.join("pr-loop-benchmark-result.json"));
+    }
+    let candidate = samples.path().join("candidate.json");
+    let output = run_collector(&candidate, &results);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&candidate).expect("candidate")).expect("JSON");
+    assert_eq!(value["kind"], "togi_pr_loop_calibration_candidate");
+    assert_eq!(value["source"]["commit"], "test-commit");
+    assert_eq!(
+        value["samples"]["cold-regular"]["wall_ms"]
+            .as_array()
+            .unwrap()
+            .len(),
+        5
+    );
+    assert!(value["samples"]["cold-regular"]["wall_ms_median"].is_number());
+    assert!(value["samples"]["cold-regular"]["wall_ms_mad"].is_number());
+
+    let wrong_count = run_collector(&samples.path().join("wrong-count.json"), &results[..4]);
+    assert!(!wrong_count.status.success());
+    let duplicate_candidate = samples.path().join("duplicate.json");
+    let duplicates = vec![results[0].clone(); 5];
+    assert!(
+        !run_collector(&duplicate_candidate, &duplicates)
+            .status
+            .success()
+    );
+    assert!(
+        !duplicate_candidate.exists(),
+        "duplicate inputs must not create a candidate"
+    );
+    let copied_duplicate_dir = samples.path().join("copied-duplicates");
+    fs::create_dir(&copied_duplicate_dir).unwrap();
+    let copied_duplicates: Vec<PathBuf> = (1..=5)
+        .map(|index| {
+            let copied = copied_duplicate_dir.join(format!("copy-{index}.json"));
+            fs::copy(&results[0], &copied).unwrap();
+            copied
+        })
+        .collect();
+    let copied_duplicate_candidate = samples.path().join("copied-duplicate.json");
+    let copied_duplicate = run_collector(&copied_duplicate_candidate, &copied_duplicates);
+    assert_eq!(copied_duplicate.status.code(), Some(2));
+    assert!(
+        !copied_duplicate_candidate.exists(),
+        "byte-identical copied inputs must not create a candidate"
+    );
+
+    let portable_dir = samples.path().join("different-leading-location");
+    fs::create_dir(&portable_dir).unwrap();
+    let portable_results: Vec<PathBuf> = results
+        .iter()
+        .enumerate()
+        .map(|(index, result)| {
+            let copied = portable_dir.join(format!("result-{index}.json"));
+            fs::copy(result, &copied).unwrap();
+            copied
+        })
+        .collect();
+    let portable_candidate = samples.path().join("portable.json");
+    assert!(
+        run_collector(&portable_candidate, &portable_results)
+            .status
+            .success()
+    );
+    let portable: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(portable_candidate).unwrap()).unwrap();
+    assert_eq!(portable["semantic_identity"], value["semantic_identity"]);
+    assert!(
+        portable["source_file_digests"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .all(|key| !key.starts_with('/'))
+    );
+
+    for (field, replacement, output_name) in [
+        (
+            "/provenance/logical_cpu_count",
+            serde_json::Value::Bool(true),
+            "boolean-cpu",
+        ),
+        (
+            "/workloads/0/timing/wall_ms",
+            serde_json::Value::Bool(false),
+            "boolean-timing",
+        ),
+        (
+            "/provenance/fixture_source_dir",
+            serde_json::Value::String("../outside".to_string()),
+            "fixture-escape",
+        ),
+        (
+            "/provenance/togi_version",
+            serde_json::Value::String("different-togi".to_string()),
+            "execution",
+        ),
+    ] {
+        let altered = samples.path().join(format!("{output_name}.json"));
+        let mut result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&results[4]).unwrap()).unwrap();
+        *result.pointer_mut(field).unwrap() = replacement;
+        fs::write(&altered, serde_json::to_vec(&result).unwrap()).unwrap();
+        let mut mismatched = results.clone();
+        mismatched[4] = altered;
+        let rejected = run_collector(
+            &samples.path().join(format!("{output_name}-out.json")),
+            &mismatched,
+        );
+        assert!(!rejected.status.success());
+        assert!(
+            !String::from_utf8_lossy(&rejected.stderr).contains("Traceback"),
+            "malformed input must have a collector error, not a traceback"
+        );
+    }
+
+    let diagnostic = samples.path().join("diagnostic.json");
+    let mut diagnostic_result: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results[4]).unwrap()).unwrap();
+    *diagnostic_result
+        .pointer_mut("/provenance/kernel_release")
+        .unwrap() = serde_json::Value::String("different-kernel".to_string());
+    let mut diagnostic_results = results.clone();
+    fs::write(&diagnostic, serde_json::to_vec(&diagnostic_result).unwrap()).unwrap();
+    diagnostic_results[4] = diagnostic;
+    let diagnostic_candidate = samples.path().join("diagnostic-out.json");
+    assert!(
+        run_collector(&diagnostic_candidate, &diagnostic_results)
+            .status
+            .success()
+    );
+    let diagnostics: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(diagnostic_candidate).unwrap()).unwrap();
+    assert_eq!(
+        diagnostics["runner_diagnostics"][4]["kernel_release"],
+        "different-kernel"
+    );
+
+    let malformed = samples.path().join("malformed.json");
+    fs::write(&malformed, "{").expect("malformed result");
+    let mut malformed_results = results.clone();
+    malformed_results[4] = malformed;
+    assert!(
+        !run_collector(
+            &samples.path().join("malformed-out.json"),
+            &malformed_results
+        )
+        .status
+        .success()
+    );
+
+    for (field, output_name) in [
+        ("/workloads/0/cache_policy", "semantic"),
+        ("/provenance/runner_label", "runner"),
+    ] {
+        let altered = samples.path().join(format!("{output_name}.json"));
+        let mut result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&results[4]).unwrap()).unwrap();
+        *result.pointer_mut(field).unwrap() = serde_json::Value::String("mismatch".to_string());
+        fs::write(&altered, serde_json::to_vec(&result).unwrap()).unwrap();
+        let mut mismatched = results.clone();
+        mismatched[4] = altered;
+        assert!(
+            !run_collector(
+                &samples.path().join(format!("{output_name}-out.json")),
+                &mismatched
+            )
+            .status
+            .success()
+        );
+    }
+}
+
+#[test]
+fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
+    let workflow =
+        fs::read_to_string(repo_root().join(".github/workflows/pr-loop-calibration.yml"))
+            .expect("calibration workflow");
+    let _: serde_yaml::Value = serde_yaml::from_str(&workflow).expect("workflow YAML");
+    assert!(workflow.contains("workflow_dispatch:"));
+    assert!(workflow.contains("if: github.ref == 'refs/heads/main'"));
+    assert!(workflow.contains("permissions:\n  contents: read"));
+    assert!(workflow.contains("runs-on: ubuntu-24.04"));
+    assert!(workflow.contains("BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64"));
+    assert!(workflow.contains("for sample in 1 2 3 4 5; do"));
+    assert!(workflow.contains("retention-days: 14"));
+    assert!(!workflow.contains("pull_request:"));
+    assert!(!workflow.contains("permissions: write"));
+}


### PR DESCRIPTION
Dispatch-only, main-only/read-only Ubuntu calibration takes five sequential real harness samples and emits a fail-closed candidate artifact for later human-reviewed baseline activation.

Ordinary PR CI remains semantic/observational; no performance baseline, threshold, or gate is added.

Refs #487 and #489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered calibration workflow for collecting five Linux benchmark samples.
  - Benchmark results now include runner and environment details.
  - Added validated aggregation of benchmark samples into calibration candidates with statistics and diagnostics.
  - Calibration artifacts are retained for 14 days.

- **Documentation**
  - Added maintainer guidance for collecting calibration evidence and reviewing baseline activation.

- **Tests**
  - Added coverage for successful aggregation, validation failures, metadata, workflow settings, and artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->