### PR TITLE
feat(bench): add PR-loop corpus provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    env:
-      BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
     steps:
       - uses: actions/checkout@v7
         with:
@@ -217,6 +215,8 @@ jobs:
           go-version: '1.26.5'
       - name: Create job-private Go build cache
         shell: bash
+        env:
+          BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
         run: |
           set -euo pipefail
           if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
@@ -262,7 +262,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: warmup
-          GOCACHE: ${{ env.BENCH_GOCACHE }}
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
           BENCHMARK_OUTPUT: ${{ runner.temp }}/togi-pr-loop-benchmarks/warmup
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$BENCHMARK_OUTPUT"
       - name: Run PR-loop benchmark harness
@@ -271,7 +271,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: primed
-          GOCACHE: ${{ env.BENCH_GOCACHE }}
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
           BENCHMARK_OUTPUT: ${{ runner.temp }}/togi-pr-loop-benchmarks/measured
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$BENCHMARK_OUTPUT"
       - name: Validate PR-loop benchmark evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    env:
+      BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
     steps:
       - uses: actions/checkout@v7
         with:
@@ -212,7 +214,18 @@ jobs:
           cache-bin: false
       - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: '1.26.5'
+      - name: Create job-private Go build cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
+            echo "job-private Go build cache $BENCH_GOCACHE must start empty" >&2
+            exit 1
+          fi
+          mkdir -p "$BENCH_GOCACHE"
+          test -d "$BENCH_GOCACHE"
+          test -z "$(ls -A "$BENCH_GOCACHE")"
       - name: Check benchmark prerequisites
         shell: bash
         run: |
@@ -249,6 +262,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: warmup
+          GOCACHE: ${{ env.BENCH_GOCACHE }}
           BENCHMARK_OUTPUT: ${{ runner.temp }}/togi-pr-loop-benchmarks/warmup
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$BENCHMARK_OUTPUT"
       - name: Run PR-loop benchmark harness
@@ -257,6 +271,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: primed
+          GOCACHE: ${{ env.BENCH_GOCACHE }}
           BENCHMARK_OUTPUT: ${{ runner.temp }}/togi-pr-loop-benchmarks/measured
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$BENCHMARK_OUTPUT"
       - name: Validate PR-loop benchmark evidence
@@ -272,9 +287,10 @@ jobs:
           jq -e '
             .ok == true
             and ([.workloads[].name]
-                 == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default"])
+                 == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default",
+                     "multi-file-regular", "multi-file-default"])
           ' "$result" >/dev/null
-          for workload in cold-regular warm-exact-cache cold-schemata pr-diff-default; do
+          for workload in cold-regular warm-exact-cache cold-schemata pr-diff-default multi-file-regular multi-file-default; do
             for suffix in report.json stdout stderr; do
               test -f "$raw/$workload.$suffix"
             done

--- a/.github/workflows/pr-loop-calibration.yml
+++ b/.github/workflows/pr-loop-calibration.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    env:
-      BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
     steps:
       - uses: actions/checkout@v7
         with:
@@ -33,6 +31,8 @@ jobs:
           go-version: '1.26.5'
       - name: Create job-private Go build cache
         shell: bash
+        env:
+          BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
         run: |
           set -euo pipefail
           if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
@@ -60,7 +60,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: warmup
-          GOCACHE: ${{ env.BENCH_GOCACHE }}
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
           CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration/warmup
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$CALIBRATION_OUTPUT"
       - name: Acquire five independent samples
@@ -69,7 +69,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: primed
-          GOCACHE: ${{ env.BENCH_GOCACHE }}
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
           CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-loop-calibration.yml
+++ b/.github/workflows/pr-loop-calibration.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    env:
+      BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-gocache
     steps:
       - uses: actions/checkout@v7
         with:
@@ -28,7 +30,18 @@ jobs:
         run: bash ./.github/scripts/assert-native-target.sh
       - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: '1.26.5'
+      - name: Create job-private Go build cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
+            echo "job-private Go build cache $BENCH_GOCACHE must start empty" >&2
+            exit 1
+          fi
+          mkdir -p "$BENCH_GOCACHE"
+          test -d "$BENCH_GOCACHE"
+          test -z "$(ls -A "$BENCH_GOCACHE")"
       - name: Check benchmark prerequisites
         shell: bash
         run: |
@@ -47,6 +60,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: warmup
+          GOCACHE: ${{ env.BENCH_GOCACHE }}
           CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration/warmup
         run: bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$CALIBRATION_OUTPUT"
       - name: Acquire five independent samples
@@ -55,6 +69,7 @@ jobs:
           TOGI_BIN: ${{ github.workspace }}/target/release/togi
           BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
           BENCH_GO_BUILD_CACHE_STATE: primed
+          GOCACHE: ${{ env.BENCH_GOCACHE }}
           CALIBRATION_OUTPUT: ${{ runner.temp }}/togi-pr-loop-calibration
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -290,16 +290,91 @@ matching older `.togi-cache` entries. Structured incremental history is stored
 under `.togi-cache/history.json`; it can reuse killed/survived results when the
 mutant source, command context, and relevant covering tests are unchanged.
 
+## PR-loop performance evidence
+
+The PR-loop benchmark harness measures togi on versioned PR-shaped corpus
+scenarios. Reproduce it locally:
+
+```bash
+cargo build --locked --release && bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh
+```
+
+Prerequisites: bash, git, go, jq, sed, sha256sum or shasum, and python3 (for
+the monotonic wall clock). The harness copies `tests/fixtures/go` into one
+disposable temp project per scenario, applies the scenario's fixed patch, and
+runs each workload through `togi check --base HEAD` (never `--all`). Semantic
+and provenance invariants fail the run; wall time is observational only.
+Local runs are `unclassified`: they make no Go build cache requirement and
+their timings are evidence for the reader, not comparable measurements.
+
+To exercise the calibration cache protocol locally (not to produce a
+comparable baseline), use exactly Go 1.26.5 and a fresh absolute private cache:
+
+```bash
+cargo build --locked --release
+test "$(go version | awk '{print $3}')" = go1.26.5
+GOCACHE="$(mktemp -d "${TMPDIR:-/tmp}/.togi-pr-loop-gocache.XXXXXX")"
+OUTPUT="$(mktemp -d "${TMPDIR:-/tmp}/.togi-pr-loop-calibration.XXXXXX")"
+trap 'rm -rf "$GOCACHE" "$OUTPUT"' EXIT
+BENCH_GO_BUILD_CACHE_STATE=warmup GOCACHE="$GOCACHE" \
+  bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$OUTPUT/warmup"
+for sample in 1 2 3 4 5; do
+  BENCH_GO_BUILD_CACHE_STATE=primed GOCACHE="$GOCACHE" \
+    bash benchmarks/pr-loop/run-pr-loop-benchmarks.sh --output "$OUTPUT/sample-$sample"
+done
+```
+
+This verifies the same empty-private-cache, warmup, and primed-acquisition
+protocol, but remains **not GHA baseline-comparable**: a local runner has a
+different runner class.
+
+The corpus (`benchmarks/pr-loop/manifest.json`, schema v2) declares two
+scenarios:
+
+- `single-file` — `fixture-change.patch` appends `Clamp` to `calc.go`
+  (4 mutations). Workloads: `cold-regular` (per-mutant, fresh cache),
+  `warm-exact-cache` (exact-cache reuse of `cold-regular`), `cold-schemata`
+  (fast-path + fallback), and `pr-diff-default` (out-of-the-box defaults).
+- `multi-file` — `fixture-change-multi.patch` rewrites `Add` in `calc.go`
+  through `Sum` and changes the `Sum` body in `numbers.go` (9 mutations
+  across both files). Workloads: `multi-file-regular` and
+  `multi-file-default`.
+
+Each scenario gets its own disposable project and `.togi-cache`; cache reuse
+never crosses scenarios, and mutation identity is compared within a scenario,
+never between them. Every workload records its scenario, runner mode
+(regular/schemata/default), resolved test command, cache policy, wall time,
+and machine/runner provenance.
+
+The metric that will support the PR-loop speed claim is the warm-exact-cache
+versus cold-regular wall-clock median, computed from a reviewed, activated
+baseline. No baseline, comparator, or timing gate exists yet; benchmark
+evidence in CI is strictly telemetry.
+
 ## PR-loop calibration acquisition
 
-Maintainers may manually dispatch **PR-loop Calibration** from `main`. An
-unmeasured warmup primes the runner-wide Go build cache, then five independent,
-observational-only Linux x86_64 harness samples run with fresh Togi `.togi-cache`
-and a primed Go build cache. The 14-day artifact contains warmup and measured
-raw outputs plus a candidate calibration JSON. It does
-not create a baseline, compare results, or gate CI. A later, separately reviewed
-baseline-activation PR must inspect that artifact and explicitly define any
-comparison policy; do not copy or invent a candidate baseline by hand.
+Maintainers may manually dispatch **PR-loop Calibration** from `main`. The
+job pins Go to 1.26.5 and creates a job-private Go build cache under
+`runner.temp`, proven empty before use. An unmeasured warmup primes that
+cache, then five independent, observational-only Linux x86_64 harness samples
+run against the identical `GOCACHE` with fresh Togi `.togi-cache` and a
+primed Go build cache; the harness refuses warmup/primed measurements whose
+`GOCACHE` is not absolute and identical to `go env GOCACHE`. The 14-day
+artifact contains warmup and measured raw outputs plus a candidate
+calibration JSON. It does not create a baseline, compare results, or gate CI.
+
+Baseline promotion is a deliberately reviewed flow: a maintainer downloads
+the calibration artifact ZIP plus its positive GitHub artifact ID and
+normalized SHA-256 digest to
+`python3 benchmarks/pr-loop/promote-baseline.py`, which fail-closed re-verifies
+the archive and extracted artifact (contained regular files, sample digests,
+manifest/fixture/patch digests, five distinct primed v2 samples, cache-policy
+identity, complete sample data, and no wall sample above 3x its per-workload
+median) before writing a deterministic baseline document. The volatile cache
+path is kept only as calibration evidence, never as cross-run identity. A
+later, separately reviewed baseline-activation PR supplies the activation
+metadata via the promoter's CLI and explicitly defines any comparison policy;
+do not copy or invent a candidate baseline by hand.
 
 ## Configuration
 

--- a/benchmarks/pr-loop/collect-calibration.py
+++ b/benchmarks/pr-loop/collect-calibration.py
@@ -9,11 +9,15 @@ import statistics
 import sys
 
 EXPECTED_KIND = "togi_pr_loop_benchmark_result"
-EXPECTED_SCHEMA = 1
+EXPECTED_SCHEMA = 2
+CANDIDATE_KIND = "togi_pr_loop_calibration_candidate"
+CANDIDATE_SCHEMA = 2
+EXPECTED_CACHE_STATE = "primed"
+EXPECTED_CACHE_POLICY = "job-private-explicit-gocache"
+RUNNER_MODES = ("regular", "schemata", "default")
 SAMPLE_COUNT = 5
 ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = ROOT / "benchmarks/pr-loop/manifest.json"
-PATCH_PATH = ROOT / "benchmarks/pr-loop/fixture-change.patch"
 
 
 def fail(message):
@@ -79,42 +83,73 @@ def validate_fixture_path(value, manifest_fixture_dir):
     return resolved
 
 
-def validate_result(result, path, expected_workloads, manifest_fixture_dir):
+def validate_fixture_scenarios(value, manifest_scenarios, path):
+    require(value, lambda item: isinstance(item, dict), f"{path}: provenance.fixture_scenarios is invalid")
+    require(sorted(value), lambda item: item == sorted(manifest_scenarios), f"{path}: provenance.fixture_scenarios keys differ from manifest scenarios")
+    for name, entry in value.items():
+        require(entry, lambda item: isinstance(item, dict), f"{path}: fixture scenario {name} is invalid")
+        for key in ("patch_file", "patch_sha256", "base_revision"):
+            require(entry.get(key), nonempty_string, f"{path}: fixture scenario {name} has invalid {key}")
+        manifest_entry = manifest_scenarios[name]
+        require(entry["patch_file"], lambda item: item == manifest_entry["patch_file"], f"{path}: fixture scenario {name} patch file differs from manifest")
+    return value
+
+
+def validate_result(result, path, expected_workloads, manifest_fixture_dir, manifest_scenarios):
     require(result.get("kind"), lambda item: item == EXPECTED_KIND, f"{path}: wrong result kind")
     require(result.get("schema_version"), lambda item: item == EXPECTED_SCHEMA, f"{path}: wrong result schema")
     require(result.get("timing_policy"), lambda item: item == "observational-only", f"{path}: wrong timing policy")
     require(result.get("ok"), lambda item: item is True, f"{path}: result is not ok")
     require(result.get("failures"), lambda item: item == [], f"{path}: result has failures")
-    require(result.get("manifest"), lambda item: item == {"name": "togi-pr-loop-benchmarks", "schema_version": 1, "path": "benchmarks/pr-loop/manifest.json"}, f"{path}: manifest identity mismatch")
+    require(result.get("manifest"), lambda item: item == {"name": "togi-pr-loop-benchmarks", "schema_version": 2, "path": "benchmarks/pr-loop/manifest.json"}, f"{path}: manifest identity mismatch")
     provenance = require(result.get("provenance"), lambda item: isinstance(item, dict), f"{path}: missing provenance")
-    for key in ("runner_label", "os", "arch", "kernel_release", "fixture_source_dir", "fixture_patch", "fixture_patch_sha256", "togi_version", "report_kind", "go_version", "git_version"):
+    for key in ("runner_label", "os", "arch", "kernel_release", "fixture_source_dir", "togi_version", "report_kind", "go_version", "git_version"):
         require(provenance.get(key), nonempty_string, f"{path}: invalid provenance.{key}")
     require(provenance.get("logical_cpu_count"), lambda item: exact_int(item) and item > 0, f"{path}: invalid provenance.logical_cpu_count")
     require(provenance.get("report_schema_version"), exact_int, f"{path}: invalid provenance.report_schema_version")
     require(
         provenance.get("go_build_cache_state"),
-        lambda item: item == "primed",
+        lambda item: item == EXPECTED_CACHE_STATE,
         f"{path}: go build cache state must be primed",
     )
+    require(
+        provenance.get("go_build_cache_policy"),
+        lambda item: item == EXPECTED_CACHE_POLICY,
+        f"{path}: go build cache policy must be {EXPECTED_CACHE_POLICY}",
+    )
+    require(provenance.get("go_build_cache_path"), nonempty_string, f"{path}: invalid provenance.go_build_cache_path")
     for key in ("image_os", "image_version"):
         require(provenance.get(key), lambda item: item is None or nonempty_string(item), f"{path}: invalid provenance.{key}")
     fixture_dir = validate_fixture_path(provenance["fixture_source_dir"], manifest_fixture_dir)
+    validate_fixture_scenarios(provenance.get("fixture_scenarios"), manifest_scenarios, path)
     cross_workload = require(result.get("cross_workload"), lambda item: isinstance(item, dict), f"{path}: missing cross-workload evidence")
-    require(cross_workload.get("mutation_identity_consistent"), lambda item: item is True, f"{path}: cross-workload mutation identity is invalid")
-    require(cross_workload.get("mutation_identity_sha256"), nonempty_string, f"{path}: missing mutation identity digest")
+    scenario_identity = require(cross_workload.get("scenarios"), lambda item: isinstance(item, dict), f"{path}: missing per-scenario identity")
+    require(sorted(scenario_identity), lambda item: item == sorted(manifest_scenarios), f"{path}: per-scenario identity keys differ from manifest scenarios")
+    for name, entry in scenario_identity.items():
+        require(entry, lambda item: isinstance(item, dict), f"{path}: scenario {name} identity is invalid")
+        require(entry.get("mutation_identity_consistent"), lambda item: item is True, f"{path}: scenario {name} mutation identity is invalid")
+        require(entry.get("mutation_identity_sha256"), nonempty_string, f"{path}: scenario {name} missing mutation identity digest")
     workloads = require(result.get("workloads"), lambda item: isinstance(item, list), f"{path}: missing workloads")
     names = [item.get("name") if isinstance(item, dict) else None for item in workloads]
-    require(names, lambda item: item == expected_workloads, f"{path}: workload order mismatch")
-    for workload in workloads:
+    require(names, lambda item: item == [name for name, _ in expected_workloads], f"{path}: workload order mismatch")
+    for workload, (expected_name, expected_scenario) in zip(workloads, expected_workloads):
         name = workload.get("name") if isinstance(workload, dict) else "unknown"
         require(workload, lambda item: isinstance(item, dict), f"{path}: workload {name} is malformed")
         require(workload.get("ok"), lambda item: item is True, f"{path}: workload {name} is not ok")
+        require(workload.get("scenario"), lambda item: item == expected_scenario, f"{path}: workload {expected_name} has wrong scenario")
+        require(workload.get("runner_mode"), lambda item: item in RUNNER_MODES, f"{path}: workload {expected_name} has invalid runner_mode")
         require(workload.get("invariants"), lambda item: isinstance(item, list) and item and all(isinstance(invariant, dict) and invariant.get("ok") is True for invariant in item), f"{path}: workload {name} has failed invariants")
         timing = require(workload.get("timing"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks timing")
         for key in ("wall_ms", "reported_duration_ms"):
             require(timing.get(key), lambda item: exact_int(item) and item >= 0, f"{path}: workload {name} has invalid {key}")
+        semantics = require(workload.get("semantics"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks semantics")
+        require(
+            semantics.get("selected_test_command"),
+            lambda item: isinstance(item, list) and item and all(nonempty_string(arg) for arg in item),
+            f"{path}: workload {name} has invalid selected_test_command",
+        )
         normalized_workload(workload, path)
-    return provenance, workloads, fixture_dir
+    return provenance, workloads, fixture_dir, scenario_identity
 
 
 def main(argv):
@@ -146,31 +181,61 @@ def main(argv):
     if args.output.exists():
         fail(f"output already exists: {args.output}")
     manifest = load_json(MANIFEST_PATH)
+    require(manifest.get("schema_version"), lambda item: item == EXPECTED_SCHEMA, "manifest schema is not v2")
     fixture = require(manifest.get("fixture"), lambda item: isinstance(item, dict), "manifest fixture is invalid")
     manifest_fixture_dir = require(fixture.get("source_dir"), lambda item: nonempty_string(item) and not Path(item).is_absolute() and ".." not in Path(item).parts, "manifest fixture source dir is invalid")
     fixture_dir = validate_fixture_path(manifest_fixture_dir, manifest_fixture_dir)
-    expected_workloads = [item.get("name") if isinstance(item, dict) else None for item in manifest.get("workloads", [])]
-    require(expected_workloads, lambda item: item and all(nonempty_string(name) for name in item), "manifest has no valid workloads")
+    scenarios = require(manifest.get("scenarios"), lambda item: isinstance(item, list) and item, "manifest scenarios are invalid")
+    manifest_scenarios = {}
+    for entry in scenarios:
+        name = require(entry.get("name") if isinstance(entry, dict) else None, nonempty_string, "manifest scenario name is invalid")
+        patch_file = require(entry.get("patch_file"), nonempty_string, f"manifest scenario {name} patch file is invalid")
+        patch_path = Path(patch_file)
+        require(patch_file, lambda item: not patch_path.is_absolute() and ".." not in patch_path.parts, f"manifest scenario {name} patch file must be repository-relative")
+        require((ROOT / patch_path).is_file(), lambda item: item, f"manifest scenario {name} patch file is unavailable")
+        manifest_scenarios[name] = {"patch_file": patch_file}
+    expected_workloads = []
+    for item in manifest.get("workloads", []):
+        name = item.get("name") if isinstance(item, dict) else None
+        scenario = item.get("scenario") if isinstance(item, dict) else None
+        require(name, nonempty_string, "manifest has an invalid workload name")
+        require(scenario, lambda value: value in manifest_scenarios, f"manifest workload {name} names an undeclared scenario")
+        expected_workloads.append((name, scenario))
+    require(expected_workloads, lambda item: bool(item), "manifest has no valid workloads")
     parsed = [(path, load_json(path)) for path in resolved_results]
-    validated = [validate_result(value, path, expected_workloads, manifest_fixture_dir) for path, value in parsed]
-    first_provenance, first_workloads, _ = validated[0]
+    validated = [validate_result(value, path, expected_workloads, manifest_fixture_dir, manifest_scenarios) for path, value in parsed]
+    first_provenance, first_workloads, _, first_scenario_identity = validated[0]
     identity = {
         "manifest": parsed[0][1]["manifest"],
         "fixture_source_dir": first_provenance["fixture_source_dir"],
-        "fixture_patch": first_provenance["fixture_patch"],
-        "fixture_patch_sha256": first_provenance["fixture_patch_sha256"],
-        "mutation_identity_sha256": parsed[0][1]["cross_workload"]["mutation_identity_sha256"],
+        "fixture_scenarios": {
+            name: {"patch_file": entry["patch_file"], "patch_sha256": entry["patch_sha256"]}
+            for name, entry in first_provenance["fixture_scenarios"].items()
+        },
+        "scenario_mutation_identity": {
+            name: entry["mutation_identity_sha256"] for name, entry in first_scenario_identity.items()
+        },
         "workloads": [normalized_workload(item, parsed[0][0]) for item in first_workloads],
     }
     runner_class = {key: first_provenance[key] for key in ("runner_label", "os", "arch", "logical_cpu_count")}
     execution_provenance = {key: first_provenance[key] for key in ("togi_version", "report_kind", "report_schema_version", "go_version", "git_version")}
-    measurement_identity = {"go_build_cache_state": first_provenance["go_build_cache_state"]}
+    measurement_identity = {
+        "go_build_cache_state": first_provenance["go_build_cache_state"],
+        "go_build_cache_policy": first_provenance["go_build_cache_policy"],
+    }
+    go_build_cache_path = first_provenance["go_build_cache_path"]
     diagnostics = []
-    for index, ((path, result), (provenance, workloads, _)) in enumerate(zip(parsed, validated), start=1):
+    for index, ((path, result), (provenance, workloads, _, scenario_identity)) in enumerate(zip(parsed, validated), start=1):
         candidate_identity = {
-            "manifest": result["manifest"], "fixture_source_dir": provenance["fixture_source_dir"],
-            "fixture_patch": provenance["fixture_patch"], "fixture_patch_sha256": provenance["fixture_patch_sha256"],
-            "mutation_identity_sha256": result["cross_workload"]["mutation_identity_sha256"],
+            "manifest": result["manifest"],
+            "fixture_source_dir": provenance["fixture_source_dir"],
+            "fixture_scenarios": {
+                name: {"patch_file": entry["patch_file"], "patch_sha256": entry["patch_sha256"]}
+                for name, entry in provenance["fixture_scenarios"].items()
+            },
+            "scenario_mutation_identity": {
+                name: entry["mutation_identity_sha256"] for name, entry in scenario_identity.items()
+            },
             "workloads": [normalized_workload(item, path) for item in workloads],
         }
         if candidate_identity != identity:
@@ -179,18 +244,23 @@ def main(argv):
             fail(f"{path}: runner class mismatch")
         if {key: provenance[key] for key in execution_provenance} != execution_provenance:
             fail(f"{path}: execution provenance mismatch")
-        diagnostics.append({"sample": f"sample-{index}", "kernel_release": provenance["kernel_release"], "image_os": provenance["image_os"], "image_version": provenance["image_version"]})
-    if identity["fixture_patch"] != fixture.get("patch_file") or identity["fixture_patch_sha256"] != digest_file(PATCH_PATH):
-        fail("current fixture patch does not match result provenance")
+        if {key: provenance[key] for key in measurement_identity} != measurement_identity:
+            fail(f"{path}: measurement identity mismatch")
+        if provenance["go_build_cache_path"] != go_build_cache_path:
+            fail(f"{path}: go build cache path differs across samples")
+        diagnostics.append({"sample": f"sample-{index}", "kernel_release": provenance["kernel_release"], "image_os": provenance["image_os"], "image_version": provenance["image_version"], "go_build_cache_path": provenance["go_build_cache_path"]})
+    for name, entry in identity["fixture_scenarios"].items():
+        if entry["patch_sha256"] != digest_file(ROOT / entry["patch_file"]):
+            fail(f"current fixture patch for scenario {name} does not match result provenance")
     samples = {}
-    for index, name in enumerate(expected_workloads):
-        wall = [workloads[index]["timing"]["wall_ms"] for _, workloads, _ in validated]
-        duration = [workloads[index]["timing"]["reported_duration_ms"] for _, workloads, _ in validated]
+    for index, (name, _) in enumerate(expected_workloads):
+        wall = [workloads[index]["timing"]["wall_ms"] for _, workloads, _, _ in validated]
+        duration = [workloads[index]["timing"]["reported_duration_ms"] for _, workloads, _, _ in validated]
         median = statistics.median(wall)
         samples[name] = {"wall_ms": wall, "duration_ms": duration, "wall_ms_median": median, "wall_ms_mad": statistics.median([abs(value - median) for value in wall])}
     candidate = {
-        "kind": "togi_pr_loop_calibration_candidate",
-        "schema_version": 1,
+        "kind": CANDIDATE_KIND,
+        "schema_version": CANDIDATE_SCHEMA,
         "comparison_policy": "not-a-baseline; no comparator or gate is defined",
         "source": {"commit": args.source_commit, "run": args.source_run, "attempt": args.source_attempt, "utc": args.source_utc},
         "runner_class": runner_class,
@@ -201,7 +271,10 @@ def main(argv):
         "samples": samples,
         "source_file_digests": {
             "benchmarks/pr-loop/manifest.json": digest_file(MANIFEST_PATH),
-            "benchmarks/pr-loop/fixture-change.patch": digest_file(PATCH_PATH),
+            **{
+                entry["patch_file"]: digest_file(ROOT / entry["patch_file"])
+                for entry in manifest_scenarios.values()
+            },
             f"{manifest_fixture_dir.rstrip('/')}/": digest_tree(fixture_dir),
             **{
                 f"sample-{index}/pr-loop-benchmark-result.json": digest

--- a/benchmarks/pr-loop/fixture-change-multi.patch
+++ b/benchmarks/pr-loop/fixture-change-multi.patch
@@ -1,0 +1,24 @@
+diff --git a/calc.go b/calc.go
+index 078eb1a..bfbc93a 100644
+--- a/calc.go
++++ b/calc.go
+@@ -2,7 +2,7 @@ package calc
+ 
+ // Add returns the sum of a and b.
+ func Add(a, b int) int {
+-	return a + b
++	return Sum(a, b) + 0
+ }
+ 
+ // IsPositive returns true if n > 0.
+diff --git a/numbers.go b/numbers.go
+index 7021adb..b5a2f83 100644
+--- a/numbers.go
++++ b/numbers.go
+@@ -2,5 +2,5 @@ package calc
+ 
+ // Sum returns the sum of a and b.
+ func Sum(a, b int) int {
+-	return a + b
++	return a + (b + 0)
+ }

--- a/benchmarks/pr-loop/manifest.json
+++ b/benchmarks/pr-loop/manifest.json
@@ -1,23 +1,43 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "togi-pr-loop-benchmarks",
-  "description": "PR-loop benchmark workloads for togi: the Go fixture is copied into a disposable temp project, committed as the base revision, modified by one fixed working-tree patch, and measured through `togi check --base HEAD` so every run represents a PR diff, never --all.",
+  "description": "PR-loop benchmark workloads for togi: the Go fixture is copied into one disposable temp project per scenario, committed as the base revision, modified by the scenario's fixed working-tree patch, and measured through `togi check --base HEAD` so every run represents a PR diff, never --all.",
   "notes": [
     "Timing is observational only: no tracked baseline, no timing threshold, no score judgment, and no CI gate is defined by this manifest.",
     "Semantic and provenance invariants are hard failures; the harness exits non-zero when any invariant fails.",
-    "expected_mutation_count and the changed-line range pin the mutation surface of fixture-change.patch; operator or fixture drift must be resolved by updating this manifest deliberately.",
-    "Workloads run in declaration order. warm-exact-cache reuses the .togi-cache seeded by cold-regular.",
+    "expected_mutation_count and the changed-file line ranges pin the mutation surface of each scenario patch; operator or fixture drift must be resolved by updating this manifest deliberately.",
+    "Workloads run in declaration order and workloads of one scenario must be contiguous. warm-exact-cache reuses the .togi-cache seeded by cold-regular inside the single-file scenario only; cache dependencies never cross scenarios.",
+    "runner_mode is declared per workload (regular, schemata, or default) and validated against the effective argv: regular requires --no-schemata, schemata requires --schemata, default requires neither.",
     "The harness requires bash, git, go, jq, sha256sum or shasum, and python3 (monotonic high-resolution wall clock)."
   ],
   "fixture": {
     "source_dir": "tests/fixtures/go",
-    "patch_file": "benchmarks/pr-loop/fixture-change.patch",
-    "patch_sha256": "f2a0c45c7606dca549c339400e40a2c845c64e9535f3d7c48b8d9d3170f90104",
-    "changed_file": "calc.go",
-    "changed_line_range": [30, 37],
-    "base_ref": "HEAD",
-    "expected_mutation_count": 4
+    "base_ref": "HEAD"
   },
+  "scenarios": [
+    {
+      "name": "single-file",
+      "description": "One-file PR diff: fixture-change.patch appends Clamp to calc.go.",
+      "patch_file": "benchmarks/pr-loop/fixture-change.patch",
+      "patch_sha256": "f2a0c45c7606dca549c339400e40a2c845c64e9535f3d7c48b8d9d3170f90104",
+      "changed_files": [
+        { "path": "calc.go", "line_range": [30, 37] }
+      ],
+      "expected_mutation_count": 4
+    },
+    {
+      "name": "multi-file",
+      "description": "Two-file PR diff: fixture-change-multi.patch rewrites Add in calc.go through Sum and changes the Sum body in numbers.go.",
+      "patch_file": "benchmarks/pr-loop/fixture-change-multi.patch",
+      "patch_sha256": "f6936a8699651ff639b4c1bb842c2072586e204731d49f2f0ab1cd8113cef0cf",
+      "changed_files": [
+        { "path": "calc.go", "line_range": [5, 5] },
+        { "path": "numbers.go", "line_range": [5, 5] }
+      ],
+      "requires_mutation_per_changed_file": true,
+      "expected_mutation_count": 9
+    }
+  ],
   "togi": {
     "binary_env": "TOGI_BIN",
     "default_binary": "target/release/togi",
@@ -34,6 +54,8 @@
   "workloads": [
     {
       "name": "cold-regular",
+      "scenario": "single-file",
+      "runner_mode": "regular",
       "description": "Cold per-mutant runner on the PR diff: fresh cache, schemata disabled, every mutation re-executed.",
       "extra_args": ["--no-schemata", "--force-rerun"],
       "cache": "fresh",
@@ -42,6 +64,8 @@
     },
     {
       "name": "warm-exact-cache",
+      "scenario": "single-file",
+      "runner_mode": "regular",
       "description": "Identical second run reusing the cache seeded by cold-regular; every verdict must come from the exact cache.",
       "extra_args": ["--no-schemata"],
       "cache": "reuse",
@@ -50,6 +74,8 @@
     },
     {
       "name": "cold-schemata",
+      "scenario": "single-file",
+      "runner_mode": "schemata",
       "description": "Cold schemata run on the PR diff: fresh cache; the patch guarantees at least one schema fast-path mutant and at least one fallback mutant.",
       "extra_args": ["--schemata", "--force-rerun"],
       "cache": "fresh",
@@ -57,7 +83,28 @@
     },
     {
       "name": "pr-diff-default",
+      "scenario": "single-file",
+      "runner_mode": "default",
       "description": "Default invocation on the PR diff (no cache or schemata flags), representing out-of-the-box PR-loop behavior; mutations must target only the patched lines.",
+      "extra_args": [],
+      "cache": "fresh",
+      "invariants": ["report-well-formed", "pr-diff-targeting"]
+    },
+    {
+      "name": "multi-file-regular",
+      "scenario": "multi-file",
+      "runner_mode": "regular",
+      "description": "Cold per-mutant runner on the two-file PR diff: fresh cache, schemata disabled, every mutation re-executed across both changed files.",
+      "extra_args": ["--no-schemata", "--force-rerun"],
+      "cache": "fresh",
+      "seeds_cache": true,
+      "invariants": ["report-well-formed", "full-fresh-execution", "pr-diff-targeting"]
+    },
+    {
+      "name": "multi-file-default",
+      "scenario": "multi-file",
+      "runner_mode": "default",
+      "description": "Default invocation on the two-file PR diff, representing out-of-the-box PR-loop behavior across files; mutations must target only the patched lines in either changed file.",
       "extra_args": [],
       "cache": "fresh",
       "invariants": ["report-well-formed", "pr-diff-targeting"]

--- a/benchmarks/pr-loop/promote-baseline.py
+++ b/benchmarks/pr-loop/promote-baseline.py
@@ -20,13 +20,13 @@ it is never part of cross-run measurement identity.
 """
 import argparse
 import hashlib
+import importlib.util
 import json
 import stat
 import tempfile
 import zipfile
 from datetime import datetime
 from pathlib import Path
-import subprocess
 import statistics
 import sys
 
@@ -140,13 +140,19 @@ def verify_archive(archive_path, expected_digest, artifact_files):
 
 
 def recollect_candidate(candidate, sample_paths):
-    collector = ROOT / "benchmarks/pr-loop/collect-calibration.py"
+    collector_path = ROOT / "benchmarks/pr-loop/collect-calibration.py"
+    spec = importlib.util.spec_from_file_location("_togi_collect_calibration", collector_path)
+    if spec is None or spec.loader is None:
+        fail("checkout collector could not be loaded")
+    collector = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(collector)
+    except (ImportError, OSError) as error:
+        fail(f"checkout collector could not be imported: {error}")
     with tempfile.TemporaryDirectory(prefix="togi-pr-loop-recollect-") as temporary:
         output = Path(temporary) / "candidate.json"
         source = candidate["source"]
-        command = [
-            sys.executable,
-            str(collector),
+        arguments = [
             "--output", str(output),
             "--source-commit", source["commit"],
             "--source-run", source["run"],
@@ -154,9 +160,10 @@ def recollect_candidate(candidate, sample_paths):
             "--source-utc", source["utc"],
             *map(str, sample_paths),
         ]
-        completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
-        if completed.returncode != 0:
-            fail(f"canonical candidate re-collection failed: {completed.stderr.strip()}")
+        try:
+            collector.main(arguments)
+        except ValueError as error:
+            fail(f"canonical candidate re-collection failed: {error}")
         return load_json(output)
 
 

--- a/benchmarks/pr-loop/promote-baseline.py
+++ b/benchmarks/pr-loop/promote-baseline.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Fail-closed promoter turning a calibration artifact into a future baseline.
+
+Reads a downloaded PR-loop calibration artifact directory (the five measured
+samples plus the collector's candidate JSON) and writes a deterministic
+baseline document. The document carries no comparator, tolerance, or gate:
+the separately reviewed activation PR defines those. Promotion verifies the
+artifact end to end instead of trusting it:
+
+* every path under the artifact directory is a contained regular file
+* the candidate's kind, schema, source commit, and sample digests hold
+* current manifest, fixture, and patch digests match the candidate
+* five distinct, valid, primed v2 result inputs back the candidate
+* semantic, runner, and cache-policy identity match across the samples
+* per-workload sample data is complete and no wall sample exceeds 3x its
+  per-workload median
+
+The volatile Go build cache path is recorded as calibration evidence only;
+it is never part of cross-run measurement identity.
+"""
+import argparse
+import hashlib
+import json
+import stat
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path
+import subprocess
+import statistics
+import sys
+
+EXPECTED_RESULT_KIND = "togi_pr_loop_benchmark_result"
+EXPECTED_RESULT_SCHEMA = 2
+EXPECTED_CANDIDATE_KIND = "togi_pr_loop_calibration_candidate"
+EXPECTED_CANDIDATE_SCHEMA = 2
+BASELINE_KIND = "togi_pr_loop_baseline"
+BASELINE_SCHEMA = 1
+EXPECTED_CACHE_STATE = "primed"
+EXPECTED_CACHE_POLICY = "job-private-explicit-gocache"
+SAMPLE_COUNT = 5
+MAX_WALL_TO_MEDIAN = 3
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "benchmarks/pr-loop/manifest.json"
+CANDIDATE_NAME = "pr-loop-calibration-candidate.json"
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def exact_int(value):
+    return type(value) is int
+
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def require(value, predicate, message):
+    if not predicate(value):
+        fail(message)
+    return value
+
+
+def digest_file(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def digest_tree(path):
+    if not path.is_dir():
+        fail(f"fixture source directory is unavailable: {path}")
+    digest = hashlib.sha256()
+    for child in sorted(path.rglob("*")):
+        if child.is_file():
+            digest.update(child.relative_to(path).as_posix().encode() + b"\0")
+            digest.update(child.read_bytes())
+    return digest.hexdigest()
+
+
+def load_json(path):
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid JSON document {path}: {error}")
+    return require(value, lambda item: isinstance(item, dict), f"document {path} is not a JSON object")
+
+
+def contained_regular_files(artifact_dir):
+    files = {}
+    for child in sorted(artifact_dir.rglob("*")):
+        resolved = child.resolve()
+        try:
+            resolved.relative_to(artifact_dir)
+        except ValueError:
+            fail(f"artifact path escapes the artifact directory: {child}")
+        if child.is_symlink():
+            fail(f"artifact path is a symlink: {child}")
+        if child.is_dir():
+            continue
+        if not child.is_file():
+            fail(f"artifact path is not a regular file: {child}")
+        files[child.relative_to(artifact_dir).as_posix()] = child
+    return files
+
+
+def archive_regular_files(archive_path):
+    try:
+        archive = zipfile.ZipFile(archive_path)
+    except (OSError, zipfile.BadZipFile) as error:
+        fail(f"invalid calibration artifact archive {archive_path}: {error}")
+    files = {}
+    with archive:
+        for member in archive.infolist():
+            name = member.filename
+            parts = Path(name).parts
+            if not name or name.startswith("/") or "\\" in name or any(part in ("", ".", "..") for part in parts):
+                fail(f"unsafe archive member path: {name!r}")
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode) or (mode and not stat.S_ISREG(mode) and not stat.S_ISDIR(mode)):
+                fail(f"archive member is not a regular file: {name}")
+            if member.is_dir() or stat.S_ISDIR(mode):
+                continue
+            if name in files:
+                fail(f"duplicate archive member: {name}")
+            files[name] = archive.read(member)
+    return files
+
+
+def verify_archive(archive_path, expected_digest, artifact_files):
+    require(expected_digest, lambda item: isinstance(item, str) and len(item) == 64 and all(char in "0123456789abcdef" for char in item), "GitHub artifact SHA-256 must be normalized lowercase 64-hex")
+    if digest_file(archive_path) != expected_digest:
+        fail("downloaded artifact archive SHA-256 does not match the supplied GitHub digest")
+    archive_files = archive_regular_files(archive_path)
+    if set(archive_files) != set(artifact_files):
+        fail("artifact archive member set does not match the extracted artifact directory")
+    for name, path in artifact_files.items():
+        if archive_files[name] != path.read_bytes():
+            fail(f"artifact archive member content does not match extracted file: {name}")
+
+
+def recollect_candidate(candidate, sample_paths):
+    collector = ROOT / "benchmarks/pr-loop/collect-calibration.py"
+    with tempfile.TemporaryDirectory(prefix="togi-pr-loop-recollect-") as temporary:
+        output = Path(temporary) / "candidate.json"
+        source = candidate["source"]
+        command = [
+            sys.executable,
+            str(collector),
+            "--output", str(output),
+            "--source-commit", source["commit"],
+            "--source-run", source["run"],
+            "--source-attempt", str(source["attempt"]),
+            "--source-utc", source["utc"],
+            *map(str, sample_paths),
+        ]
+        completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        if completed.returncode != 0:
+            fail(f"canonical candidate re-collection failed: {completed.stderr.strip()}")
+        return load_json(output)
+
+
+def validate_rfc3339_utc(value, message):
+    require(value, nonempty_string, message)
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        fail(message)
+    return value
+
+
+def validate_result(path, expected_workload_names):
+    result = load_json(path)
+    require(result.get("kind"), lambda item: item == EXPECTED_RESULT_KIND, f"{path}: wrong result kind")
+    require(result.get("schema_version"), lambda item: item == EXPECTED_RESULT_SCHEMA, f"{path}: wrong result schema")
+    require(result.get("ok"), lambda item: item is True, f"{path}: result is not ok")
+    require(result.get("failures"), lambda item: item == [], f"{path}: result has failures")
+    provenance = require(result.get("provenance"), lambda item: isinstance(item, dict), f"{path}: missing provenance")
+    require(provenance.get("go_build_cache_state"), lambda item: item == EXPECTED_CACHE_STATE, f"{path}: go build cache state must be primed")
+    require(provenance.get("go_build_cache_policy"), lambda item: item == EXPECTED_CACHE_POLICY, f"{path}: go build cache policy must be {EXPECTED_CACHE_POLICY}")
+    require(provenance.get("go_build_cache_path"), nonempty_string, f"{path}: invalid go_build_cache_path")
+    workloads = require(result.get("workloads"), lambda item: isinstance(item, list), f"{path}: missing workloads")
+    names = [item.get("name") if isinstance(item, dict) else None for item in workloads]
+    require(names, lambda item: item == expected_workload_names, f"{path}: workload order mismatch")
+    wall = {}
+    for workload in workloads:
+        name = workload.get("name")
+        require(workload.get("ok"), lambda item: item is True, f"{path}: workload {name} is not ok")
+        timing = require(workload.get("timing"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks timing")
+        for key in ("wall_ms", "reported_duration_ms"):
+            require(timing.get(key), lambda item: exact_int(item) and item >= 0, f"{path}: workload {name} has invalid {key}")
+        wall[name] = (timing["wall_ms"], timing["reported_duration_ms"])
+    return result, wall
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", required=True, type=Path, help="downloaded calibration artifact directory")
+    parser.add_argument("--artifact-archive", required=True, type=Path, help="downloaded GitHub artifact ZIP archive")
+    parser.add_argument("--github-artifact-id", required=True, type=int, help="positive GitHub artifact id")
+    parser.add_argument("--github-artifact-sha256", required=True, help="normalized SHA-256 of the downloaded GitHub artifact ZIP")
+    parser.add_argument("--output", required=True, type=Path, help="new baseline JSON path")
+    parser.add_argument("--expected-source-commit", required=True, help="source commit the artifact must calibrate")
+    parser.add_argument("--activation-pr", type=int, default=None, help="activation PR number, supplied by the activation flow")
+    parser.add_argument("--activation-actor", default=None, help="activation actor, supplied by the activation flow")
+    parser.add_argument("--activation-utc", default=None, help="activation time (RFC 3339 UTC), supplied by the activation flow")
+    parser.add_argument("--overwrite", action="store_true", help="replace an existing output document")
+    args = parser.parse_args(argv)
+
+    require(args.expected_source_commit, nonempty_string, "expected source commit is required")
+    require(args.github_artifact_id, lambda item: exact_int(item) and item > 0, "GitHub artifact id must be a positive integer")
+    archive_path = args.artifact_archive.resolve()
+    if not archive_path.is_file():
+        fail(f"artifact archive is unavailable: {args.artifact_archive}")
+    artifact_dir = args.artifact_dir.resolve()
+    if not artifact_dir.is_dir():
+        fail(f"artifact directory is unavailable: {args.artifact_dir}")
+    files = contained_regular_files(artifact_dir)
+    verify_archive(archive_path, args.github_artifact_sha256, files)
+    candidate_path = files.get(CANDIDATE_NAME)
+    if candidate_path is None:
+        fail(f"artifact directory lacks {CANDIDATE_NAME}")
+    candidate = load_json(candidate_path)
+    require(candidate.get("kind"), lambda item: item == EXPECTED_CANDIDATE_KIND, "candidate kind mismatch")
+    require(candidate.get("schema_version"), lambda item: item == EXPECTED_CANDIDATE_SCHEMA, "candidate schema mismatch")
+    source = require(candidate.get("source"), lambda item: isinstance(item, dict), "candidate source is invalid")
+    require(source.get("commit"), lambda item: item == args.expected_source_commit, "candidate source commit does not match the expected source commit")
+    require(source.get("run"), nonempty_string, "candidate source run is invalid")
+    require(source.get("attempt"), lambda item: exact_int(item) and item >= 1, "candidate source attempt is invalid")
+    validate_rfc3339_utc(source.get("utc"), "candidate source UTC must be RFC 3339 UTC (YYYY-MM-DDTHH:MM:SSZ)")
+
+    digests = require(candidate.get("source_file_digests"), lambda item: isinstance(item, dict), "candidate source_file_digests is invalid")
+    sample_keys = sorted(key for key in digests if key.startswith("sample-"))
+    require(sample_keys, lambda item: len(item) == SAMPLE_COUNT and item == [f"sample-{index}/pr-loop-benchmark-result.json" for index in range(1, SAMPLE_COUNT + 1)], "candidate does not name exactly five sample results")
+    for key in sample_keys:
+        require(digests[key], lambda item: isinstance(item, str) and len(item) == 64 and all(char in "0123456789abcdef" for char in item), f"candidate digest for {key} is invalid")
+        path = files.get(key)
+        if path is None:
+            fail(f"artifact directory lacks {key}")
+        if digest_file(path) != digests[key]:
+            fail(f"artifact digest mismatch for {key}")
+    if len({digests[key] for key in sample_keys}) != SAMPLE_COUNT:
+        fail("candidate sample digests are not five distinct values")
+    canonical_candidate = recollect_candidate(candidate, [files[key] for key in sample_keys])
+    if candidate != canonical_candidate:
+        fail("candidate does not exactly match canonical re-collection from artifact samples")
+
+    manifest = load_json(MANIFEST_PATH)
+    require(manifest.get("schema_version"), lambda item: item == EXPECTED_RESULT_SCHEMA, "current manifest schema is not v2")
+    scenarios = require(manifest.get("scenarios"), lambda item: isinstance(item, list) and item, "current manifest scenarios are invalid")
+    patch_files = []
+    for entry in scenarios:
+        patch_file = require(entry.get("patch_file") if isinstance(entry, dict) else None, nonempty_string, "current manifest scenario patch file is invalid")
+        if patch_file not in patch_files:
+            patch_files.append(patch_file)
+    fixture = require(manifest.get("fixture"), lambda item: isinstance(item, dict), "current manifest fixture is invalid")
+    fixture_dir = require(fixture.get("source_dir"), nonempty_string, "current manifest fixture source dir is invalid")
+    current_digests = {"benchmarks/pr-loop/manifest.json": digest_file(MANIFEST_PATH)}
+    for patch_file in patch_files:
+        current_digests[patch_file] = digest_file(ROOT / patch_file)
+    current_digests[f"{fixture_dir.rstrip('/')}/"] = digest_tree(ROOT / fixture_dir)
+    for key, digest in current_digests.items():
+        if digests.get(key) != digest:
+            fail(f"current {key} digest does not match the candidate; recalibrate against this checkout")
+
+    semantic_identity = require(candidate.get("semantic_identity"), lambda item: isinstance(item, dict), "candidate semantic identity is invalid")
+    require(
+        semantic_identity.get("manifest"),
+        lambda item: item == {"name": "togi-pr-loop-benchmarks", "schema_version": 2, "path": "benchmarks/pr-loop/manifest.json"},
+        "candidate semantic identity is not v2",
+    )
+    identity_workloads = require(semantic_identity.get("workloads"), lambda item: isinstance(item, list) and item, "candidate semantic identity lacks workloads")
+    workload_names = []
+    for item in identity_workloads:
+        name = item.get("name") if isinstance(item, dict) else None
+        require(name, nonempty_string, "candidate semantic identity has an invalid workload name")
+        workload_names.append(name)
+    runner_class = require(candidate.get("runner_class"), lambda item: isinstance(item, dict), "candidate runner class is invalid")
+    for key in ("runner_label", "os", "arch"):
+        require(runner_class.get(key), nonempty_string, f"candidate runner class has invalid {key}")
+    require(runner_class.get("logical_cpu_count"), lambda item: exact_int(item) and item > 0, "candidate runner class has invalid logical_cpu_count")
+    measurement_identity = require(
+        candidate.get("measurement_identity"),
+        lambda item: item == {"go_build_cache_state": EXPECTED_CACHE_STATE, "go_build_cache_policy": EXPECTED_CACHE_POLICY},
+        "candidate measurement identity must be primed with the job-private explicit GOCACHE policy",
+    )
+
+    results = []
+    walls = []
+    for key in sample_keys:
+        result, wall = validate_result(files[key], workload_names)
+        results.append(result)
+        walls.append(wall)
+    cache_path = results[0]["provenance"]["go_build_cache_path"]
+    for result in results[1:]:
+        if result["provenance"]["go_build_cache_path"] != cache_path:
+            fail("go build cache path differs across samples")
+
+    candidate_samples = require(candidate.get("samples"), lambda item: isinstance(item, dict), "candidate samples are invalid")
+    require(sorted(candidate_samples), lambda item: item == sorted(workload_names), "candidate samples do not cover every workload")
+    samples = {}
+    for name in workload_names:
+        wall = [entry[name][0] for entry in walls]
+        duration = [entry[name][1] for entry in walls]
+        median = statistics.median(wall)
+        recomputed = {
+            "wall_ms": wall,
+            "duration_ms": duration,
+            "wall_ms_median": median,
+            "wall_ms_mad": statistics.median([abs(value - median) for value in wall]),
+        }
+        if candidate_samples.get(name) != recomputed:
+            fail(f"candidate samples for workload {name} do not match the artifact results")
+        if median <= 0:
+            fail(f"workload {name} has a non-positive wall median")
+        for value in wall:
+            if value > MAX_WALL_TO_MEDIAN * median:
+                fail(f"workload {name} has a wall sample above {MAX_WALL_TO_MEDIAN}x its median")
+        samples[name] = recomputed
+
+    if args.activation_pr is not None and args.activation_pr < 1:
+        fail("activation PR must be a positive integer")
+    if args.activation_actor is not None:
+        require(args.activation_actor, nonempty_string, "activation actor must be non-empty")
+    if args.activation_utc is not None:
+        validate_rfc3339_utc(args.activation_utc, "activation UTC must be RFC 3339 UTC (YYYY-MM-DDTHH:MM:SSZ)")
+
+    baseline = {
+        "kind": BASELINE_KIND,
+        "schema_version": BASELINE_SCHEMA,
+        "status": "pending-activation",
+        "comparison_policy": "no comparator, tolerance, or gate is defined by this document; the separately reviewed activation PR defines the review mechanism",
+        "activation": {
+            "pr": args.activation_pr,
+            "actor": args.activation_actor,
+            "utc": args.activation_utc,
+        },
+        "source": {
+            **source,
+            "github_artifact_id": args.github_artifact_id,
+            "github_artifact_sha256": args.github_artifact_sha256,
+        },
+        "runner_class": runner_class,
+        "execution_provenance": require(candidate.get("execution_provenance"), lambda item: isinstance(item, dict), "candidate execution provenance is invalid"),
+        "measurement_identity": measurement_identity,
+        "semantic_identity": semantic_identity,
+        "samples": samples,
+        "calibration_evidence": {
+            "note": "go_build_cache_path is volatile per-run evidence, never cross-run measurement identity",
+            "go_build_cache_path": cache_path,
+            "runner_diagnostics": require(candidate.get("runner_diagnostics"), lambda item: isinstance(item, list) and len(item) == SAMPLE_COUNT, "candidate runner diagnostics are invalid"),
+        },
+        "source_file_digests": digests,
+    }
+    if args.output.exists() and not args.overwrite:
+        fail(f"output already exists: {args.output} (pass --overwrite to replace it)")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+if __name__ == "__main__":
+    try:
+        main(sys.argv[1:])
+    except ValueError as error:
+        print(f"baseline promotion failed: {error}", file=sys.stderr)
+        sys.exit(2)

--- a/benchmarks/pr-loop/run-pr-loop-benchmarks.sh
+++ b/benchmarks/pr-loop/run-pr-loop-benchmarks.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 # PR-loop benchmark harness for togi (issue #487-A).
 #
-# Copies tests/fixtures/go into a disposable temp project, initializes a local
-# Git history, applies one fixed working-tree patch, and runs the workloads
-# declared in manifest.json through `togi check --base HEAD` so every
-# measurement represents a PR diff, never --all.
+# Copies tests/fixtures/go into one disposable temp project per scenario,
+# initializes a local Git history, applies the scenario's fixed working-tree
+# patch, and runs the workloads declared in manifest.json through
+# `togi check --base HEAD` so every measurement represents a PR diff, never
+# --all.
 #
 # Semantic/provenance invariant failures fail the harness (exit 1). Timing is
 # recorded for observation only; nothing here compares against a baseline.
+#
+# Go build cache provenance: when BENCH_GO_BUILD_CACHE_STATE is warmup or
+# primed, the harness requires an absolute GOCACHE exactly matching
+# `go env GOCACHE` (exit 2 otherwise) and records the resolved path plus the
+# job-private-explicit-gocache policy in provenance. The default unclassified
+# state makes no cache requirement and stays observational.
 #
 # Usage: run-pr-loop-benchmarks.sh [--output DIR] [--keep-workspace]
 # Env:   TOGI_BIN  path to the togi binary (default: target/release/togi)
@@ -24,9 +31,12 @@ usage() {
   echo "Usage: $0 [--output DIR] [--keep-workspace]" >&2
   echo "  --output DIR       directory for raw reports and the normalized result" >&2
   echo "                     (default: a fresh dir under RUNNER_TEMP/TMPDIR)" >&2
-  echo "  --keep-workspace   keep the disposable temp project for debugging" >&2
+  echo "  --keep-workspace   keep the disposable temp projects for debugging" >&2
   echo "Env: TOGI_BIN (default: <repo>/target/release/togi)" >&2
   echo "     BENCH_MANIFEST (default: <repo>/benchmarks/pr-loop/manifest.json)" >&2
+  echo "     BENCH_GO_BUILD_CACHE_STATE (unclassified|warmup|primed;" >&2
+  echo "          warmup/primed require an absolute GOCACHE matching" >&2
+  echo "          'go env GOCACHE' and an existing cache directory)" >&2
   echo "Requires: bash, git, go, jq, sed, sha256sum|shasum, and python3" >&2
   echo "          (python3 provides the monotonic high-resolution clock)" >&2
 }
@@ -118,8 +128,8 @@ if [ ! -f "$MANIFEST" ]; then
 fi
 
 MANIFEST_SCHEMA=$(jq -r '.schema_version // "missing"' "$MANIFEST")
-if [ "$MANIFEST_SCHEMA" != "1" ]; then
-  echo "unsupported manifest schema_version $MANIFEST_SCHEMA (expected 1)" >&2
+if [ "$MANIFEST_SCHEMA" != "2" ]; then
+  echo "unsupported manifest schema_version $MANIFEST_SCHEMA (expected 2)" >&2
   exit 2
 fi
 
@@ -129,30 +139,43 @@ if ! jq -e '
   (.name | type == "string" and length > 0)
   and (.fixture | type == "object")
   and (.fixture.source_dir | type == "string" and length > 0)
-  and (.fixture.patch_file | type == "string" and length > 0)
-  and (.fixture.patch_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
-  and (.fixture.changed_file | type == "string" and length > 0)
-  and (.fixture.changed_line_range | type == "array" and length == 2
-       and ([.[] | type == "number"] | all)
-       and (.[0] <= .[1]))
   and (.fixture.base_ref | type == "string" and length > 0)
-  and (.fixture.expected_mutation_count | type == "number" and . > 0 and floor == .)
+  and (.scenarios | type == "array" and length > 0
+       and (([.[].name] | unique | length) == length)
+       and ([.[] |
+             ((.name | type == "string" and length > 0)
+              and (.patch_file | type == "string" and length > 0)
+              and (.patch_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+              and (.changed_files | type == "array" and length > 0
+                   and ([.[] |
+                        ((.path | type == "string" and length > 0)
+                         and (.line_range | type == "array" and length == 2
+                              and ([.[] | type == "number"] | all)
+                              and (.[0] <= .[1])))]
+                       | all))
+              and ((has("requires_mutation_per_changed_file") | not) or (.requires_mutation_per_changed_file | type == "boolean"))
+              and (.expected_mutation_count | type == "number" and . > 0 and floor == .))]
+            | all))
   and (.togi | type == "object")
   and (.togi.common_args | type == "array" and length > 0
        and ([.[] | type == "string"] | all))
 ' "$MANIFEST" >/dev/null; then
   echo "manifest $MANIFEST failed schema/provenance validation" >&2
-  echo "required: name, fixture.{source_dir, patch_file, patch_sha256 (64-hex)," >&2
-  echo "  changed_file, changed_line_range [min,max], base_ref," >&2
-  echo "  expected_mutation_count > 0}, togi.common_args [non-empty strings]" >&2
+  echo "  [{path, line_range [min,max]}], optional requires_mutation_per_changed_file," >&2
+  echo "  expected_mutation_count > 0}]," >&2
+  echo "  togi.common_args [non-empty strings]" >&2
   exit 2
 fi
 
 # Keep the known-invariant list here in sync with invariant_filter().
 if ! jq -e '
-  (.workloads | type == "array" and length == 4)
+  (.workloads | type == "array" and length == 6)
   and ([.workloads[] |
         ((.name | type == "string" and length > 0)
+         and (.scenario | type == "string" and length > 0)
+         and ((.runner_mode // "") == "regular"
+              or (.runner_mode // "") == "schemata"
+              or (.runner_mode // "") == "default")
          and ((.cache // "") == "fresh" or (.cache // "") == "reuse")
          and (.extra_args | type == "array" and ([.[] | type == "string"] | all))
          and (.invariants | type == "array" and length > 0
@@ -164,23 +187,86 @@ if ! jq -e '
                                       "pr-diff-targeting"] | index($i) != null)]
                    | all)))]
        | all)
+  and (. as $m
+       | [.workloads[].scenario]
+       | all(. as $s | [$m.scenarios[].name] | index($s) != null))
 ' "$MANIFEST" >/dev/null; then
-  echo "manifest $MANIFEST must declare exactly 4 workloads, each with name," >&2
+  echo "manifest $MANIFEST must declare exactly 6 workloads, each with name," >&2
+  echo "  scenario (a declared scenario), runner_mode (regular|schemata|default)," >&2
   echo "  cache (fresh|reuse), extra_args [strings], and non-empty invariants" >&2
   echo "  drawn from the known list, always including report-well-formed" >&2
   exit 2
 fi
 
 if ! jq -e '
-  ([.workloads[].name]
-     == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default"])
+  ([.scenarios[].name] == ["single-file", "multi-file"])
+  and ([.workloads[].name]
+       == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default",
+           "multi-file-regular", "multi-file-default"])
+  and ([.workloads[].scenario]
+       == ["single-file", "single-file", "single-file", "single-file",
+           "multi-file", "multi-file"])
+  and ([.workloads[].runner_mode]
+       == ["regular", "regular", "schemata", "default", "regular", "default"])
   and (.workloads[0].cache == "fresh" and .workloads[0].seeds_cache == true)
   and (.workloads[1].cache == "reuse"
        and (.workloads[1].expects_cache_from // "") == "cold-regular")
+  and (.workloads[4].cache == "fresh" and .workloads[4].seeds_cache == true)
 ' "$MANIFEST" >/dev/null; then
   echo "manifest $MANIFEST must order workloads cold-regular, warm-exact-cache," >&2
-  echo "  cold-schemata, pr-diff-default, with warm-exact-cache reusing the cache" >&2
-  echo "  seeded by cold-regular" >&2
+  echo "  cold-schemata, pr-diff-default (single-file), then multi-file-regular," >&2
+  echo "  multi-file-default (multi-file), with warm-exact-cache reusing the" >&2
+  echo "  cache seeded by cold-regular inside the single-file scenario" >&2
+  exit 2
+fi
+
+# Cache dependencies never cross scenarios: expects_cache_from may only name
+# an earlier workload in the same scenario that seeds its cache.
+if ! jq -e '
+  . as $m
+  | [.workloads | to_entries[]
+     | select(.value.expects_cache_from != null)
+     | . as $edge
+     | ([$m.workloads[0:$edge.key][]
+         | select(.name == $edge.value.expects_cache_from
+                  and .scenario == $edge.value.scenario
+                  and (.seeds_cache // false))]
+        | length == 1)]
+  | all
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the cache dependency contract:" >&2
+  echo "  expects_cache_from must name exactly one earlier workload in the" >&2
+  echo "  same scenario that declares seeds_cache" >&2
+  exit 2
+fi
+
+# runner_mode must match the effective argv of every workload: regular pins
+# --no-schemata, schemata pins --schemata, default pins neither, and the
+# selected test command must come from exactly one --test-cmd pair.
+if ! jq -e '
+  . as $m
+  | ([$m.togi.common_args[] | select(. == "--test-cmd")] | length == 1)
+    and (([$m.togi.common_args | to_entries[] | select(.value == "--test-cmd") | .key][0]) as $i
+         | ($i + 1) < ($m.togi.common_args | length)
+           and ($m.togi.common_args[$i + 1] | length > 0))
+    and ([range(0; ($m.workloads | length)) | . as $w
+          | ($m.togi.common_args + $m.workloads[$w].extra_args) as $argv
+          | ([$argv[] | select(. == "--test-cmd")] | length) as $cmds
+          | ([$argv[] | select(. == "--no-schemata")] | length) as $no
+          | ([$argv[] | select(. == "--schemata")] | length) as $yes
+          | ($cmds == 1)
+            and (if $m.workloads[$w].runner_mode == "regular"
+                 then ($no == 1 and $yes == 0)
+                 elif $m.workloads[$w].runner_mode == "schemata"
+                 then ($yes == 1 and $no == 0)
+                 else ($yes == 0 and $no == 0) end)]
+         | all)
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the runner_mode/test-command contract:" >&2
+  echo "  regular requires exactly one --no-schemata and no --schemata," >&2
+  echo "  schemata requires exactly one --schemata and no --no-schemata," >&2
+  echo "  default requires neither, and every effective argv must carry" >&2
+  echo "  exactly one split --test-cmd pair" >&2
   exit 2
 fi
 
@@ -209,28 +295,105 @@ if ! jq -e '
   exit 2
 fi
 
-EXPECTED_MUTATIONS=$(jq -r '.fixture.expected_mutation_count' "$MANIFEST")
-CHANGED_FILE=$(jq -r '.fixture.changed_file' "$MANIFEST")
-LINE_MIN=$(jq -r '.fixture.changed_line_range[0]' "$MANIFEST")
-LINE_MAX=$(jq -r '.fixture.changed_line_range[1]' "$MANIFEST")
 FIXTURE_SOURCE_DIR=$(jq -r '.fixture.source_dir' "$MANIFEST")
-EXPECTED_PATCH_SHA=$(jq -r '.fixture.patch_sha256' "$MANIFEST")
-PATCH_FILE="$REPO_ROOT/$(jq -r '.fixture.patch_file' "$MANIFEST")"
 WORKLOAD_COUNT=$(jq -r '.workloads | length' "$MANIFEST")
+SCENARIO_COUNT=$(jq -r '.scenarios | length' "$MANIFEST")
 
-ACTUAL_PATCH_SHA=$(sha256_file "$PATCH_FILE")
-if [ "$ACTUAL_PATCH_SHA" != "$EXPECTED_PATCH_SHA" ]; then
-  echo "fixture patch digest mismatch:" >&2
-  echo "  manifest: $EXPECTED_PATCH_SHA" >&2
-  echo "  actual:   $ACTUAL_PATCH_SHA" >&2
-  echo "update manifest.json deliberately if the patch changed" >&2
-  exit 1
-fi
+# The selected test command every workload must resolve to, derived from the
+# single --test-cmd pair in common_args.
+TEST_CMD_INDEX=$(jq -r '[.togi.common_args | to_entries[] | select(.value == "--test-cmd") | .key][0]' "$MANIFEST")
+TEST_CMD_VALUE=$(jq -r --argjson i "$TEST_CMD_INDEX" '.togi.common_args[$i + 1]' "$MANIFEST")
+EXPECTED_TEST_COMMAND_JSON=$(printf '%s' "$TEST_CMD_VALUE" | tr ' ' '\n' | sed '/^$/d' | jq -Rn '[inputs]')
+
+# Scenario state is kept in parallel indexed arrays (bash 3.2 compatible);
+# scenario_index maps a scenario name to its slot.
+declare -a SCENARIO_ORDER=()
+declare -a SCENARIO_PATCH_FILE=()
+declare -a SCENARIO_PATCH_SHA=()
+declare -a SCENARIO_REQUIRE_PER_CHANGED_FILE=()
+declare -a SCENARIO_EXPECTED=()
+declare -a SCENARIO_CHANGED_FILES=()
+
+scenario_index() {
+  local i
+  for i in "${!SCENARIO_ORDER[@]}"; do
+    if [ "${SCENARIO_ORDER[$i]}" = "$1" ]; then
+      printf '%s\n' "$i"
+      return 0
+    fi
+  done
+  return 1
+}
+
+while IFS= read -r scenario; do
+  S_NAME=$(jq -r '.name' <<<"$scenario")
+  SCENARIO_ORDER+=("$S_NAME")
+  SCENARIO_PATCH_FILE+=("$REPO_ROOT/$(jq -r '.patch_file' <<<"$scenario")")
+  SCENARIO_PATCH_SHA+=($(jq -r '.patch_sha256' <<<"$scenario"))
+  SCENARIO_REQUIRE_PER_CHANGED_FILE+=($(jq -r '.requires_mutation_per_changed_file // false' <<<"$scenario"))
+  SCENARIO_EXPECTED+=($(jq -r '.expected_mutation_count' <<<"$scenario"))
+  SCENARIO_CHANGED_FILES+=("$(jq -c '.changed_files' <<<"$scenario")")
+done < <(jq -c '.scenarios[]' "$MANIFEST")
+
+# Every scenario patch digest is verified before any run.
+for i in "${!SCENARIO_ORDER[@]}"; do
+  ACTUAL_PATCH_SHA=$(sha256_file "${SCENARIO_PATCH_FILE[$i]}")
+  if [ "$ACTUAL_PATCH_SHA" != "${SCENARIO_PATCH_SHA[$i]}" ]; then
+    echo "fixture patch digest mismatch for scenario ${SCENARIO_ORDER[$i]}:" >&2
+    echo "  manifest: ${SCENARIO_PATCH_SHA[$i]}" >&2
+    echo "  actual:   $ACTUAL_PATCH_SHA" >&2
+    echo "update manifest.json deliberately if the patch changed" >&2
+    exit 1
+  fi
+done
 
 COMMON_ARGS=()
 while IFS= read -r arg; do
   COMMON_ARGS+=("$arg")
 done < <(jq -r '.togi.common_args[]' "$MANIFEST")
+
+# Go build cache provenance contract. warmup and primed measurements must
+# run against a job-private explicit GOCACHE; unclassified local runs make
+# no cache requirement and stay observational.
+BENCH_GO_BUILD_CACHE_STATE=${BENCH_GO_BUILD_CACHE_STATE:-unclassified}
+case "$BENCH_GO_BUILD_CACHE_STATE" in
+  warmup|primed)
+    if [ -z "${GOCACHE:-}" ]; then
+      echo "BENCH_GO_BUILD_CACHE_STATE=$BENCH_GO_BUILD_CACHE_STATE requires GOCACHE to be set" >&2
+      exit 2
+    fi
+    case "$GOCACHE" in
+      /*) ;;
+      *)
+        echo "GOCACHE must be an absolute path for $BENCH_GO_BUILD_CACHE_STATE measurements, got '$GOCACHE'" >&2
+        exit 2
+        ;;
+    esac
+    if [ ! -d "$GOCACHE" ]; then
+      echo "GOCACHE directory $GOCACHE does not exist for $BENCH_GO_BUILD_CACHE_STATE measurements" >&2
+      exit 2
+    fi
+    RESOLVED_GOCACHE=$(go env GOCACHE) || {
+      echo "go env GOCACHE failed for $BENCH_GO_BUILD_CACHE_STATE measurements" >&2
+      exit 2
+    }
+    if [ "$RESOLVED_GOCACHE" != "$GOCACHE" ]; then
+      echo "GOCACHE ($GOCACHE) does not match 'go env GOCACHE' ($RESOLVED_GOCACHE)" >&2
+      exit 2
+    fi
+    GO_BUILD_CACHE_POLICY="job-private-explicit-gocache"
+    GO_BUILD_CACHE_PATH_JSON=$(jq -n --arg path "$RESOLVED_GOCACHE" '$path')
+    ;;
+  unclassified)
+    GO_BUILD_CACHE_POLICY="unenforced"
+    GO_BUILD_CACHE_PATH_JSON="null"
+    ;;
+  *)
+    echo "unknown BENCH_GO_BUILD_CACHE_STATE '$BENCH_GO_BUILD_CACHE_STATE'" >&2
+    echo "expected unclassified, warmup, or primed" >&2
+    exit 2
+    ;;
+esac
 
 if [ -z "$OUT_DIR" ]; then
   OUT_DIR=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/togi-pr-loop-benchmarks.XXXXXX")
@@ -239,7 +402,6 @@ mkdir -p "$OUT_DIR/raw"
 OUT_DIR=$(cd "$OUT_DIR" && pwd)
 
 WORK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/togi-pr-loop-work.XXXXXX")
-PROJECT_DIR="$WORK_ROOT/project"
 cleanup() {
   if [ "$KEEP_WORKSPACE" = "1" ]; then
     echo "workspace kept: $WORK_ROOT" >&2
@@ -249,18 +411,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Disposable temp project: fixture copy, local Git history, one fixed
-# working-tree patch applied on top of the base commit.
-mkdir -p "$PROJECT_DIR"
-cp -R "$REPO_ROOT/$FIXTURE_SOURCE_DIR/." "$PROJECT_DIR/"
-git -C "$PROJECT_DIR" -c init.defaultBranch=main init -q
-git -C "$PROJECT_DIR" config user.email "togi-pr-loop-bench@example.invalid"
-git -C "$PROJECT_DIR" config user.name "togi-pr-loop-bench"
-git -C "$PROJECT_DIR" config commit.gpgsign false
-git -C "$PROJECT_DIR" add .
-git -C "$PROJECT_DIR" commit -qm "fixture base"
-git -C "$PROJECT_DIR" apply "$PATCH_FILE"
-BASE_REVISION=$(git -C "$PROJECT_DIR" rev-parse HEAD)
+# One disposable temp project per scenario: fixture copy, local Git history,
+# the scenario's fixed working-tree patch applied on top of the base commit.
+declare -a SCENARIO_PROJECT=()
+declare -a SCENARIO_BASE_REVISION=()
+for i in "${!SCENARIO_ORDER[@]}"; do
+  S_PROJECT="$WORK_ROOT/project-${SCENARIO_ORDER[$i]}"
+  mkdir -p "$S_PROJECT"
+  cp -R "$REPO_ROOT/$FIXTURE_SOURCE_DIR/." "$S_PROJECT/"
+  git -C "$S_PROJECT" -c init.defaultBranch=main init -q
+  git -C "$S_PROJECT" config user.email "togi-pr-loop-bench@example.invalid"
+  git -C "$S_PROJECT" config user.name "togi-pr-loop-bench"
+  git -C "$S_PROJECT" config commit.gpgsign false
+  git -C "$S_PROJECT" add .
+  git -C "$S_PROJECT" commit -qm "fixture base"
+  git -C "$S_PROJECT" apply "${SCENARIO_PATCH_FILE[$i]}"
+  SCENARIO_PROJECT+=("$S_PROJECT")
+  SCENARIO_BASE_REVISION+=($(git -C "$S_PROJECT" rev-parse HEAD))
+done
 
 TOGI_VERSION=$("$TOGI_BIN" --version)
 GO_VERSION=$(go version)
@@ -279,10 +447,10 @@ fi
 KERNEL_RELEASE=$(uname -r)
 IMAGE_OS=${ImageOS:-}
 IMAGE_VERSION=${ImageVersion:-}
-BENCH_GO_BUILD_CACHE_STATE=${BENCH_GO_BUILD_CACHE_STATE:-unclassified}
 
-# jq filter for each named invariant. Manifest values are injected as
-# $expected_mutations, $changed_file, $line_min, and $line_max.
+# jq filter for each named invariant. Scenario values are injected as
+# $expected_mutations, $changed_files, and $requires_per_changed_file; the
+# manifest's selected test command is injected as $expected_test_command.
 invariant_filter() {
   case "$1" in
     report-well-formed)
@@ -298,7 +466,8 @@ and ((.mutations | length) == .total)
 and (.timeout == 0)
 and (.build_errors == 0)
 and (.duration_ms > 0)
-and ((.test_command // []) == ["go", "test", "./..."])
+and ((.test_command // []) == $expected_test_command)
+and ([.mutations[] | ((.test_selection? // {"mode": "full"}).mode == "full")] | all)
 EOF
       ;;
     full-fresh-execution)
@@ -326,8 +495,19 @@ EOF
       ;;
     pr-diff-targeting)
       cat <<'EOF'
-(([.mutations[].file] | unique) == [$changed_file])
-and ([.mutations[].line | (. >= $line_min and . <= $line_max)] | all)
+([.mutations[]
+  | .file as $file
+  | .line as $line
+  | ([$changed_files[]
+      | select(.path == $file
+               and $line >= .line_range[0]
+               and $line <= .line_range[1])]
+     | length >= 1)]
+ | all)
+and (if $requires_per_changed_file then
+       ([.mutations[].file] | unique | sort)
+       == ([$changed_files[].path] | unique | sort)
+     else true end)
 EOF
       ;;
     *)
@@ -338,13 +518,26 @@ EOF
 
 FRAGMENTS=()
 FAILURES=()
-REFERENCE_DIGEST=""
-DIGESTS_CONSISTENT=1
+declare -a SCENARIO_REF_DIGEST=()
+declare -a SCENARIO_CONSISTENT=()
+for i in "${!SCENARIO_ORDER[@]}"; do
+  SCENARIO_REF_DIGEST+=("")
+  SCENARIO_CONSISTENT+=(1)
+done
 OVERALL_OK=1
 
 while IFS= read -r workload; do
   WL_NAME=$(jq -r '.name' <<<"$workload")
+  WL_SCENARIO=$(jq -r '.scenario' <<<"$workload")
+  RUNNER_MODE=$(jq -r '.runner_mode' <<<"$workload")
   CACHE_POLICY=$(jq -r '.cache' <<<"$workload")
+  WL_SCENARIO_INDEX=$(scenario_index "$WL_SCENARIO") || {
+    echo "workload $WL_NAME names undeclared scenario '$WL_SCENARIO'" >&2
+    exit 2
+  }
+  PROJECT_DIR="${SCENARIO_PROJECT[$WL_SCENARIO_INDEX]}"
+  EXPECTED_MUTATIONS="${SCENARIO_EXPECTED[$WL_SCENARIO_INDEX]}"
+  CHANGED_FILES_JSON="${SCENARIO_CHANGED_FILES[$WL_SCENARIO_INDEX]}"
 
   EXTRA_ARGS=()
   while IFS= read -r arg; do
@@ -375,7 +568,7 @@ while IFS= read -r workload; do
   RAW_STDERR="$OUT_DIR/raw/$WL_NAME.stderr"
   REPORT_JSON="$OUT_DIR/raw/$WL_NAME.report.json"
 
-  echo "running workload $WL_NAME" >&2
+  echo "running workload $WL_NAME (scenario $WL_SCENARIO)" >&2
   START_MS=$(now_ms)
   set +e
   ( cd "$PROJECT_DIR" && "${CMD[@]}" ) >"$RAW_STDOUT" 2>"$RAW_STDERR"
@@ -396,6 +589,7 @@ while IFS= read -r workload; do
 
   SEMANTICS="null"
   DIGEST=""
+  RUNNER_MODE_OK=1
   if [ "$REPORT_OK" = "1" ]; then
     SEMANTICS=$(jq -c '{
       total, planned_total, tested, killed, survived, timeout, build_errors,
@@ -406,16 +600,37 @@ while IFS= read -r workload; do
       partial,
       reported_duration_ms: .duration_ms,
       schemata: (.schemata // null),
+      selected_test_command: (.test_command // null),
+      test_selection: {
+        mode: (if ([.mutations[] | ((.test_selection? // {"mode": "full"}).mode == "full")] | all) then "full-suite" else "narrowed" end),
+        full_suite_mutation_count: ([.mutations[] | select((.test_selection? // {"mode": "full"}).mode == "full")] | length),
+        narrowed_mutation_count: ([.mutations[] | select((.test_selection? // {"mode": "full"}).mode != "full")] | length)
+      },
       mutation_count: (.mutations | length)
     }' "$REPORT_JSON")
     DIGEST=$(jq -r '[.mutations[]
       | "\(.file):\(.line):\(.column // 0):\(.operator):\(.original // "")->\(.replacement // "")"]
       | sort | .[]' "$REPORT_JSON" | sha256_stdin)
-    if [ -z "$REFERENCE_DIGEST" ]; then
-      REFERENCE_DIGEST=$DIGEST
-    elif [ "$DIGEST" != "$REFERENCE_DIGEST" ]; then
-      DIGESTS_CONSISTENT=0
+    if [ -z "${SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]}" ]; then
+      SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]=$DIGEST
+    elif [ "$DIGEST" != "${SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]}" ]; then
+      SCENARIO_CONSISTENT[$WL_SCENARIO_INDEX]=0
       FAILURES+=("$WL_NAME:mutation-identity-drift")
+    fi
+    # runner_mode is manifest-declared and argv-validated; the report's
+    # schemata evidence must agree with it. Default mode makes no assertion:
+    # it deliberately inherits togi's own defaults.
+    if [ "$RUNNER_MODE" = "schemata" ]; then
+      if ! jq -e '.schemata != null' "$REPORT_JSON" >/dev/null; then
+        RUNNER_MODE_OK=0
+      fi
+    elif [ "$RUNNER_MODE" = "regular" ]; then
+      if ! jq -e '.schemata == null' "$REPORT_JSON" >/dev/null; then
+        RUNNER_MODE_OK=0
+      fi
+    fi
+    if [ "$RUNNER_MODE_OK" != "1" ]; then
+      FAILURES+=("$WL_NAME:runner-mode-consistency")
     fi
   fi
 
@@ -430,9 +645,9 @@ while IFS= read -r workload; do
     if [ "$REPORT_OK" = "1" ] \
       && jq -e \
         --argjson expected_mutations "$EXPECTED_MUTATIONS" \
-        --arg changed_file "$CHANGED_FILE" \
-        --argjson line_min "$LINE_MIN" \
-        --argjson line_max "$LINE_MAX" \
+        --argjson changed_files "$CHANGED_FILES_JSON" \
+        --argjson requires_per_changed_file "${SCENARIO_REQUIRE_PER_CHANGED_FILE[$WL_SCENARIO_INDEX]}" \
+        --argjson expected_test_command "$EXPECTED_TEST_COMMAND_JSON" \
         "$FILTER" "$REPORT_JSON" >/dev/null; then
       INV_OK="true"
     else
@@ -447,6 +662,9 @@ while IFS= read -r workload; do
     WL_OK=0
     FAILURES+=("$WL_NAME:report-extraction")
   fi
+  if [ "$RUNNER_MODE_OK" != "1" ]; then
+    WL_OK=0
+  fi
   if [ "$WL_OK" != "1" ]; then
     OVERALL_OK=0
   fi
@@ -456,6 +674,8 @@ while IFS= read -r workload; do
   FRAGMENT="$WORK_ROOT/workload-$WL_NAME.json"
   jq -n \
     --arg name "$WL_NAME" \
+    --arg scenario "$WL_SCENARIO" \
+    --arg runner_mode "$RUNNER_MODE" \
     --arg cache_policy "$CACHE_POLICY" \
     --argjson command "$CMD_JSON" \
     --argjson exit_status "$STATUS" \
@@ -470,6 +690,8 @@ while IFS= read -r workload; do
     --arg report "raw/$WL_NAME.report.json" \
     '{
       name: $name,
+      scenario: $scenario,
+      runner_mode: $runner_mode,
       cache_policy: $cache_policy,
       command: $command,
       exit_status: $exit_status,
@@ -503,14 +725,26 @@ if [ "${#FRAGMENTS[@]}" -ne "$WORKLOAD_COUNT" ]; then
   exit 2
 fi
 
-if [ "$DIGESTS_CONSISTENT" != "1" ]; then
-  OVERALL_OK=0
-fi
-if [ "$DIGESTS_CONSISTENT" = "1" ]; then
-  DIGESTS_CONSISTENT_JSON="true"
-else
-  DIGESTS_CONSISTENT_JSON="false"
-fi
+# Per-scenario mutation identity: workloads of one scenario must agree, and
+# scenarios legitimately differ from each other.
+SCENARIOS_JSON="{}"
+for i in "${!SCENARIO_ORDER[@]}"; do
+  if [ "${SCENARIO_CONSISTENT[$i]}" != "1" ]; then
+    OVERALL_OK=0
+    S_CONSISTENT="false"
+  else
+    S_CONSISTENT="true"
+  fi
+  SCENARIOS_JSON=$(jq \
+    --arg name "${SCENARIO_ORDER[$i]}" \
+    --argjson consistent "$S_CONSISTENT" \
+    --arg digest "${SCENARIO_REF_DIGEST[$i]}" \
+    '. + {($name): {
+      mutation_identity_consistent: $consistent,
+      mutation_identity_sha256: (if $consistent and $digest != "" then $digest else null end)
+    }}' <<<"$SCENARIOS_JSON")
+done
+
 if [ "$OVERALL_OK" = "1" ]; then
   OVERALL_OK_JSON="true"
 else
@@ -521,6 +755,22 @@ FAILURES_JSON="[]"
 if [ ${#FAILURES[@]} -gt 0 ]; then
   FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]}" | jq -Rn '[inputs]')
 fi
+
+# Per-scenario fixture provenance: patch identity and base revision of each
+# disposable project.
+FIXTURE_SCENARIOS_JSON="{}"
+for i in "${!SCENARIO_ORDER[@]}"; do
+  FIXTURE_SCENARIOS_JSON=$(jq \
+    --arg name "${SCENARIO_ORDER[$i]}" \
+    --arg patch_file "${SCENARIO_PATCH_FILE[$i]#"$REPO_ROOT"/}" \
+    --arg patch_sha "${SCENARIO_PATCH_SHA[$i]}" \
+    --arg base_revision "${SCENARIO_BASE_REVISION[$i]}" \
+    '. + {($name): {
+      patch_file: $patch_file,
+      patch_sha256: $patch_sha,
+      base_revision: $base_revision
+    }}' <<<"$FIXTURE_SCENARIOS_JSON")
+done
 
 META_JSON="$WORK_ROOT/meta.json"
 jq -n \
@@ -536,17 +786,18 @@ jq -n \
   --arg image_os "$IMAGE_OS" \
   --arg image_version "$IMAGE_VERSION" \
   --arg go_build_cache_state "$BENCH_GO_BUILD_CACHE_STATE" \
+  --arg go_build_cache_policy "$GO_BUILD_CACHE_POLICY" \
+  --argjson go_build_cache_path "$GO_BUILD_CACHE_PATH_JSON" \
   --arg started_at "$STARTED_AT" \
   --arg fixture_source "$FIXTURE_SOURCE_DIR" \
-  --arg patch_sha "$ACTUAL_PATCH_SHA" \
-  --arg base_revision "$BASE_REVISION" \
+  --argjson fixture_scenarios "$FIXTURE_SCENARIOS_JSON" \
   '{
     kind: "togi_pr_loop_benchmark_result",
-    schema_version: 1,
+    schema_version: 2,
     timing_policy: "observational-only",
     manifest: {
       name: "togi-pr-loop-benchmarks",
-      schema_version: 1,
+      schema_version: 2,
       path: "benchmarks/pr-loop/manifest.json"
     },
     provenance: {
@@ -564,32 +815,30 @@ jq -n \
       image_version: (if $image_version == "" then null else $image_version end),
       git_version: $git_version,
       go_build_cache_state: $go_build_cache_state,
+      go_build_cache_policy: $go_build_cache_policy,
+      go_build_cache_path: $go_build_cache_path,
       fixture_source_dir: $fixture_source,
-      fixture_patch: "benchmarks/pr-loop/fixture-change.patch",
-      fixture_patch_sha256: $patch_sha,
-      fixture_base_revision: $base_revision,
+      fixture_scenarios: $fixture_scenarios,
       started_at_utc: $started_at
     }
   }' > "$META_JSON"
 
 RESULT_JSON="$OUT_DIR/pr-loop-benchmark-result.json"
 jq -s \
-  --arg digest "$REFERENCE_DIGEST" \
-  --argjson consistent "$DIGESTS_CONSISTENT_JSON" \
+  --argjson scenarios "$SCENARIOS_JSON" \
   --argjson ok "$OVERALL_OK_JSON" \
   --argjson failures "$FAILURES_JSON" \
   '.[0] + {
     workloads: .[1:],
     cross_workload: {
-      mutation_identity_consistent: $consistent,
-      mutation_identity_sha256: (if $consistent then $digest else null end)
+      scenarios: $scenarios
     },
     ok: $ok,
     failures: $failures
   }' "$META_JSON" "${FRAGMENTS[@]}" > "$RESULT_JSON"
 
 jq -r '.workloads[]
-  | "\(.name): exit=\(.exit_status) wall=\(.timing.wall_ms)ms reported=\(.timing.reported_duration_ms // 0)ms ok=\(.ok)"' \
+  | "\(.name) [\(.scenario)]: exit=\(.exit_status) wall=\(.timing.wall_ms)ms reported=\(.timing.reported_duration_ms // 0)ms ok=\(.ok)"' \
   "$RESULT_JSON"
 echo "normalized result: $RESULT_JSON"
 echo "raw reports: $OUT_DIR/raw"

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -66,7 +66,10 @@ to force the regular runner for all mutations.
   `pr-loop-benchmarks` job, Linux x86_64 only on `ubuntu-24.04` with the same
   fail-closed native target/arch assertion): builds the release binary and
   uploads the complete PR-loop harness output, including raw files and
-  `pr-loop-benchmark-result.json`. Timing is observational only: there is no
+  `pr-loop-benchmark-result.json`. Go is pinned to 1.26.5 and every harness
+  invocation binds one job-private `GOCACHE` (created empty, warmed before
+  measurement) so cache provenance is explicit. Timing is observational only:
+  there is no
   current baseline, threshold, or merge gate.
 
 ### Auto-detection fallback

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4594,7 +4594,7 @@ fn pr_loop_benchmark_workflow_collects_observational_evidence() {
             "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8",
             Some("stable"),
         ),
-        ("actions/setup-go@v7", Some("stable")),
+        ("actions/setup-go@v7", Some("1.26.5")),
     ] {
         let step = steps
             .iter()

--- a/tests/fixtures/go/calc_test.go
+++ b/tests/fixtures/go/calc_test.go
@@ -25,3 +25,9 @@ func TestMax(t *testing.T) {
 }
 
 // Missing: TestAbs entirely!
+
+func TestSum(t *testing.T) {
+	if Sum(2, 3) != 5 {
+		t.Error("expected 5")
+	}
+}

--- a/tests/fixtures/go/numbers.go
+++ b/tests/fixtures/go/numbers.go
@@ -1,0 +1,6 @@
+package calc
+
+// Sum returns the sum of a and b.
+func Sum(a, b int) int {
+	return a + b
+}

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -244,16 +244,18 @@ fn harness_tools_available() -> bool {
 /// Content digest helper mirroring the harness's sha256sum/shasum fallback,
 /// used to re-digest artifact files after deliberate test tampering.
 fn sha256_file(path: &Path) -> String {
-    let (program, args): (&str, &[&str]) = if tool_on_path("sha256sum") {
-        ("sha256sum", &[])
+    let output = if tool_on_path("sha256sum") {
+        Command::new("sha256sum")
+            .arg(path)
+            .output()
+            .expect("spawn sha256sum")
     } else {
-        ("shasum", &["-a", "256"])
+        Command::new("shasum")
+            .args(["-a", "256"])
+            .arg(path)
+            .output()
+            .expect("spawn shasum")
     };
-    let output = Command::new(program)
-        .args(args)
-        .arg(path)
-        .output()
-        .expect("spawn sha256 tool");
     assert!(output.status.success(), "sha256 tool failed for {path:?}");
     String::from_utf8_lossy(&output.stdout)
         .split_whitespace()

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -1261,9 +1261,9 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
         })
         .collect::<Result<_, _>>()?;
     keys.sort_unstable();
-    if keys != ["env", "name", "permissions", "runs-on", "steps"] {
+    if keys != ["name", "permissions", "runs-on", "steps"] {
         return Err(format!(
-            "benchmark job keys must be exactly name, runs-on, permissions, env, and steps; got {keys:?}"
+            "benchmark job keys must be exactly name, runs-on, permissions, and steps; got {keys:?}"
         ));
     }
     if job.get("name").and_then(|value| value.as_str()) != Some("PR-loop Benchmark Evidence")
@@ -1281,15 +1281,8 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
     {
         return Err("benchmark job top-level values must match the approved contract".to_string());
     }
-    if job
-        .get("env")
-        .and_then(|env| env.get("BENCH_GOCACHE"))
-        .and_then(|value| value.as_str())
-        != Some("${{ runner.temp }}/togi-pr-loop-gocache")
-    {
-        return Err(
-            "benchmark job must define the job-private BENCH_GOCACHE under runner.temp".to_string(),
-        );
+    if job.get("env").is_some() {
+        return Err("benchmark job must not define job-level environment".to_string());
     }
 
     let steps = job
@@ -1365,9 +1358,14 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
     }
     if steps[5].get("shell").and_then(|value| value.as_str()) != Some("bash")
         || steps[5].get("run").and_then(|value| value.as_str()) != Some(APPROVED_GO_CACHE_CREATION)
+        || steps[5]
+            .get("env")
+            .and_then(|env| env.get("BENCH_GOCACHE"))
+            .and_then(|value| value.as_str())
+            != Some("${{ runner.temp }}/togi-pr-loop-gocache")
     {
         return Err(
-            "cache creation step must create the job-private GOCACHE fail-closed and prove it empty"
+            "cache creation step must bind and create the job-private GOCACHE fail-closed"
                 .to_string(),
         );
     }
@@ -1402,7 +1400,7 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             .get("env")
             .and_then(|env| env.get("GOCACHE"))
             .and_then(|value| value.as_str())
-            != Some("${{ env.BENCH_GOCACHE }}")
+            != Some("${{ runner.temp }}/togi-pr-loop-gocache")
         {
             return Err(
                 "warmup and measured steps must bind the identical explicit GOCACHE".to_string(),
@@ -1556,7 +1554,7 @@ fn ci_pr_loop_benchmark_contract_is_structural() {
             .get("env")
             .and_then(|env| env.get("GOCACHE"))
             .and_then(|value| value.as_str()),
-        Some("${{ env.BENCH_GOCACHE }}")
+        Some("${{ runner.temp }}/togi-pr-loop-gocache")
     );
     assert_eq!(
         harness
@@ -2151,10 +2149,9 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
             .expect("calibration workflow");
     let parsed: serde_yaml::Value = serde_yaml::from_str(&workflow).expect("workflow YAML");
     let job = &parsed["jobs"]["calibrate"];
-    assert_eq!(
-        job["env"]["BENCH_GOCACHE"].as_str(),
-        Some("${{ runner.temp }}/togi-pr-loop-gocache"),
-        "calibration job must define the job-private BENCH_GOCACHE"
+    assert!(
+        job.get("env").is_none(),
+        "calibration job must not use job-level runner context"
     );
     let steps = job["steps"]
         .as_sequence()
@@ -2176,10 +2173,14 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
         "calibration must pin Go to exactly 1.26.5"
     );
     let (create_index, create) = step("Create job-private Go build cache");
-    assert_eq!(create["shell"].as_str(), Some("bash"));
-    assert_eq!(create["run"].as_str(), Some(APPROVED_GO_CACHE_CREATION));
     let (warmup_index, warmup) = step("Warm Go build cache");
     let (acquisition_index, acquisition) = step("Acquire five independent samples");
+    assert_eq!(create["shell"].as_str(), Some("bash"));
+    assert_eq!(create["run"].as_str(), Some(APPROVED_GO_CACHE_CREATION));
+    assert_eq!(
+        create["env"]["BENCH_GOCACHE"].as_str(),
+        Some("${{ runner.temp }}/togi-pr-loop-gocache")
+    );
     assert!(create_index < warmup_index);
     assert!(warmup_index < acquisition_index);
     assert_eq!(
@@ -2188,7 +2189,7 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
     );
     assert_eq!(
         warmup["env"]["GOCACHE"].as_str(),
-        Some("${{ env.BENCH_GOCACHE }}")
+        Some("${{ runner.temp }}/togi-pr-loop-gocache")
     );
     assert_eq!(
         warmup["env"]["CALIBRATION_OUTPUT"].as_str(),
@@ -2204,7 +2205,7 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
     );
     assert_eq!(
         acquisition["env"]["GOCACHE"].as_str(),
-        Some("${{ env.BENCH_GOCACHE }}"),
+        Some("${{ runner.temp }}/togi-pr-loop-gocache"),
         "warmup and measured acquisition must bind the identical explicit GOCACHE"
     );
     assert_eq!(

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -3,9 +3,10 @@
 //! These drive `benchmarks/pr-loop/run-pr-loop-benchmarks.sh` with a fake
 //! `togi` binary and a stub `go`, so `cargo test` needs neither the Go
 //! toolchain nor a built togi. The fake emits canned mutation reports keyed
-//! off its argv and the presence of `.togi-cache`, and logs every invocation
-//! so the tests can prove the harness runs `check --base HEAD` (never
-//! `--all`) and manages the temp-project/cache lifecycle correctly.
+//! off its argv, the applied scenario patch, and the presence of
+//! `.togi-cache`, and logs every invocation so the tests can prove the
+//! harness runs `check --base HEAD` (never `--all`) and manages the
+//! per-scenario temp-project/cache lifecycle correctly.
 //!
 //! Tests skip when the harness's documented tool requirements (bash, git,
 //! jq, python3) are unavailable, mirroring the toolchain gating of the
@@ -45,8 +46,25 @@ for arg in "$@"; do
     --schemata) schemata=true ;;
   esac
 done
+# Tests may decouple schemata evidence from argv to prove the harness checks
+# runner_mode against the report, not just the manifest.
+if [ "${FAKE_TOGI_SCHEMATA:-}" = "on" ]; then
+  schemata=true
+elif [ "${FAKE_TOGI_SCHEMATA:-}" = "off" ]; then
+  schemata=false
+fi
+
+# The multi-file scenario patch rewrites calc.go to call Sum; the
+# single-file scenario leaves that line untouched.
+scenario=single
+if grep -q 'Sum(a, b)' calc.go; then
+  scenario=multi
+fi
 
 total=${FAKE_TOGI_TOTAL:-4}
+if [ "$scenario" = multi ]; then
+  total=${FAKE_TOGI_TOTAL:-9}
+fi
 tested=$total
 exact=0
 state="executed"
@@ -60,24 +78,63 @@ touch .togi-cache/seed
 
 schemata_json="null"
 if [ "$schemata" = true ]; then
-  schemata_json='{"fast_path":1,"fallback":3,"fallback_reasons":[{"reason":"unsupported_operator","count":2},{"reason":"overlapping_range","count":1}]}'
+  schemata_json=$(jq -nc --argjson total "$total" '
+    {fast_path: 1, fallback: ($total - 1),
+     fallback_reasons: [{reason: "unsupported_operator", count: ($total - 1)}]}')
 fi
 
-mutations_json=$(jq -nc --arg state "$state" --argjson count "${FAKE_TOGI_MUTATIONS:-4}" '
-  ([
-    {id: 1, file: "calc.go", line: 34, column: 7, operator: "gt_to_gte",
-     original: ">", replacement: ">=", description: "fake",
-     result: "survived", execution: {state: $state}, language: "go"},
-    {id: 2, file: "calc.go", line: 35, column: 14, operator: "plus_to_minus",
-     original: "+", replacement: "-", description: "fake",
-     result: "survived", execution: {state: $state}, language: "go"},
-    {id: 3, file: "calc.go", line: 34, column: 2, operator: "remove_if_body",
-     description: "fake",
-     result: "survived", execution: {state: $state}, language: "go"},
-    {id: 4, file: "calc.go", line: 34, column: 6, operator: "negate_condition",
-     description: "fake",
-     result: "survived", execution: {state: $state}, language: "go"}
-  ] | .[0:$count])')
+if [ "$scenario" = multi ]; then
+  mutations_json=$(jq -nc --arg state "$state" --argjson count "${FAKE_TOGI_MUTATIONS:-9}" '
+    ([
+      {id: 1, file: "calc.go", line: 5, column: 22, operator: "zero_to_one",
+       original: "0", replacement: "1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 2, file: "calc.go", line: 5, column: 22, operator: "increment_numeric",
+       original: "0", replacement: "1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 3, file: "calc.go", line: 5, column: 22, operator: "decrement_numeric",
+       original: "0", replacement: "-1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 4, file: "calc.go", line: 5, column: 20, operator: "plus_to_minus",
+       original: "+", replacement: "-", description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"},
+      {id: 5, file: "numbers.go", line: 5, column: 12, operator: "zero_to_one",
+       original: "0", replacement: "1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 6, file: "numbers.go", line: 5, column: 12, operator: "increment_numeric",
+       original: "0", replacement: "1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 7, file: "numbers.go", line: 5, column: 12, operator: "decrement_numeric",
+       original: "0", replacement: "-1", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"},
+      {id: 8, file: "numbers.go", line: 5, column: 10, operator: "plus_to_minus",
+       original: "+", replacement: "-", description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"},
+      {id: 9, file: "numbers.go", line: 5, column: 16, operator: "plus_to_minus",
+       original: "+", replacement: "-", description: "fake",
+       result: "killed", execution: {state: $state}, language: "go"}
+    ] | .[0:$count])')
+else
+  mutations_json=$(jq -nc --arg state "$state" --argjson count "${FAKE_TOGI_MUTATIONS:-4}" '
+    ([
+      {id: 1, file: "calc.go", line: 34, column: 7, operator: "gt_to_gte",
+       original: ">", replacement: ">=", description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"},
+      {id: 2, file: "calc.go", line: 35, column: 14, operator: "plus_to_minus",
+       original: "+", replacement: "-", description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"},
+      {id: 3, file: "calc.go", line: 34, column: 2, operator: "remove_if_body",
+       description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"},
+      {id: 4, file: "calc.go", line: 34, column: 6, operator: "negate_condition",
+       description: "fake",
+       result: "survived", execution: {state: $state}, language: "go"}
+    ] | .[0:$count])')
+fi
+
+if [ "$scenario" = multi ] && [ "${FAKE_TOGI_MULTI_ONE_FILE:-}" = "1" ]; then
+  mutations_json=$(jq 'map(.file = "calc.go" | .line = 5)' <<<"$mutations_json")
+fi
 
 jq -n \
   --arg state "$state" \
@@ -85,6 +142,7 @@ jq -n \
   --argjson tested "$tested" \
   --argjson exact "$exact" \
   --argjson schemata "$schemata_json" \
+  --arg selection "${FAKE_TOGI_TEST_SELECTION:-full}" \
   --argjson mutations "$mutations_json" \
   '{
     kind: "mutation_report",
@@ -106,7 +164,7 @@ jq -n \
     build_command: [],
     schemata: $schemata,
     build_error_groups: [],
-    mutations: $mutations
+    mutations: ($mutations | map(if $selection == "narrowed" then . + {test_selection: {mode: "narrowed"}} else . end))
   }'
 exit 1
 "#;
@@ -116,8 +174,27 @@ if [ "${1:-}" = "version" ]; then
   echo "go version go1.0.0-stub test/test"
   exit 0
 fi
+if [ "${1:-}" = "env" ] && [ "${2:-}" = "GOCACHE" ]; then
+  if [ -n "${FAKE_GO_ENV_GOCACHE:-}" ]; then
+    printf '%s\n' "$FAKE_GO_ENV_GOCACHE"
+  elif [ -n "${GOCACHE:-}" ]; then
+    printf '%s\n' "$GOCACHE"
+  else
+    printf '%s\n' "/fake-go-build-cache"
+  fi
+  exit 0
+fi
 exit 0
 "#;
+
+const WORKLOAD_NAMES: [&str; 6] = [
+    "cold-regular",
+    "warm-exact-cache",
+    "cold-schemata",
+    "pr-diff-default",
+    "multi-file-regular",
+    "multi-file-default",
+];
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -164,6 +241,27 @@ fn harness_tools_available() -> bool {
         && (tool_on_path("sha256sum") || tool_on_path("shasum"))
 }
 
+/// Content digest helper mirroring the harness's sha256sum/shasum fallback,
+/// used to re-digest artifact files after deliberate test tampering.
+fn sha256_file(path: &Path) -> String {
+    let (program, args): (&str, &[&str]) = if tool_on_path("sha256sum") {
+        ("sha256sum", &[])
+    } else {
+        ("shasum", &["-a", "256"])
+    };
+    let output = Command::new(program)
+        .args(args)
+        .arg(path)
+        .output()
+        .expect("spawn sha256 tool");
+    assert!(output.status.success(), "sha256 tool failed for {path:?}");
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .expect("sha256 output")
+        .to_string()
+}
+
 struct FakeTools {
     _dir: tempfile::TempDir,
     bin: PathBuf,
@@ -205,6 +303,9 @@ fn run_harness(
         .arg(out_dir)
         .env("TOGI_BIN", &tools.togi)
         .env("FAKE_TOGI_LOG", &tools.log)
+        // Cache provenance must come from the test, never the host env.
+        .env_remove("GOCACHE")
+        .env_remove("BENCH_GO_BUILD_CACHE_STATE")
         .env(
             "PATH",
             format!(
@@ -281,8 +382,16 @@ fn assert_pr_diff_command(args: &[&str]) {
     assert_eq!(args[jobs_pos + 1], "1", "jobs must be pinned to 1");
 }
 
+fn invocation_log(tools: &FakeTools) -> Vec<serde_json::Value> {
+    fs::read_to_string(&tools.log)
+        .expect("invocation log")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("invocation log line"))
+        .collect()
+}
+
 #[test]
-fn pr_loop_harness_runs_all_four_workloads_against_a_pr_diff() {
+fn pr_loop_harness_runs_all_six_workloads_across_two_scenarios() {
     if !harness_tools_available() {
         eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
         return;
@@ -299,27 +408,69 @@ fn pr_loop_harness_runs_all_four_workloads_against_a_pr_diff() {
     );
 
     let result = read_result(out_dir.path());
+    assert_eq!(result["schema_version"], 2);
     assert_eq!(result["ok"], true);
     assert_eq!(result["failures"], serde_json::json!([]));
     assert_eq!(result["provenance"]["go_build_cache_state"], "unclassified");
+    assert_eq!(result["provenance"]["go_build_cache_policy"], "unenforced");
     assert_eq!(
-        result["cross_workload"]["mutation_identity_consistent"],
-        true
+        result["provenance"]["go_build_cache_path"],
+        serde_json::Value::Null
     );
-    assert!(result["cross_workload"]["mutation_identity_sha256"].is_string());
+    let mut fixture_scenarios: Vec<&str> = result["provenance"]["fixture_scenarios"]
+        .as_object()
+        .expect("fixture scenarios")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    fixture_scenarios.sort_unstable();
+    assert_eq!(fixture_scenarios, ["multi-file", "single-file"]);
+
+    let scenarios = result["cross_workload"]["scenarios"]
+        .as_object()
+        .expect("per-scenario identity");
+    for name in ["single-file", "multi-file"] {
+        assert_eq!(
+            scenarios[name]["mutation_identity_consistent"], true,
+            "scenario {name} must have consistent mutation identity"
+        );
+        assert!(scenarios[name]["mutation_identity_sha256"].is_string());
+    }
+    assert_ne!(
+        scenarios["single-file"]["mutation_identity_sha256"],
+        scenarios["multi-file"]["mutation_identity_sha256"],
+        "scenarios legitimately produce different mutation identities"
+    );
 
     let workloads = result["workloads"].as_array().expect("workloads array");
     let names: Vec<&str> = workloads
         .iter()
         .map(|workload| workload["name"].as_str().expect("workload name"))
         .collect();
+    assert_eq!(names, WORKLOAD_NAMES);
+    let scenario_of: Vec<&str> = workloads
+        .iter()
+        .map(|workload| workload["scenario"].as_str().expect("workload scenario"))
+        .collect();
     assert_eq!(
-        names,
+        scenario_of,
         [
-            "cold-regular",
-            "warm-exact-cache",
-            "cold-schemata",
-            "pr-diff-default"
+            "single-file",
+            "single-file",
+            "single-file",
+            "single-file",
+            "multi-file",
+            "multi-file"
+        ]
+    );
+    let runner_modes: Vec<&str> = workloads
+        .iter()
+        .map(|workload| workload["runner_mode"].as_str().expect("runner mode"))
+        .collect();
+    assert_eq!(
+        runner_modes,
+        [
+            "regular", "regular", "schemata", "default", "regular", "default"
         ]
     );
 
@@ -333,6 +484,24 @@ fn pr_loop_harness_runs_all_four_workloads_against_a_pr_diff() {
             );
         }
         assert_pr_diff_command(&command_strings(workload));
+        assert_eq!(
+            workload["semantics"]["selected_test_command"],
+            serde_json::json!(["go", "test", "./..."]),
+            "workload {} must expose the resolved test command",
+            workload["name"]
+        );
+        assert_eq!(
+            workload["semantics"]["test_selection"]["mode"],
+            "full-suite"
+        );
+        assert_eq!(
+            workload["semantics"]["test_selection"]["full_suite_mutation_count"],
+            workload["semantics"]["mutation_count"]
+        );
+        assert_eq!(
+            workload["semantics"]["test_selection"]["narrowed_mutation_count"],
+            0
+        );
         assert!(
             workload["timing"]["wall_ms"]
                 .as_u64()
@@ -360,6 +529,10 @@ fn pr_loop_harness_runs_all_four_workloads_against_a_pr_diff() {
             .expect("fallback")
             >= 1
     );
+    // Multi-file coverage: 9 mutations spanning both changed files.
+    assert_eq!(workloads[4]["semantics"]["total"], 9);
+    assert_eq!(workloads[4]["semantics"]["tested"], 9);
+    assert_eq!(workloads[5]["semantics"]["total"], 9);
 
     // Raw artifacts persist for every workload.
     for name in &names {
@@ -373,46 +546,56 @@ fn pr_loop_harness_runs_all_four_workloads_against_a_pr_diff() {
         );
     }
 
-    // Invocation log: one temp project, `check --base HEAD`, cache lifecycle.
-    let log = fs::read_to_string(&tools.log).expect("invocation log");
-    let runs: Vec<serde_json::Value> = log
-        .lines()
-        .map(|line| serde_json::from_str(line).expect("invocation log line"))
-        .collect();
-    assert_eq!(runs.len(), 4, "expected exactly four togi invocations");
+    // Invocation log: one temp project per scenario, `check --base HEAD`,
+    // per-scenario cache lifecycle.
+    let runs = invocation_log(&tools);
+    assert_eq!(runs.len(), 6, "expected exactly six togi invocations");
 
-    let project_dir = runs[0]["cwd"].as_str().expect("invocation cwd");
+    let single_project = runs[0]["cwd"].as_str().expect("invocation cwd");
+    let multi_project = runs[4]["cwd"].as_str().expect("invocation cwd");
     assert_ne!(
-        Path::new(project_dir),
+        Path::new(single_project),
         repo_root().join("tests/fixtures/go"),
-        "harness must copy the fixture into a disposable project"
+        "harness must copy the fixture into disposable projects"
     );
+    assert_ne!(
+        single_project, multi_project,
+        "each scenario must get its own disposable project"
+    );
+    for (index, run) in runs.iter().enumerate() {
+        let expected = if index < 4 {
+            single_project
+        } else {
+            multi_project
+        };
+        assert_eq!(
+            run["cwd"].as_str().expect("cwd"),
+            expected,
+            "workloads of one scenario must share that scenario's project"
+        );
+        assert_pr_diff_command(&argv_strings(run));
+    }
     let cache_sequence: Vec<bool> = runs
         .iter()
         .map(|run| run["cache_present"].as_bool().expect("cache flag"))
         .collect();
     assert_eq!(
         cache_sequence,
-        [false, true, false, false],
+        [false, true, false, false, false, false],
         "cold runs must start cacheless and the warm run must reuse the seeded cache"
     );
     let force_rerun_sequence: Vec<bool> = runs
         .iter()
         .map(|run| argv_strings(run).contains(&"--force-rerun"))
         .collect();
-    assert_eq!(force_rerun_sequence, [true, false, true, false]);
+    assert_eq!(
+        force_rerun_sequence,
+        [true, false, true, false, true, false]
+    );
 
-    for run in &runs {
-        assert_eq!(
-            run["cwd"].as_str().expect("cwd"),
-            project_dir,
-            "all workloads must share the single disposable project"
-        );
-        assert_pr_diff_command(&argv_strings(run));
-    }
     assert!(
-        !Path::new(project_dir).exists(),
-        "disposable project must be removed after the run: {project_dir}"
+        !Path::new(single_project).exists() && !Path::new(multi_project).exists(),
+        "disposable projects must be removed after the run"
     );
 }
 
@@ -439,11 +622,11 @@ fn pr_loop_harness_rejects_malformed_manifests() {
     let mut object_workloads = base.clone();
     object_workloads["workloads"] = serde_json::json!({});
 
-    let mut three_workloads = base.clone();
-    three_workloads["workloads"]
+    let mut five_workloads = base.clone();
+    five_workloads["workloads"]
         .as_array_mut()
         .unwrap()
-        .truncate(3);
+        .truncate(5);
 
     let mut wrong_order = base.clone();
     wrong_order["workloads"].as_array_mut().unwrap().reverse();
@@ -452,22 +635,72 @@ fn pr_loop_harness_rejects_malformed_manifests() {
     warm_not_reuse["workloads"][1]["cache"] = serde_json::json!("fresh");
 
     let mut missing_count = base.clone();
-    missing_count["fixture"]
+    missing_count["scenarios"][0]
         .as_object_mut()
         .unwrap()
         .remove("expected_mutation_count");
 
     let mut zero_count = base.clone();
-    zero_count["fixture"]["expected_mutation_count"] = serde_json::json!(0);
+    zero_count["scenarios"][0]["expected_mutation_count"] = serde_json::json!(0);
 
     let mut bad_patch_digest = base.clone();
-    bad_patch_digest["fixture"]["patch_sha256"] = serde_json::json!("not-a-digest");
+    bad_patch_digest["scenarios"][1]["patch_sha256"] = serde_json::json!("not-a-digest");
+
+    let mut empty_changed_files = base.clone();
+    empty_changed_files["scenarios"][1]["changed_files"] = serde_json::json!([]);
+
+    let mut inverted_line_range = base.clone();
+    inverted_line_range["scenarios"][1]["changed_files"][0]["line_range"] =
+        serde_json::json!([5, 4]);
+
+    let mut missing_scenario_field = base.clone();
+    missing_scenario_field["workloads"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("scenario");
+
+    let mut undeclared_scenario = base.clone();
+    undeclared_scenario["workloads"][0]["scenario"] = serde_json::json!("no-such-scenario");
+
+    let mut missing_scenarios = base.clone();
+    missing_scenarios
+        .as_object_mut()
+        .unwrap()
+        .remove("scenarios");
+
+    let mut dropped_multi_file_scenario = base.clone();
+    dropped_multi_file_scenario["scenarios"]
+        .as_array_mut()
+        .unwrap()
+        .truncate(1);
+
+    let mut interleaved_scenarios = base.clone();
+    {
+        let workloads = interleaved_scenarios["workloads"].as_array_mut().unwrap();
+        let moved = workloads.remove(4);
+        workloads.insert(1, moved);
+    }
+
+    let mut cross_scenario_dependency = base.clone();
+    cross_scenario_dependency["workloads"][1]["expects_cache_from"] =
+        serde_json::json!("multi-file-regular");
+
+    let mut dependency_without_seed = base.clone();
+    dependency_without_seed["workloads"][2]["expects_cache_from"] =
+        serde_json::json!("pr-diff-default");
+
+    let mut forward_dependency = base.clone();
+    forward_dependency["workloads"][0]["expects_cache_from"] =
+        serde_json::json!("warm-exact-cache");
 
     let mut unknown_invariant = base.clone();
     unknown_invariant["workloads"][0]["invariants"] = serde_json::json!(["made-up-invariant"]);
 
+    let mut previous_schema = base.clone();
+    previous_schema["schema_version"] = serde_json::json!(1);
+
     let mut future_schema = base.clone();
-    future_schema["schema_version"] = serde_json::json!(2);
+    future_schema["schema_version"] = serde_json::json!(3);
 
     let mut all_flag = base.clone();
     all_flag["togi"]["common_args"]
@@ -540,17 +773,55 @@ fn pr_loop_harness_rejects_malformed_manifests() {
         .unwrap()
         .extend([serde_json::json!("--base"), serde_json::json!("HEAD")]);
 
+    let mut runner_mode_mismatch = base.clone();
+    runner_mode_mismatch["workloads"][0]["runner_mode"] = serde_json::json!("schemata");
+
+    let mut default_with_schemata_flag = base.clone();
+    default_with_schemata_flag["workloads"][3]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--schemata"));
+
+    let mut regular_without_flag = base.clone();
+    regular_without_flag["workloads"][0]["extra_args"] = serde_json::json!([]);
+
+    let mut unknown_runner_mode = base.clone();
+    unknown_runner_mode["workloads"][0]["runner_mode"] = serde_json::json!("turbo");
+
+    let mut duplicate_test_cmd = base.clone();
+    duplicate_test_cmd["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([
+            serde_json::json!("--test-cmd"),
+            serde_json::json!("go test ./..."),
+        ]);
+
     let cases: Vec<(&str, serde_json::Value)> = vec![
         ("missing workloads field", missing_workloads),
         ("empty workloads array", empty_workloads),
         ("non-array workloads", object_workloads),
-        ("only three workloads", three_workloads),
+        ("only five workloads", five_workloads),
         ("workloads in wrong order", wrong_order),
         ("warm workload not reusing cache", warm_not_reuse),
         ("missing expected_mutation_count", missing_count),
         ("zero expected_mutation_count", zero_count),
         ("malformed patch digest", bad_patch_digest),
+        ("empty changed_files", empty_changed_files),
+        ("inverted line range", inverted_line_range),
+        ("workload missing scenario", missing_scenario_field),
+        ("undeclared scenario reference", undeclared_scenario),
+        ("missing scenarios field", missing_scenarios),
+        ("dropped multi-file scenario", dropped_multi_file_scenario),
+        ("interleaved scenario workloads", interleaved_scenarios),
+        ("cross-scenario cache dependency", cross_scenario_dependency),
+        (
+            "cache dependency without seeds_cache",
+            dependency_without_seed,
+        ),
+        ("forward cache dependency", forward_dependency),
         ("unknown invariant name", unknown_invariant),
+        ("previous schema_version", previous_schema),
         ("unsupported schema_version", future_schema),
         ("--all in common_args", all_flag),
         ("missing --base in common_args", missing_base),
@@ -577,6 +848,17 @@ fn pr_loop_harness_rejects_malformed_manifests() {
             "duplicate --base injected via extra_args",
             extra_args_duplicate_base,
         ),
+        ("runner_mode contradicting argv", runner_mode_mismatch),
+        (
+            "default workload with --schemata",
+            default_with_schemata_flag,
+        ),
+        (
+            "regular workload without --no-schemata",
+            regular_without_flag,
+        ),
+        ("unknown runner_mode", unknown_runner_mode),
+        ("duplicate --test-cmd in extra_args", duplicate_test_cmd),
     ];
 
     for (label, manifest) in cases {
@@ -608,6 +890,134 @@ fn pr_loop_harness_rejects_malformed_manifests() {
 }
 
 #[test]
+fn pr_loop_harness_rejects_scenario_patch_digest_drift() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+    let tools = install_fake_tools();
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(manifest_path()).expect("read repo manifest"))
+            .expect("repo manifest is valid JSON");
+    // A well-formed 64-hex digest that does not match the multi-file patch.
+    manifest["scenarios"][1]["patch_sha256"] = serde_json::json!("0".repeat(64));
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let manifest_file = dir.path().join("manifest.json");
+    fs::write(
+        &manifest_file,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .expect("write case manifest");
+    let output = run_harness(&tools, &dir.path().join("out"), Some(&manifest_file), &[]);
+    assert!(!output.status.success(), "patch digest drift must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("digest mismatch"),
+        "expected digest mismatch error, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn pr_loop_harness_enforces_go_build_cache_provenance() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+
+    // warmup and primed runs bind and record the job-private explicit cache.
+    for state in ["warmup", "primed"] {
+        let tools = install_fake_tools();
+        let gocache = tempfile::tempdir().expect("gocache tempdir");
+        let out_dir = tempfile::tempdir().expect("output tempdir");
+        let cache_path = gocache.path().to_str().expect("gocache path").to_string();
+        let output = run_harness(
+            &tools,
+            out_dir.path(),
+            None,
+            &[
+                ("BENCH_GO_BUILD_CACHE_STATE", state),
+                ("GOCACHE", &cache_path),
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "{state} run with a valid GOCACHE must succeed\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result = read_result(out_dir.path());
+        assert_eq!(result["provenance"]["go_build_cache_state"], state);
+        assert_eq!(
+            result["provenance"]["go_build_cache_policy"],
+            "job-private-explicit-gocache"
+        );
+        assert_eq!(
+            result["provenance"]["go_build_cache_path"],
+            serde_json::Value::String(cache_path.clone())
+        );
+    }
+
+    // Rejection conditions: missing, relative, nonexistent, mismatched, or
+    // unknown cache state must never produce measured evidence.
+    let tools = install_fake_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
+    let cache_path = gocache.path().to_str().expect("gocache path").to_string();
+    let missing_dir = gocache.path().join("does-not-exist");
+    let cases: Vec<(&str, Vec<(&str, &str)>)> = vec![
+        (
+            "primed without GOCACHE",
+            vec![("BENCH_GO_BUILD_CACHE_STATE", "primed")],
+        ),
+        (
+            "warmup without GOCACHE",
+            vec![("BENCH_GO_BUILD_CACHE_STATE", "warmup")],
+        ),
+        (
+            "relative GOCACHE",
+            vec![
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                ("GOCACHE", "relative/cache"),
+            ],
+        ),
+        (
+            "nonexistent GOCACHE directory",
+            vec![
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                ("GOCACHE", missing_dir.to_str().expect("missing path")),
+            ],
+        ),
+        (
+            "GOCACHE disagreeing with go env",
+            vec![
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                ("GOCACHE", &cache_path),
+                ("FAKE_GO_ENV_GOCACHE", "/somewhere/else"),
+            ],
+        ),
+        (
+            "unknown cache state",
+            vec![("BENCH_GO_BUILD_CACHE_STATE", "prime")],
+        ),
+    ];
+    for (label, env) in cases {
+        let out_dir = tempfile::tempdir().expect("output tempdir");
+        let output = run_harness(&tools, out_dir.path(), None, &env);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "harness must exit 2 for {label}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !out_dir
+                .path()
+                .join("pr-loop-benchmark-result.json")
+                .exists(),
+            "{label} must never produce a result"
+        );
+    }
+}
+
+#[test]
 fn pr_loop_harness_fails_when_mutation_records_are_truncated() {
     if !harness_tools_available() {
         eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
@@ -627,7 +1037,7 @@ fn pr_loop_harness_fails_when_mutation_records_are_truncated() {
         );
         assert!(
             !output.status.success(),
-            "harness must fail with {emitted} of 4 mutation records\nstdout: {}\nstderr: {}",
+            "harness must fail with {emitted} mutation records\nstdout: {}\nstderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
@@ -683,8 +1093,9 @@ fn pr_loop_harness_fails_when_report_semantics_drift() {
     let tools = install_fake_tools();
     let out_dir = tempfile::tempdir().expect("output tempdir");
 
-    // The fake reports five mutations while the manifest pins four: the
-    // report-well-formed invariant must fail the harness, never pass silently.
+    // The fake reports five mutations while the single-file scenario pins
+    // four: the report-well-formed invariant must fail the harness, never
+    // pass silently.
     let output = run_harness(&tools, out_dir.path(), None, &[("FAKE_TOGI_TOTAL", "5")]);
 
     assert!(
@@ -706,6 +1117,90 @@ fn pr_loop_harness_fails_when_report_semantics_drift() {
         "expected cold-regular:report-well-formed in {failures:?}"
     );
 }
+
+#[test]
+fn pr_loop_harness_fails_when_runner_mode_report_disagrees() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+    // A regular workload whose report carries schemata evidence (or a
+    // schemata workload without it) contradicts the declared runner_mode.
+    // The fake's FAKE_TOGI_SCHEMATA override decouples its schemata evidence
+    // from argv so the manifest stays valid.
+    for (name, override_value) in [("cold-regular", "on"), ("cold-schemata", "off")] {
+        let tools = install_fake_tools();
+        let out_dir = tempfile::tempdir().expect("output tempdir");
+        let output = run_harness(
+            &tools,
+            out_dir.path(),
+            None,
+            &[("FAKE_TOGI_SCHEMATA", override_value)],
+        );
+        assert!(
+            !output.status.success(),
+            "runner_mode/report disagreement must fail for {name}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result = read_result(out_dir.path());
+        assert_eq!(result["ok"], false);
+        let failures: Vec<&str> = result["failures"]
+            .as_array()
+            .expect("failures array")
+            .iter()
+            .map(|failure| failure.as_str().expect("failure string"))
+            .collect();
+        let expected = format!("{name}:runner-mode-consistency");
+        assert!(
+            failures.contains(&expected.as_str()),
+            "expected {expected} in {failures:?}"
+        );
+    }
+}
+
+#[test]
+fn pr_loop_harness_rejects_narrowed_selection_and_single_file_multi_evidence() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools unavailable");
+        return;
+    }
+    for (environment, expected) in [
+        (
+            ("FAKE_TOGI_TEST_SELECTION", "narrowed"),
+            "cold-regular:report-well-formed",
+        ),
+        (
+            ("FAKE_TOGI_MULTI_ONE_FILE", "1"),
+            "multi-file-regular:pr-diff-targeting",
+        ),
+    ] {
+        let tools = install_fake_tools();
+        let output_dir = tempfile::tempdir().expect("output tempdir");
+        let output = run_harness(&tools, output_dir.path(), None, &[environment]);
+        assert!(!output.status.success(), "invalid evidence must fail");
+        let result = read_result(output_dir.path());
+        let failures: Vec<&str> = result["failures"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item.as_str().unwrap())
+            .collect();
+        assert!(
+            failures.contains(&expected),
+            "expected {expected} in {failures:?}"
+        );
+    }
+}
+
+const APPROVED_GO_CACHE_CREATION: &str = r#"set -euo pipefail
+if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
+  echo "job-private Go build cache $BENCH_GOCACHE must start empty" >&2
+  exit 1
+fi
+mkdir -p "$BENCH_GOCACHE"
+test -d "$BENCH_GOCACHE"
+test -z "$(ls -A "$BENCH_GOCACHE")"
+"#;
 
 const APPROVED_BENCHMARK_PREREQUISITES: &str = r#"set -euo pipefail
 packages=()
@@ -742,9 +1237,10 @@ test -d "$raw"
 jq -e '
   .ok == true
   and ([.workloads[].name]
-       == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default"])
+       == ["cold-regular", "warm-exact-cache", "cold-schemata", "pr-diff-default",
+           "multi-file-regular", "multi-file-default"])
 ' "$result" >/dev/null
-for workload in cold-regular warm-exact-cache cold-schemata pr-diff-default; do
+for workload in cold-regular warm-exact-cache cold-schemata pr-diff-default multi-file-regular multi-file-default; do
   for suffix in report.json stdout stderr; do
     test -f "$raw/$workload.$suffix"
   done
@@ -763,9 +1259,9 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
         })
         .collect::<Result<_, _>>()?;
     keys.sort_unstable();
-    if keys != ["name", "permissions", "runs-on", "steps"] {
+    if keys != ["env", "name", "permissions", "runs-on", "steps"] {
         return Err(format!(
-            "benchmark job keys must be exactly name, runs-on, permissions, and steps; got {keys:?}"
+            "benchmark job keys must be exactly name, runs-on, permissions, env, and steps; got {keys:?}"
         ));
     }
     if job.get("name").and_then(|value| value.as_str()) != Some("PR-loop Benchmark Evidence")
@@ -782,6 +1278,16 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             })
     {
         return Err("benchmark job top-level values must match the approved contract".to_string());
+    }
+    if job
+        .get("env")
+        .and_then(|env| env.get("BENCH_GOCACHE"))
+        .and_then(|value| value.as_str())
+        != Some("${{ runner.temp }}/togi-pr-loop-gocache")
+    {
+        return Err(
+            "benchmark job must define the job-private BENCH_GOCACHE under runner.temp".to_string(),
+        );
     }
 
     let steps = job
@@ -800,6 +1306,7 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
         ),
         ("uses", "actions/setup-go@v7"),
+        ("name", "Create job-private Go build cache"),
         ("name", "Check benchmark prerequisites"),
         ("name", "Build release binary"),
         ("name", "Warm Go build cache for PR-loop benchmark evidence"),
@@ -826,7 +1333,7 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             return Err(format!("benchmark step {index} must not mask failure"));
         }
         let condition = step.get("if").and_then(|value| value.as_str());
-        if index == 10 {
+        if index == 11 {
             if condition != Some("${{ always() }}") {
                 return Err("artifact upload must be the sole unconditional step".to_string());
             }
@@ -834,7 +1341,7 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             return Err(format!("benchmark step {index} must not be conditional"));
         }
     }
-    for index in [0, 1, 3, 4, 10] {
+    for index in [0, 1, 3, 4, 11] {
         if steps[index].get("run").is_some() {
             return Err(format!(
                 "non-executable benchmark setup/upload step {index} must not contain `run`"
@@ -846,8 +1353,24 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
     {
         return Err("native assertion step must be the exact assertion script".to_string());
     }
+    if steps[4]
+        .get("with")
+        .and_then(|with| with.get("go-version"))
+        .and_then(|value| value.as_str())
+        != Some("1.26.5")
+    {
+        return Err("benchmark job must pin Go to exactly 1.26.5".to_string());
+    }
     if steps[5].get("shell").and_then(|value| value.as_str()) != Some("bash")
-        || steps[5].get("run").and_then(|value| value.as_str())
+        || steps[5].get("run").and_then(|value| value.as_str()) != Some(APPROVED_GO_CACHE_CREATION)
+    {
+        return Err(
+            "cache creation step must create the job-private GOCACHE fail-closed and prove it empty"
+                .to_string(),
+        );
+    }
+    if steps[6].get("shell").and_then(|value| value.as_str()) != Some("bash")
+        || steps[6].get("run").and_then(|value| value.as_str())
             != Some(APPROVED_BENCHMARK_PREREQUISITES)
     {
         return Err(
@@ -855,12 +1378,12 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
                 .to_string(),
         );
     }
-    if steps[6].get("run").and_then(|value| value.as_str())
+    if steps[7].get("run").and_then(|value| value.as_str())
         != Some("cargo build --locked --release")
     {
         return Err("only the named release-build step may build togi".to_string());
     }
-    for index in [7, 8] {
+    for index in [8, 9] {
         if steps[index]
             .get("run")
             .and_then(|value| value.as_str())
@@ -873,13 +1396,23 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
                 "only the named warmup and harness steps may run the benchmark harness".to_string(),
             );
         }
+        if steps[index]
+            .get("env")
+            .and_then(|env| env.get("GOCACHE"))
+            .and_then(|value| value.as_str())
+            != Some("${{ env.BENCH_GOCACHE }}")
+        {
+            return Err(
+                "warmup and measured steps must bind the identical explicit GOCACHE".to_string(),
+            );
+        }
     }
-    if steps[7]
+    if steps[8]
         .get("env")
         .and_then(|env| env.get("BENCH_GO_BUILD_CACHE_STATE"))
         .and_then(|value| value.as_str())
         != Some("warmup")
-        || steps[8]
+        || steps[9]
             .get("env")
             .and_then(|env| env.get("BENCH_GO_BUILD_CACHE_STATE"))
             .and_then(|value| value.as_str())
@@ -887,20 +1420,20 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
     {
         return Err("warmup must precede primed measured evidence".to_string());
     }
-    if steps[9].get("shell").and_then(|value| value.as_str()) != Some("bash")
-        || steps[9]
+    if steps[10].get("shell").and_then(|value| value.as_str()) != Some("bash")
+        || steps[10]
             .get("env")
             .and_then(|env| env.get("BENCHMARK_OUTPUT"))
             .and_then(|value| value.as_str())
             != Some("${{ runner.temp }}/togi-pr-loop-benchmarks/measured")
-        || steps[9].get("run").and_then(|value| value.as_str())
+        || steps[10].get("run").and_then(|value| value.as_str())
             != Some(APPROVED_BENCHMARK_EVIDENCE_VALIDATION)
     {
         return Err(
             "only the named validation step may verify measured benchmark evidence".to_string(),
         );
     }
-    if steps[10].get("if").and_then(|value| value.as_str()) != Some("${{ always() }}") {
+    if steps[11].get("if").and_then(|value| value.as_str()) != Some("${{ always() }}") {
         return Err("only the named upload step must be unconditional".to_string());
     }
     Ok(())
@@ -974,6 +1507,21 @@ fn ci_pr_loop_benchmark_contract_is_structural() {
         );
     }
 
+    let create_cache = step("Create job-private Go build cache");
+    let warmup = step("Warm Go build cache for PR-loop benchmark evidence");
+    let create_index = steps
+        .iter()
+        .position(|step| std::ptr::eq(step, create_cache))
+        .expect("cache creation step index");
+    let warmup_index = steps
+        .iter()
+        .position(|step| std::ptr::eq(step, warmup))
+        .expect("warmup step index");
+    assert!(
+        create_index < warmup_index,
+        "job-private cache creation must precede warmup"
+    );
+
     let build = step("Build release binary");
     assert_eq!(
         build.get("run").and_then(|value| value.as_str()),
@@ -1000,6 +1548,13 @@ fn ci_pr_loop_benchmark_contract_is_structural() {
             .and_then(|env| env.get("BENCH_GO_BUILD_CACHE_STATE"))
             .and_then(|value| value.as_str()),
         Some("primed")
+    );
+    assert_eq!(
+        harness
+            .get("env")
+            .and_then(|env| env.get("GOCACHE"))
+            .and_then(|value| value.as_str()),
+        Some("${{ env.BENCH_GOCACHE }}")
     );
     assert_eq!(
         harness
@@ -1078,12 +1633,12 @@ fn ci_pr_loop_benchmark_contract_rejects_evaluator_in_prerequisite_step() {
         .get_mut("steps")
         .and_then(|steps| steps.as_sequence_mut())
         .expect("benchmark job must have mutable steps");
-    let prerequisite = steps[5]
+    let prerequisite = steps[6]
         .get("run")
         .and_then(|run| run.as_str())
         .expect("prerequisite step must have a run command")
         .to_string();
-    steps[5].as_mapping_mut().unwrap().insert(
+    steps[6].as_mapping_mut().unwrap().insert(
         serde_yaml::Value::String("run".to_string()),
         serde_yaml::Value::String(format!("{prerequisite}\npython3 evaluator.py")),
     );
@@ -1110,7 +1665,7 @@ fn ci_pr_loop_benchmark_contract_rejects_harness_control_flow() {
         let mut job = base.clone();
         job.get_mut("steps")
             .and_then(|steps| steps.as_sequence_mut())
-            .expect("benchmark job must have mutable steps")[7]
+            .expect("benchmark job must have mutable steps")[8]
             .as_mapping_mut()
             .unwrap()
             .insert(serde_yaml::Value::String(field.to_string()), value);
@@ -1119,6 +1674,63 @@ fn ci_pr_loop_benchmark_contract_rejects_harness_control_flow() {
             "harness `{field}` control flow must be rejected"
         );
     }
+}
+
+#[test]
+fn ci_pr_loop_benchmark_contract_rejects_go_version_and_cache_drift() {
+    let ci: serde_yaml::Value = serde_yaml::from_str(
+        &fs::read_to_string(repo_root().join(".github/workflows/ci.yml")).unwrap(),
+    )
+    .expect("ci.yml must parse as YAML");
+    let base = ci
+        .get("jobs")
+        .and_then(|jobs| jobs.get("pr-loop-benchmarks"))
+        .expect("benchmark job must exist");
+
+    let mut unpinned = base.clone();
+    unpinned
+        .get_mut("steps")
+        .and_then(|steps| steps.as_sequence_mut())
+        .expect("benchmark job must have mutable steps")[4]
+        .get_mut("with")
+        .and_then(|with| with.as_mapping_mut())
+        .expect("setup-go must have inputs")
+        .insert(
+            serde_yaml::Value::String("go-version".to_string()),
+            serde_yaml::Value::String("stable".to_string()),
+        );
+    assert!(
+        validate_pr_loop_benchmark_step_set(&unpinned).is_err(),
+        "an unpinned Go toolchain must be rejected"
+    );
+
+    let mut missing_create = base.clone();
+    missing_create
+        .get_mut("steps")
+        .and_then(|steps| steps.as_sequence_mut())
+        .expect("benchmark job must have mutable steps")
+        .remove(5);
+    assert!(
+        validate_pr_loop_benchmark_step_set(&missing_create).is_err(),
+        "dropping the cache creation step must be rejected"
+    );
+
+    let mut divergent_gocache = base.clone();
+    divergent_gocache
+        .get_mut("steps")
+        .and_then(|steps| steps.as_sequence_mut())
+        .expect("benchmark job must have mutable steps")[9]
+        .get_mut("env")
+        .and_then(|env| env.as_mapping_mut())
+        .expect("harness step must have env")
+        .insert(
+            serde_yaml::Value::String("GOCACHE".to_string()),
+            serde_yaml::Value::String("/tmp/other-cache".to_string()),
+        );
+    assert!(
+        validate_pr_loop_benchmark_step_set(&divergent_gocache).is_err(),
+        "a measured GOCACHE diverging from warmup must be rejected"
+    );
 }
 
 #[test]
@@ -1158,7 +1770,7 @@ fn ci_pr_loop_benchmark_contract_rejects_missing_or_wrong_evidence_validation() 
         .get_mut("steps")
         .and_then(|steps| steps.as_sequence_mut())
         .expect("benchmark job must have mutable steps")
-        .remove(8);
+        .remove(9);
     assert!(
         validate_pr_loop_benchmark_step_set(&missing).is_err(),
         "a successful harness must be followed by the required evidence validation"
@@ -1168,7 +1780,7 @@ fn ci_pr_loop_benchmark_contract_rejects_missing_or_wrong_evidence_validation() 
     wrong_path
         .get_mut("steps")
         .and_then(|steps| steps.as_sequence_mut())
-        .expect("benchmark job must have mutable steps")[8]
+        .expect("benchmark job must have mutable steps")[10]
         .as_mapping_mut()
         .unwrap()
         .insert(
@@ -1207,6 +1819,32 @@ fn run_collector(output: &Path, results: &[PathBuf]) -> Output {
     command.output().expect("spawn collector")
 }
 
+/// Runs five primed samples bound to one explicit GOCACHE, mirroring the
+/// calibration workflow's measured acquisition.
+fn run_primed_samples(tools: &FakeTools, samples_dir: &Path, gocache: &Path) -> Vec<PathBuf> {
+    let cache_path = gocache.to_str().expect("gocache path");
+    let mut results = Vec::new();
+    for sample in 1..=5 {
+        let output = samples_dir.join(format!("sample-{sample}"));
+        let run = run_harness(
+            tools,
+            &output,
+            None,
+            &[
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                ("GOCACHE", cache_path),
+            ],
+        );
+        assert!(
+            run.status.success(),
+            "sample {sample} harness run failed\nstderr: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+        results.push(output.join("pr-loop-benchmark-result.json"));
+    }
+    results
+}
+
 #[test]
 fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
     if !harness_tools_available() || !tool_on_path("python3") {
@@ -1214,22 +1852,9 @@ fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
         return;
     }
     let tools = install_fake_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
     let samples = tempfile::tempdir().expect("sample tempdir");
-    let mut results = Vec::new();
-    for sample in 1..=5 {
-        let output = samples.path().join(format!("sample-{sample}"));
-        assert!(
-            run_harness(
-                &tools,
-                &output,
-                None,
-                &[("BENCH_GO_BUILD_CACHE_STATE", "primed")]
-            )
-            .status
-            .success()
-        );
-        results.push(output.join("pr-loop-benchmark-result.json"));
-    }
+    let results = run_primed_samples(&tools, samples.path(), gocache.path());
     let candidate = samples.path().join("candidate.json");
     let output = run_collector(&candidate, &results);
     assert!(
@@ -1240,20 +1865,45 @@ fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&candidate).expect("candidate")).expect("JSON");
     assert_eq!(value["kind"], "togi_pr_loop_calibration_candidate");
+    assert_eq!(value["schema_version"], 2);
     assert_eq!(value["source"]["commit"], "test-commit");
-    assert_eq!(
-        value["samples"]["cold-regular"]["wall_ms"]
-            .as_array()
-            .unwrap()
-            .len(),
-        5
-    );
+    for name in WORKLOAD_NAMES {
+        assert_eq!(
+            value["samples"][name]["wall_ms"].as_array().unwrap().len(),
+            5,
+            "workload {name} must retain five wall samples"
+        );
+    }
     assert!(value["samples"]["cold-regular"]["wall_ms_median"].is_number());
     assert!(value["samples"]["cold-regular"]["wall_ms_mad"].is_number());
     assert_eq!(
         value["measurement_identity"]["go_build_cache_state"],
         "primed"
     );
+    assert_eq!(
+        value["measurement_identity"]["go_build_cache_policy"],
+        "job-private-explicit-gocache"
+    );
+    assert!(
+        value["measurement_identity"]
+            .get("go_build_cache_path")
+            .is_none(),
+        "the volatile cache path must not be measurement identity"
+    );
+    assert_eq!(
+        value["runner_diagnostics"][0]["go_build_cache_path"],
+        serde_json::Value::String(gocache.path().to_str().expect("gocache path").to_string()),
+        "the cache path is kept as per-sample diagnostic evidence"
+    );
+    let mut identity_scenarios: Vec<&str> =
+        value["semantic_identity"]["scenario_mutation_identity"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+    identity_scenarios.sort_unstable();
+    assert_eq!(identity_scenarios, ["multi-file", "single-file"]);
 
     let wrong_count = run_collector(&samples.path().join("wrong-count.json"), &results[..4]);
     assert!(!wrong_count.status.success());
@@ -1283,6 +1933,35 @@ fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
     assert!(
         !copied_duplicate_candidate.exists(),
         "byte-identical copied inputs must not create a candidate"
+    );
+
+    // A sample measured against a different cache path is not comparable.
+    let other_gocache = tempfile::tempdir().expect("other gocache");
+    let other_sample_dir = samples.path().join("other-cache-sample");
+    assert!(
+        run_harness(
+            &tools,
+            &other_sample_dir,
+            None,
+            &[
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                (
+                    "GOCACHE",
+                    other_gocache.path().to_str().expect("other gocache path")
+                ),
+            ],
+        )
+        .status
+        .success()
+    );
+    let mut divergent_cache = results.clone();
+    divergent_cache[4] = other_sample_dir.join("pr-loop-benchmark-result.json");
+    let divergent_candidate = samples.path().join("divergent-cache.json");
+    let divergent = run_collector(&divergent_candidate, &divergent_cache);
+    assert_eq!(divergent.status.code(), Some(2));
+    assert!(
+        !divergent_candidate.exists(),
+        "divergent cache paths must not create a candidate"
     );
 
     let portable_dir = samples.path().join("different-leading-location");
@@ -1338,6 +2017,26 @@ fn pr_loop_calibration_collector_fails_closed_and_preserves_samples() {
             "/provenance/go_build_cache_state",
             serde_json::Value::String("warmup".to_string()),
             "go-cache-state",
+        ),
+        (
+            "/provenance/go_build_cache_policy",
+            serde_json::Value::String("unenforced".to_string()),
+            "go-cache-policy",
+        ),
+        (
+            "/provenance/go_build_cache_path",
+            serde_json::Value::String("/elsewhere/go-cache".to_string()),
+            "go-cache-path",
+        ),
+        (
+            "/workloads/4/scenario",
+            serde_json::Value::String("single-file".to_string()),
+            "workload-scenario",
+        ),
+        (
+            "/workloads/0/runner_mode",
+            serde_json::Value::String("turbo".to_string()),
+            "runner-mode",
         ),
     ] {
         let altered = samples.path().join(format!("{output_name}.json"));
@@ -1449,7 +2148,13 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
         fs::read_to_string(repo_root().join(".github/workflows/pr-loop-calibration.yml"))
             .expect("calibration workflow");
     let parsed: serde_yaml::Value = serde_yaml::from_str(&workflow).expect("workflow YAML");
-    let steps = parsed["jobs"]["calibrate"]["steps"]
+    let job = &parsed["jobs"]["calibrate"];
+    assert_eq!(
+        job["env"]["BENCH_GOCACHE"].as_str(),
+        Some("${{ runner.temp }}/togi-pr-loop-gocache"),
+        "calibration job must define the job-private BENCH_GOCACHE"
+    );
+    let steps = job["steps"]
         .as_sequence()
         .expect("calibration must have steps");
     let step = |name| {
@@ -1459,12 +2164,29 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
             .map(|index| (index, &steps[index]))
             .unwrap_or_else(|| panic!("missing calibration step {name}"))
     };
+    let setup_go = steps
+        .iter()
+        .find(|item| item["uses"].as_str() == Some("actions/setup-go@v7"))
+        .expect("calibration must set up Go");
+    assert_eq!(
+        setup_go["with"]["go-version"].as_str(),
+        Some("1.26.5"),
+        "calibration must pin Go to exactly 1.26.5"
+    );
+    let (create_index, create) = step("Create job-private Go build cache");
+    assert_eq!(create["shell"].as_str(), Some("bash"));
+    assert_eq!(create["run"].as_str(), Some(APPROVED_GO_CACHE_CREATION));
     let (warmup_index, warmup) = step("Warm Go build cache");
     let (acquisition_index, acquisition) = step("Acquire five independent samples");
+    assert!(create_index < warmup_index);
     assert!(warmup_index < acquisition_index);
     assert_eq!(
         warmup["env"]["BENCH_GO_BUILD_CACHE_STATE"].as_str(),
         Some("warmup")
+    );
+    assert_eq!(
+        warmup["env"]["GOCACHE"].as_str(),
+        Some("${{ env.BENCH_GOCACHE }}")
     );
     assert_eq!(
         warmup["env"]["CALIBRATION_OUTPUT"].as_str(),
@@ -1477,6 +2199,11 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
     assert_eq!(
         acquisition["env"]["BENCH_GO_BUILD_CACHE_STATE"].as_str(),
         Some("primed")
+    );
+    assert_eq!(
+        acquisition["env"]["GOCACHE"].as_str(),
+        Some("${{ env.BENCH_GOCACHE }}"),
+        "warmup and measured acquisition must bind the identical explicit GOCACHE"
     );
     assert_eq!(
         acquisition["env"]["CALIBRATION_OUTPUT"].as_str(),
@@ -1513,4 +2240,473 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
     assert!(workflow.contains("retention-days: 14"));
     assert!(!workflow.contains("pull_request:"));
     assert!(!workflow.contains("permissions: write"));
+}
+
+fn promoter_path() -> PathBuf {
+    repo_root().join("benchmarks/pr-loop/promote-baseline.py")
+}
+
+fn archive_artifact(artifact_dir: &Path, archive: &Path) {
+    let script = r#"import pathlib, sys, zipfile
+root, output = map(pathlib.Path, sys.argv[1:])
+with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and not path.is_symlink():
+            archive.write(path, path.relative_to(root).as_posix())
+"#;
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .arg(artifact_dir)
+        .arg(archive)
+        .output()
+        .expect("create artifact archive");
+    assert!(
+        output.status.success(),
+        "archive failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_promoter(
+    artifact_dir: &Path,
+    output: &Path,
+    expected_commit: &str,
+    extra: &[&str],
+) -> Output {
+    let archive = output.with_extension("artifact.zip");
+    if !archive.exists() {
+        archive_artifact(artifact_dir, &archive);
+    }
+    let mut command = Command::new("python3");
+    command
+        .arg(promoter_path())
+        .arg("--artifact-dir")
+        .arg(artifact_dir)
+        .arg("--artifact-archive")
+        .arg(&archive)
+        .arg("--github-artifact-id")
+        .arg("123")
+        .arg("--github-artifact-sha256")
+        .arg(sha256_file(&archive))
+        .arg("--output")
+        .arg(output)
+        .arg("--expected-source-commit")
+        .arg(expected_commit);
+    for arg in extra {
+        command.arg(arg);
+    }
+    command.output().expect("spawn promoter")
+}
+
+/// Builds a calibration-shaped artifact directory: five primed samples plus
+/// the collector's candidate JSON, mirroring the uploaded CI artifact.
+fn build_calibration_artifact(tools: &FakeTools, artifact: &Path, gocache: &Path) -> Vec<PathBuf> {
+    let results = run_primed_samples(tools, artifact, gocache);
+    let candidate = artifact.join("pr-loop-calibration-candidate.json");
+    let collected = run_collector(&candidate, &results);
+    assert!(
+        collected.status.success(),
+        "artifact candidate collection failed\nstderr: {}",
+        String::from_utf8_lossy(&collected.stderr)
+    );
+    results
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("read JSON")).expect("valid JSON")
+}
+
+#[test]
+fn pr_loop_promote_baseline_happy_path_is_deterministic_and_never_overwrites() {
+    if !harness_tools_available() || !tool_on_path("python3") {
+        eprintln!("skipping: harness or Python tools unavailable");
+        return;
+    }
+    let tools = install_fake_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let artifact = workspace.path().join("artifact");
+    fs::create_dir(&artifact).unwrap();
+    build_calibration_artifact(&tools, &artifact, gocache.path());
+
+    let baseline = workspace.path().join("baseline.json");
+    let promoted = run_promoter(
+        &artifact,
+        &baseline,
+        "test-commit",
+        &[
+            "--activation-pr",
+            "487",
+            "--activation-actor",
+            "octocat",
+            "--activation-utc",
+            "2026-08-04T00:00:00Z",
+        ],
+    );
+    assert!(
+        promoted.status.success(),
+        "promotion must succeed\nstderr: {}",
+        String::from_utf8_lossy(&promoted.stderr)
+    );
+    let value = read_json(&baseline);
+    assert_eq!(value["kind"], "togi_pr_loop_baseline");
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["status"], "pending-activation");
+    assert_eq!(value["activation"]["pr"], 487);
+    assert_eq!(value["activation"]["actor"], "octocat");
+    assert_eq!(value["activation"]["utc"], "2026-08-04T00:00:00Z");
+    assert_eq!(value["source"]["commit"], "test-commit");
+    assert_eq!(
+        value["measurement_identity"],
+        serde_json::json!({
+            "go_build_cache_state": "primed",
+            "go_build_cache_policy": "job-private-explicit-gocache"
+        }),
+        "measurement identity must not carry the volatile cache path"
+    );
+    assert_eq!(
+        value["calibration_evidence"]["go_build_cache_path"],
+        serde_json::Value::String(gocache.path().to_str().unwrap().to_string()),
+        "the volatile cache path survives only as calibration evidence"
+    );
+    assert_eq!(value["semantic_identity"]["manifest"]["schema_version"], 2);
+    for name in WORKLOAD_NAMES {
+        assert_eq!(
+            value["samples"][name]["wall_ms"].as_array().unwrap().len(),
+            5,
+            "baseline must carry five wall samples for {name}"
+        );
+    }
+
+    // Deterministic: identical inputs and metadata produce identical bytes.
+    let second = workspace.path().join("baseline-second.json");
+    assert!(
+        run_promoter(
+            &artifact,
+            &second,
+            "test-commit",
+            &[
+                "--activation-pr",
+                "487",
+                "--activation-actor",
+                "octocat",
+                "--activation-utc",
+                "2026-08-04T00:00:00Z",
+            ],
+        )
+        .status
+        .success()
+    );
+    assert_eq!(
+        fs::read(&baseline).unwrap(),
+        fs::read(&second).unwrap(),
+        "promotion must be deterministic"
+    );
+
+    // No overwrite by default; explicit --overwrite opts in.
+    let third = run_promoter(&artifact, &baseline, "test-commit", &[]);
+    assert_eq!(third.status.code(), Some(2));
+    let overwritten = run_promoter(&artifact, &baseline, "test-commit", &["--overwrite"]);
+    assert!(overwritten.status.success());
+    let without_activation = read_json(&baseline);
+    assert_eq!(
+        without_activation["activation"]["pr"],
+        serde_json::Value::Null
+    );
+}
+
+#[test]
+fn pr_loop_promote_baseline_rejects_wall_outlier() {
+    if !harness_tools_available() || !tool_on_path("python3") {
+        eprintln!("skipping: harness or Python tools unavailable");
+        return;
+    }
+    let tools = install_fake_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let artifact = workspace.path().join("artifact");
+    fs::create_dir(&artifact).unwrap();
+    let results = run_primed_samples(&tools, &artifact, gocache.path());
+
+    // Poison the last sample's cold-regular wall time to 12x the median of
+    // the others: the collector accepts it, the promoter must not.
+    let mut walls: Vec<u64> = results[..4]
+        .iter()
+        .map(|path| {
+            read_json(path)["workloads"][0]["timing"]["wall_ms"]
+                .as_u64()
+                .unwrap()
+        })
+        .collect();
+    walls.sort_unstable();
+    let median = walls[walls.len() / 2].max(1);
+    let poisoned = artifact.join("sample-5/pr-loop-benchmark-result.json");
+    let mut result = read_json(&poisoned);
+    result["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(12 * median);
+    fs::write(&poisoned, serde_json::to_vec_pretty(&result).unwrap()).unwrap();
+
+    let candidate = artifact.join("pr-loop-calibration-candidate.json");
+    let collected = run_collector(&candidate, &results);
+    assert!(
+        collected.status.success(),
+        "collector has no outlier policy and must still collect\nstderr: {}",
+        String::from_utf8_lossy(&collected.stderr)
+    );
+    let promoted = run_promoter(
+        &artifact,
+        &workspace.path().join("baseline.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(promoted.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&promoted.stderr).contains("median"),
+        "expected an outlier rejection, got: {}",
+        String::from_utf8_lossy(&promoted.stderr)
+    );
+}
+
+#[test]
+fn pr_loop_promote_baseline_fails_closed_on_artifact_tampering() {
+    if !harness_tools_available() || !tool_on_path("python3") {
+        eprintln!("skipping: harness or Python tools unavailable");
+        return;
+    }
+    let tools = install_fake_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let artifact = workspace.path().join("artifact");
+    fs::create_dir(&artifact).unwrap();
+    build_calibration_artifact(&tools, &artifact, gocache.path());
+    let candidate = artifact.join("pr-loop-calibration-candidate.json");
+    let sample5 = artifact.join("sample-5/pr-loop-benchmark-result.json");
+
+    // Wrong expected source commit.
+    let rejected = run_promoter(
+        &artifact,
+        &workspace.path().join("wrong-commit.json"),
+        "different-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Artifact directory without the candidate.
+    let no_candidate = workspace.path().join("no-candidate");
+    fs::create_dir(&no_candidate).unwrap();
+    let rejected = run_promoter(
+        &no_candidate,
+        &workspace.path().join("no-candidate-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Symlink anywhere in the artifact tree is rejected.
+    let symlinked = workspace.path().join("symlinked");
+    copy_dir(&artifact, &symlinked);
+    std::os::unix::fs::symlink("/etc/hostname", symlinked.join("evil-link")).unwrap();
+    let rejected = run_promoter(
+        &symlinked,
+        &workspace.path().join("symlinked-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Missing sample file named by the candidate.
+    let missing_sample = workspace.path().join("missing-sample");
+    copy_dir(&artifact, &missing_sample);
+    fs::remove_file(missing_sample.join("sample-5/pr-loop-benchmark-result.json")).unwrap();
+    let rejected = run_promoter(
+        &missing_sample,
+        &workspace.path().join("missing-sample-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Sample content drift after collection breaks the recorded digest.
+    let drifted = workspace.path().join("drifted");
+    copy_dir(&artifact, &drifted);
+    let drifted_sample = drifted.join("sample-5/pr-loop-benchmark-result.json");
+    let mut result = read_json(&drifted_sample);
+    result["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(1);
+    fs::write(&drifted_sample, serde_json::to_vec_pretty(&result).unwrap()).unwrap();
+
+    // Candidate identity is derived from all five raw reports, never trusted.
+    for (pointer, replacement, name) in [
+        (
+            "/semantic_identity/workloads/0/runner_mode",
+            serde_json::json!("forged"),
+            "runner-mode",
+        ),
+        (
+            "/semantic_identity/workloads/0/semantics/selected_test_command/2",
+            serde_json::json!("./only"),
+            "test-command",
+        ),
+        (
+            "/semantic_identity/scenario_mutation_identity/multi-file",
+            serde_json::json!("0".repeat(64)),
+            "scenario-identity",
+        ),
+        (
+            "/runner_class/runner_label",
+            serde_json::json!("forged-runner"),
+            "runner-class",
+        ),
+        (
+            "/execution_provenance/go_version",
+            serde_json::json!("forged-go"),
+            "execution-provenance",
+        ),
+    ] {
+        let forged = workspace.path().join(format!("forged-{name}"));
+        copy_dir(&artifact, &forged);
+        let candidate_path = forged.join("pr-loop-calibration-candidate.json");
+        let mut forged_candidate = read_json(&candidate_path);
+        *forged_candidate
+            .pointer_mut(pointer)
+            .expect("candidate field") = replacement;
+        fs::write(
+            &candidate_path,
+            serde_json::to_vec_pretty(&forged_candidate).unwrap(),
+        )
+        .unwrap();
+        let output = workspace.path().join(format!("forged-{name}.json"));
+        let rejected = run_promoter(&forged, &output, "test-commit", &[]);
+        assert_eq!(rejected.status.code(), Some(2), "{name} must fail closed");
+        assert!(!output.exists(), "{name} must not write a baseline");
+    }
+    let rejected = run_promoter(
+        &drifted,
+        &workspace.path().join("drifted-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Candidate sample data disagreeing with the artifact results.
+    let tampered_samples = workspace.path().join("tampered-samples");
+    copy_dir(&artifact, &tampered_samples);
+    let tampered_candidate = tampered_samples.join("pr-loop-calibration-candidate.json");
+    let mut value = read_json(&tampered_candidate);
+    value["samples"]["cold-regular"]["wall_ms"][0] = serde_json::json!(1);
+    fs::write(
+        &tampered_candidate,
+        serde_json::to_vec_pretty(&value).unwrap(),
+    )
+    .unwrap();
+
+    // GitHub archive custody is mandatory: positive id, normalized digest,
+    // and an exact regular-file archive/extraction match.
+    let rejected = run_promoter(
+        &artifact,
+        &workspace.path().join("bad-artifact-id.json"),
+        "test-commit",
+        &["--github-artifact-id", "0"],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+    let rejected = run_promoter(
+        &artifact,
+        &workspace.path().join("bad-artifact-digest.json"),
+        "test-commit",
+        &["--github-artifact-sha256", &"0".repeat(64)],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+    let archive_output = workspace.path().join("archive-extra.json");
+    let archive = archive_output.with_extension("artifact.zip");
+    archive_artifact(&artifact, &archive);
+    let added = Command::new("python3")
+        .args([
+            "-c",
+            "import sys, zipfile; zipfile.ZipFile(sys.argv[1], 'a').writestr('extra', b'x')",
+        ])
+        .arg(&archive)
+        .output()
+        .expect("append archive member");
+    assert!(added.status.success());
+    let rejected = run_promoter(&artifact, &archive_output, "test-commit", &[]);
+    assert_eq!(rejected.status.code(), Some(2));
+    let rejected = run_promoter(
+        &tampered_samples,
+        &workspace.path().join("tampered-samples-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // Candidate pinned to a different manifest/fixture digest generation.
+    let stale = workspace.path().join("stale");
+    copy_dir(&artifact, &stale);
+    let stale_candidate = stale.join("pr-loop-calibration-candidate.json");
+    let mut value = read_json(&stale_candidate);
+    value["source_file_digests"]["benchmarks/pr-loop/manifest.json"] =
+        serde_json::json!("0".repeat(64));
+    fs::write(&stale_candidate, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+    let rejected = run_promoter(
+        &stale,
+        &workspace.path().join("stale-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // A non-primed input, even with a re-digested candidate entry.
+    let unprimed = workspace.path().join("unprimed");
+    copy_dir(&artifact, &unprimed);
+    let unprimed_sample = unprimed.join("sample-5/pr-loop-benchmark-result.json");
+    let mut result = read_json(&unprimed_sample);
+    result["provenance"]["go_build_cache_state"] = serde_json::json!("unclassified");
+    fs::write(
+        &unprimed_sample,
+        serde_json::to_vec_pretty(&result).unwrap(),
+    )
+    .unwrap();
+    let unprimed_candidate = unprimed.join("pr-loop-calibration-candidate.json");
+    let mut value = read_json(&unprimed_candidate);
+    value["source_file_digests"]["sample-5/pr-loop-benchmark-result.json"] =
+        serde_json::json!(sha256_file(&unprimed_sample));
+    fs::write(
+        &unprimed_candidate,
+        serde_json::to_vec_pretty(&value).unwrap(),
+    )
+    .unwrap();
+    let rejected = run_promoter(
+        &unprimed,
+        &workspace.path().join("unprimed-out.json"),
+        "test-commit",
+        &[],
+    );
+    assert_eq!(rejected.status.code(), Some(2));
+
+    // The pristine artifact still promotes after all tampering variants.
+    assert!(candidate.exists() && sample5.exists());
+    let promoted = run_promoter(
+        &artifact,
+        &workspace.path().join("pristine.json"),
+        "test-commit",
+        &[],
+    );
+    assert!(
+        promoted.status.success(),
+        "pristine artifact must still promote\nstderr: {}",
+        String::from_utf8_lossy(&promoted.stderr)
+    );
+}
+
+/// Recursively copies a directory tree of regular files (test artifacts only).
+fn copy_dir(source: &Path, target: &Path) {
+    fs::create_dir_all(target).unwrap();
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let destination = target.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &destination);
+        } else {
+            fs::copy(&path, &destination).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
- References #487
- Adds schema-v2 PR-loop corpus: two scenarios and six workloads.
- Adds auditable private-GOCACHE calibration and fail-closed promoter/archive provenance chain.
- Explicitly adds no baseline, comparator, or regression gate.

Local verification: cargo stable/MSRV tests, clippy/fmt, and harness smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multi-file benchmark scenarios and expanded coverage to six workloads.
  - Added detailed benchmark evidence, cache provenance, and calibration guidance.

- **Bug Fixes**
  - Improved benchmark consistency by using a pinned Go version and isolated build caches.
  - Added safeguards to reject incomplete, inconsistent, tampered, or outlier calibration results.

- **Documentation**
  - Documented benchmark reproduction steps, prerequisites, cache handling, telemetry limitations, and baseline activation procedures.

- **Tests**
  - Expanded integration and workflow validation for scenarios, cache behavior, workload selection, and baseline promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->