### PR TITLE
bench: add observational PR-loop scaling corpus

### DIFF
--- a/benchmarks/pr-loop-scale/manifest.json
+++ b/benchmarks/pr-loop-scale/manifest.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 3,
+  "name": "togi-pr-loop-scale-benchmarks",
+  "description": "Observational PR-loop scaling corpus for togi (issue #498): the Go scale fixture is copied into a disposable temp project, committed as the base revision, modified by the pinned scale patch, and measured through `togi check --base HEAD` so every run represents a PR diff, never --all.",
+  "notes": [
+    "Timing is observational only: no tracked baseline, no timing threshold, no score judgment, and no CI gate is defined by this manifest.",
+    "Semantic and provenance invariants are hard failures; the harness exits non-zero when any invariant fails.",
+    "expected_mutation_count and the changed-file line ranges pin the mutation surface of the scenario patch; operator or fixture drift must be resolved by updating this manifest deliberately.",
+    "Workloads run in declaration order and workloads of one scenario must be contiguous. scale-warm-exact-cache reuses the .togi-cache seeded by scale-regular-jobs1 inside the scale-file scenario only; cache dependencies never cross scenarios.",
+    "runner_mode is declared per workload (regular, schemata, or default) and validated against the effective argv: regular requires --no-schemata, schemata requires --schemata, default requires neither.",
+    "Zero-config runs enable schemata; this fixture's togi.toml omits the schemata key, whose config-file default is off, so scale-default measures the zero-flag config-present path: regular runner with default parallelism (jobs from available_parallelism), schemata null. Only the explicit --schemata workloads carry schemata evidence; --jobs only affects fallback/regular execution because the schema fast path runs sequentially per language.",
+    "The harness requires bash, git, go, jq, sed, sha256sum or shasum, and python3 (monotonic high-resolution wall clock)."
+  ],
+  "fixture": {
+    "source_dir": "tests/fixtures/go-scale",
+    "base_ref": "HEAD"
+  },
+  "scenarios": [
+    {
+      "name": "scale-file",
+      "description": "Scale PR diff: scale-change.patch appends seven expression-dense functions to scale.go, calibrated to a 98-mutant surface with at least one schemata fast-path and one fallback mutant.",
+      "patch_file": "benchmarks/pr-loop-scale/scale-change.patch",
+      "patch_sha256": "ac993114dfef39cd4e52d2cedbe26935e4410048471924a3df2431c13cef41dd",
+      "changed_files": [
+        { "path": "scale.go", "line_range": [15, 74] }
+      ],
+      "expected_mutation_count": 98
+    }
+  ],
+  "togi": {
+    "common_args": [
+      "check",
+      "--base", "HEAD",
+      "--timeout", "60",
+      "--max-per-run", "500",
+      "--test-cmd", "go test ./...",
+      "--format", "json"
+    ]
+  },
+  "workloads": [
+    {
+      "name": "scale-regular-jobs1",
+      "scenario": "scale-file",
+      "runner_mode": "regular",
+      "description": "Cold per-mutant runner on the scale diff with one job: fresh cache, schemata disabled, every mutation re-executed.",
+      "extra_args": ["--no-schemata", "--force-rerun", "--jobs", "1"],
+      "cache": "fresh",
+      "seeds_cache": true,
+      "invariants": ["report-well-formed", "full-fresh-execution"]
+    },
+    {
+      "name": "scale-warm-exact-cache",
+      "scenario": "scale-file",
+      "runner_mode": "regular",
+      "description": "Identical second run reusing the cache seeded by scale-regular-jobs1; every verdict must come from the exact cache.",
+      "extra_args": ["--no-schemata", "--jobs", "1"],
+      "cache": "reuse",
+      "expects_cache_from": "scale-regular-jobs1",
+      "invariants": ["report-well-formed", "full-exact-cache-reuse"]
+    },
+    {
+      "name": "scale-regular-jobs4",
+      "scenario": "scale-file",
+      "runner_mode": "regular",
+      "description": "Cold per-mutant runner on the scale diff with four jobs: fresh cache, schemata disabled, every mutation re-executed.",
+      "extra_args": ["--no-schemata", "--force-rerun", "--jobs", "4"],
+      "cache": "fresh",
+      "invariants": ["report-well-formed", "full-fresh-execution"]
+    },
+    {
+      "name": "scale-schemata",
+      "scenario": "scale-file",
+      "runner_mode": "schemata",
+      "description": "Cold schemata run on the scale diff: fresh cache; the patch guarantees at least one schema fast-path mutant and at least one fallback mutant.",
+      "extra_args": ["--schemata", "--force-rerun", "--jobs", "1"],
+      "cache": "fresh",
+      "invariants": ["report-well-formed", "schemata-fast-path-and-fallback"]
+    },
+    {
+      "name": "scale-schemata-jobs4",
+      "scenario": "scale-file",
+      "runner_mode": "schemata",
+      "description": "Cold schemata run on the scale diff with four jobs: --jobs affects only the fallback mutants because the schema fast path executes sequentially per language.",
+      "extra_args": ["--schemata", "--force-rerun", "--jobs", "4"],
+      "cache": "fresh",
+      "invariants": ["report-well-formed", "schemata-fast-path-and-fallback"]
+    },
+    {
+      "name": "scale-default",
+      "scenario": "scale-file",
+      "runner_mode": "default",
+      "description": "Zero-flag invocation on the scale diff (no cache, schemata, or jobs flags): the config-present default path, a regular run with default parallelism and schemata null; mutations must target only the patched lines.",
+      "extra_args": [],
+      "cache": "fresh",
+      "invariants": ["report-well-formed", "pr-diff-targeting"]
+    }
+  ]
+}

--- a/benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh
+++ b/benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh
@@ -1,0 +1,940 @@
+#!/usr/bin/env bash
+# PR-loop scaling benchmark harness for togi (issue #498, observational).
+#
+# Copies tests/fixtures/go-scale into one disposable temp project per
+# scenario, initializes a local Git history, applies the scenario's fixed
+# working-tree patch, and runs the workloads declared in manifest.json
+# through `togi check --base HEAD` so every measurement represents a PR diff,
+# never --all.
+#
+# This harness emits schema_version 3 results for the observational scale
+# corpus only; the schema-2 gated comparator rejects them by construction.
+# Semantic/provenance invariant failures fail the harness (exit 1). Timing is
+# recorded for observation only; nothing here compares against a baseline.
+#
+# Intentional mirroring: the execution engine below mirrors the frozen v2
+# gated harness at benchmarks/pr-loop/run-pr-loop-benchmarks.sh. That file is
+# byte-frozen by the regression-gate contract, so the shared logic is
+# duplicated here on purpose; any fix to the shared execution logic must be
+# ported to both files deliberately. The closed invariant-name list shared by
+# both files is asserted in sync by the Rust integration tests.
+#
+# Go build cache provenance: when BENCH_GO_BUILD_CACHE_STATE is warmup or
+# primed, the harness requires an absolute GOCACHE exactly matching
+# `go env GOCACHE` (exit 2 otherwise) and records the resolved path plus the
+# job-private-explicit-gocache policy in provenance. The default unclassified
+# state makes no cache requirement and stays observational.
+#
+# Usage: run-pr-loop-scale-benchmarks.sh [--output DIR] [--keep-workspace]
+# Env:   TOGI_BIN  path to the togi binary (default: target/release/togi)
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+MANIFEST=${BENCH_MANIFEST:-"$SCRIPT_DIR/manifest.json"}
+
+OUT_DIR=""
+KEEP_WORKSPACE=0
+
+usage() {
+  echo "Usage: $0 [--output DIR] [--keep-workspace]" >&2
+  echo "  --output DIR       directory for raw reports and the normalized result" >&2
+  echo "                     (default: a fresh dir under RUNNER_TEMP/TMPDIR)" >&2
+  echo "  --keep-workspace   keep the disposable temp projects for debugging" >&2
+  echo "Env: TOGI_BIN (default: <repo>/target/release/togi)" >&2
+  echo "     BENCH_MANIFEST (default: <repo>/benchmarks/pr-loop-scale/manifest.json)" >&2
+  echo "     BENCH_GO_BUILD_CACHE_STATE (unclassified|warmup|primed;" >&2
+  echo "          warmup/primed require an absolute GOCACHE matching" >&2
+  echo "          'go env GOCACHE' and an existing cache directory)" >&2
+  echo "Requires: bash, git, go, jq, sed, sha256sum|shasum, and python3" >&2
+  echo "          (python3 provides the monotonic high-resolution clock)" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output)
+      if [ $# -lt 2 ]; then
+        echo "--output requires a directory argument" >&2
+        usage
+        exit 2
+      fi
+      case "$2" in
+        -*)
+          echo "--output requires a directory argument, got option '$2'" >&2
+          usage
+          exit 2
+          ;;
+      esac
+      OUT_DIR=$2
+      shift 2
+      ;;
+    --keep-workspace)
+      KEEP_WORKSPACE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+for tool in git go jq sed; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required for the PR-loop scale benchmarks" >&2
+    exit 1
+  fi
+done
+
+# python3 supplies the monotonic high-resolution clock used for wall timings.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for monotonic wall timing in the PR-loop scale benchmarks" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256_CMD="shasum -a 256"
+else
+  echo "sha256sum or shasum is required for the PR-loop scale benchmarks" >&2
+  exit 1
+fi
+
+sha256_stdin() {
+  $SHA256_CMD | cut -d ' ' -f 1
+}
+
+sha256_file() {
+  $SHA256_CMD "$1" | cut -d ' ' -f 1
+}
+
+# Milliseconds from python3's monotonic high-resolution clock. Portable
+# across GNU and BSD userlands; wall-clock date math is not.
+now_ms() {
+  python3 -c 'import time; print(time.monotonic_ns() // 1_000_000)'
+}
+
+TOGI_BIN=${TOGI_BIN:-"$REPO_ROOT/target/release/togi"}
+case "$TOGI_BIN" in
+  /*) ;;
+  *) TOGI_BIN="$REPO_ROOT/$TOGI_BIN" ;;
+esac
+if [ ! -x "$TOGI_BIN" ]; then
+  echo "togi binary not found at $TOGI_BIN" >&2
+  echo "build it with 'cargo build --locked --release' or set TOGI_BIN" >&2
+  exit 1
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "manifest not found at $MANIFEST" >&2
+  exit 2
+fi
+
+MANIFEST_SCHEMA=$(jq -r '.schema_version // "missing"' "$MANIFEST")
+if [ "$MANIFEST_SCHEMA" != "3" ]; then
+  echo "unsupported manifest schema_version $MANIFEST_SCHEMA (expected 3)" >&2
+  exit 2
+fi
+
+# Schema/name coherence: a schema v3 manifest must declare the scale corpus
+# identity, so a relabeled v2 manifest fails closed before any setup while
+# v3 workload names and counts stay generic.
+if [ "$(jq -r '.name // "missing"' "$MANIFEST")" != "togi-pr-loop-scale-benchmarks" ]; then
+  echo "manifest $MANIFEST declares name '$(jq -r '.name // "missing"' "$MANIFEST")'" >&2
+  echo "  but manifest schema v3 requires 'togi-pr-loop-scale-benchmarks'" >&2
+  exit 2
+fi
+
+# Full manifest shape validation, checked directly before any setup so a
+# malformed or empty manifest can never yield a zero-workload success.
+# Scenario names are safe identifiers because they name filesystem paths.
+if ! jq -e '
+  (.name | type == "string" and length > 0)
+  and (.fixture | type == "object")
+  and (.fixture.source_dir | type == "string" and length > 0)
+  and (.fixture.base_ref | type == "string" and length > 0)
+  and (.scenarios | type == "array" and length > 0
+       and (([.[].name] | unique | length) == length)
+       and ([.[] |
+             ((.name | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_-]*$"))
+              and (.patch_file | type == "string" and length > 0)
+              and (.patch_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+              and (.changed_files | type == "array" and length > 0
+                   and ([.[] |
+                        ((.path | type == "string" and length > 0)
+                         and (.line_range | type == "array" and length == 2
+                              and ([.[] | type == "number"] | all)
+                              and (.[0] <= .[1])))]
+                       | all))
+              and ((has("requires_mutation_per_changed_file") | not) or (.requires_mutation_per_changed_file | type == "boolean"))
+              and (.expected_mutation_count | type == "number" and . > 0 and floor == .))]
+            | all))
+  and (.togi | type == "object")
+  and (.togi.common_args | type == "array" and length > 0
+       and ([.[] | type == "string"] | all))
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST failed schema/provenance validation:" >&2
+  echo "  expected name, fixture {source_dir, base_ref}, scenarios [{name" >&2
+  echo "  matching ^[A-Za-z0-9][A-Za-z0-9_-]*\$, patch_file, patch_sha256," >&2
+  echo "  changed_files [{path, line_range [min,max]}], optional" >&2
+  echo "  requires_mutation_per_changed_file, expected_mutation_count > 0}]," >&2
+  echo "  and togi.common_args [non-empty strings]" >&2
+  exit 2
+fi
+
+# Generic v3 workload validation: unique safe-identifier workload names
+# (they name raw artifact paths), declared scenarios only, contiguous
+# per-scenario workload blocks, and the closed invariant list shared with
+# the frozen v2 harness (keep it in sync with invariant_filter()).
+if ! jq -e '
+  (.workloads | type == "array" and length > 0)
+  and (([.workloads[].name] | unique | length) == (.workloads | length))
+  and ([.workloads[] |
+        ((.name | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_-]*$"))
+         and (.scenario | type == "string" and length > 0)
+         and ((.runner_mode // "") == "regular"
+              or (.runner_mode // "") == "schemata"
+              or (.runner_mode // "") == "default")
+         and ((.cache // "") == "fresh" or (.cache // "") == "reuse")
+         and (.extra_args | type == "array" and ([.[] | type == "string"] | all))
+         and (.invariants | type == "array" and length > 0
+              and (index("report-well-formed") != null)
+              and ([.[] | type == "string"
+                      and (. as $i | ["report-well-formed", "full-fresh-execution",
+                                      "full-exact-cache-reuse",
+                                      "schemata-fast-path-and-fallback",
+                                      "pr-diff-targeting"] | index($i) != null)]
+                   | all)))]
+       | all)
+  and (. as $m
+       | [.workloads[].scenario]
+       | all(. as $s | [$m.scenarios[].name] | index($s) != null))
+  and (. as $m
+       | [$m.workloads[].scenario] as $seq
+       | [$m.scenarios[].name]
+       | all(. as $s
+             | ([range(0; $seq | length) | select($seq[.] == $s)]) as $idx
+             | ($idx | length) == 0
+               or (($idx[-1] - $idx[0] + 1) == ($idx | length))))
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST failed schema v3 workload validation:" >&2
+  echo "  workloads must be a non-empty array with unique names matching" >&2
+  echo "  ^[A-Za-z0-9][A-Za-z0-9_-]*\$, each naming a declared scenario," >&2
+  echo "  runner_mode (regular|schemata|default), cache (fresh|reuse)," >&2
+  echo "  extra_args [strings], and non-empty invariants drawn from the" >&2
+  echo "  known list, always including report-well-formed; workloads of" >&2
+  echo "  one scenario must form one contiguous block" >&2
+  exit 2
+fi
+
+# Strict v3 argv contract, checked before any setup: every effective argv
+# (togi.common_args + workloads[].extra_args) must reject elements carrying
+# CR or LF (the `IFS= read` execution loop would split them into argv
+# entries validation never saw), reject inline --flag=value forms of the
+# controlled flags, carry exactly one split --timeout pair with value 60,
+# exactly one split --max-per-run pair with value 500, exactly one split
+# --test-cmd pair with value 'go test ./...', and at most one split --jobs
+# pair with a positive integer value.
+if ! jq -e '
+  . as $m
+  | [range(0; ($m.workloads | length)) | . as $w
+     | ($m.togi.common_args + $m.workloads[$w].extra_args) as $argv
+     | ([$argv[] | select(test("[\r\n]"))] | length == 0)
+       and ([$argv[] | select(test("^--(jobs|timeout|max-per-run|test-cmd)="))] | length == 0)
+       and (([$argv | to_entries[] | select(.value == "--timeout") | .key]) as $timeout
+            | ($timeout | length) == 1
+              and ($timeout[0] + 1) < ($argv | length)
+              and $argv[$timeout[0] + 1] == "60")
+       and (([$argv | to_entries[] | select(.value == "--max-per-run") | .key]) as $maxrun
+            | ($maxrun | length) == 1
+              and ($maxrun[0] + 1) < ($argv | length)
+              and $argv[$maxrun[0] + 1] == "500")
+       and (([$argv | to_entries[] | select(.value == "--test-cmd") | .key]) as $testcmd
+            | ($testcmd | length) == 1
+              and ($testcmd[0] + 1) < ($argv | length)
+              and $argv[$testcmd[0] + 1] == "go test ./...")
+       and (([$argv | to_entries[] | select(.value == "--jobs") | .key]) as $jobs
+            | ($jobs | length) <= 1
+              and (($jobs | length) == 0
+                   or (($jobs[0] + 1) < ($argv | length)
+                       and ($argv[$jobs[0] + 1] | test("^[1-9][0-9]*$")))))]
+  | all
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the strict v3 argv contract:" >&2
+  echo "  no effective argv element may contain CR or LF (the execution" >&2
+  echo "  loop splits on newlines); inline --jobs=/--timeout=/--max-per-run=/" >&2
+  echo "  --test-cmd= forms are rejected; every effective argv must carry" >&2
+  echo "  exactly one split --timeout 60 pair, one split --max-per-run 500" >&2
+  echo "  pair, one split --test-cmd 'go test ./...' pair, and at most one" >&2
+  echo "  split --jobs pair with a positive integer value" >&2
+  exit 2
+fi
+
+# Fixture/patch paths must be repository-relative and exist before any
+# setup; the per-scenario patch digests are verified below.
+V3_FIXTURE_DIR=$(jq -r '.fixture.source_dir' "$MANIFEST")
+case "$V3_FIXTURE_DIR" in
+  /*|*..*)
+    echo "manifest $MANIFEST fixture.source_dir must be repository-relative, got '$V3_FIXTURE_DIR'" >&2
+    exit 2
+    ;;
+esac
+if [ ! -d "$REPO_ROOT/$V3_FIXTURE_DIR" ]; then
+  echo "manifest $MANIFEST fixture.source_dir '$V3_FIXTURE_DIR' does not exist" >&2
+  exit 2
+fi
+while IFS= read -r v3_patch; do
+  case "$v3_patch" in
+    /*|*..*)
+      echo "manifest $MANIFEST scenario patch_file must be repository-relative, got '$v3_patch'" >&2
+      exit 2
+      ;;
+  esac
+  if [ ! -f "$REPO_ROOT/$v3_patch" ]; then
+    echo "manifest $MANIFEST scenario patch_file '$v3_patch' does not exist" >&2
+    exit 2
+  fi
+done < <(jq -r '.scenarios[].patch_file' "$MANIFEST")
+
+# Cache dependencies never cross scenarios: expects_cache_from may only name
+# an earlier workload in the same scenario that seeds its cache, and no
+# cache-clearing (fresh) workload of that scenario may interleave between
+# the seed and its consumer.
+if ! jq -e '
+  . as $m
+  | [.workloads | to_entries[]
+     | select(.value.expects_cache_from != null)
+     | . as $edge
+     | ([$m.workloads[0:$edge.key] | to_entries[]
+        | select(.value.name == $edge.value.expects_cache_from
+                 and .value.scenario == $edge.value.scenario
+                 and (.value.seeds_cache // false))]
+        | length == 1
+        and ((. [0].key) as $seed_idx
+             | ([$m.workloads[$seed_idx + 1:$edge.key][]
+                 | select(.scenario == $edge.value.scenario
+                          and .cache == "fresh")]
+                | length == 0)))]
+  | all
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the cache dependency contract:" >&2
+  echo "  expects_cache_from must name exactly one earlier workload in the" >&2
+  echo "  same scenario that declares seeds_cache, and no fresh workload of" >&2
+  echo "  that scenario may interleave between the seed and its consumer" >&2
+  exit 2
+fi
+
+# runner_mode must match the effective argv of every workload: regular pins
+# --no-schemata, schemata pins --schemata, default pins neither, and the
+# selected test command must come from exactly one --test-cmd pair.
+if ! jq -e '
+  . as $m
+  | ([$m.togi.common_args[] | select(. == "--test-cmd")] | length == 1)
+    and (([$m.togi.common_args | to_entries[] | select(.value == "--test-cmd") | .key][0]) as $i
+         | ($i + 1) < ($m.togi.common_args | length)
+           and ($m.togi.common_args[$i + 1] | length > 0))
+    and ([range(0; ($m.workloads | length)) | . as $w
+          | ($m.togi.common_args + $m.workloads[$w].extra_args) as $argv
+          | ([$argv[] | select(. == "--test-cmd")] | length) as $cmds
+          | ([$argv[] | select(. == "--no-schemata")] | length) as $no
+          | ([$argv[] | select(. == "--schemata")] | length) as $yes
+          | ($cmds == 1)
+            and (if $m.workloads[$w].runner_mode == "regular"
+                 then ($no == 1 and $yes == 0)
+                 elif $m.workloads[$w].runner_mode == "schemata"
+                 then ($yes == 1 and $no == 0)
+                 else ($yes == 0 and $no == 0) end)]
+         | all)
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the runner_mode/test-command contract:" >&2
+  echo "  regular requires exactly one --no-schemata and no --schemata," >&2
+  echo "  schemata requires exactly one --schemata and no --no-schemata," >&2
+  echo "  default requires neither, and every effective argv must carry" >&2
+  echo "  exactly one split --test-cmd pair" >&2
+  exit 2
+fi
+
+# PR-diff invocation contract: the benchmark only measures `check --base
+# HEAD` on a working-tree diff. Every workload's effective argv (common_args
+# + extra_args) is validated, so selector flags injected through either list
+# are rejected before any run.
+if ! jq -e '
+  . as $m
+  | ($m.fixture.base_ref == "HEAD")
+    and ([range(0; ($m.workloads | length)) as $w
+          | ($m.togi.common_args + $m.workloads[$w].extra_args) as $argv
+          | ($argv[0] == "check")
+            and ([$argv[] | select(. == "--all")] | length == 0)
+            and ([$argv[] | select(. == "--base")] | length == 1)
+            and ([$argv[] | select(startswith("--base="))] | length == 0)
+            and ((($argv | index("--base")) + 1) as $i
+                 | $i < ($argv | length) and $argv[$i] == "HEAD")
+         ] | all)
+' "$MANIFEST" >/dev/null; then
+  echo "manifest $MANIFEST violates the PR-diff invocation contract:" >&2
+  echo "  fixture.base_ref must be HEAD, and every workload's effective argv" >&2
+  echo "  (togi.common_args + workloads[].extra_args) must start with 'check'," >&2
+  echo "  pass exactly one split '--base HEAD' pair (no --base= form, no" >&2
+  echo "  duplicates), and must not contain '--all'" >&2
+  exit 2
+fi
+
+FIXTURE_SOURCE_DIR=$(jq -r '.fixture.source_dir' "$MANIFEST")
+WORKLOAD_COUNT=$(jq -r '.workloads | length' "$MANIFEST")
+
+# The selected test command every workload must resolve to, derived from the
+# single --test-cmd pair in common_args.
+TEST_CMD_INDEX=$(jq -r '[.togi.common_args | to_entries[] | select(.value == "--test-cmd") | .key][0]' "$MANIFEST")
+TEST_CMD_VALUE=$(jq -r --argjson i "$TEST_CMD_INDEX" '.togi.common_args[$i + 1]' "$MANIFEST")
+EXPECTED_TEST_COMMAND_JSON=$(printf '%s' "$TEST_CMD_VALUE" | tr ' ' '\n' | sed '/^$/d' | jq -Rn '[inputs]')
+
+# Scenario state is kept in parallel indexed arrays (bash 3.2 compatible);
+# scenario_index maps a scenario name to its slot.
+declare -a SCENARIO_ORDER=()
+declare -a SCENARIO_PATCH_FILE=()
+declare -a SCENARIO_PATCH_SHA=()
+declare -a SCENARIO_REQUIRE_PER_CHANGED_FILE=()
+declare -a SCENARIO_EXPECTED=()
+declare -a SCENARIO_CHANGED_FILES=()
+
+scenario_index() {
+  local i
+  for i in "${!SCENARIO_ORDER[@]}"; do
+    if [ "${SCENARIO_ORDER[$i]}" = "$1" ]; then
+      printf '%s\n' "$i"
+      return 0
+    fi
+  done
+  return 1
+}
+
+while IFS= read -r scenario; do
+  S_NAME=$(jq -r '.name' <<<"$scenario")
+  SCENARIO_ORDER+=("$S_NAME")
+  SCENARIO_PATCH_FILE+=("$REPO_ROOT/$(jq -r '.patch_file' <<<"$scenario")")
+  SCENARIO_PATCH_SHA+=("$(jq -r '.patch_sha256' <<<"$scenario")")
+  SCENARIO_REQUIRE_PER_CHANGED_FILE+=("$(jq -r '.requires_mutation_per_changed_file // false' <<<"$scenario")")
+  SCENARIO_EXPECTED+=("$(jq -r '.expected_mutation_count' <<<"$scenario")")
+  SCENARIO_CHANGED_FILES+=("$(jq -c '.changed_files' <<<"$scenario")")
+done < <(jq -c '.scenarios[]' "$MANIFEST")
+
+# Every scenario patch digest is verified before any run.
+for i in "${!SCENARIO_ORDER[@]}"; do
+  ACTUAL_PATCH_SHA=$(sha256_file "${SCENARIO_PATCH_FILE[$i]}")
+  if [ "$ACTUAL_PATCH_SHA" != "${SCENARIO_PATCH_SHA[$i]}" ]; then
+    echo "fixture patch digest mismatch for scenario ${SCENARIO_ORDER[$i]}:" >&2
+    echo "  manifest: ${SCENARIO_PATCH_SHA[$i]}" >&2
+    echo "  actual:   $ACTUAL_PATCH_SHA" >&2
+    echo "update manifest.json deliberately if the patch changed" >&2
+    exit 1
+  fi
+done
+
+COMMON_ARGS=()
+while IFS= read -r arg; do
+  COMMON_ARGS+=("$arg")
+done < <(jq -r '.togi.common_args[]' "$MANIFEST")
+
+# Go build cache provenance contract. warmup and primed measurements must
+# run against a job-private explicit GOCACHE; unclassified local runs make
+# no cache requirement and stay observational.
+BENCH_GO_BUILD_CACHE_STATE=${BENCH_GO_BUILD_CACHE_STATE:-unclassified}
+case "$BENCH_GO_BUILD_CACHE_STATE" in
+  warmup|primed)
+    if [ -z "${GOCACHE:-}" ]; then
+      echo "BENCH_GO_BUILD_CACHE_STATE=$BENCH_GO_BUILD_CACHE_STATE requires GOCACHE to be set" >&2
+      exit 2
+    fi
+    case "$GOCACHE" in
+      /*) ;;
+      *)
+        echo "GOCACHE must be an absolute path for $BENCH_GO_BUILD_CACHE_STATE measurements, got '$GOCACHE'" >&2
+        exit 2
+        ;;
+    esac
+    if [ ! -d "$GOCACHE" ]; then
+      echo "GOCACHE directory $GOCACHE does not exist for $BENCH_GO_BUILD_CACHE_STATE measurements" >&2
+      exit 2
+    fi
+    RESOLVED_GOCACHE=$(go env GOCACHE) || {
+      echo "go env GOCACHE failed for $BENCH_GO_BUILD_CACHE_STATE measurements" >&2
+      exit 2
+    }
+    if [ "$RESOLVED_GOCACHE" != "$GOCACHE" ]; then
+      echo "GOCACHE ($GOCACHE) does not match 'go env GOCACHE' ($RESOLVED_GOCACHE)" >&2
+      exit 2
+    fi
+    GO_BUILD_CACHE_POLICY="job-private-explicit-gocache"
+    GO_BUILD_CACHE_PATH_JSON=$(jq -n --arg path "$RESOLVED_GOCACHE" '$path')
+    ;;
+  unclassified)
+    GO_BUILD_CACHE_POLICY="unenforced"
+    GO_BUILD_CACHE_PATH_JSON="null"
+    ;;
+  *)
+    echo "unknown BENCH_GO_BUILD_CACHE_STATE '$BENCH_GO_BUILD_CACHE_STATE'" >&2
+    echo "expected unclassified, warmup, or primed" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/togi-pr-loop-scale-benchmarks.XXXXXX")
+fi
+mkdir -p "$OUT_DIR/raw"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+
+WORK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/togi-pr-loop-scale-work.XXXXXX")
+cleanup() {
+  if [ "$KEEP_WORKSPACE" = "1" ]; then
+    echo "workspace kept: $WORK_ROOT" >&2
+  else
+    rm -rf "$WORK_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+# One disposable temp project per scenario: fixture copy, local Git history,
+# the scenario's fixed working-tree patch applied on top of the base commit.
+declare -a SCENARIO_PROJECT=()
+declare -a SCENARIO_BASE_REVISION=()
+for i in "${!SCENARIO_ORDER[@]}"; do
+  S_PROJECT="$WORK_ROOT/project-${SCENARIO_ORDER[$i]}"
+  mkdir -p "$S_PROJECT"
+  cp -R "$REPO_ROOT/$FIXTURE_SOURCE_DIR/." "$S_PROJECT/"
+  git -C "$S_PROJECT" -c init.defaultBranch=main init -q
+  git -C "$S_PROJECT" config user.email "togi-pr-loop-bench@example.invalid"
+  git -C "$S_PROJECT" config user.name "togi-pr-loop-bench"
+  git -C "$S_PROJECT" config commit.gpgsign false
+  git -C "$S_PROJECT" add .
+  git -C "$S_PROJECT" commit -qm "fixture base"
+  git -C "$S_PROJECT" apply "${SCENARIO_PATCH_FILE[$i]}"
+  SCENARIO_PROJECT+=("$S_PROJECT")
+  SCENARIO_BASE_REVISION+=("$(git -C "$S_PROJECT" rev-parse HEAD)")
+done
+
+TOGI_VERSION=$("$TOGI_BIN" --version)
+GO_VERSION=$(go version)
+GIT_VERSION=$(git --version)
+OS_NAME=$(uname -s)
+ARCH_NAME=$(uname -m)
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+BENCH_RUNNER_LABEL=${BENCH_RUNNER_LABEL:-local}
+if command -v getconf >/dev/null 2>&1; then
+  LOGICAL_CPU_COUNT=$(getconf _NPROCESSORS_ONLN)
+elif command -v sysctl >/dev/null 2>&1; then
+  LOGICAL_CPU_COUNT=$(sysctl -n hw.logicalcpu)
+else
+  LOGICAL_CPU_COUNT=$(nproc)
+fi
+KERNEL_RELEASE=$(uname -r)
+IMAGE_OS=${ImageOS:-}
+IMAGE_VERSION=${ImageVersion:-}
+
+# jq filter for each named invariant. Scenario values are injected as
+# $expected_mutations, $changed_files, and $requires_per_changed_file; the
+# manifest's selected test command is injected as $expected_test_command.
+invariant_filter() {
+  case "$1" in
+    report-well-formed)
+      cat <<'EOF'
+(.kind == "mutation_report")
+and (.schema_version == 1)
+and ((.generator // "") | startswith("togi/"))
+and (.partial == false)
+and (.planned_total == .total)
+and (.total == $expected_mutations)
+and (.mutations | type == "array")
+and ((.mutations | length) == .total)
+and (.timeout == 0)
+and (.build_errors == 0)
+and (.duration_ms > 0)
+and ((.test_command // []) == $expected_test_command)
+and ([.mutations[] | ((.test_selection? // {"mode": "full"}).mode == "full")] | all)
+EOF
+      ;;
+    full-fresh-execution)
+      cat <<'EOF'
+(.tested == .total)
+and ((.exact_cache_reused // 0) == 0)
+and ((.incremental_history_reused // 0) == 0)
+and ([.mutations[].execution.state == "executed"] | all)
+EOF
+      ;;
+    full-exact-cache-reuse)
+      cat <<'EOF'
+(.tested == 0)
+and ((.exact_cache_reused // 0) == .total)
+and ([.mutations[].execution.state == "exact_cache"] | all)
+EOF
+      ;;
+    schemata-fast-path-and-fallback)
+      cat <<'EOF'
+(.schemata != null)
+and (.schemata.fast_path >= 1)
+and (.schemata.fallback >= 1)
+and ((.schemata.fast_path + .schemata.fallback) == .total)
+EOF
+      ;;
+    pr-diff-targeting)
+      cat <<'EOF'
+([.mutations[]
+  | .file as $file
+  | .line as $line
+  | ([$changed_files[]
+      | select(.path == $file
+               and $line >= .line_range[0]
+               and $line <= .line_range[1])]
+     | length >= 1)]
+ | all)
+and (if $requires_per_changed_file then
+       ([.mutations[].file] | unique | sort)
+       == ([$changed_files[].path] | unique | sort)
+     else true end)
+EOF
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+FRAGMENTS=()
+FAILURES=()
+declare -a SCENARIO_REF_DIGEST=()
+declare -a SCENARIO_CONSISTENT=()
+for i in "${!SCENARIO_ORDER[@]}"; do
+  SCENARIO_REF_DIGEST+=("")
+  SCENARIO_CONSISTENT+=(1)
+done
+OVERALL_OK=1
+
+while IFS= read -r workload; do
+  WL_NAME=$(jq -r '.name' <<<"$workload")
+  WL_SCENARIO=$(jq -r '.scenario' <<<"$workload")
+  RUNNER_MODE=$(jq -r '.runner_mode' <<<"$workload")
+  CACHE_POLICY=$(jq -r '.cache' <<<"$workload")
+  WL_SCENARIO_INDEX=$(scenario_index "$WL_SCENARIO") || {
+    echo "workload $WL_NAME names undeclared scenario '$WL_SCENARIO'" >&2
+    exit 2
+  }
+  PROJECT_DIR="${SCENARIO_PROJECT[$WL_SCENARIO_INDEX]}"
+  EXPECTED_MUTATIONS="${SCENARIO_EXPECTED[$WL_SCENARIO_INDEX]}"
+  CHANGED_FILES_JSON="${SCENARIO_CHANGED_FILES[$WL_SCENARIO_INDEX]}"
+
+  EXTRA_ARGS=()
+  while IFS= read -r arg; do
+    EXTRA_ARGS+=("$arg")
+  done < <(jq -r '.extra_args[]' <<<"$workload")
+
+  CMD=("$TOGI_BIN")
+  if [ ${#COMMON_ARGS[@]} -gt 0 ]; then
+    CMD+=("${COMMON_ARGS[@]}")
+  fi
+  if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
+    CMD+=("${EXTRA_ARGS[@]}")
+  fi
+
+  case "$CACHE_POLICY" in
+    fresh)
+      rm -rf "$PROJECT_DIR/.togi-cache"
+      ;;
+    reuse)
+      ;;
+    *)
+      echo "unknown cache policy '$CACHE_POLICY' for workload $WL_NAME" >&2
+      exit 2
+      ;;
+  esac
+
+  RAW_STDOUT="$OUT_DIR/raw/$WL_NAME.stdout"
+  RAW_STDERR="$OUT_DIR/raw/$WL_NAME.stderr"
+  REPORT_JSON="$OUT_DIR/raw/$WL_NAME.report.json"
+
+  echo "running workload $WL_NAME (scenario $WL_SCENARIO)" >&2
+  START_MS=$(now_ms)
+  set +e
+  ( cd "$PROJECT_DIR" && "${CMD[@]}" ) >"$RAW_STDOUT" 2>"$RAW_STDERR"
+  STATUS=$?
+  set -e
+  WALL_MS=$(( $(now_ms) - START_MS ))
+
+  REPORT_OK=0
+  if [ "$STATUS" != "0" ] && [ "$STATUS" != "1" ]; then
+    echo "workload $WL_NAME: togi exited with unexpected status $STATUS" >&2
+  elif sed -n '/^{/,$p' "$RAW_STDOUT" > "$REPORT_JSON" \
+    && [ -s "$REPORT_JSON" ] \
+    && jq -e . "$REPORT_JSON" >/dev/null 2>&1; then
+    REPORT_OK=1
+  else
+    echo "workload $WL_NAME: could not extract a JSON report from togi stdout" >&2
+  fi
+
+  SEMANTICS="null"
+  DIGEST=""
+  RUNNER_MODE_OK=1
+  if [ "$REPORT_OK" = "1" ]; then
+    SEMANTICS=$(jq -c '{
+      total, planned_total, tested, killed, survived, timeout, build_errors,
+      uncovered: (.uncovered // 0),
+      subsumed: (.subsumed // 0),
+      exact_cache_reused: (.exact_cache_reused // 0),
+      incremental_history_reused: (.incremental_history_reused // 0),
+      partial,
+      reported_duration_ms: .duration_ms,
+      schemata: (.schemata // null),
+      selected_test_command: (.test_command // null),
+      test_selection: {
+        mode: (if ([.mutations[] | ((.test_selection? // {"mode": "full"}).mode == "full")] | all) then "full-suite" else "narrowed" end),
+        full_suite_mutation_count: ([.mutations[] | select((.test_selection? // {"mode": "full"}).mode == "full")] | length),
+        narrowed_mutation_count: ([.mutations[] | select((.test_selection? // {"mode": "full"}).mode != "full")] | length)
+      },
+      mutation_count: (.mutations | length)
+    }' "$REPORT_JSON")
+    DIGEST=$(jq -r '[.mutations[]
+      | "\(.file):\(.line):\(.column // 0):\(.operator):\(.original // "")->\(.replacement // "")"]
+      | sort | .[]' "$REPORT_JSON" | sha256_stdin)
+    if [ -z "${SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]}" ]; then
+      SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]=$DIGEST
+    elif [ "$DIGEST" != "${SCENARIO_REF_DIGEST[$WL_SCENARIO_INDEX]}" ]; then
+      SCENARIO_CONSISTENT[$WL_SCENARIO_INDEX]=0
+      FAILURES+=("$WL_NAME:mutation-identity-drift")
+    fi
+    # runner_mode is manifest-declared and argv-validated; the report's
+    # schemata evidence must agree with it. Default mode makes no assertion:
+    # it deliberately inherits togi's own defaults.
+    if [ "$RUNNER_MODE" = "schemata" ]; then
+      if ! jq -e '.schemata != null' "$REPORT_JSON" >/dev/null; then
+        RUNNER_MODE_OK=0
+      fi
+    elif [ "$RUNNER_MODE" = "regular" ]; then
+      if ! jq -e '.schemata == null' "$REPORT_JSON" >/dev/null; then
+        RUNNER_MODE_OK=0
+      fi
+    fi
+    if [ "$RUNNER_MODE_OK" != "1" ]; then
+      FAILURES+=("$WL_NAME:runner-mode-consistency")
+    fi
+  fi
+
+  INVARIANTS_JSON="[]"
+  WL_OK=1
+  while IFS= read -r invariant; do
+    if ! FILTER=$(invariant_filter "$invariant"); then
+      echo "unknown invariant '$invariant' declared by workload $WL_NAME" >&2
+      exit 2
+    fi
+    INV_OK="false"
+    if [ "$REPORT_OK" = "1" ] \
+      && jq -e \
+        --argjson expected_mutations "$EXPECTED_MUTATIONS" \
+        --argjson changed_files "$CHANGED_FILES_JSON" \
+        --argjson requires_per_changed_file "${SCENARIO_REQUIRE_PER_CHANGED_FILE[$WL_SCENARIO_INDEX]}" \
+        --argjson expected_test_command "$EXPECTED_TEST_COMMAND_JSON" \
+        "$FILTER" "$REPORT_JSON" >/dev/null; then
+      INV_OK="true"
+    else
+      WL_OK=0
+      FAILURES+=("$WL_NAME:$invariant")
+    fi
+    INVARIANTS_JSON=$(jq -c --arg name "$invariant" --argjson ok "$INV_OK" \
+      '. + [{name: $name, ok: $ok}]' <<<"$INVARIANTS_JSON")
+  done < <(jq -r '.invariants[]' <<<"$workload")
+
+  if [ "$REPORT_OK" != "1" ]; then
+    WL_OK=0
+    FAILURES+=("$WL_NAME:report-extraction")
+  fi
+  if [ "$RUNNER_MODE_OK" != "1" ]; then
+    WL_OK=0
+  fi
+  if [ "$WL_OK" != "1" ]; then
+    OVERALL_OK=0
+  fi
+
+  CMD_JSON=$(printf '%s\n' "${CMD[@]}" | jq -Rn '[inputs]')
+
+  FRAGMENT="$WORK_ROOT/workload-$WL_NAME.json"
+  jq -n \
+    --arg name "$WL_NAME" \
+    --arg scenario "$WL_SCENARIO" \
+    --arg runner_mode "$RUNNER_MODE" \
+    --arg cache_policy "$CACHE_POLICY" \
+    --argjson command "$CMD_JSON" \
+    --argjson exit_status "$STATUS" \
+    --argjson wall_ms "$WALL_MS" \
+    --argjson report_ok "$REPORT_OK" \
+    --argjson semantics "$SEMANTICS" \
+    --arg digest "$DIGEST" \
+    --argjson invariants "$INVARIANTS_JSON" \
+    --argjson ok "$WL_OK" \
+    --arg raw_stdout "raw/$WL_NAME.stdout" \
+    --arg raw_stderr "raw/$WL_NAME.stderr" \
+    --arg report "raw/$WL_NAME.report.json" \
+    '{
+      name: $name,
+      scenario: $scenario,
+      runner_mode: $runner_mode,
+      cache_policy: $cache_policy,
+      command: $command,
+      exit_status: $exit_status,
+      timing: {
+        wall_ms: $wall_ms,
+        reported_duration_ms: (
+          if $report_ok == 1 then $semantics.reported_duration_ms else null end
+        )
+      },
+      semantics: (
+        if $report_ok == 1
+        then $semantics + {mutation_identity_sha256: $digest}
+        else null
+        end
+      ),
+      artifacts: {
+        raw_stdout: $raw_stdout,
+        raw_stderr: $raw_stderr,
+        report: (if $report_ok == 1 then $report else null end)
+      },
+      invariants: $invariants,
+      ok: ($ok == 1)
+    }' > "$FRAGMENT"
+  FRAGMENTS+=("$FRAGMENT")
+done < <(jq -c '.workloads[]' "$MANIFEST")
+
+# Guard against any loop truncation the pre-flight validation cannot see:
+# a result with fewer workloads than the manifest declares is never success.
+if [ "${#FRAGMENTS[@]}" -ne "$WORKLOAD_COUNT" ]; then
+  echo "harness error: ran ${#FRAGMENTS[@]} of $WORKLOAD_COUNT declared workloads" >&2
+  exit 2
+fi
+
+# Per-scenario mutation identity: workloads of one scenario must agree, and
+# scenarios legitimately differ from each other.
+SCENARIOS_JSON="{}"
+for i in "${!SCENARIO_ORDER[@]}"; do
+  if [ "${SCENARIO_CONSISTENT[$i]}" != "1" ]; then
+    OVERALL_OK=0
+    S_CONSISTENT="false"
+  else
+    S_CONSISTENT="true"
+  fi
+  SCENARIOS_JSON=$(jq \
+    --arg name "${SCENARIO_ORDER[$i]}" \
+    --argjson consistent "$S_CONSISTENT" \
+    --arg digest "${SCENARIO_REF_DIGEST[$i]}" \
+    '. + {($name): {
+      mutation_identity_consistent: $consistent,
+      mutation_identity_sha256: (if $consistent and $digest != "" then $digest else null end)
+    }}' <<<"$SCENARIOS_JSON")
+done
+
+if [ "$OVERALL_OK" = "1" ]; then
+  OVERALL_OK_JSON="true"
+else
+  OVERALL_OK_JSON="false"
+fi
+
+FAILURES_JSON="[]"
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]}" | jq -Rn '[inputs]')
+fi
+
+# Per-scenario fixture provenance: patch identity and base revision of each
+# disposable project.
+FIXTURE_SCENARIOS_JSON="{}"
+for i in "${!SCENARIO_ORDER[@]}"; do
+  FIXTURE_SCENARIOS_JSON=$(jq \
+    --arg name "${SCENARIO_ORDER[$i]}" \
+    --arg patch_file "${SCENARIO_PATCH_FILE[$i]#"$REPO_ROOT"/}" \
+    --arg patch_sha "${SCENARIO_PATCH_SHA[$i]}" \
+    --arg base_revision "${SCENARIO_BASE_REVISION[$i]}" \
+    '. + {($name): {
+      patch_file: $patch_file,
+      patch_sha256: $patch_sha,
+      base_revision: $base_revision
+    }}' <<<"$FIXTURE_SCENARIOS_JSON")
+done
+
+META_JSON="$WORK_ROOT/meta.json"
+jq -n \
+  --arg togi_version "$TOGI_VERSION" \
+  --arg togi_bin "$TOGI_BIN" \
+  --arg go_version "$GO_VERSION" \
+  --arg git_version "$GIT_VERSION" \
+  --arg os "$OS_NAME" \
+  --arg arch "$ARCH_NAME" \
+  --arg runner_label "$BENCH_RUNNER_LABEL" \
+  --argjson logical_cpu_count "$LOGICAL_CPU_COUNT" \
+  --arg kernel_release "$KERNEL_RELEASE" \
+  --arg image_os "$IMAGE_OS" \
+  --arg image_version "$IMAGE_VERSION" \
+  --arg go_build_cache_state "$BENCH_GO_BUILD_CACHE_STATE" \
+  --arg go_build_cache_policy "$GO_BUILD_CACHE_POLICY" \
+  --argjson go_build_cache_path "$GO_BUILD_CACHE_PATH_JSON" \
+  --arg started_at "$STARTED_AT" \
+  --arg fixture_source "$FIXTURE_SOURCE_DIR" \
+  --argjson fixture_scenarios "$FIXTURE_SCENARIOS_JSON" \
+  '{
+    kind: "togi_pr_loop_benchmark_result",
+    schema_version: 3,
+    timing_policy: "observational-only",
+    manifest: {
+      name: "togi-pr-loop-scale-benchmarks",
+      schema_version: 3,
+      path: "benchmarks/pr-loop-scale/manifest.json"
+    },
+    provenance: {
+      togi_version: $togi_version,
+      togi_binary: $togi_bin,
+      report_kind: "mutation_report",
+      report_schema_version: 1,
+      os: $os,
+      arch: $arch,
+      go_version: $go_version,
+      runner_label: $runner_label,
+      logical_cpu_count: $logical_cpu_count,
+      kernel_release: $kernel_release,
+      image_os: (if $image_os == "" then null else $image_os end),
+      image_version: (if $image_version == "" then null else $image_version end),
+      git_version: $git_version,
+      go_build_cache_state: $go_build_cache_state,
+      go_build_cache_policy: $go_build_cache_policy,
+      go_build_cache_path: $go_build_cache_path,
+      fixture_source_dir: $fixture_source,
+      fixture_scenarios: $fixture_scenarios,
+      started_at_utc: $started_at
+    }
+  }' > "$META_JSON"
+
+RESULT_JSON="$OUT_DIR/pr-loop-benchmark-result.json"
+jq -s \
+  --argjson scenarios "$SCENARIOS_JSON" \
+  --argjson ok "$OVERALL_OK_JSON" \
+  --argjson failures "$FAILURES_JSON" \
+  '.[0] + {
+    workloads: .[1:],
+    cross_workload: {
+      scenarios: $scenarios
+    },
+    ok: $ok,
+    failures: $failures
+  }' "$META_JSON" "${FRAGMENTS[@]}" > "$RESULT_JSON"
+
+jq -r '.workloads[]
+  | "\(.name) [\(.scenario)]: exit=\(.exit_status) wall=\(.timing.wall_ms)ms reported=\(.timing.reported_duration_ms // 0)ms ok=\(.ok)"' \
+  "$RESULT_JSON"
+echo "normalized result: $RESULT_JSON"
+echo "raw reports: $OUT_DIR/raw"
+
+if [ "$OVERALL_OK" != "1" ]; then
+  echo "PR-loop scale benchmark invariants failed:" >&2
+  jq -r '.failures[] | "  - \(.)"' "$RESULT_JSON" >&2
+  exit 1
+fi
+echo "all PR-loop scale benchmark invariants passed"

--- a/benchmarks/pr-loop-scale/scale-change.patch
+++ b/benchmarks/pr-loop-scale/scale-change.patch
@@ -1,0 +1,68 @@
+diff --git a/scale.go b/scale.go
+index 6547fbb..fea20f5 100644
+--- a/scale.go
++++ b/scale.go
+@@ -12,3 +12,63 @@ func Sign(n int) int {
+ 	}
+ 	return -1
+ }
++
++// The Scale* family below is deliberately expression-dense arithmetic. It
++// exists so the PR-loop scaling corpus produces a 50-150 mutant PR diff
++// while the underlying computations stay trivial and deterministic.
++
++// ScaleAlpha weights a against b with a small bias.
++func ScaleAlpha(a, b int) int {
++	if a*2-1 > b {
++		return a + b - 1
++	}
++	return a - b
++}
++
++// ScaleBeta weights a against b with a medium bias.
++func ScaleBeta(a, b int) int {
++	if a*3-2 > b {
++		return a + b - 2
++	}
++	return a - b
++}
++
++// ScaleGamma weights a against b with a larger bias.
++func ScaleGamma(a, b int) int {
++	if a*4-3 > b {
++		return a + b - 3
++	}
++	return a - b
++}
++
++// ScaleDelta blends a and b under a skewed threshold.
++func ScaleDelta(a, b int) int {
++	if a*5-4 > b {
++		return a + b - 4
++	}
++	return a - b
++}
++
++// ScaleEpsilon balances a and b with a wide margin.
++func ScaleEpsilon(a, b int) int {
++	if a*6-5 > b {
++		return a + b - 5
++	}
++	return a - b
++}
++
++// ScaleZeta folds a into b under a steep weight.
++func ScaleZeta(a, b int) int {
++	if a*7-6 > b {
++		return a + b - 6
++	}
++	return a - b
++}
++
++// ScaleEta merges a and b with the steepest weight.
++func ScaleEta(a, b int) int {
++	if a*8-7 > b {
++		return a + b - 7
++	}
++	return a - b
++}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12981,6 +12981,93 @@ rmdir "$lock"
 
     #[cfg(unix)]
     #[test]
+    fn cache_identity_excludes_parallelism() {
+        // Exact-cache identity must not include the runner's parallelism:
+        // a mutation executed by a jobs=1 run must be an exact cache hit for
+        // an otherwise identical jobs=4 run. This guards the real regression
+        // (adding jobs to CacheKey::new or the cache context) that the
+        // benchmark harness fakes cannot see.
+        let dir = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let file = dir.path().join("target.txt");
+        std::fs::write(&file, b"hello world").unwrap();
+        let mut mutation = make_test_mutation(&file);
+        mutation.id = 7;
+        mutation.description = "jobs cache identity".into();
+
+        let script = r#"
+lock="$STATE_DIR/lock"
+while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+runs=0
+if [ -f "$STATE_DIR/runs" ]; then runs=$(cat "$STATE_DIR/runs"); fi
+runs=$((runs + 1))
+printf '%s\n' "$runs" > "$STATE_DIR/runs"
+rmdir "$lock"
+"#;
+        let mut env = HashMap::new();
+        env.insert("STATE_DIR".to_string(), state.path().display().to_string());
+
+        let make_runner = |parallelism: usize| TestRunner {
+            commands: CommandConfig {
+                command: vec!["sh".into(), "-c".into(), script.into()],
+                force_default_command: false,
+                force_default_timeout: false,
+                project_commands: vec![],
+                language_commands: HashMap::new(),
+                build_command: vec![],
+                sandbox_command: vec![],
+                build_command_explicit: false,
+                timeout: Duration::from_secs(5),
+                language_timeouts: HashMap::new(),
+                test_selection: None,
+            },
+            parallelism,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: env.clone(),
+            incremental_history: true,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        // Phase 1: a jobs=1 run executes the mutation and seeds the cache.
+        let first = make_runner(1).run(vec![mutation.clone()]).report;
+        assert_eq!(first.total, 1);
+        assert_eq!(first.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            first.execution_for(first.results[0].0.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+
+        // Phase 2: an otherwise identical jobs=4 run must hit the exact cache.
+        let second = make_runner(4).run(vec![mutation]).report;
+        assert_eq!(second.total, 1);
+        assert_eq!(second.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            second.execution_for(second.results[0].0.id, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert_eq!(second.tested_count(), 0);
+        assert_eq!(second.execution_counts().exact_cache_reused, 1);
+
+        let runs: usize = std::fs::read_to_string(state.path().join("runs"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            runs, 1,
+            "parallelism must not change exact-cache identity: the underlying test ran once"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn max_tested_does_not_count_build_errors() {
         let dir = tempfile::tempdir().unwrap();
 

--- a/tests/fixtures/go-scale/go.mod
+++ b/tests/fixtures/go-scale/go.mod
@@ -1,0 +1,3 @@
+module example.com/scale
+
+go 1.21

--- a/tests/fixtures/go-scale/scale.go
+++ b/tests/fixtures/go-scale/scale.go
@@ -1,0 +1,14 @@
+package scale
+
+// Double returns twice n.
+func Double(n int) int {
+	return n * 2
+}
+
+// Sign returns 1 for positive n, -1 otherwise.
+func Sign(n int) int {
+	if n > 0 {
+		return 1
+	}
+	return -1
+}

--- a/tests/fixtures/go-scale/scale_test.go
+++ b/tests/fixtures/go-scale/scale_test.go
@@ -1,0 +1,19 @@
+package scale
+
+import "testing"
+
+// Deliberately thin tests: fast, deterministic, and far from exhaustive.
+// The scale corpus measures runner behavior, not fixture test quality.
+
+func TestDouble(t *testing.T) {
+	if Double(3) != 6 {
+		t.Error("expected 6")
+	}
+}
+
+func TestSign(t *testing.T) {
+	if Sign(5) != 1 {
+		t.Error("expected 1 for positive input")
+	}
+	// Missing: zero and negative inputs.
+}

--- a/tests/fixtures/go-scale/togi.toml
+++ b/tests/fixtures/go-scale/togi.toml
@@ -1,0 +1,9 @@
+# The scale corpus needs the full mutation surface of its scenario patch;
+# the engine's default per-file cap (20) would silently truncate it.
+# Schemata is deliberately not configured here: a zero-config run would
+# enable schemata, while a config file that omits the schemata key defaults
+# it off. The scale-default workload therefore measures the zero-flag,
+# config-present path (regular runner, default parallelism, schemata null).
+# Schemata evidence comes from the explicit --schemata workloads only.
+[mutations]
+max_per_file = 0

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -4356,3 +4356,945 @@ fn pr_loop_regression_gate_workflow_is_fail_closed_and_comparator_driven() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Schema v3 observational scale corpus (issue #498, PR 1).
+//
+// These tests drive the same harness with the additive v3 scale manifest via
+// BENCH_MANIFEST and a dedicated fake scale togi. They prove the v3 branch
+// accepts the scale corpus, enforces its generic contracts, emits schema 3
+// results, keeps per-workload mutation identity, and that the schema-2
+// comparator fails closed on v3 results. No existing v2 test is modified.
+// ---------------------------------------------------------------------------
+
+/// Fake togi for the scale corpus: same contract as FAKE_TOGI (logs argv,
+/// cwd, and cache presence; seeds .togi-cache; exits 1) but emits a
+/// synthesized 98-mutant report for tests/fixtures/go-scale with all lines
+/// inside the scenario patch's changed range [15, 74].
+const FAKE_SCALE_TOGI: &str = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  echo "togi 0.5.0-fake-scale"
+  exit 0
+fi
+
+log=${FAKE_TOGI_LOG:?FAKE_TOGI_LOG must be set}
+cache_present=false
+if [ -d .togi-cache ]; then
+  cache_present=true
+fi
+argv_json=$(printf '%s\n' "$@" | jq -Rn '[inputs]')
+jq -nc \
+  --argjson argv "$argv_json" \
+  --arg cwd "$(pwd)" \
+  --argjson cache_present "$cache_present" \
+  '{argv: $argv, cwd: $cwd, cache_present: $cache_present}' >> "$log"
+
+force_rerun=false
+schemata=false
+for arg in "$@"; do
+  case "$arg" in
+    --force-rerun) force_rerun=true ;;
+    --schemata) schemata=true ;;
+    --no-schemata) schemata=false ;;
+  esac
+done
+
+total=${FAKE_TOGI_TOTAL:-98}
+tested=$total
+exact=0
+state="executed"
+if [ "$cache_present" = true ] && [ "$force_rerun" = false ]; then
+  tested=0
+  exact=$total
+  state="exact_cache"
+fi
+mkdir -p .togi-cache
+touch .togi-cache/seed
+
+schemata_json="null"
+if [ "$schemata" = true ]; then
+  schemata_json=$(jq -nc --argjson total "$total" '
+    {fast_path: ($total - 1), fallback: 1,
+     fallback_reasons: [{reason: "unsupported_operator", count: 1}]}')
+fi
+
+mutations_json=$(jq -nc --arg state "$state" --argjson total "$total" '
+  [range(1; $total + 1)
+   | {id: ., file: "scale.go", line: (15 + ((. - 1) % 60)), column: 7,
+      operator: "gt_to_gte", original: ">", replacement: ">=",
+      description: "fake", result: "survived",
+      execution: {state: $state}, language: "go"}]')
+
+jq -n \
+  --argjson total "$total" \
+  --argjson tested "$tested" \
+  --argjson exact "$exact" \
+  --argjson schemata "$schemata_json" \
+  --argjson mutations "$mutations_json" \
+  '{
+    kind: "mutation_report",
+    schema_version: 1,
+    generator: "togi/0.5.0-fake-scale",
+    total: $total,
+    planned_total: $total,
+    tested: $tested,
+    killed: 0,
+    survived: $total,
+    timeout: 0,
+    build_errors: 0,
+    exact_cache_reused: $exact,
+    incremental_history_reused: 0,
+    partial: false,
+    mutation_score: 0,
+    duration_ms: 42,
+    test_command: ["go", "test", "./..."],
+    build_command: [],
+    schemata: $schemata,
+    build_error_groups: [],
+    mutations: $mutations
+  }'
+exit 1
+"#;
+
+const SCALE_WORKLOAD_NAMES: [&str; 6] = [
+    "scale-regular-jobs1",
+    "scale-warm-exact-cache",
+    "scale-regular-jobs4",
+    "scale-schemata",
+    "scale-schemata-jobs4",
+    "scale-default",
+];
+
+fn scale_script_path() -> PathBuf {
+    repo_root().join("benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh")
+}
+
+/// Mirror of run_harness targeting the self-contained v3 scale harness.
+fn run_scale_harness(
+    tools: &FakeTools,
+    out_dir: &Path,
+    manifest: Option<&Path>,
+    extra_env: &[(&str, &str)],
+) -> Output {
+    let mut command = Command::new("bash");
+    command
+        .arg(scale_script_path())
+        .arg("--output")
+        .arg(out_dir)
+        .env("TOGI_BIN", &tools.togi)
+        .env("FAKE_TOGI_LOG", &tools.log)
+        // Cache provenance must come from the test, never the host env.
+        .env_remove("GOCACHE")
+        .env_remove("BENCH_GO_BUILD_CACHE_STATE")
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                tools.bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+    if let Some(manifest) = manifest {
+        command.env("BENCH_MANIFEST", manifest);
+    }
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command.output().expect("spawn scale harness")
+}
+
+fn scale_manifest_path() -> PathBuf {
+    repo_root().join("benchmarks/pr-loop-scale/manifest.json")
+}
+
+fn install_fake_scale_tools() -> FakeTools {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir for fake scale tools");
+    let bin = dir.path().join("bin");
+    fs::create_dir(&bin).expect("fake bin dir");
+    let togi = bin.join("togi");
+    let go = bin.join("go");
+    fs::write(&togi, FAKE_SCALE_TOGI).expect("write fake scale togi");
+    fs::write(&go, FAKE_GO).expect("write stub go");
+    fs::set_permissions(&togi, fs::Permissions::from_mode(0o755)).expect("chmod fake scale togi");
+    fs::set_permissions(&go, fs::Permissions::from_mode(0o755)).expect("chmod stub go");
+    let log = dir.path().join("invocations.jsonl");
+    FakeTools {
+        _dir: dir,
+        bin,
+        togi,
+        log,
+    }
+}
+
+/// Assert a scale-corpus argv/command vector invokes `check --base HEAD`
+/// with exactly one --timeout 60, one --max-per-run 500, one --test-cmd
+/// "go test ./...", and never --all. Mirrors the v3 argv contract; unlike
+/// the v2 helper, --jobs is per-workload and checked by the caller.
+fn assert_scale_pr_diff_command(args: &[&str]) {
+    let check_pos = args
+        .iter()
+        .position(|arg| *arg == "check")
+        .expect("command must invoke `check`");
+    let base_positions: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter_map(|(index, arg)| (*arg == "--base").then_some(index))
+        .collect();
+    assert_eq!(
+        base_positions.len(),
+        1,
+        "exactly one split --base: {args:?}"
+    );
+    assert!(
+        check_pos < base_positions[0],
+        "`check` must precede --base: {args:?}"
+    );
+    assert_eq!(
+        args[base_positions[0] + 1],
+        "HEAD",
+        "diff base must be HEAD (PR diff), got: {args:?}"
+    );
+    assert!(
+        !args.contains(&"--all"),
+        "benchmarks must never use --all: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|arg| arg.starts_with("--base=")),
+        "inline --base= form is rejected: {args:?}"
+    );
+    for (flag, value) in [
+        ("--timeout", "60"),
+        ("--max-per-run", "500"),
+        ("--test-cmd", "go test ./..."),
+    ] {
+        let positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| (*arg == flag).then_some(index))
+            .collect();
+        assert_eq!(
+            positions.len(),
+            1,
+            "exactly one {flag} pair expected: {args:?}"
+        );
+        assert_eq!(
+            args[positions[0] + 1],
+            value,
+            "{flag} must be pinned to {value}: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn pr_loop_scale_harness_runs_all_six_workloads_in_one_scenario() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+    let tools = install_fake_scale_tools();
+    let out_dir = tempfile::tempdir().expect("output tempdir");
+
+    let output = run_scale_harness(&tools, out_dir.path(), Some(&scale_manifest_path()), &[]);
+    assert!(
+        output.status.success(),
+        "scale harness must succeed with well-formed fake reports\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result = read_result(out_dir.path());
+    assert_eq!(result["kind"], "togi_pr_loop_benchmark_result");
+    assert_eq!(result["schema_version"], 3);
+    assert_eq!(result["manifest"]["name"], "togi-pr-loop-scale-benchmarks");
+    assert_eq!(result["manifest"]["schema_version"], 3);
+    assert_eq!(
+        result["manifest"]["path"],
+        "benchmarks/pr-loop-scale/manifest.json"
+    );
+    assert_eq!(result["timing_policy"], "observational-only");
+    assert_eq!(result["ok"], true);
+    assert_eq!(result["failures"], serde_json::json!([]));
+    assert_eq!(
+        result["provenance"]["fixture_source_dir"],
+        "tests/fixtures/go-scale"
+    );
+    let scale_provenance = &result["provenance"]["fixture_scenarios"]["scale-file"];
+    assert_eq!(
+        scale_provenance["patch_file"],
+        "benchmarks/pr-loop-scale/scale-change.patch"
+    );
+    assert_eq!(
+        scale_provenance["patch_sha256"],
+        "ac993114dfef39cd4e52d2cedbe26935e4410048471924a3df2431c13cef41dd"
+    );
+
+    let scenarios = result["cross_workload"]["scenarios"]
+        .as_object()
+        .expect("per-scenario identity");
+    assert_eq!(scenarios.len(), 1, "the scale corpus has one scenario");
+    assert_eq!(
+        scenarios["scale-file"]["mutation_identity_consistent"], true,
+        "all six workloads must share one mutation identity"
+    );
+    let identity = scenarios["scale-file"]["mutation_identity_sha256"]
+        .as_str()
+        .expect("scenario mutation identity digest")
+        .to_string();
+
+    let workloads = result["workloads"].as_array().expect("workloads array");
+    let names: Vec<&str> = workloads
+        .iter()
+        .map(|workload| workload["name"].as_str().expect("workload name"))
+        .collect();
+    assert_eq!(names, SCALE_WORKLOAD_NAMES);
+    let runner_modes: Vec<&str> = workloads
+        .iter()
+        .map(|workload| workload["runner_mode"].as_str().expect("runner mode"))
+        .collect();
+    assert_eq!(
+        runner_modes,
+        [
+            "regular", "regular", "regular", "schemata", "schemata", "default"
+        ]
+    );
+
+    let expected_jobs = [Some("1"), Some("1"), Some("4"), Some("1"), Some("4"), None];
+    for (workload, jobs) in workloads.iter().zip(expected_jobs) {
+        assert_eq!(workload["ok"], true, "workload {} failed", workload["name"]);
+        for invariant in workload["invariants"].as_array().expect("invariants") {
+            assert_eq!(
+                invariant["ok"], true,
+                "invariant {} failed for workload {}",
+                invariant["name"], workload["name"]
+            );
+        }
+        let args = command_strings(workload);
+        assert_scale_pr_diff_command(&args);
+        let jobs_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| (*arg == "--jobs").then_some(index))
+            .collect();
+        match jobs {
+            Some(value) => {
+                assert_eq!(
+                    jobs_positions.len(),
+                    1,
+                    "workload {} must pin --jobs once",
+                    workload["name"]
+                );
+                assert_eq!(args[jobs_positions[0] + 1], value);
+            }
+            None => assert!(
+                jobs_positions.is_empty(),
+                "scale-default must inherit togi's job default: {args:?}"
+            ),
+        }
+        assert_eq!(
+            workload["semantics"]["total"], 98,
+            "workload {} must see the pinned mutation count",
+            workload["name"]
+        );
+        assert_eq!(
+            workload["semantics"]["mutation_identity_sha256"]
+                .as_str()
+                .expect("workload mutation identity"),
+            identity,
+            "workload {} mutation identity must match the scenario",
+            workload["name"]
+        );
+    }
+
+    // Cache reuse is proven semantically from the report, not by directory
+    // presence: every verdict of the warm run must come from the exact cache.
+    assert_eq!(workloads[1]["semantics"]["tested"], 0);
+    assert_eq!(workloads[1]["semantics"]["exact_cache_reused"], 98);
+    // Fresh runs execute every mutation without cache hits.
+    for index in [0, 2, 3, 4, 5] {
+        assert_eq!(workloads[index]["semantics"]["tested"], 98);
+        assert_eq!(workloads[index]["semantics"]["exact_cache_reused"], 0);
+    }
+    // Both flag-driven schemata workloads report at least one fast-path
+    // and one fallback.
+    for index in [3, 4] {
+        let schemata = &workloads[index]["semantics"]["schemata"];
+        assert!(schemata["fast_path"].as_u64().expect("fast_path") >= 1);
+        assert!(schemata["fallback"].as_u64().expect("fallback") >= 1);
+        assert_eq!(
+            schemata["fast_path"].as_u64().unwrap() + schemata["fallback"].as_u64().unwrap(),
+            98
+        );
+    }
+    // The zero-flag default workload is the config-present path: the
+    // fixture config omits the schemata key, whose config-file default is
+    // off (a zero-config run would enable it), so the report must carry
+    // schemata: null.
+    assert_eq!(
+        workloads[5]["semantics"]["schemata"],
+        serde_json::Value::Null,
+        "scale-default must report schemata null on the config-present path"
+    );
+    let default_args = command_strings(&workloads[5]);
+    assert!(
+        !default_args.contains(&"--schemata") && !default_args.contains(&"--no-schemata"),
+        "scale-default must pass no schemata flag"
+    );
+
+    // Raw artifacts persist for every workload.
+    for name in &names {
+        assert!(
+            out_dir
+                .path()
+                .join("raw")
+                .join(format!("{name}.report.json"))
+                .exists(),
+            "raw report missing for {name}"
+        );
+    }
+
+    // Invocation log: one shared disposable project, `check --base HEAD`,
+    // and the seeded-cache lifecycle.
+    let runs = invocation_log(&tools);
+    assert_eq!(runs.len(), 6, "expected exactly six togi invocations");
+    let project = runs[0]["cwd"].as_str().expect("invocation cwd");
+    assert_ne!(
+        Path::new(project),
+        repo_root().join("tests/fixtures/go-scale"),
+        "harness must copy the fixture into a disposable project"
+    );
+    for run in &runs {
+        assert_eq!(
+            run["cwd"].as_str().expect("cwd"),
+            project,
+            "all scale workloads share the scenario's disposable project"
+        );
+        assert_scale_pr_diff_command(&argv_strings(run));
+    }
+    let cache_sequence: Vec<bool> = runs
+        .iter()
+        .map(|run| run["cache_present"].as_bool().expect("cache flag"))
+        .collect();
+    assert_eq!(
+        cache_sequence,
+        [false, true, false, false, false, false],
+        "only the warm run may observe the seeded cache"
+    );
+    let force_rerun_sequence: Vec<bool> = runs
+        .iter()
+        .map(|run| argv_strings(run).contains(&"--force-rerun"))
+        .collect();
+    assert_eq!(force_rerun_sequence, [true, false, true, true, true, false]);
+    assert!(
+        !Path::new(project).exists(),
+        "the disposable project must be removed after the run"
+    );
+}
+
+#[test]
+fn pr_loop_scale_harness_rejects_malformed_manifests() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+    let tools = install_fake_scale_tools();
+    let base: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(scale_manifest_path()).expect("read scale manifest"),
+    )
+    .expect("scale manifest is valid JSON");
+
+    let mut empty_workloads = base.clone();
+    empty_workloads["workloads"] = serde_json::json!([]);
+
+    let mut duplicate_names = base.clone();
+    duplicate_names["workloads"][1]["name"] = serde_json::json!("scale-regular-jobs1");
+
+    let mut undeclared_scenario = base.clone();
+    undeclared_scenario["workloads"][0]["scenario"] = serde_json::json!("no-such-scenario");
+
+    // A second declared scenario lets the contiguity and cache-edge checks
+    // be exercised in isolation.
+    let with_second_scenario = |manifest: &mut serde_json::Value| {
+        let mut second = manifest["scenarios"][0].clone();
+        second["name"] = serde_json::json!("scale-b");
+        manifest["scenarios"].as_array_mut().unwrap().push(second);
+    };
+
+    let mut non_contiguous = base.clone();
+    with_second_scenario(&mut non_contiguous);
+    non_contiguous["workloads"][2]["scenario"] = serde_json::json!("scale-b");
+
+    let mut cross_scenario_edge = base.clone();
+    with_second_scenario(&mut cross_scenario_edge);
+    {
+        let workloads = cross_scenario_edge["workloads"].as_array_mut().unwrap();
+        let mut warm = workloads[1].clone();
+        warm["scenario"] = serde_json::json!("scale-b");
+        // Contiguous order (the scale-b workload moves last), but its cache
+        // edge still names a workload from the scale-file scenario.
+        warm["expects_cache_from"] = serde_json::json!("scale-regular-jobs1");
+        workloads.remove(1);
+        workloads.push(warm);
+    }
+
+    let mut forward_dependency = base.clone();
+    forward_dependency["workloads"][0]["expects_cache_from"] =
+        serde_json::json!("scale-warm-exact-cache");
+
+    let mut dependency_without_seed = base.clone();
+    dependency_without_seed["workloads"][3]["expects_cache_from"] =
+        serde_json::json!("scale-warm-exact-cache");
+
+    let mut missing_well_formed = base.clone();
+    missing_well_formed["workloads"][3]["invariants"] =
+        serde_json::json!(["schemata-fast-path-and-fallback"]);
+
+    let mut unknown_invariant = base.clone();
+    unknown_invariant["workloads"][0]["invariants"] = serde_json::json!(["made-up-invariant"]);
+
+    let mut all_flag = base.clone();
+    all_flag["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--all"));
+
+    let mut missing_base = base.clone();
+    missing_base["togi"]["common_args"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|arg| arg != "--base" && arg != "HEAD");
+
+    let mut wrong_base_value = base.clone();
+    wrong_base_value["workloads"][2]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--base"), serde_json::json!("HEAD~1")]);
+
+    let mut inline_base_form = base.clone();
+    inline_base_form["workloads"][3]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--base=HEAD"));
+
+    let mut duplicate_base = base.clone();
+    duplicate_base["workloads"][1]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--base"), serde_json::json!("HEAD")]);
+
+    let mut wrong_subcommand = base.clone();
+    wrong_subcommand["togi"]["common_args"][0] = serde_json::json!("list-operators");
+
+    let mut base_ref_not_head = base.clone();
+    base_ref_not_head["fixture"]["base_ref"] = serde_json::json!("HEAD~1");
+
+    let mut runner_mode_mismatch = base.clone();
+    runner_mode_mismatch["workloads"][0]["runner_mode"] = serde_json::json!("schemata");
+
+    let mut regular_without_flag = base.clone();
+    regular_without_flag["workloads"][0]["extra_args"] =
+        serde_json::json!(["--force-rerun", "--jobs", "1"]);
+
+    let mut default_with_schemata_flag = base.clone();
+    default_with_schemata_flag["workloads"][5]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--schemata"));
+
+    let mut unknown_runner_mode = base.clone();
+    unknown_runner_mode["workloads"][0]["runner_mode"] = serde_json::json!("turbo");
+
+    let mut duplicate_test_cmd = base.clone();
+    duplicate_test_cmd["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([
+            serde_json::json!("--test-cmd"),
+            serde_json::json!("go test ./..."),
+        ]);
+
+    let mut duplicate_timeout = base.clone();
+    duplicate_timeout["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--timeout"), serde_json::json!("30")]);
+
+    let mut duplicate_max_per_run = base.clone();
+    duplicate_max_per_run["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--max-per-run"), serde_json::json!("100")]);
+
+    let mut non_integer_jobs = base.clone();
+    non_integer_jobs["workloads"][0]["extra_args"][3] = serde_json::json!("0");
+
+    let mut dangling_jobs = base.clone();
+    dangling_jobs["workloads"][5]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--jobs"));
+
+    let mut zero_count = base.clone();
+    zero_count["scenarios"][0]["expected_mutation_count"] = serde_json::json!(0);
+
+    let mut bad_patch_digest = base.clone();
+    bad_patch_digest["scenarios"][0]["patch_sha256"] = serde_json::json!("not-a-digest");
+
+    let mut absolute_patch = base.clone();
+    absolute_patch["scenarios"][0]["patch_file"] = serde_json::json!("/etc/passwd");
+
+    let mut escaping_patch = base.clone();
+    escaping_patch["scenarios"][0]["patch_file"] = serde_json::json!("benchmarks/../escape.patch");
+
+    let mut missing_patch = base.clone();
+    missing_patch["scenarios"][0]["patch_file"] =
+        serde_json::json!("benchmarks/pr-loop-scale/no-such.patch");
+
+    let mut absolute_fixture = base.clone();
+    absolute_fixture["fixture"]["source_dir"] = serde_json::json!("/tmp");
+
+    let mut escaping_fixture = base.clone();
+    escaping_fixture["fixture"]["source_dir"] = serde_json::json!("tests/../escape");
+
+    let mut unknown_schema = base.clone();
+    unknown_schema["schema_version"] = serde_json::json!(4);
+
+    let mut mismatched_name = base.clone();
+    mismatched_name["name"] = serde_json::json!("togi-pr-loop-benchmarks");
+
+    // P1a: inline forms and wrong values for the controlled flags must be
+    // rejected during preflight, before any fixture copy or togi execution.
+    let mut inline_jobs = base.clone();
+    inline_jobs["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--jobs=0"));
+
+    let mut inline_jobs_negative = base.clone();
+    inline_jobs_negative["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--jobs=-1"));
+
+    let mut duplicate_jobs = base.clone();
+    duplicate_jobs["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--jobs"), serde_json::json!("2")]);
+
+    let mut inline_timeout = base.clone();
+    inline_timeout["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--timeout=60"));
+
+    let mut wrong_timeout = base.clone();
+    wrong_timeout["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--timeout"), serde_json::json!("30")]);
+
+    let mut missing_timeout = base.clone();
+    missing_timeout["togi"]["common_args"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|arg| arg != "--timeout" && arg != "60");
+
+    let mut inline_max_per_run = base.clone();
+    inline_max_per_run["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--max-per-run=500"));
+
+    let mut wrong_max_per_run = base.clone();
+    wrong_max_per_run["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .extend([serde_json::json!("--max-per-run"), serde_json::json!("25")]);
+
+    let mut inline_test_cmd = base.clone();
+    inline_test_cmd["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--test-cmd=go test ./..."));
+
+    // P1b: scenario/workload names are interpolated into filesystem paths,
+    // so anything outside the safe-identifier syntax is rejected preflight.
+    let mut traversal_workload = base.clone();
+    traversal_workload["workloads"][5]["name"] = serde_json::json!("../../outside");
+
+    let mut slash_workload = base.clone();
+    slash_workload["workloads"][5]["name"] = serde_json::json!("a/b");
+
+    let mut absolute_workload = base.clone();
+    absolute_workload["workloads"][5]["name"] = serde_json::json!("/abs");
+
+    let mut dotdot_workload = base.clone();
+    dotdot_workload["workloads"][5]["name"] = serde_json::json!("..");
+
+    let mut dash_workload = base.clone();
+    dash_workload["workloads"][5]["name"] = serde_json::json!("-x");
+
+    let mut space_workload = base.clone();
+    space_workload["workloads"][5]["name"] = serde_json::json!("with space");
+
+    let mut traversal_scenario = base.clone();
+    traversal_scenario["scenarios"][0]["name"] = serde_json::json!("../../outside");
+
+    // CR/LF integrity: `IFS= read` would split embedded newlines after
+    // validation, so the executed argv could gain flags validation never
+    // saw; every such element is rejected preflight.
+    let mut newline_all_extra = base.clone();
+    newline_all_extra["workloads"][0]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--force-rerun\n--all"));
+
+    let mut newline_controlled_split = base.clone();
+    newline_controlled_split["workloads"][5]["extra_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--jobs\n8"));
+
+    let mut carriage_return_common = base.clone();
+    carriage_return_common["togi"]["common_args"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!("--format\rjson"));
+
+    // A fresh workload between the cache seed and its consumer resets the
+    // scenario's cache; preflight must reject the interleaving.
+    let mut interleaved_fresh_reset = base.clone();
+    {
+        let workloads = interleaved_fresh_reset["workloads"].as_array_mut().unwrap();
+        let warm = workloads.remove(1);
+        workloads.insert(2, warm);
+    }
+
+    let cases: Vec<(&str, serde_json::Value)> = vec![
+        ("empty workloads array", empty_workloads),
+        ("duplicate workload names", duplicate_names),
+        ("undeclared scenario reference", undeclared_scenario),
+        ("non-contiguous scenario workloads", non_contiguous),
+        ("cross-scenario cache dependency", cross_scenario_edge),
+        ("forward cache dependency", forward_dependency),
+        (
+            "cache dependency without seeds_cache",
+            dependency_without_seed,
+        ),
+        ("workload missing report-well-formed", missing_well_formed),
+        ("unknown invariant name", unknown_invariant),
+        ("--all injected via extra_args", all_flag),
+        ("missing --base in common_args", missing_base),
+        (
+            "wrong split --base injected via extra_args",
+            wrong_base_value,
+        ),
+        ("inline --base= injected via extra_args", inline_base_form),
+        ("duplicate --base injected via extra_args", duplicate_base),
+        ("wrong subcommand in common_args", wrong_subcommand),
+        ("fixture.base_ref not HEAD", base_ref_not_head),
+        ("runner_mode contradicting argv", runner_mode_mismatch),
+        (
+            "regular workload without --no-schemata",
+            regular_without_flag,
+        ),
+        (
+            "default workload with --schemata",
+            default_with_schemata_flag,
+        ),
+        ("unknown runner_mode", unknown_runner_mode),
+        ("duplicate --test-cmd in extra_args", duplicate_test_cmd),
+        ("duplicate --timeout in extra_args", duplicate_timeout),
+        (
+            "duplicate --max-per-run in extra_args",
+            duplicate_max_per_run,
+        ),
+        ("non-positive --jobs value", non_integer_jobs),
+        ("dangling --jobs without value", dangling_jobs),
+        ("zero expected_mutation_count", zero_count),
+        ("malformed patch digest", bad_patch_digest),
+        ("absolute patch_file path", absolute_patch),
+        ("escaping patch_file path", escaping_patch),
+        ("nonexistent patch_file", missing_patch),
+        ("absolute fixture source_dir", absolute_fixture),
+        ("escaping fixture source_dir", escaping_fixture),
+        ("unsupported schema_version", unknown_schema),
+        ("schema v3 with v2 manifest name", mismatched_name),
+        ("inline --jobs= form", inline_jobs),
+        ("inline --jobs= negative form", inline_jobs_negative),
+        ("duplicate --jobs pairs", duplicate_jobs),
+        ("inline --timeout= form", inline_timeout),
+        ("wrong --timeout value", wrong_timeout),
+        ("missing --timeout pair", missing_timeout),
+        ("inline --max-per-run= form", inline_max_per_run),
+        ("wrong --max-per-run value", wrong_max_per_run),
+        ("inline --test-cmd= form", inline_test_cmd),
+        ("traversal workload name", traversal_workload),
+        ("slash workload name", slash_workload),
+        ("absolute workload name", absolute_workload),
+        ("dotdot workload name", dotdot_workload),
+        ("leading-dash workload name", dash_workload),
+        ("space workload name", space_workload),
+        ("traversal scenario name", traversal_scenario),
+        ("newline --all injected via extra_args", newline_all_extra),
+        (
+            "newline splitting a controlled flag pair",
+            newline_controlled_split,
+        ),
+        ("carriage return in common_args", carriage_return_common),
+        (
+            "fresh workload interleaved between seed and consumer",
+            interleaved_fresh_reset,
+        ),
+    ];
+
+    for (label, manifest) in cases {
+        let dir = tempfile::tempdir().expect("case tempdir");
+        let manifest_file = dir.path().join("manifest.json");
+        fs::write(
+            &manifest_file,
+            serde_json::to_string_pretty(&manifest).expect("serialize manifest"),
+        )
+        .expect("write case manifest");
+        let out_dir = dir.path().join("out");
+
+        let output = run_scale_harness(&tools, &out_dir, Some(&manifest_file), &[]);
+        assert!(
+            !output.status.success(),
+            "scale harness must reject {label}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !out_dir.exists(),
+            "scale harness must reject {label} before creating any output"
+        );
+        let result_path = out_dir.join("pr-loop-benchmark-result.json");
+        if result_path.exists() {
+            let result = read_result(&out_dir);
+            assert_ne!(
+                result["ok"], true,
+                "scale harness must never emit success for {label}"
+            );
+        }
+    }
+
+    assert!(
+        !tools.log.exists(),
+        "every malformed manifest must be rejected before togi is ever invoked"
+    );
+}
+
+#[test]
+fn pr_loop_scale_result_fails_the_v2_comparator() {
+    if !tool_on_path("python3") {
+        eprintln!("skipping: python3 unavailable");
+        return;
+    }
+    // Cross-contamination guard: the schema-2 comparator must fail closed on
+    // v3 scale results, independently of their other content.
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let mut results = Vec::new();
+    for index in 0..3 {
+        let path = dir.path().join(format!("scale-result-{index}.json"));
+        fs::write(
+            &path,
+            serde_json::json!({
+                "kind": "togi_pr_loop_benchmark_result",
+                "schema_version": 3,
+                "probe": index
+            })
+            .to_string(),
+        )
+        .expect("write schema-3 result");
+        results.push(path);
+    }
+    let output = run_comparator(
+        &repo_root().join("benchmarks/pr-loop/baseline.json"),
+        &results,
+        None,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "comparator must exit 2 on schema-3 results\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("wrong result schema"),
+        "comparator must name the schema mismatch, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Extract the closed invariant-name list literal from a harness script,
+/// whitespace-normalized so only the names and their order are compared.
+fn extract_invariant_list(script: &str) -> String {
+    let start = script
+        .find("[\"report-well-formed\"")
+        .expect("harness must contain the closed invariant list");
+    let rest = &script[start..];
+    let end = rest.find(']').expect("invariant list terminator");
+    rest[..=end]
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect()
+}
+
+#[test]
+fn pr_loop_harnesses_share_the_closed_invariant_list() {
+    // Duplication-drift control for the intentional v2/v3 mirroring: the one
+    // truly shared contract is the closed invariant-name list, which the v2
+    // header requires keeping in sync with invariant_filter().
+    let v2 = fs::read_to_string(script_path()).expect("read v2 harness");
+    let v3 = fs::read_to_string(scale_script_path()).expect("read v3 harness");
+    let v2_list = extract_invariant_list(&v2);
+    let v3_list = extract_invariant_list(&v3);
+    assert_eq!(
+        v2_list, v3_list,
+        "the frozen v2 and mirrored v3 harnesses must declare the same closed invariant list"
+    );
+    assert_eq!(
+        v2_list,
+        "[\"report-well-formed\",\"full-fresh-execution\",\"full-exact-cache-reuse\",\"schemata-fast-path-and-fallback\",\"pr-diff-targeting\"]",
+        "the shared invariant list itself drifted"
+    );
+}
+
+#[test]
+fn pr_loop_v2_harness_rejects_the_v3_scale_manifest() {
+    if !harness_tools_available() {
+        eprintln!("skipping: harness tools (bash/git/jq/sed/sha256sum|shasum/python3) unavailable");
+        return;
+    }
+    // Schema isolation: the frozen v2 harness must fail closed on the scale
+    // manifest, so the two corpora can never be cross-executed.
+    let tools = install_fake_tools();
+    let out_dir = tempfile::tempdir().expect("output tempdir");
+    let output = run_harness(&tools, out_dir.path(), Some(&scale_manifest_path()), &[]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "v2 harness must exit 2 on the v3 manifest\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("unsupported manifest schema_version 3 (expected 2)"),
+        "v2 harness must name the schema rejection, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !out_dir
+            .path()
+            .join("pr-loop-benchmark-result.json")
+            .exists(),
+        "v2 harness must not emit a result for the v3 manifest"
+    );
+}


### PR DESCRIPTION
PR 1 of #498: observational scale corpus + additive schema-v3 harness. Telemetry corpus only — it measures, compares nothing, and gates nothing.

## Scope

- New `tests/fixtures/go-scale/` fixture (own Go module, deterministic trivial tests, `togi.toml` lifting only the per-file cap) plus sha256-pinned `benchmarks/pr-loop-scale/scale-change.patch` — empirically **98 mutations** (band 50–150), with schemata fast_path 7 / fallback 91 on real runs.
- New `benchmarks/pr-loop-scale/manifest.json` (schema v3), one `scale-file` scenario, six telemetry workloads: `scale-regular-jobs1` (seeds cache), `scale-warm-exact-cache` (exact-cache reuse), `scale-regular-jobs4`, `scale-schemata`, `scale-schemata-jobs4`, and `scale-default` (zero-flag config-present path: regular runner, default parallelism, schemata null — zero-config runs would enable schemata; this fixture's config omits the key, whose config-file default is off). All `check --base HEAD`, `--max-per-run 500`, `--timeout 60`, `--test-cmd "go test ./..."`.
- New self-contained v3-only harness `benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh` (intentionally mirrors the frozen v2 execution engine; header documents the port-deliberately rule). Strict preflight validation: safe-identifier scenario/workload names, CR/LF rejection in every effective argv element (the execution loop splits on newlines), inline-form rejection for controlled flags, pinned split `--timeout 60` / `--max-per-run 500` / `--test-cmd 'go test ./...'`, optional positive split `--jobs`, repo-relative existing fixture/patch paths, sha256 patch verification, shared cache-edge/runner-mode/PR-diff contracts, and rejection of fresh workloads interleaved between a cache seed and its consumer. Results emit literal `schema_version: 3`, so the schema-2 `compare-baseline.py` rejects them by construction (exit 2, tested).
- `src/runner.rs` (test module only): `cache_identity_excludes_parallelism` — real engine proof that a jobs=1 run's exact-cache entry is reused by an otherwise identical jobs=4 run while the underlying test executes once.
- `tests/integration/benchmarks.rs` (append-only): v3 acceptance (command/cache/mutation-identity/jobs/schemata-null invariants), 54-case malformed-manifest rejection with empty-invocation-log proof, comparator cross-contamination exit-2 test, v2-rejects-v3-manifest isolation test, and a sync-guard asserting both harnesses share the closed invariant list.

## Frozen-corpus guarantees

- `git diff 6894d0e -- benchmarks/pr-loop/run-pr-loop-benchmarks.sh` is **empty** (sha256 `17ee4183…` matches the origin blob); the nine pre-existing v2 harness tests (plus the new shared-invariant guard) pass, and the v2 tests are unmodified.
- No changes to `benchmarks/pr-loop/` assets (manifest/baseline/comparator/promoter/patches), `tests/fixtures/go/`, workflows, CODEOWNERS, rulesets, or docs. No performance claims.

## Validation (all local, reproducible)

- `cargo test --locked` and `cargo +1.87 test --locked`: all suites green (688 lib incl. new engine test; 55 integration).
- `cargo clippy --locked --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `bash -n` clean on both harnesses.
- Real v3 harness smoke (primed isolated GOCACHE): all six workloads pass every invariant; all totals 98; one shared mutation identity; warm run tested=0 / exact_cache_reused=98; scale-default schemata null.
- Real v2 harness smoke on the restored frozen script: all invariants pass, result remains schema 2.

Follow-ups per #498: PR 2 summarizer+docs, PR 3 telemetry workflow+CODEOWNERS.
