### PR TITLE
bench: summarize observational scale evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,48 @@ a refreshed baseline lands. The authorized procedure is:
 Minimize the gate-red window; never leave the required-check enforcement
 disabled after the fast-follow lands.
 
+## PR-loop scaling evidence (observational)
+
+Beside the gated corpus, `benchmarks/pr-loop-scale/` holds an observational
+scaling corpus: `tests/fixtures/go-scale` plus a sha256-pinned patch that
+produces a 98-mutation PR diff, measured by six workloads
+(`scale-regular-jobs1`, `scale-warm-exact-cache`, `scale-regular-jobs4`,
+`scale-schemata`, `scale-schemata-jobs4`, `scale-default`). The harness
+emits schema-3 results, which the schema-2 gate comparator rejects by
+construction: this corpus has no baseline, no tolerance, and no gate, and
+its numbers are runner-class evidence only, never a general performance
+claim. `scale-default` is the zero-flag, config-present path: the fixture's
+`togi.toml` omits the schemata key (whose config-file default is off; a
+zero-config run would enable it), so it measures a regular run with default
+parallelism and `schemata: null`.
+
+Reproduce locally with a primed private Go build cache and summarize three
+samples:
+
+```bash
+cargo build --locked --release
+GOCACHE="$(mktemp -d "${TMPDIR:-/tmp}/.togi-pr-loop-scale-gocache.XXXXXX")"
+OUTPUT="$(mktemp -d "${TMPDIR:-/tmp}/.togi-pr-loop-scale.XXXXXX")"
+trap 'rm -rf "$GOCACHE" "$OUTPUT"' EXIT
+BENCH_GO_BUILD_CACHE_STATE=warmup GOCACHE="$GOCACHE" \
+  bash benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh --output "$OUTPUT/warmup"
+for sample in 1 2 3; do
+  BENCH_GO_BUILD_CACHE_STATE=primed GOCACHE="$GOCACHE" \
+    bash benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh --output "$OUTPUT/sample-$sample"
+done
+python3 benchmarks/pr-loop-scale/summarize-scale.py \
+  --output "$OUTPUT/scale-summary.json" \
+  "$OUTPUT"/sample-{1,2,3}/pr-loop-benchmark-result.json
+```
+
+The summarizer is stdlib-only and parse-only: it requires exactly three
+successful primed v3 results from one runner class and fails closed (exit 2)
+on anything else. It reports per-workload medians, the signed
+wall-minus-reported diagnostic (a diagnostic only — it is not an
+engine-versus-test-time attribution), and the four wall-ms ratio families
+(jobs4/jobs1 regular, schemata/jobs1 regular, schemata-jobs4/schemata-jobs1,
+warm/cold), each as the median of the three paired per-sample ratios.
+
 ## Configuration
 
 Optional. togi auto-detects a test command where supported; see [Before first run](#before-first-run) for its exact scope, prerequisites, and support boundaries.

--- a/benchmarks/pr-loop-scale/summarize-scale.py
+++ b/benchmarks/pr-loop-scale/summarize-scale.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Observational PR-loop scale summary (issue #498, PR 2).
+
+Parses exactly three normalized, primed schema-v3 scale-harness results and
+emits a schema-1 scale summary: per-workload raw and median-of-three
+wall/reported timings, the signed wall-minus-reported diagnostic, and the
+four wall-ms ratio families as medians of paired per-sample ratios (never
+ratios of medians), emitted as exact fractions.
+
+This tool is parse-only and stdlib-only: it never shells out, never reads
+the current checkout, and has no baseline, threshold, tolerance, gate, or
+per-mutant attribution logic. The summary compares nothing; it is evidence
+for the reader on one runner class only.
+
+Exit codes:
+
+* 0  summary emitted (JSON on stdout; with --output the identical bytes are
+     written to a new path, created exclusively and never overwriting an
+     existing file or a dangling symlink)
+* 2  malformed, missing, duplicated, or incomparable input, or an output
+     path that already exists
+"""
+import argparse
+from fractions import Fraction
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+EXPECTED_RESULT_KIND = "togi_pr_loop_benchmark_result"
+EXPECTED_RESULT_SCHEMA = 3
+EXPECTED_TIMING_POLICY = "observational-only"
+EXPECTED_MANIFEST_IDENTITY = {
+    "name": "togi-pr-loop-scale-benchmarks",
+    "schema_version": 3,
+    "path": "benchmarks/pr-loop-scale/manifest.json",
+}
+EXPECTED_CACHE_STATE = "primed"
+EXPECTED_CACHE_POLICY = "job-private-explicit-gocache"
+EXPECTED_SCENARIO = "scale-file"
+EXPECTED_TOTAL = 98
+EXPECTED_TEST_COMMAND = ["go", "test", "./..."]
+EXPECTED_REPORT_KIND = "mutation_report"
+EXPECTED_REPORT_SCHEMA = 1
+SAMPLE_COUNT = 3
+COMMON_ARGV_TAIL = (
+    "check", "--base", "HEAD", "--timeout", "60", "--max-per-run", "500",
+    "--test-cmd", "go test ./...", "--format", "json",
+)
+# The six telemetry workloads, in declaration order, with their runner mode,
+# cache policy, exact invariant-name list, and exact command argv tail
+# (everything after the binary path). Any drift in name, order, mode,
+# policy, invariants, or argv is incomparable input: this summarizer is
+# corpus-specific by design.
+EXPECTED_WORKLOADS = (
+    ("scale-regular-jobs1", "regular", "fresh", ("report-well-formed", "full-fresh-execution"),
+     COMMON_ARGV_TAIL + ("--no-schemata", "--force-rerun", "--jobs", "1")),
+    ("scale-warm-exact-cache", "regular", "reuse", ("report-well-formed", "full-exact-cache-reuse"),
+     COMMON_ARGV_TAIL + ("--no-schemata", "--jobs", "1")),
+    ("scale-regular-jobs4", "regular", "fresh", ("report-well-formed", "full-fresh-execution"),
+     COMMON_ARGV_TAIL + ("--no-schemata", "--force-rerun", "--jobs", "4")),
+    ("scale-schemata", "schemata", "fresh", ("report-well-formed", "schemata-fast-path-and-fallback"),
+     COMMON_ARGV_TAIL + ("--schemata", "--force-rerun", "--jobs", "1")),
+    ("scale-schemata-jobs4", "schemata", "fresh", ("report-well-formed", "schemata-fast-path-and-fallback"),
+     COMMON_ARGV_TAIL + ("--schemata", "--force-rerun", "--jobs", "4")),
+    ("scale-default", "default", "fresh", ("report-well-formed", "pr-diff-targeting"),
+     COMMON_ARGV_TAIL),
+)
+RUNNER_CLASS_KEYS = ("runner_label", "os", "arch", "logical_cpu_count")
+TOOLCHAIN_KEYS = ("go_version", "togi_version", "git_version", "kernel_release")
+# Every provenance dimension that must hold for one three-sample primed
+# acquisition; any drift is incomparable input, never a warning.
+IDENTITY_PROVENANCE_KEYS = RUNNER_CLASS_KEYS + TOOLCHAIN_KEYS + (
+    "fixture_source_dir",
+    "go_build_cache_path",
+)
+# The four wall-ms ratio families. Each entry is (output key, numerator
+# workload, denominator workload); every ratio is the median of the three
+# paired per-sample ratios, never the ratio of the medians.
+RATIO_FAMILIES = (
+    ("regular_jobs4_over_jobs1", "scale-regular-jobs4", "scale-regular-jobs1"),
+    ("schemata_over_regular_jobs1", "scale-schemata", "scale-regular-jobs1"),
+    ("schemata_jobs4_over_schemata_jobs1", "scale-schemata-jobs4", "scale-schemata"),
+    ("warm_over_cold", "scale-warm-exact-cache", "scale-regular-jobs1"),
+)
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def exact_int(value):
+    return type(value) is int
+
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def is_hex_digest(value):
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def require(value, predicate, message):
+    if not predicate(value):
+        fail(message)
+    return value
+
+
+def exact_integer(value, expected, message):
+    """Exact JSON integer equality: floats and booleans never pass."""
+    if not (exact_int(value) and value == expected):
+        fail(message)
+
+
+def read_input(path):
+    """Read one regular input once; return (raw bytes, parsed JSON object).
+
+    The content digest and the JSON parse both cover exactly these bytes."""
+    if not path.is_file():
+        fail(f"{path}: input is not a regular file")
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        fail(f"cannot read result {path}: {error}")
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid JSON document {path}: {error}")
+    require(value, lambda item: isinstance(item, dict), f"document {path} is not a JSON object")
+    return data, value
+
+
+def positive_int(value):
+    return exact_int(value) and value > 0
+
+
+def validate_workload_semantics(path, name, mode, cache_policy, entry):
+    """Validate the exact scale-corpus semantics of one workload, returning
+    its (wall_ms, reported_duration_ms) timing pair."""
+    require(entry.get("ok"), lambda item: item is True, f"{path}: workload {name} is not ok")
+    require(entry.get("exit_status"), lambda item: exact_int(item) and item in (0, 1), f"{path}: workload {name} has an unexpected exit status")
+    semantics = require(entry.get("semantics"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks semantics")
+    for key in ("total", "planned_total", "mutation_count"):
+        exact_integer(semantics.get(key), EXPECTED_TOTAL, f"{path}: workload {name} {key} must be {EXPECTED_TOTAL}")
+    require(semantics.get("selected_test_command"), lambda item: item == EXPECTED_TEST_COMMAND, f"{path}: workload {name} test command mismatch")
+    selection = require(semantics.get("test_selection"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks test selection evidence")
+    require(selection.get("mode"), lambda item: item == "full-suite", f"{path}: workload {name} test selection must be full-suite")
+    exact_integer(selection.get("full_suite_mutation_count"), EXPECTED_TOTAL, f"{path}: workload {name} full-suite count mismatch")
+    exact_integer(selection.get("narrowed_mutation_count"), 0, f"{path}: workload {name} has narrowed mutations")
+    timing = require(entry.get("timing"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks timing")
+    wall = require(timing.get("wall_ms"), positive_int, f"{path}: workload {name} wall_ms must be a positive integer")
+    reported = require(timing.get("reported_duration_ms"), positive_int, f"{path}: workload {name} reported_duration_ms must be a positive integer")
+    exact_integer(semantics.get("reported_duration_ms"), reported, f"{path}: workload {name} reported duration disagrees with its timing")
+    schemata = semantics.get("schemata")
+    if mode == "schemata":
+        require(schemata, lambda item: isinstance(item, dict), f"{path}: workload {name} lacks schemata evidence")
+        fast_path = require(schemata.get("fast_path"), positive_int, f"{path}: workload {name} must have a schemata fast path")
+        fallback = require(schemata.get("fallback"), positive_int, f"{path}: workload {name} must have schemata fallback mutants")
+        require(fast_path + fallback, lambda item: item == EXPECTED_TOTAL, f"{path}: workload {name} schemata split must sum to {EXPECTED_TOTAL}")
+    else:
+        require(schemata, lambda item: item is None, f"{path}: workload {name} must report schemata null")
+    if cache_policy == "reuse":
+        exact_integer(semantics.get("tested"), 0, f"{path}: workload {name} must reuse, not re-execute")
+        exact_integer(semantics.get("exact_cache_reused"), EXPECTED_TOTAL, f"{path}: workload {name} must come entirely from the exact cache")
+    else:
+        exact_integer(semantics.get("tested"), EXPECTED_TOTAL, f"{path}: workload {name} must execute every mutation")
+        exact_integer(semantics.get("exact_cache_reused"), 0, f"{path}: workload {name} must not reuse the exact cache")
+        exact_integer(semantics.get("incremental_history_reused"), 0, f"{path}: workload {name} must not reuse incremental history")
+    return wall, reported
+
+
+def validate_result(path, result):
+    """Validate one primed v3 scale result; return (workload timings, identity)."""
+    exact_integer(result.get("schema_version"), EXPECTED_RESULT_SCHEMA, f"{path}: wrong result schema")
+    require(result.get("kind"), lambda item: item == EXPECTED_RESULT_KIND, f"{path}: wrong result kind")
+    require(result.get("timing_policy"), lambda item: item == EXPECTED_TIMING_POLICY, f"{path}: wrong timing policy")
+    require(result.get("manifest"), lambda item: item == EXPECTED_MANIFEST_IDENTITY, f"{path}: manifest identity mismatch")
+    manifest = result["manifest"]
+    exact_integer(manifest.get("schema_version"), EXPECTED_RESULT_SCHEMA, f"{path}: manifest schema version must be an exact integer")
+    require(result.get("ok"), lambda item: item is True, f"{path}: result is not ok")
+    require(result.get("failures"), lambda item: item == [], f"{path}: result has failures")
+
+    provenance = require(result.get("provenance"), lambda item: isinstance(item, dict), f"{path}: missing provenance")
+    require(provenance.get("report_kind"), lambda item: item == EXPECTED_REPORT_KIND, f"{path}: invalid provenance.report_kind")
+    exact_integer(provenance.get("report_schema_version"), EXPECTED_REPORT_SCHEMA, f"{path}: invalid provenance.report_schema_version")
+    for key in IDENTITY_PROVENANCE_KEYS:
+        require(provenance.get(key), nonempty_string if not key == "logical_cpu_count" else positive_int, f"{path}: invalid provenance.{key}")
+    for key in ("image_os", "image_version"):
+        require(provenance.get(key), lambda item: item is None or nonempty_string(item), f"{path}: invalid provenance.{key}")
+    require(provenance.get("go_build_cache_state"), lambda item: item == EXPECTED_CACHE_STATE, f"{path}: go build cache state must be primed")
+    require(provenance.get("go_build_cache_policy"), lambda item: item == EXPECTED_CACHE_POLICY, f"{path}: go build cache policy must be {EXPECTED_CACHE_POLICY}")
+    require(provenance["go_build_cache_path"], lambda item: item.startswith("/"), f"{path}: go build cache path must be absolute")
+
+    fixture_scenarios = require(provenance.get("fixture_scenarios"), lambda item: isinstance(item, dict), f"{path}: missing fixture scenario provenance")
+    scale_scenario = require(fixture_scenarios.get(EXPECTED_SCENARIO), lambda item: isinstance(item, dict), f"{path}: missing {EXPECTED_SCENARIO} fixture provenance")
+    patch_sha256 = require(scale_scenario.get("patch_sha256"), is_hex_digest, f"{path}: invalid {EXPECTED_SCENARIO} patch digest")
+
+    cross_workload = require(result.get("cross_workload"), lambda item: isinstance(item, dict), f"{path}: missing cross-workload evidence")
+    scenarios = require(cross_workload.get("scenarios"), lambda item: isinstance(item, dict), f"{path}: missing per-scenario identity")
+    identity = require(scenarios.get(EXPECTED_SCENARIO), lambda item: isinstance(item, dict), f"{path}: missing {EXPECTED_SCENARIO} identity")
+    require(identity.get("mutation_identity_consistent"), lambda item: item is True, f"{path}: {EXPECTED_SCENARIO} mutation identity is inconsistent")
+    mutation_identity = require(identity.get("mutation_identity_sha256"), is_hex_digest, f"{path}: invalid {EXPECTED_SCENARIO} mutation digest")
+
+    workloads = require(result.get("workloads"), lambda item: isinstance(item, list), f"{path}: workloads must be an array")
+    require(workloads, lambda item: len(item) == len(EXPECTED_WORKLOADS), f"{path}: expected exactly {len(EXPECTED_WORKLOADS)} workloads")
+    samples = {}
+    for entry, (expected_name, expected_mode, expected_cache, expected_invariants, expected_tail) in zip(workloads, EXPECTED_WORKLOADS):
+        require(entry, lambda item: isinstance(item, dict), f"{path}: workload entries must be objects")
+        name = require(entry.get("name"), nonempty_string, f"{path}: workload lacks a name")
+        require(name, lambda item: item == expected_name, f"{path}: expected workload {expected_name}, found {name}")
+        require(entry.get("scenario"), lambda item: item == EXPECTED_SCENARIO, f"{path}: workload {name} scenario mismatch")
+        require(entry.get("runner_mode"), lambda item: item == expected_mode, f"{path}: workload {name} runner mode mismatch")
+        require(entry.get("cache_policy"), lambda item: item == expected_cache, f"{path}: workload {name} cache policy mismatch")
+        invariants = require(entry.get("invariants"), lambda item: isinstance(item, list) and item, f"{path}: workload {name} lacks invariants")
+        invariant_names = []
+        for invariant in invariants:
+            require(invariant, lambda item: isinstance(item, dict), f"{path}: workload {name} invariant entries must be objects")
+            require(invariant.get("ok"), lambda item: item is True, f"{path}: workload {name} has a failed invariant")
+            invariant_names.append(require(invariant.get("name"), nonempty_string, f"{path}: workload {name} invariant lacks a name"))
+        require(invariant_names, lambda item: item == list(expected_invariants), f"{path}: workload {name} invariant names must be exactly {list(expected_invariants)}")
+        command = require(entry.get("command"), lambda item: isinstance(item, list) and item and nonempty_string(item[0]) and all(isinstance(arg, str) for arg in item), f"{path}: workload {name} lacks a command argv")
+        require(command[1:], lambda item: item == list(expected_tail), f"{path}: workload {name} command argv tail mismatch")
+        semantics = require(entry.get("semantics"), lambda item: isinstance(item, dict), f"{path}: workload {name} lacks semantics")
+        require(semantics.get("mutation_identity_sha256"), lambda item: item == mutation_identity, f"{path}: workload {name} mutation identity differs from the scenario identity")
+        samples[name] = validate_workload_semantics(path, name, expected_mode, expected_cache, entry)
+
+    comparable_identity = {
+        "runner_class": {key: provenance[key] for key in RUNNER_CLASS_KEYS},
+        "toolchain": {key: provenance[key] for key in TOOLCHAIN_KEYS},
+        "corpus": {
+            "fixture_source_dir": provenance["fixture_source_dir"],
+            "scenario": EXPECTED_SCENARIO,
+            "patch_sha256": patch_sha256,
+            "mutation_identity_sha256": mutation_identity,
+        },
+        "provenance": {key: provenance[key] for key in IDENTITY_PROVENANCE_KEYS},
+        "image": {"image_os": provenance["image_os"], "image_version": provenance["image_version"]},
+    }
+    return samples, comparable_identity
+
+
+def median_of_three(values):
+    return sorted(values)[1]
+
+
+def build_summary(per_sample):
+    """Assemble the schema-1 summary from three validated samples."""
+    identities = [identity for _, identity in per_sample]
+    first = identities[0]
+    for key in ("runner_class", "toolchain", "corpus", "provenance", "image"):
+        for other in identities[1:]:
+            require(other[key], lambda item: item == first[key], f"samples disagree on {key}; not one primed acquisition on one runner class")
+
+    workload_summaries = []
+    for name, mode, cache_policy, _, _ in EXPECTED_WORKLOADS:
+        walls = [samples[name][0] for samples, _ in per_sample]
+        reported = [samples[name][1] for samples, _ in per_sample]
+        median_wall = median_of_three(walls)
+        median_reported = median_of_three(reported)
+        workload_summaries.append({
+            "name": name,
+            "scenario": EXPECTED_SCENARIO,
+            "runner_mode": mode,
+            "cache_policy": cache_policy,
+            "wall_ms": walls,
+            "reported_duration_ms": reported,
+            "median_wall_ms": median_wall,
+            "median_reported_duration_ms": median_reported,
+            "diagnostic_wall_minus_reported_ms": median_wall - median_reported,
+        })
+
+    ratios = {}
+    for key, numerator, denominator in RATIO_FAMILIES:
+        pairs = []
+        paired = []
+        for samples, _ in per_sample:
+            num = samples[numerator][0]
+            den = samples[denominator][0]
+            pairs.append([num, den])
+            paired.append(Fraction(num, den))
+        median_ratio = median_of_three(paired)
+        ratios[key] = {
+            "metric": "wall_ms",
+            "numerator_workload": numerator,
+            "denominator_workload": denominator,
+            "sample_pairs_ms": pairs,
+            "median_fraction": {
+                "numerator": median_ratio.numerator,
+                "denominator": median_ratio.denominator,
+            },
+        }
+
+    return {
+        "kind": "togi_pr_loop_scale_summary",
+        "schema_version": 1,
+        "timing_policy": EXPECTED_TIMING_POLICY,
+        "sample_count": SAMPLE_COUNT,
+        "aggregation": {
+            "workload_timings": "median_of_three",
+            "ratios": "median_of_paired_sample_ratios",
+            "ratio_metric": "wall_ms",
+        },
+        "identity": {
+            "manifest": EXPECTED_MANIFEST_IDENTITY,
+            "runner_class": first["runner_class"],
+            "toolchain": first["toolchain"],
+            "corpus": first["corpus"],
+            "image": first["image"],
+            "measurement": {
+                "go_build_cache_state": EXPECTED_CACHE_STATE,
+                "go_build_cache_policy": EXPECTED_CACHE_POLICY,
+                "go_build_cache_path": first["provenance"]["go_build_cache_path"],
+            },
+        },
+        "workloads": workload_summaries,
+        "ratios": ratios,
+    }
+
+
+def write_output_exclusive(path, text):
+    """Create path exclusively (never overwrite, never follow a dangling
+    symlink) and write text atomically with respect to other creators."""
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        fail(f"output already exists: {path}")
+    except OSError as error:
+        fail(f"cannot create output {path}: {error}")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    except OSError as error:
+        fail(f"cannot write output {path}: {error}")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=None, help="write the summary JSON to this new path (exclusive create; never overwrites)")
+    parser.add_argument("results", nargs="*", type=Path, help="exactly three normalized primed v3 scale-harness results")
+    args = parser.parse_args(argv)
+    if len(args.results) != SAMPLE_COUNT:
+        fail(f"expected exactly {SAMPLE_COUNT} results, received {len(args.results)}")
+
+    for path in args.results:
+        if path.is_symlink():
+            fail(f"{path}: input must be a regular file, not a symlink")
+    resolved = [path.resolve() for path in args.results]
+    if len(set(resolved)) != SAMPLE_COUNT:
+        fail("result paths must name three independent files")
+    digests = []
+    per_sample = []
+    for resolved_path in resolved:
+        data, result = read_input(resolved_path)
+        digests.append(hashlib.sha256(data).hexdigest())
+        per_sample.append(validate_result(resolved_path, result))
+    if len(set(digests)) != SAMPLE_COUNT:
+        fail("results must have three distinct content digests")
+
+    summary = build_summary(per_sample)
+    summary["identity"]["input_sha256"] = digests
+    text = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        write_output_exclusive(args.output, text)
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except (ValueError, OverflowError) as error:
+        print(f"scale summary failed: {error}", file=sys.stderr)
+        sys.exit(2)

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -5298,3 +5298,1100 @@ fn pr_loop_v2_harness_rejects_the_v3_scale_manifest() {
         "v2 harness must not emit a result for the v3 manifest"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Schema-1 observational scale summary (issue #498, PR 2).
+//
+// These drive benchmarks/pr-loop-scale/summarize-scale.py with synthetic
+// primed v3 results in the real harness output shape, plus one end-to-end
+// run over three fake-tools harness acquisitions. The happy path proves the
+// paired per-sample ratio median (not the ratio of medians), the signed
+// wall-minus-reported diagnostic, and the identity/digest evidence; the
+// fail-closed table proves every malformed/missing/incomparable input exits
+// 2 with no stdout JSON.
+// ---------------------------------------------------------------------------
+
+const SCALE_SUMMARY_IDENTITY: &str =
+    "abababababababababababababababababababababababababababababababab";
+
+fn summarizer_path() -> PathBuf {
+    repo_root().join("benchmarks/pr-loop-scale/summarize-scale.py")
+}
+
+fn run_summarizer(results: &[PathBuf], output: Option<&Path>) -> Output {
+    let mut command = Command::new("python3");
+    command.arg(summarizer_path());
+    if let Some(output) = output {
+        command.arg("--output").arg(output);
+    }
+    for result in results {
+        command.arg(result);
+    }
+    command.output().expect("spawn summarizer")
+}
+
+/// Full-fidelity workload semantics for a valid primed v3 scale result:
+/// fresh workloads fully execute with zero reuse, the warm workload is
+/// entirely exact-cache, and schemata workloads carry a 7/91 split.
+fn scale_workload_semantics(name: &str, reported: u64) -> serde_json::Value {
+    let (tested, exact, schemata) = match name {
+        "scale-warm-exact-cache" => (0, 98, serde_json::Value::Null),
+        "scale-schemata" | "scale-schemata-jobs4" => {
+            (98, 0, serde_json::json!({"fast_path": 7, "fallback": 91}))
+        }
+        _ => (98, 0, serde_json::Value::Null),
+    };
+    serde_json::json!({
+        "total": 98,
+        "planned_total": 98,
+        "tested": tested,
+        "killed": 0,
+        "survived": 98,
+        "timeout": 0,
+        "build_errors": 0,
+        "uncovered": 0,
+        "subsumed": 0,
+        "exact_cache_reused": exact,
+        "incremental_history_reused": 0,
+        "partial": false,
+        "reported_duration_ms": reported,
+        "schemata": schemata,
+        "selected_test_command": ["go", "test", "./..."],
+        "test_selection": {
+            "mode": "full-suite",
+            "full_suite_mutation_count": 98,
+            "narrowed_mutation_count": 0
+        },
+        "mutation_count": 98,
+        "mutation_identity_sha256": SCALE_SUMMARY_IDENTITY
+    })
+}
+
+fn scale_workload_invariants(name: &str) -> serde_json::Value {
+    let extra = match name {
+        "scale-warm-exact-cache" => "full-exact-cache-reuse",
+        "scale-schemata" | "scale-schemata-jobs4" => "schemata-fast-path-and-fallback",
+        "scale-default" => "pr-diff-targeting",
+        _ => "full-fresh-execution",
+    };
+    serde_json::json!([
+        {"name": "report-well-formed", "ok": true},
+        {"name": extra, "ok": true}
+    ])
+}
+
+const SCALE_COMMON_TAIL: [&str; 11] = [
+    "check",
+    "--base",
+    "HEAD",
+    "--timeout",
+    "60",
+    "--max-per-run",
+    "500",
+    "--test-cmd",
+    "go test ./...",
+    "--format",
+    "json",
+];
+
+fn scale_workload_command(name: &str) -> serde_json::Value {
+    let extras: &[&str] = match name {
+        "scale-regular-jobs1" => &["--no-schemata", "--force-rerun", "--jobs", "1"],
+        "scale-warm-exact-cache" => &["--no-schemata", "--jobs", "1"],
+        "scale-regular-jobs4" => &["--no-schemata", "--force-rerun", "--jobs", "4"],
+        "scale-schemata" => &["--schemata", "--force-rerun", "--jobs", "1"],
+        "scale-schemata-jobs4" => &["--schemata", "--force-rerun", "--jobs", "4"],
+        _ => &[],
+    };
+    let mut argv = vec!["togi"];
+    argv.extend_from_slice(&SCALE_COMMON_TAIL);
+    argv.extend_from_slice(extras);
+    serde_json::json!(argv)
+}
+
+/// A valid primed v3 scale result in the real harness output shape, with
+/// the given per-workload wall/reported timings (declaration order).
+fn scale_result_value(walls: [u64; 6], reported: [u64; 6]) -> serde_json::Value {
+    let workloads: Vec<serde_json::Value> = SCALE_WORKLOAD_NAMES
+        .iter()
+        .zip([
+            ("regular", "fresh"),
+            ("regular", "reuse"),
+            ("regular", "fresh"),
+            ("schemata", "fresh"),
+            ("schemata", "fresh"),
+            ("default", "fresh"),
+        ])
+        .zip(walls.iter().zip(reported.iter()))
+        .map(|((name, (mode, cache)), (wall, rep))| {
+            serde_json::json!({
+                "name": name,
+                "scenario": "scale-file",
+                "runner_mode": mode,
+                "cache_policy": cache,
+                "ok": true,
+                "exit_status": 1,
+                "command": scale_workload_command(name),
+                "timing": {"wall_ms": wall, "reported_duration_ms": rep},
+                "semantics": scale_workload_semantics(name, *rep),
+                "invariants": scale_workload_invariants(name),
+                "artifacts": {"raw_stdout": "raw/x.stdout", "raw_stderr": "raw/x.stderr", "report": "raw/x.report.json"}
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "kind": "togi_pr_loop_benchmark_result",
+        "schema_version": 3,
+        "timing_policy": "observational-only",
+        "manifest": {
+            "name": "togi-pr-loop-scale-benchmarks",
+            "schema_version": 3,
+            "path": "benchmarks/pr-loop-scale/manifest.json"
+        },
+        "ok": true,
+        "failures": [],
+        "provenance": {
+            "togi_version": "togi 0.5.0",
+            "togi_binary": "/opt/togi",
+            "report_kind": "mutation_report",
+            "report_schema_version": 1,
+            "runner_label": "local",
+            "os": "Darwin",
+            "arch": "arm64",
+            "logical_cpu_count": 18,
+            "kernel_release": "25.5.0",
+            "git_version": "git version 2.50.1",
+            "go_version": "go version go1.26.4 darwin/arm64",
+            "image_os": null,
+            "image_version": null,
+            "fixture_source_dir": "tests/fixtures/go-scale",
+            "go_build_cache_state": "primed",
+            "go_build_cache_policy": "job-private-explicit-gocache",
+            "go_build_cache_path": "/tmp/scale-gocache",
+            "started_at_utc": "2026-08-04T00:00:00Z",
+            "fixture_scenarios": {"scale-file": {
+                "patch_file": "benchmarks/pr-loop-scale/scale-change.patch",
+                "patch_sha256": SCALE_SUMMARY_IDENTITY,
+                "base_revision": SCALE_SUMMARY_IDENTITY
+            }}
+        },
+        "cross_workload": {"scenarios": {"scale-file": {
+            "mutation_identity_consistent": true,
+            "mutation_identity_sha256": SCALE_SUMMARY_IDENTITY
+        }}},
+        "workloads": workloads,
+    })
+}
+
+/// Three distinct valid samples; the values make the paired per-sample
+/// ratio median differ from the ratio of medians.
+fn write_valid_summary_samples(dir: &Path) -> Vec<PathBuf> {
+    let walls: [[u64; 6]; 3] = [
+        [5, 3, 10, 6, 7, 4],
+        [100, 8, 20, 95, 50, 90],
+        [100, 9, 90, 105, 60, 88],
+    ];
+    let mut paths = Vec::new();
+    for (index, walls_for_sample) in walls.iter().enumerate() {
+        let reported: [u64; 6] = walls_for_sample.map(|wall| wall - 1);
+        let path = dir.join(format!("sample-{index}.json"));
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&scale_result_value(*walls_for_sample, reported))
+                .expect("serialize sample"),
+        )
+        .expect("write sample");
+        paths.push(path);
+    }
+    paths
+}
+
+#[test]
+fn pr_loop_scale_summary_reports_paired_ratio_medians_and_identity() {
+    if !tool_on_path("python3") {
+        eprintln!("skipping: python3 unavailable");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+
+    let output = run_summarizer(&samples, None);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "summarizer must accept three valid primed v3 results\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("summary is valid JSON");
+    assert_eq!(summary["kind"], "togi_pr_loop_scale_summary");
+    assert_eq!(summary["schema_version"], 1);
+    assert_eq!(summary["timing_policy"], "observational-only");
+    assert_eq!(summary["sample_count"], 3);
+    assert_eq!(
+        summary["aggregation"],
+        serde_json::json!({
+            "workload_timings": "median_of_three",
+            "ratios": "median_of_paired_sample_ratios",
+            "ratio_metric": "wall_ms"
+        })
+    );
+
+    let workloads = summary["workloads"].as_array().expect("workloads array");
+    let names: Vec<&str> = workloads
+        .iter()
+        .map(|workload| workload["name"].as_str().expect("name"))
+        .collect();
+    assert_eq!(names, SCALE_WORKLOAD_NAMES);
+    assert_eq!(workloads[0]["wall_ms"], serde_json::json!([5, 100, 100]));
+    assert_eq!(workloads[0]["median_wall_ms"], 100);
+    assert_eq!(workloads[0]["median_reported_duration_ms"], 99);
+    assert_eq!(workloads[0]["diagnostic_wall_minus_reported_ms"], 1);
+
+    // jobs4 walls [10, 20, 90] over jobs1 walls [5, 100, 100]: the paired
+    // per-sample ratios are [2.0, 0.2, 0.9] with median 9/10, while the
+    // ratio of medians would be 20/100 = 1/5. Observing the exact fraction
+    // and the stored pairs proves the contract's aggregation rule.
+    let ratio = &summary["ratios"]["regular_jobs4_over_jobs1"];
+    assert_eq!(ratio["metric"], "wall_ms");
+    assert_eq!(
+        ratio["sample_pairs_ms"],
+        serde_json::json!([[10, 5], [20, 100], [90, 100]])
+    );
+    assert_eq!(
+        ratio["median_fraction"],
+        serde_json::json!({"numerator": 9, "denominator": 10})
+    );
+    assert_ne!(
+        ratio["median_fraction"],
+        serde_json::json!({"numerator": 1, "denominator": 5}),
+        "must be the median of paired ratios, never the ratio of medians"
+    );
+    assert_eq!(ratio["numerator_workload"], "scale-regular-jobs4");
+    assert_eq!(ratio["denominator_workload"], "scale-regular-jobs1");
+    let ratio_keys: Vec<&str> = summary["ratios"]
+        .as_object()
+        .expect("ratios object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        ratio_keys,
+        [
+            "regular_jobs4_over_jobs1",
+            "schemata_jobs4_over_schemata_jobs1",
+            "schemata_over_regular_jobs1",
+            "warm_over_cold"
+        ]
+    );
+    assert_eq!(
+        summary["ratios"]["schemata_jobs4_over_schemata_jobs1"]["denominator_workload"],
+        "scale-schemata"
+    );
+    assert_eq!(
+        summary["ratios"]["warm_over_cold"]["median_fraction"],
+        serde_json::json!({"numerator": 9, "denominator": 100})
+    );
+
+    let identity = &summary["identity"];
+    assert_eq!(
+        identity["manifest"]["path"],
+        "benchmarks/pr-loop-scale/manifest.json"
+    );
+    assert_eq!(identity["runner_class"]["logical_cpu_count"], 18);
+    assert_eq!(identity["toolchain"]["togi_version"], "togi 0.5.0");
+    assert_eq!(identity["toolchain"]["git_version"], "git version 2.50.1");
+    assert_eq!(
+        identity["corpus"]["mutation_identity_sha256"],
+        SCALE_SUMMARY_IDENTITY
+    );
+    assert_eq!(identity["measurement"]["go_build_cache_state"], "primed");
+    assert_eq!(
+        identity["measurement"]["go_build_cache_path"], "/tmp/scale-gocache",
+        "one shared primed cache path across the three samples"
+    );
+    let digests: Vec<&str> = identity["input_sha256"]
+        .as_array()
+        .expect("input digests")
+        .iter()
+        .map(|digest| digest.as_str().expect("digest string"))
+        .collect();
+    assert_eq!(digests.len(), 3);
+    for digest in &digests {
+        assert_eq!(digest.len(), 64);
+    }
+    let mut sorted = digests.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), 3, "sample content digests must be distinct");
+}
+
+#[test]
+fn pr_loop_scale_summary_output_is_exclusive_and_stdout_only() {
+    if !tool_on_path("python3") {
+        eprintln!("skipping: python3 unavailable");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+
+    let output_path = dir.path().join("scale-summary.json");
+    let first = run_summarizer(&samples, Some(&output_path));
+    assert_eq!(first.status.code(), Some(0));
+    let file_bytes = fs::read(&output_path).expect("summary file");
+    assert_eq!(
+        file_bytes, first.stdout,
+        "--output must contain exactly the stdout JSON"
+    );
+
+    let second = run_summarizer(&samples, Some(&output_path));
+    assert_eq!(
+        second.status.code(),
+        Some(2),
+        "re-running with the same --output must fail closed"
+    );
+    assert!(
+        String::from_utf8_lossy(&second.stderr).contains("output already exists"),
+        "clobber refusal must be named: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert!(
+        second.stdout.is_empty(),
+        "a failed run must not emit partial JSON"
+    );
+    assert_eq!(
+        fs::read(&output_path).expect("summary file"),
+        file_bytes,
+        "an existing output must never be overwritten"
+    );
+
+    let dangling = dir.path().join("dangling.json");
+    std::os::unix::fs::symlink(dir.path().join("no-such-target"), &dangling)
+        .expect("create dangling symlink");
+    let third = run_summarizer(&samples, Some(&dangling));
+    assert_eq!(
+        third.status.code(),
+        Some(2),
+        "a dangling symlink output path must be refused"
+    );
+
+    for count in [2usize, 4] {
+        let wrong: Vec<PathBuf> = (0..count).map(|index| samples[index % 3].clone()).collect();
+        let output = run_summarizer(&wrong, None);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "exactly three results are required, not {count}"
+        );
+    }
+}
+
+/// (label, mutation, scope) for the summarizer fail-closed table; scope is
+/// "all", "first", or "second" and selects which samples get mutated.
+type SummaryMutationCase = (&'static str, fn(&mut serde_json::Value), &'static str);
+
+#[test]
+fn pr_loop_scale_summary_fails_closed_on_bad_inputs() {
+    if !tool_on_path("python3") {
+        eprintln!("skipping: python3 unavailable");
+        return;
+    }
+
+    let cases: Vec<SummaryMutationCase> = vec![
+        (
+            "wrong result kind",
+            |value| {
+                value["kind"] = serde_json::json!("mutation_report");
+            },
+            "all",
+        ),
+        (
+            "schema 2 result",
+            |value| {
+                value["schema_version"] = serde_json::json!(2);
+            },
+            "all",
+        ),
+        (
+            "wrong timing policy",
+            |value| {
+                value["timing_policy"] = serde_json::json!("gated");
+            },
+            "all",
+        ),
+        (
+            "manifest identity mismatch",
+            |value| {
+                value["manifest"]["name"] = serde_json::json!("togi-pr-loop-benchmarks");
+            },
+            "all",
+        ),
+        (
+            "ok false",
+            |value| {
+                value["ok"] = serde_json::json!(false);
+            },
+            "all",
+        ),
+        (
+            "non-empty failures",
+            |value| {
+                value["failures"] = serde_json::json!(["scale-default:report-well-formed"]);
+            },
+            "all",
+        ),
+        (
+            "five workloads",
+            |value| {
+                value["workloads"].as_array_mut().unwrap().truncate(5);
+            },
+            "all",
+        ),
+        (
+            "workloads in wrong order",
+            |value| {
+                value["workloads"].as_array_mut().unwrap().swap(0, 1);
+            },
+            "all",
+        ),
+        (
+            "runner mode mismatch",
+            |value| {
+                value["workloads"][3]["runner_mode"] = serde_json::json!("regular");
+            },
+            "all",
+        ),
+        (
+            "cache policy mismatch",
+            |value| {
+                value["workloads"][1]["cache_policy"] = serde_json::json!("fresh");
+            },
+            "all",
+        ),
+        (
+            "failed invariant",
+            |value| {
+                value["workloads"][0]["invariants"][0]["ok"] = serde_json::json!(false);
+            },
+            "all",
+        ),
+        (
+            "wrong invariant names",
+            |value| {
+                value["workloads"][0]["invariants"][1]["name"] =
+                    serde_json::json!("full-exact-cache-reuse");
+            },
+            "all",
+        ),
+        (
+            "workload not ok",
+            |value| {
+                value["workloads"][0]["ok"] = serde_json::json!(false);
+            },
+            "all",
+        ),
+        (
+            "unexpected exit status",
+            |value| {
+                value["workloads"][0]["exit_status"] = serde_json::json!(2);
+            },
+            "all",
+        ),
+        (
+            "command argv tail mismatch",
+            |value| {
+                value["workloads"][0]["command"] = serde_json::json!([
+                    "togi",
+                    "check",
+                    "--base",
+                    "HEAD",
+                    "--timeout",
+                    "60",
+                    "--max-per-run",
+                    "500",
+                    "--test-cmd",
+                    "go test ./...",
+                    "--format",
+                    "json",
+                    "--no-schemata",
+                    "--force-rerun",
+                    "--jobs",
+                    "2"
+                ]);
+            },
+            "all",
+        ),
+        (
+            "image_os wrong type",
+            |value| {
+                value["provenance"]["image_os"] = serde_json::json!(42);
+            },
+            "all",
+        ),
+        (
+            "image identity drift",
+            |value| {
+                value["provenance"]["image_os"] = serde_json::json!("ubuntu-24.04");
+            },
+            "second",
+        ),
+        (
+            "empty command binary",
+            |value| {
+                value["workloads"][0]["command"][0] = serde_json::json!("");
+            },
+            "all",
+        ),
+        (
+            "wrong mutation total",
+            |value| {
+                value["workloads"][0]["semantics"]["total"] = serde_json::json!(97);
+            },
+            "all",
+        ),
+        (
+            "planned total mismatch",
+            |value| {
+                value["workloads"][0]["semantics"]["planned_total"] = serde_json::json!(97);
+            },
+            "all",
+        ),
+        (
+            "mutation count mismatch",
+            |value| {
+                value["workloads"][0]["semantics"]["mutation_count"] = serde_json::json!(97);
+            },
+            "all",
+        ),
+        (
+            "wrong test command",
+            |value| {
+                value["workloads"][0]["semantics"]["selected_test_command"] =
+                    serde_json::json!(["go", "test"]);
+            },
+            "all",
+        ),
+        (
+            "narrowed test selection",
+            |value| {
+                value["workloads"][0]["semantics"]["test_selection"]["mode"] =
+                    serde_json::json!("narrowed");
+            },
+            "all",
+        ),
+        (
+            "reported duration disagrees with timing",
+            |value| {
+                value["workloads"][0]["semantics"]["reported_duration_ms"] = serde_json::json!(1);
+            },
+            "all",
+        ),
+        (
+            "fresh workload not fully executed",
+            |value| {
+                value["workloads"][0]["semantics"]["tested"] = serde_json::json!(97);
+            },
+            "all",
+        ),
+        (
+            "fresh workload reusing cache",
+            |value| {
+                value["workloads"][0]["semantics"]["exact_cache_reused"] = serde_json::json!(1);
+            },
+            "all",
+        ),
+        (
+            "fresh workload reusing history",
+            |value| {
+                value["workloads"][0]["semantics"]["incremental_history_reused"] =
+                    serde_json::json!(1);
+            },
+            "all",
+        ),
+        (
+            "warm workload re-executing",
+            |value| {
+                value["workloads"][1]["semantics"]["tested"] = serde_json::json!(1);
+            },
+            "all",
+        ),
+        (
+            "warm workload partial cache",
+            |value| {
+                value["workloads"][1]["semantics"]["exact_cache_reused"] = serde_json::json!(97);
+            },
+            "all",
+        ),
+        (
+            "schemata without fast path",
+            |value| {
+                value["workloads"][3]["semantics"]["schemata"]["fast_path"] = serde_json::json!(0);
+            },
+            "all",
+        ),
+        (
+            "schemata without fallback",
+            |value| {
+                value["workloads"][3]["semantics"]["schemata"]["fallback"] = serde_json::json!(0);
+            },
+            "all",
+        ),
+        (
+            "schemata split not summing to total",
+            |value| {
+                value["workloads"][3]["semantics"]["schemata"]["fallback"] = serde_json::json!(90);
+            },
+            "all",
+        ),
+        (
+            "regular workload with schemata evidence",
+            |value| {
+                value["workloads"][0]["semantics"]["schemata"] =
+                    serde_json::json!({"fast_path": 7, "fallback": 91});
+            },
+            "all",
+        ),
+        (
+            "workload identity differs from scenario",
+            |value| {
+                value["workloads"][2]["semantics"]["mutation_identity_sha256"] =
+                    serde_json::json!("cd".repeat(32));
+            },
+            "all",
+        ),
+        (
+            "scenario identity inconsistent",
+            |value| {
+                value["cross_workload"]["scenarios"]["scale-file"]["mutation_identity_consistent"] =
+                    serde_json::json!(false);
+            },
+            "all",
+        ),
+        (
+            "float wall time",
+            |value| {
+                value["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(100.5);
+            },
+            "all",
+        ),
+        (
+            "zero wall time",
+            |value| {
+                value["workloads"][1]["timing"]["wall_ms"] = serde_json::json!(0);
+            },
+            "all",
+        ),
+        (
+            "float mutation total",
+            |value| {
+                value["workloads"][0]["semantics"]["total"] = serde_json::json!(98.0);
+            },
+            "all",
+        ),
+        (
+            "float full-suite count",
+            |value| {
+                value["workloads"][0]["semantics"]["test_selection"]["full_suite_mutation_count"] =
+                    serde_json::json!(98.0);
+            },
+            "all",
+        ),
+        (
+            "float narrowed count",
+            |value| {
+                value["workloads"][0]["semantics"]["test_selection"]["narrowed_mutation_count"] =
+                    serde_json::json!(0.0);
+            },
+            "all",
+        ),
+        (
+            "float tested count",
+            |value| {
+                value["workloads"][0]["semantics"]["tested"] = serde_json::json!(98.0);
+            },
+            "all",
+        ),
+        (
+            "boolean exact-cache count",
+            |value| {
+                value["workloads"][0]["semantics"]["exact_cache_reused"] = serde_json::json!(false);
+            },
+            "all",
+        ),
+        (
+            "boolean report schema version",
+            |value| {
+                value["provenance"]["report_schema_version"] = serde_json::json!(true);
+            },
+            "all",
+        ),
+        (
+            "float result schema version",
+            |value| {
+                value["schema_version"] = serde_json::json!(3.0);
+            },
+            "all",
+        ),
+        (
+            "float manifest schema version",
+            |value| {
+                value["manifest"]["schema_version"] = serde_json::json!(3.0);
+            },
+            "all",
+        ),
+        (
+            "malformed patch digest",
+            |value| {
+                value["provenance"]["fixture_scenarios"]["scale-file"]["patch_sha256"] =
+                    serde_json::json!("not-a-digest");
+            },
+            "all",
+        ),
+        (
+            "patch digest drift",
+            |value| {
+                value["provenance"]["fixture_scenarios"]["scale-file"]["patch_sha256"] =
+                    serde_json::json!("cd".repeat(32));
+            },
+            "second",
+        ),
+        (
+            "zero logical cpu count",
+            |value| {
+                value["provenance"]["logical_cpu_count"] = serde_json::json!(0);
+            },
+            "all",
+        ),
+        (
+            "logical cpu drift",
+            |value| {
+                value["provenance"]["logical_cpu_count"] = serde_json::json!(16);
+            },
+            "second",
+        ),
+        (
+            "negative wall time",
+            |value| {
+                value["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(-1);
+            },
+            "all",
+        ),
+        (
+            "boolean wall time",
+            |value| {
+                value["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(true);
+            },
+            "all",
+        ),
+        (
+            "null wall time",
+            |value| {
+                value["workloads"][0]["timing"]["wall_ms"] = serde_json::Value::Null;
+            },
+            "all",
+        ),
+        (
+            "string reported time",
+            |value| {
+                value["workloads"][0]["timing"]["reported_duration_ms"] = serde_json::json!("42");
+            },
+            "all",
+        ),
+        (
+            "unprimed cache state",
+            |value| {
+                value["provenance"]["go_build_cache_state"] = serde_json::json!("unclassified");
+            },
+            "all",
+        ),
+        (
+            "wrong cache policy",
+            |value| {
+                value["provenance"]["go_build_cache_policy"] = serde_json::json!("unenforced");
+            },
+            "all",
+        ),
+        (
+            "relative cache path",
+            |value| {
+                value["provenance"]["go_build_cache_path"] = serde_json::json!("tmp/cache");
+            },
+            "all",
+        ),
+        (
+            "empty cache path",
+            |value| {
+                value["provenance"]["go_build_cache_path"] = serde_json::json!("");
+            },
+            "all",
+        ),
+        (
+            "cache path drift across samples",
+            |value| {
+                value["provenance"]["go_build_cache_path"] = serde_json::json!("/tmp/other-cache");
+            },
+            "second",
+        ),
+        (
+            "missing report kind",
+            |value| {
+                value["provenance"]["report_kind"] = serde_json::json!("other_report");
+            },
+            "all",
+        ),
+        (
+            "wrong report schema version",
+            |value| {
+                value["provenance"]["report_schema_version"] = serde_json::json!(2);
+            },
+            "all",
+        ),
+        (
+            "missing git version",
+            |value| {
+                value["provenance"]["git_version"] = serde_json::json!("");
+            },
+            "all",
+        ),
+        (
+            "missing kernel release",
+            |value| {
+                value["provenance"]["kernel_release"] = serde_json::json!("");
+            },
+            "all",
+        ),
+        (
+            "runner class drift",
+            |value| {
+                value["provenance"]["runner_label"] = serde_json::json!("github-actions");
+            },
+            "second",
+        ),
+        (
+            "toolchain drift",
+            |value| {
+                value["provenance"]["go_version"] =
+                    serde_json::json!("go version go1.25.0 darwin/arm64");
+            },
+            "first",
+        ),
+        (
+            "togi version drift",
+            |value| {
+                value["provenance"]["togi_version"] = serde_json::json!("togi 0.5.1");
+            },
+            "second",
+        ),
+        (
+            "git version drift",
+            |value| {
+                value["provenance"]["git_version"] = serde_json::json!("git version 2.49.0");
+            },
+            "second",
+        ),
+        (
+            "kernel drift",
+            |value| {
+                value["provenance"]["kernel_release"] = serde_json::json!("25.4.0");
+            },
+            "second",
+        ),
+        (
+            "mutation identity drift",
+            |value| {
+                value["cross_workload"]["scenarios"]["scale-file"]["mutation_identity_sha256"] =
+                    serde_json::json!("cd".repeat(32));
+            },
+            "second",
+        ),
+    ];
+
+    for (label, mutation, scope) in cases {
+        let dir = tempfile::tempdir().expect("case tempdir");
+        let samples = write_valid_summary_samples(dir.path());
+        let targets: &[usize] = match scope {
+            "all" => &[0, 1, 2],
+            "first" => &[0],
+            "second" => &[1],
+            _ => unreachable!(),
+        };
+        for index in targets {
+            let mut value: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&samples[*index]).expect("read sample"))
+                    .expect("sample JSON");
+            mutation(&mut value);
+            fs::write(
+                &samples[*index],
+                serde_json::to_string_pretty(&value).expect("serialize"),
+            )
+            .expect("rewrite sample");
+        }
+        let output = run_summarizer(&samples, None);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "summarizer must exit 2 for {label}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "no JSON on stdout for rejected input {label}"
+        );
+    }
+
+    // Non-JSON and non-object documents.
+    for (label, contents) in [("malformed JSON", "{"), ("non-object JSON", "[]")] {
+        let dir = tempfile::tempdir().expect("case tempdir");
+        let samples = write_valid_summary_samples(dir.path());
+        fs::write(&samples[0], contents).expect("corrupt sample");
+        let output = run_summarizer(&samples, None);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "summarizer must exit 2 for {label}"
+        );
+    }
+
+    // Same path twice.
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+    let output = run_summarizer(
+        &[samples[0].clone(), samples[0].clone(), samples[1].clone()],
+        None,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "duplicate result paths must fail closed"
+    );
+
+    // Distinct paths, identical content.
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+    let clone_path = dir.path().join("clone.json");
+    fs::copy(&samples[0], &clone_path).expect("clone sample");
+    let output = run_summarizer(&[samples[0].clone(), clone_path, samples[1].clone()], None);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "identical content digests must fail closed"
+    );
+
+    // Symlink input.
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+    let link = dir.path().join("linked.json");
+    std::os::unix::fs::symlink(&samples[2], &link).expect("symlink sample");
+    let output = run_summarizer(&[samples[0].clone(), samples[1].clone(), link], None);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "symlink inputs must fail closed"
+    );
+
+    // Missing input.
+    let dir = tempfile::tempdir().expect("case tempdir");
+    let samples = write_valid_summary_samples(dir.path());
+    let output = run_summarizer(
+        &[
+            samples[0].clone(),
+            samples[1].clone(),
+            dir.path().join("missing.json"),
+        ],
+        None,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing inputs must fail closed"
+    );
+}
+
+/// End-to-end compatibility: three real fake-tools harness acquisitions
+/// (primed, one shared private GOCACHE) must summarize successfully. This
+//  proves the summarizer accepts the current harness result shape, not only
+//  synthetic fixtures.
+#[test]
+fn pr_loop_scale_summary_accepts_real_harness_output_shape() {
+    if !harness_tools_available() || !tool_on_path("python3") {
+        eprintln!("skipping: harness or Python tools unavailable");
+        return;
+    }
+    let tools = install_fake_scale_tools();
+    let gocache = tempfile::tempdir().expect("gocache tempdir");
+    let cache_path = gocache.path().to_str().expect("gocache path").to_string();
+
+    let mut results = Vec::new();
+    let mut sample_dirs = Vec::new();
+    for sample in 1..=3 {
+        let out_dir = tempfile::tempdir().expect("sample output tempdir");
+        let output = run_scale_harness(
+            &tools,
+            out_dir.path(),
+            Some(&scale_manifest_path()),
+            &[
+                ("BENCH_GO_BUILD_CACHE_STATE", "primed"),
+                ("GOCACHE", cache_path.as_str()),
+                ("FAKE_GO_ENV_GOCACHE", cache_path.as_str()),
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "harness sample {sample} must succeed\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        // Guarantee distinct content digests with a minimal timing tweak.
+        let result_path = out_dir.path().join("pr-loop-benchmark-result.json");
+        let mut result = read_result(out_dir.path());
+        result["workloads"][0]["timing"]["wall_ms"] = serde_json::json!(100 + sample);
+        let kept = result_path.clone();
+        fs::write(&kept, serde_json::to_string_pretty(&result).unwrap()).expect("rewrite sample");
+        results.push(kept);
+        sample_dirs.push(out_dir); // retained so the samples live until drop
+    }
+
+    let output = run_summarizer(&results, None);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "summarizer must accept three real harness results\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("summary is valid JSON");
+    assert_eq!(summary["kind"], "togi_pr_loop_scale_summary");
+    assert_eq!(summary["schema_version"], 1);
+    assert_eq!(summary["sample_count"], 3);
+    assert_eq!(
+        summary["identity"]["corpus"]["mutation_identity_sha256"]
+            .as_str()
+            .expect("digest")
+            .len(),
+        64
+    );
+    assert_eq!(
+        summary["identity"]["measurement"]["go_build_cache_path"],
+        cache_path.as_str()
+    );
+    let ratio_keys: Vec<&str> = summary["ratios"]
+        .as_object()
+        .expect("ratios")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        ratio_keys,
+        [
+            "regular_jobs4_over_jobs1",
+            "schemata_jobs4_over_schemata_jobs1",
+            "schemata_over_regular_jobs1",
+            "warm_over_cold"
+        ]
+    );
+    for workload in summary["workloads"].as_array().expect("workloads") {
+        assert!(workload["median_wall_ms"].as_u64().expect("median") > 0);
+    }
+    drop(sample_dirs);
+}

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -2344,6 +2344,70 @@ fn build_calibration_artifact(tools: &FakeTools, artifact: &Path, gocache: &Path
     results
 }
 
+/// Acquires a fresh calibration artifact and promotes it, retrying the
+/// ENTIRE acquisition at most three times only when the promoter rejects
+/// exactly one fake-wall outlier diagnostic under test-host load. Any other
+/// failure — or exhausted retries — panics. Each attempt uses distinct paths.
+/// Returns (artifact dir, baseline path).
+fn acquire_and_promote_calibration(
+    tools: &FakeTools,
+    workspace: &Path,
+    gocache: &Path,
+    commit: &str,
+) -> (PathBuf, PathBuf) {
+    for attempt in 1..=3 {
+        let artifact = workspace.join(format!("artifact-attempt-{attempt}"));
+        fs::create_dir(&artifact).unwrap();
+        build_calibration_artifact(tools, &artifact, gocache);
+        let baseline = workspace.join(format!("baseline-attempt-{attempt}.json"));
+        let promoted = run_promoter(&artifact, &baseline, commit, &[]);
+        if promoted.status.success() {
+            return (artifact, baseline);
+        }
+        let stderr = String::from_utf8_lossy(&promoted.stderr);
+        assert!(
+            is_retryable_calibration_wall_outlier(&stderr),
+            "calibration promotion failed for a non-flake reason\nstderr: {stderr}"
+        );
+    }
+    panic!("calibration acquisition hit the above-3x-median flake three times in a row");
+}
+
+fn is_retryable_calibration_wall_outlier(stderr: &str) -> bool {
+    const PREFIX: &str = "baseline promotion failed: workload ";
+    const SUFFIX: &str = " has a wall sample above 3x its median";
+
+    stderr
+        .trim()
+        .strip_prefix(PREFIX)
+        .and_then(|diagnostic| diagnostic.strip_suffix(SUFFIX))
+        .is_some_and(|workload| !workload.trim().is_empty() && !workload.contains(['\n', '\r']))
+}
+
+#[test]
+fn calibration_wall_outlier_retry_predicate_is_exact() {
+    let diagnostic =
+        "baseline promotion failed: workload package/example has a wall sample above 3x its median";
+
+    assert!(is_retryable_calibration_wall_outlier(diagnostic));
+    assert!(is_retryable_calibration_wall_outlier(&format!(
+        "\n  {diagnostic}\t"
+    )));
+
+    for nonretryable in [
+        "baseline promotion failed: workload  has a wall sample above 3x its median",
+        "baseline promotion failed: workload package/example has a reported-duration sample above 3x its median",
+        "baseline promotion failed: workload package/example has a wall sample above 3x its median; retrying",
+        "baseline promotion failed: workload package/example\nhas a wall sample above 3x its median",
+        "another failure above 3x its median",
+    ] {
+        assert!(
+            !is_retryable_calibration_wall_outlier(nonretryable),
+            "unexpectedly retryable: {nonretryable:?}"
+        );
+    }
+}
+
 fn read_json(path: &Path) -> serde_json::Value {
     serde_json::from_str(&fs::read_to_string(path).expect("read JSON")).expect("valid JSON")
 }
@@ -2357,17 +2421,8 @@ fn pr_loop_promote_baseline_happy_path_is_deterministic_and_never_overwrites() {
     let tools = install_fake_tools();
     let gocache = tempfile::tempdir().expect("gocache tempdir");
     let workspace = tempfile::tempdir().expect("workspace");
-    let artifact = workspace.path().join("artifact");
-    fs::create_dir(&artifact).unwrap();
-    build_calibration_artifact(&tools, &artifact, gocache.path());
-
-    let baseline = workspace.path().join("baseline.json");
-    let promoted = run_promoter(&artifact, &baseline, "test-commit", &[]);
-    assert!(
-        promoted.status.success(),
-        "promotion must succeed\nstderr: {}",
-        String::from_utf8_lossy(&promoted.stderr)
-    );
+    let (artifact, baseline) =
+        acquire_and_promote_calibration(&tools, workspace.path(), gocache.path(), "test-commit");
     let value = read_json(&baseline);
     assert_eq!(value["kind"], "togi_pr_loop_baseline");
     assert_eq!(value["schema_version"], 1);
@@ -2511,9 +2566,8 @@ fn pr_loop_promote_baseline_fails_closed_on_artifact_tampering() {
     let tools = install_fake_tools();
     let gocache = tempfile::tempdir().expect("gocache tempdir");
     let workspace = tempfile::tempdir().expect("workspace");
-    let artifact = workspace.path().join("artifact");
-    fs::create_dir(&artifact).unwrap();
-    build_calibration_artifact(&tools, &artifact, gocache.path());
+    let (artifact, _pristine_baseline) =
+        acquire_and_promote_calibration(&tools, workspace.path(), gocache.path(), "test-commit");
     let candidate = artifact.join("pr-loop-calibration-candidate.json");
     let sample5 = artifact.join("sample-5/pr-loop-benchmark-result.json");
 
@@ -2916,16 +2970,8 @@ fn build_gate_fixture() -> (FakeTools, GateFixture) {
     let tools = install_fake_tools();
     let gocache = tempfile::tempdir().expect("gocache tempdir");
     let workspace = tempfile::tempdir().expect("workspace");
-    let artifact = workspace.path().join("artifact");
-    fs::create_dir(&artifact).unwrap();
-    build_calibration_artifact(&tools, &artifact, gocache.path());
-    let baseline = workspace.path().join("baseline.json");
-    let promoted = run_promoter(&artifact, &baseline, "test-commit", &[]);
-    assert!(
-        promoted.status.success(),
-        "gate fixture promotion failed\nstderr: {}",
-        String::from_utf8_lossy(&promoted.stderr)
-    );
+    let (_artifact, baseline) =
+        acquire_and_promote_calibration(&tools, workspace.path(), gocache.path(), "test-commit");
     let samples_dir = workspace.path().join("gate-samples");
     fs::create_dir(&samples_dir).unwrap();
     let results = run_gate_samples(&tools, &samples_dir, gocache.path(), 3);


### PR DESCRIPTION
PR 2 of #498: observational scale-evidence summarizer + README. Telemetry only — no baseline, threshold, tolerance, gate, or per-mutant attribution logic is added.

## Scope

- `benchmarks/pr-loop-scale/summarize-scale.py`: stdlib-only, parse-only summary of exactly three successful primed schema-v3 scale results from one acquisition. It emits kind `togi_pr_loop_scale_summary`, schema 1, with raw and median timings, signed wall-minus-reported diagnostics, and exact paired-ratio median fractions; `--output` writes the same bytes as stdout and never overwrites an existing target.
- `tests/integration/benchmarks.rs`: four summarizer integration tests, including a 68-case fail-closed mutation table and real-harness compatibility coverage. There are now 60 integration tests total, including the four summarizer tests and one calibration-retry predicate test.
- Bounded test-only calibration fixture retry: at most three complete acquisitions, retried only for the exact trimmed promoter wall-outlier diagnostic. The promoter's 3x rule and its negative-outlier tests are untouched.
- README subsection “PR-loop scaling evidence (observational)” documents the local primed three-sample reproduction and summary command. COMPATIBILITY.md remains deferred to PR 3 with the telemetry workflow.

## Frozen-corpus guarantees

- No changes to `benchmarks/pr-loop/` assets, `tests/fixtures/go/`, workflows, CODEOWNERS, rulesets, or the comparator; the v2 corpus remains bit-identical.
- No performance claims; the summary compares nothing and gates nothing.

## Validation

- `cargo fmt` completed successfully.
- `cargo test --locked`: 860 passed across 7 suites; 11 ignored.
- Focused promoter, comparator, and scale-summary integration filters pass; the calibration retry predicate test passes.

Follow-up per #498: PR 3 adds the telemetry workflow, CODEOWNERS, and the COMPATIBILITY.md bullet.