### PR TITLE
ci: collect PR-loop scale evidence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 # self-authorize by rewriting the baseline, corpus, comparator, or gate.
 # Changes to any of these paths require @Darkroom4364 review.
 /benchmarks/pr-loop/ @Darkroom4364
+/benchmarks/pr-loop-scale/ @Darkroom4364
 /.github/workflows/pr-loop-regression-gate.yml @Darkroom4364
 /.github/workflows/pr-loop-calibration.yml @Darkroom4364
+/.github/workflows/pr-loop-scale-evidence.yml @Darkroom4364
 /.github/CODEOWNERS @Darkroom4364

--- a/.github/workflows/pr-loop-scale-evidence.yml
+++ b/.github/workflows/pr-loop-scale-evidence.yml
@@ -1,0 +1,103 @@
+name: PR-loop Scale Evidence
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  acquire:
+    if: github.ref == 'refs/heads/main'
+    name: Acquire PR-loop scale evidence
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - name: Assert native Linux x86_64 runner
+        shell: bash
+        env:
+          TOGI_EXPECTED_TARGET: x86_64-unknown-linux-gnu
+          TOGI_EXPECTED_ARCH: x86_64
+        run: bash ./.github/scripts/assert-native-target.sh
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.5'
+      - name: Create job-private Go build cache
+        shell: bash
+        env:
+          BENCH_GOCACHE: ${{ runner.temp }}/togi-pr-loop-scale-gocache
+        run: |
+          set -euo pipefail
+          if [ -e "$BENCH_GOCACHE" ] && [ -n "$(ls -A "$BENCH_GOCACHE" 2>/dev/null)" ]; then
+            echo "job-private Go build cache $BENCH_GOCACHE must start empty" >&2
+            exit 1
+          fi
+          mkdir -p "$BENCH_GOCACHE"
+          test -d "$BENCH_GOCACHE"
+          test -z "$(ls -A "$BENCH_GOCACHE")"
+      - name: Check benchmark prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          for tool in bash git go jq sed sha256sum python3; do
+            command -v "$tool" >/dev/null 2>&1 || {
+              echo "missing scale benchmark prerequisite: $tool" >&2
+              exit 1
+            }
+          done
+      - name: Build release binary
+        run: cargo build --locked --release
+      - name: Warm Go build cache
+        shell: bash
+        env:
+          TOGI_BIN: ${{ github.workspace }}/target/release/togi
+          BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
+          BENCH_GO_BUILD_CACHE_STATE: warmup
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-scale-gocache
+          SCALE_OUTPUT: ${{ runner.temp }}/togi-pr-loop-scale/warmup
+        run: bash benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh --output "$SCALE_OUTPUT"
+      - name: Acquire three independent samples
+        shell: bash
+        env:
+          TOGI_BIN: ${{ github.workspace }}/target/release/togi
+          BENCH_RUNNER_LABEL: github-actions-ubuntu-24.04-linux-x86_64
+          BENCH_GO_BUILD_CACHE_STATE: primed
+          GOCACHE: ${{ runner.temp }}/togi-pr-loop-scale-gocache
+          SCALE_OUTPUT: ${{ runner.temp }}/togi-pr-loop-scale
+        run: |
+          set -euo pipefail
+          mkdir -p "$SCALE_OUTPUT"
+          for sample in 1 2 3; do
+            bash benchmarks/pr-loop-scale/run-pr-loop-scale-benchmarks.sh --output "$SCALE_OUTPUT/sample-$sample"
+          done
+      - name: Summarize scale evidence
+        shell: bash
+        env:
+          SCALE_OUTPUT: ${{ runner.temp }}/togi-pr-loop-scale
+        run: |
+          set -euo pipefail
+          python3 benchmarks/pr-loop-scale/summarize-scale.py \
+            --output "$SCALE_OUTPUT/scale-summary.json" \
+            "$SCALE_OUTPUT/sample-1/pr-loop-benchmark-result.json" \
+            "$SCALE_OUTPUT/sample-2/pr-loop-benchmark-result.json" \
+            "$SCALE_OUTPUT/sample-3/pr-loop-benchmark-result.json"
+      - name: Upload scale evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pr-loop-scale-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/togi-pr-loop-scale
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -70,6 +70,13 @@ to force the regular runner for all mutations.
   invocation binds one job-private `GOCACHE` (created empty, warmed before
   measurement) so cache provenance is explicit. This job is telemetry only:
   it compares nothing and gates nothing.
+- **PR-loop Scale Evidence**
+  ([`pr-loop-scale-evidence.yml`](../.github/workflows/pr-loop-scale-evidence.yml),
+  Linux x86_64 only on the `ubuntu-24.04` runner class with the same
+  fail-closed native target/arch assertion): Go 1.26.5 uses a job-private cache
+  created empty, warmed once, then acquires three primed schema-v3 scale-harness
+  samples and uploads their complete output plus `scale-summary.json` as an
+  artifact. This evidence compares nothing and gates nothing.
 - **PR-loop Regression Gate**
   ([`pr-loop-regression-gate.yml`](../.github/workflows/pr-loop-regression-gate.yml),
   Linux x86_64 only on `ubuntu-24.04` with the same fail-closed native


### PR DESCRIPTION
- Adds a telemetry-only Linux x86_64 `ubuntu-24.04` workflow for push to `main`, weekly, and manual runs: Go 1.26.5, a job-private cache warmup, three primed v3 samples, and a schema-1 summary artifact.
- Protects the scale corpus and new workflow in CODEOWNERS and documents its runner-class and non-gate status.
- No `pull_request` trigger/status context, comparator/baseline/tolerance/gate/ruleset change; all gated v2 corpus/harness/workflows/fixtures remain untouched.

Local proof: pinned-actions check, YAML parse, 860 stable + MSRV tests, fmt/clippy, and a release-build fresh-private-GOCACHE warmup/three-sample/summarize smoke all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to build the release binary, collect scale benchmark samples, generate a summary, and upload evidence artifacts.
  * Added scheduled and manual options for running scale evidence collection.
  * Added validation for the required Linux x86_64 environment and development tools.

* **Documentation**
  * Updated compatibility documentation with the scale evidence workflow, sampling details, and informational status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->