### PR TITLE
chore(deps): bump actions/upload-artifact to v7.0.1 (#493)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           done
       - name: Upload PR-loop benchmark evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-loop-benchmarks-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/togi-pr-loop-benchmarks

--- a/.github/workflows/pr-loop-calibration.yml
+++ b/.github/workflows/pr-loop-calibration.yml
@@ -96,7 +96,7 @@ jobs:
             "$CALIBRATION_OUTPUT/sample-5/pr-loop-benchmark-result.json"
       - name: Upload calibration evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-loop-calibration-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/togi-pr-loop-calibration

--- a/.github/workflows/pr-loop-regression-gate.yml
+++ b/.github/workflows/pr-loop-regression-gate.yml
@@ -126,7 +126,7 @@ jobs:
             "$GATE_OUTPUT/sample-3/pr-loop-benchmark-result.json"
       - name: Upload regression gate evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-loop-regression-gate-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/togi-pr-loop-gate

--- a/.github/workflows/pr-loop-scale-evidence.yml
+++ b/.github/workflows/pr-loop-scale-evidence.yml
@@ -95,7 +95,7 @@ jobs:
             "$SCALE_OUTPUT/sample-3/pr-loop-benchmark-result.json"
       - name: Upload scale evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-loop-scale-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/togi-pr-loop-scale

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: Compress-Archive -Path target/${{ matrix.target }}/release/togi.exe -DestinationPath ${{ matrix.name }}.zip
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.name }}
           path: |

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
 
     - name: Upload replayable report
       if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.report-artifact-name }}
         path: ${{ runner.temp }}/togi-report.json

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3815,7 +3815,7 @@ fn github_action_declares_replay_report_contract() {
         "TOGI_REPORT_PATH: ${{ runner.temp }}/togi-report.json",
         "report-artifact-name:",
         "if: ${{ always() && inputs.upload-report == 'true' && steps.run-togi.outputs.report-path != '' }}",
-        "uses: actions/upload-artifact@v7",
+        "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7",
         "name: ${{ inputs.report-artifact-name }}",
         "path: ${{ runner.temp }}/togi-report.json",
         "retention-days: ${{ inputs.report-retention-days }}",
@@ -3824,6 +3824,41 @@ fn github_action_declares_replay_report_contract() {
         assert!(
             action_yml.contains(expected),
             "action.yml is missing `{expected}`"
+        );
+    }
+}
+
+#[test]
+fn production_upload_artifact_pins_are_immutable() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let expected = "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7";
+
+    for path in [
+        "action.yml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/pr-loop-calibration.yml",
+        ".github/workflows/pr-loop-regression-gate.yml",
+        ".github/workflows/pr-loop-scale-evidence.yml",
+        ".github/workflows/release.yml",
+    ] {
+        let source = fs::read_to_string(root.join(path))
+            .unwrap()
+            .replace("\r\n", "\n");
+        let mut pins = source
+            .lines()
+            .map(str::trim)
+            .map(|line| line.strip_prefix("- ").unwrap_or(line))
+            .filter(|line| line.starts_with("uses: actions/upload-artifact@"));
+
+        assert_eq!(
+            pins.next(),
+            Some(expected),
+            "{path} must use the immutable upload-artifact v7 pin"
+        );
+        assert_eq!(
+            pins.next(),
+            None,
+            "{path} must declare exactly one upload-artifact use"
         );
     }
 }
@@ -4692,7 +4727,7 @@ fn pr_loop_benchmark_workflow_collects_observational_evidence() {
         .iter()
         .find(|step| {
             step.get("uses").and_then(|value| value.as_str())
-                == Some("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")
+                == Some("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
         })
         .expect("benchmark job must upload evidence with a pinned action");
     assert_eq!(

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -1571,7 +1571,7 @@ fn ci_pr_loop_benchmark_contract_is_structural() {
     );
     assert_eq!(
         upload.get("uses").and_then(|value| value.as_str()),
-        Some("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")
+        Some("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
     );
     for (key, expected) in [
         ("path", "${{ runner.temp }}/togi-pr-loop-benchmarks"),
@@ -4374,7 +4374,7 @@ fn pr_loop_regression_gate_workflow_is_fail_closed_and_comparator_driven() {
     assert_eq!(upload["if"].as_str(), Some("${{ always() }}"));
     assert_eq!(
         upload["uses"].as_str(),
-        Some("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")
+        Some("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a")
     );
     assert_eq!(
         upload["with"]["name"].as_str(),


### PR DESCRIPTION
Supersedes stale Dependabot #493.

Pins all six current actions/upload-artifact callsites to the v7.0.1 immutable SHA and updates matching contract assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact uploads across automated workflows to use a consistent, securely pinned action version.
  * Applied the same artifact-upload version updates to release and replayable report processes.
* **Tests**
  * Updated workflow validation tests to reflect the standardized artifact-upload configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->