### PR TITLE
fix(check): classify configured build failures before tests (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ togi check --operators=binary,removal
 # Stop on first test failure per mutation
 togi check --fail-fast
 
-# Use a build check before running tests
+# Run an explicitly configured build check before tests
 togi check --build-cmd "cargo check"
 
 # Only mutate lines covered by an LCOV file
@@ -523,7 +523,9 @@ calibrate_timeout = false
 timeout_multiplier = 4.0
 timeout_slack = 2
 jobs = 2
-build_command = ["go", "build", "./..."]
+# Optional: opt in to a build check before each mutation's tests.
+# Use "NUL" instead of "/dev/null" on Windows.
+build_command = ["go", "test", "-c", "-vet=off", "-o", "/dev/null", "./..."]
 sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--"]
 
 [test.languages.python]
@@ -566,6 +568,18 @@ include runner-specific fail-fast flags in `--test-cmd` instead.
 Resource profiles provide defaults only: explicit CLI flags and `togi.toml`
 settings such as `jobs` keep taking precedence.
 
+A nonempty `[test] build_command` or `--build-cmd` opts in to a build check
+before each mutant's test command. A failed configured build is reported as a
+build error and does not count as a test kill.
+
+`togi init` suggests a safe `build_command` when it detects exactly one root
+build system, but detection alone never runs a build before tests. Uncomment
+or copy that suggestion to opt in.
+
+For Go, the suggested compile-only command is `go test -c -vet=off -o <host
+null device> ./...`: `/dev/null` on Unix and `NUL` on Windows. It compiles
+test code without running package initialization, `TestMain`, or `go vet`.
+
 `[test] sandbox_command` is an optional wrapper that runs every build and test
 command inside your own sandbox tool. togi appends the selected command after
 the wrapper argv, so tools that expect `--` as a separator can use it directly.
@@ -573,7 +587,7 @@ the wrapper argv, so tools that expect `--` as a separator can use it directly.
 `--calibrate-timeout` (or `[test] calibrate_timeout = true`) runs the
 unmutated build/test command once in a disposable workspace, then sets the
 default mutation timeout to `max(build_time, test_time) * timeout_multiplier +
-timeout_slack`. When `build_command` is not set, only `test_time` is used.
+timeout_slack`. When no build check is available, only `test_time` is used.
 Explicit `--timeout` wins. Use `--skip-baseline-timing` in CI jobs that already
 provide a tuned timeout or should avoid repeating the baseline run across
 shards.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::ValueEnum;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -45,7 +45,8 @@ pub struct LanguageTestConfig {
 }
 
 /// Where the effective build command came from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BuildCommandOrigin {
     /// No build command is available for this run.
     None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,11 +44,56 @@ pub struct LanguageTestConfig {
     pub timeout: Option<u64>,
 }
 
+/// Where the effective build command came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildCommandOrigin {
+    /// No build command is available for this run.
+    None,
+    /// A safe command suggested from project markers; it is not executed until
+    /// the user configures it.
+    AutoDetected,
+    /// The user supplied a nonempty command through config or the CLI.
+    Configured,
+}
+
+/// Known Unix null device used by the automatic Go compile check.
+pub(crate) const AUTO_GO_COMPILE_UNIX_OUTPUT: &str = "/dev/null";
+/// Known Windows null device used by the automatic Go compile check.
+pub(crate) const AUTO_GO_COMPILE_WINDOWS_OUTPUT: &str = "NUL";
+/// Null device used to discard automatically compiled Go test binaries.
+#[cfg(windows)]
+pub(crate) const AUTO_GO_COMPILE_OUTPUT: &str = AUTO_GO_COMPILE_WINDOWS_OUTPUT;
+/// Null device used to discard automatically compiled Go test binaries.
+#[cfg(not(windows))]
+pub(crate) const AUTO_GO_COMPILE_OUTPUT: &str = AUTO_GO_COMPILE_UNIX_OUTPUT;
+
+/// Compile Go packages and tests without running test code or `go vet`.
+pub(crate) const AUTO_GO_COMPILE_COMMAND: [&str; 7] = [
+    "go",
+    "test",
+    "-c",
+    "-vet=off",
+    "-o",
+    AUTO_GO_COMPILE_OUTPUT,
+    "./...",
+];
+
+impl BuildCommandOrigin {
+    /// Whether this command should run before each test command.
+    ///
+    /// Auto-detection is only a `togi init` suggestion, never an implicit
+    /// mutation pre-filter.
+    pub const fn runs_before_tests(self) -> bool {
+        matches!(self, Self::Configured)
+    }
+}
+
 #[derive(Debug)]
 pub struct TestConfig {
     pub profile: Option<ResourceProfile>,
     pub command: Vec<String>,
     pub build_command: Vec<String>,
+    pub build_command_origin: BuildCommandOrigin,
     pub sandbox_command: Vec<String>,
     pub timeout: u64,
     pub calibrate_timeout: bool,
@@ -90,10 +135,16 @@ impl<'de> Deserialize<'de> for TestConfig {
         D: serde::Deserializer<'de>,
     {
         let raw = RawTestConfig::deserialize(deserializer)?;
+        let build_command_origin = if raw.build_command.is_empty() {
+            BuildCommandOrigin::None
+        } else {
+            BuildCommandOrigin::Configured
+        };
         Ok(Self {
             profile: raw.profile,
             command: raw.command,
             build_command: raw.build_command,
+            build_command_origin,
             sandbox_command: raw.sandbox_command,
             timeout: raw.timeout.unwrap_or_else(default_timeout),
             calibrate_timeout: raw.calibrate_timeout.unwrap_or(false),
@@ -190,17 +241,66 @@ fn default_test_command() -> Vec<String> {
     vec![]
 }
 
-/// Auto-detect the test command based on project files in the given root.
-fn has_file_with_ext(dir: &Path, ext: &str) -> bool {
-    dir.read_dir()
-        .map(|entries| {
-            entries.filter_map(Result::ok).any(|e| {
-                e.path()
-                    .extension()
-                    .is_some_and(|e| e.eq_ignore_ascii_case(ext))
-            })
-        })
-        .unwrap_or(false)
+/// Regular top-level .NET project or solution candidates.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+enum DotnetCandidates {
+    #[default]
+    None,
+    Single(String),
+    Ambiguous,
+}
+
+impl DotnetCandidates {
+    fn scan(dir: &Path) -> Self {
+        let Ok(entries) = dir.read_dir() else {
+            return Self::None;
+        };
+        let mut candidates = Vec::new();
+        for entry in entries {
+            let Ok(entry) = entry else {
+                return Self::Ambiguous;
+            };
+            let path = entry.path();
+            let is_dotnet_candidate = path.extension().is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("sln") || extension.eq_ignore_ascii_case("csproj")
+            });
+            if !is_dotnet_candidate {
+                continue;
+            }
+            let Ok(file_type) = entry.file_type() else {
+                return Self::Ambiguous;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Self::Ambiguous;
+            };
+            candidates.push(file_name.to_owned());
+        }
+        candidates.sort_unstable();
+        match candidates.len() {
+            0 => Self::None,
+            1 => candidates.pop().map_or(Self::None, Self::Single),
+            _ => Self::Ambiguous,
+        }
+    }
+
+    fn single(&self) -> Option<&str> {
+        match self {
+            Self::Single(candidate) => Some(candidate),
+            Self::None | Self::Ambiguous => None,
+        }
+    }
+
+    const fn is_ambiguous(&self) -> bool {
+        matches!(self, Self::Ambiguous)
+    }
+
+    fn test_command_ambiguity_marker(&self) -> Option<&'static str> {
+        self.is_ambiguous().then_some(".sln/.csproj")
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,11 +356,11 @@ struct ProjectInspection {
     python_manifest: Option<&'static str>,
     javascript_runner: Option<JavaScriptRunner>,
     has_pom_xml: bool,
-    has_gradle: bool,
     gradle_manifest: Option<&'static str>,
     has_gemfile: bool,
+    has_makefile: bool,
     has_cmake: bool,
-    has_dotnet_project: bool,
+    dotnet_candidates: DotnetCandidates,
     has_tsconfig: bool,
 }
 
@@ -294,12 +394,13 @@ impl ProjectInspection {
             python_manifest,
             javascript_runner: JavaScriptRunner::detect(project_root),
             has_pom_xml: project_root.join("pom.xml").exists(),
-            has_gradle: gradle_manifest.is_some(),
             gradle_manifest,
             has_gemfile: project_root.join("Gemfile").exists(),
+            has_makefile: ["Makefile", "makefile", "GNUmakefile"]
+                .iter()
+                .any(|name| project_root.join(name).exists()),
             has_cmake: project_root.join("CMakeLists.txt").exists(),
-            has_dotnet_project: has_file_with_ext(project_root, "sln")
-                || has_file_with_ext(project_root, "csproj"),
+            dotnet_candidates: DotnetCandidates::scan(project_root),
             has_tsconfig: project_root.join("tsconfig.json").exists(),
         }
     }
@@ -362,35 +463,50 @@ impl ProjectInspection {
                 languages: &["c", "cpp"],
             });
         }
-        if self.has_dotnet_project {
+        if let Some(candidate) = self.dotnet_candidates.single() {
             detected.push(DetectedTestRoute {
                 marker: ".sln/.csproj",
-                command: vec!["dotnet".into(), "test".into()],
+                command: vec!["dotnet".into(), "test".into(), candidate.into()],
                 languages: &["c_sharp"],
             });
         }
         detected
     }
 
+    /// Return a build command only when exactly one safe root build system exists.
     fn detect_build_command(&self) -> Vec<String> {
+        // Build detection must honor every root signal that can select a test
+        // command or imply a `make test` fallback. A standalone tsconfig still
+        // prevents inferring another toolchain in a mixed root, even though
+        // TypeScript has no package-manager-agnostic automatic build command.
+        let root_signals = self.detected_test_routes().len()
+            + usize::from(self.has_tsconfig && self.javascript_runner.is_none())
+            + usize::from(self.has_makefile)
+            + usize::from(self.dotnet_candidates.is_ambiguous());
+        if root_signals != 1 {
+            return vec![];
+        }
+
         if self.has_cargo_toml {
             return vec!["cargo".into(), "check".into()];
         }
         if self.has_go_mod {
-            return vec!["go".into(), "build".into(), "./...".into()];
-        }
-        if self.has_tsconfig {
-            return vec!["npx".into(), "tsc".into(), "--noEmit".into()];
+            return AUTO_GO_COMPILE_COMMAND
+                .iter()
+                .map(|argument| (*argument).into())
+                .collect();
         }
         if self.has_pom_xml {
             return vec!["mvn".into(), "compile".into(), "-q".into()];
         }
-        if self.has_gradle {
-            return vec!["./gradlew".into(), "compileJava".into()];
+        if let Some(candidate) = self.dotnet_candidates.single() {
+            // Isolated workspaces intentionally omit ignored obj/ assets.
+            // Restore must therefore remain enabled for automatic checks.
+            return vec!["dotnet".into(), "build".into(), candidate.into()];
         }
-        if self.has_dotnet_project {
-            return vec!["dotnet".into(), "build".into(), "--no-restore".into()];
-        }
+
+        // Gradle and CMake are root signals, but neither has a portable,
+        // manifest-only compile command. Users can still configure one.
         vec![]
     }
 
@@ -569,6 +685,15 @@ impl TestConfig {
         }
     }
 
+    pub fn set_build_command(&mut self, build_command: Vec<String>) {
+        self.build_command_origin = if build_command.is_empty() {
+            BuildCommandOrigin::None
+        } else {
+            BuildCommandOrigin::Configured
+        };
+        self.build_command = build_command;
+    }
+
     pub fn jobs_was_explicit(&self) -> bool {
         self.jobs_explicit
     }
@@ -580,6 +705,7 @@ impl Default for TestConfig {
             profile: None,
             command: default_test_command(),
             build_command: vec![],
+            build_command_origin: BuildCommandOrigin::None,
             sandbox_command: vec![],
             timeout: default_timeout(),
             calibrate_timeout: false,
@@ -746,11 +872,15 @@ impl Config {
             return TestCommandResolution::Resolved;
         }
 
-        let detected = ProjectInspection::scan(project_root).detected_test_routes();
-        if detected.len() > 1 {
-            return TestCommandResolution::Ambiguous(AmbiguousTestCommand {
-                candidates: detected.iter().map(|route| route.marker).collect(),
-            });
+        let inspection = ProjectInspection::scan(project_root);
+        let detected = inspection.detected_test_routes();
+        let ambiguity_marker = inspection.dotnet_candidates.test_command_ambiguity_marker();
+        if detected.len() > 1 || ambiguity_marker.is_some() {
+            let mut candidates: Vec<_> = detected.iter().map(|route| route.marker).collect();
+            if let Some(marker) = ambiguity_marker {
+                candidates.push(marker);
+            }
+            return TestCommandResolution::Ambiguous(AmbiguousTestCommand { candidates });
         }
 
         self.test.command = if let Some(route) = detected.into_iter().next() {
@@ -765,10 +895,24 @@ impl Config {
         TestCommandResolution::Resolved
     }
 
-    /// If no build command was explicitly set in togi.toml, auto-detect from project files.
-    pub fn resolve_build_command(&mut self, project_root: &Path) {
-        if self.test.build_command.is_empty() {
-            self.test.build_command = detect_build_command(project_root);
+    /// Resolve an effective build command without selecting an arbitrary
+    /// pre-filter for ambiguous roots.
+    pub fn resolve_build_command(&mut self, project_root: &Path) -> BuildCommandOrigin {
+        if !matches!(self.test.build_command_origin, BuildCommandOrigin::None) {
+            return self.test.build_command_origin;
+        }
+        if !self.test.build_command.is_empty() {
+            self.test.build_command_origin = BuildCommandOrigin::Configured;
+            return self.test.build_command_origin;
+        }
+
+        let build_command = detect_build_command(project_root);
+        if build_command.is_empty() {
+            BuildCommandOrigin::None
+        } else {
+            self.test.build_command = build_command;
+            self.test.build_command_origin = BuildCommandOrigin::AutoDetected;
+            self.test.build_command_origin
         }
     }
 
@@ -780,6 +924,11 @@ impl Config {
             .unwrap_or(Path::new("."));
         let inspection = ProjectInspection::scan(project_root);
         let routes = inspection.detected_test_routes();
+        if let Some(marker) = inspection.dotnet_candidates.test_command_ambiguity_marker() {
+            let mut candidates: Vec<_> = routes.iter().map(|route| route.marker).collect();
+            candidates.push(marker);
+            return Err(AmbiguousTestCommand { candidates }.error());
+        }
         validate_init_language_routes(&routes)?;
         let test_cmd = select_primary_test_command(&routes);
         let build_cmd = inspection.detect_build_command();
@@ -799,7 +948,7 @@ impl Config {
             let build_cmd_toml: Vec<String> =
                 build_cmd.iter().map(|s| format!("\"{}\"", s)).collect();
             template.push_str(&format!(
-                "# build_command = [{}]  # uncomment to pre-filter mutations that don't compile\n",
+                "# build_command = [{}]  # optional compile check before each mutation's tests\n",
                 build_cmd_toml.join(", ")
             ));
         }
@@ -1259,7 +1408,7 @@ sandbox_command = ["bwrap", "--ro-bind", "/", "/", "--"]
             ("ruby", vec!["bundle", "exec", "rspec"]),
             ("c", vec!["ctest"]),
             ("cpp", vec!["ctest"]),
-            ("c_sharp", vec!["dotnet", "test"]),
+            ("c_sharp", vec!["dotnet", "test", "example.csproj"]),
         ] {
             let expected: Vec<String> = expected.into_iter().map(str::to_owned).collect();
             assert_eq!(
@@ -1434,17 +1583,13 @@ fail_on_uncovered_diff = true
     }
 
     #[test]
-    fn has_file_with_ext_returns_false_when_no_match() {
+    fn dotnet_candidates_ignore_nonmatching_or_missing_roots() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("foo.txt"), "").unwrap();
-        assert!(!has_file_with_ext(dir.path(), "rs"));
-    }
+        assert_eq!(DotnetCandidates::scan(dir.path()), DotnetCandidates::None);
 
-    #[test]
-    fn has_file_with_ext_returns_false_for_nonexistent_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let bad = dir.path().join("nonexistent");
-        assert!(!has_file_with_ext(&bad, "rs"));
+        let missing = dir.path().join("nonexistent");
+        assert_eq!(DotnetCandidates::scan(&missing), DotnetCandidates::None);
     }
 
     #[test]
@@ -1471,6 +1616,257 @@ fail_on_uncovered_diff = true
         assert_eq!(
             ambiguity.error().to_string(),
             "multiple test runtimes detected (setup.cfg, build.gradle.kts); set [test] command in togi.toml or pass --test-cmd <command>"
+        );
+    }
+
+    #[test]
+    fn ambiguous_dotnet_candidates_block_cargo_test_autodetection() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        std::fs::write(dir.path().join("First.csproj"), "").unwrap();
+        std::fs::write(dir.path().join("Second.csproj"), "").unwrap();
+
+        let mut automatic = Config::default();
+        let TestCommandResolution::Ambiguous(ambiguity) =
+            automatic.resolve_test_command(dir.path())
+        else {
+            panic!("ambiguous .NET candidates must block automatic Cargo selection");
+        };
+        assert!(automatic.test.command.is_empty());
+        assert_eq!(
+            ambiguity.error().to_string(),
+            "multiple test runtimes detected (Cargo.toml, .sln/.csproj); set [test] command in togi.toml or pass --test-cmd <command>"
+        );
+
+        let mut explicit: Config =
+            toml::from_str("[test]\ncommand = [\"echo\", \"explicit\"]\n").unwrap();
+        assert!(matches!(
+            explicit.resolve_test_command(dir.path()),
+            TestCommandResolution::Resolved
+        ));
+        assert_eq!(explicit.test.command, vec!["echo", "explicit"]);
+    }
+
+    #[test]
+    fn resolve_build_command_suggests_one_safe_root_without_enabling_it() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example.com/calculator\n").unwrap();
+        let mut config = Config::default();
+
+        let origin = config.resolve_build_command(dir.path());
+        assert_eq!(origin, BuildCommandOrigin::AutoDetected);
+        assert!(!origin.runs_before_tests());
+        assert_eq!(
+            config.test.build_command,
+            AUTO_GO_COMPILE_COMMAND
+                .iter()
+                .map(|argument| (*argument).to_string())
+                .collect::<Vec<_>>(),
+            "a single Go root gets the safe built-in compile check"
+        );
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::AutoDetected,
+            "re-resolution must preserve suggestion provenance"
+        );
+    }
+
+    #[test]
+    fn resolve_build_command_keeps_configured_command_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example.com/calculator\n").unwrap();
+        let mut config: Config =
+            toml::from_str("[test]\nbuild_command = [\"echo\", \"configured\"]\n").unwrap();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::Configured
+        );
+        assert_eq!(config.test.build_command, vec!["echo", "configured"]);
+    }
+
+    #[test]
+    fn resolve_build_command_does_not_assume_npx_for_package_managers() {
+        for (lockfile, binary) in [
+            ("bun.lock", "bun"),
+            ("pnpm-lock.yaml", "pnpm"),
+            ("yarn.lock", "yarn"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+            std::fs::write(dir.path().join(lockfile), "").unwrap();
+            std::fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+
+            assert_eq!(
+                detect_test_command(dir.path()),
+                vec![binary.to_string(), "test".to_string()]
+            );
+            let mut config = Config::default();
+            assert_eq!(
+                config.resolve_build_command(dir.path()),
+                BuildCommandOrigin::None,
+                "{lockfile} must not assume npx is available"
+            );
+            assert!(config.test.build_command.is_empty(), "{lockfile}");
+        }
+    }
+
+    #[test]
+    fn resolve_build_command_keeps_configured_typescript_command_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("pnpm-lock.yaml"), "").unwrap();
+        std::fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        let mut config: Config =
+            toml::from_str("[test]\nbuild_command = [\"pnpm\", \"exec\", \"tsc\", \"--noEmit\"]\n")
+                .unwrap();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::Configured
+        );
+        assert_eq!(
+            config.test.build_command,
+            vec!["pnpm", "exec", "tsc", "--noEmit"]
+        );
+    }
+
+    #[test]
+    fn resolve_build_command_skips_package_manager_go_ambiguity() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("bun.lock"), "").unwrap();
+        std::fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example.com/mixed\n").unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+    }
+
+    #[test]
+    fn resolve_build_command_skips_ambiguous_root() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example.com/calculator\n").unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"calculator\"\n",
+        )
+        .unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+    }
+
+    #[test]
+    fn resolve_build_command_skips_cargo_cmake_root() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"calculator\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("CMakeLists.txt"),
+            "cmake_minimum_required(VERSION 3.20)\n",
+        )
+        .unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+    }
+
+    #[test]
+    fn resolve_build_command_skips_cargo_make_root() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"calculator\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("Makefile"), "test:\n\t@true\n").unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+    }
+
+    #[test]
+    fn resolve_build_command_skips_ambiguous_dotnet_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("First.csproj"), "").unwrap();
+        std::fs::write(dir.path().join("Second.csproj"), "").unwrap();
+        let mut config: Config =
+            toml::from_str("[test]\ncommand = [\"echo\", \"custom\"]\n").unwrap();
+
+        assert_eq!(
+            ProjectInspection::scan(dir.path()).dotnet_candidates,
+            DotnetCandidates::Ambiguous
+        );
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+        assert_eq!(config.test.command, vec!["echo", "custom"]);
+    }
+
+    #[test]
+    fn resolve_build_command_ignores_dotnet_named_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("fake.csproj")).unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            ProjectInspection::scan(dir.path()).dotnet_candidates,
+            DotnetCandidates::None
+        );
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::None
+        );
+        assert!(config.test.build_command.is_empty());
+    }
+
+    #[test]
+    fn detect_build_command_does_not_guess_gradle() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.gradle"), "").unwrap();
+
+        assert!(detect_build_command(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn detect_dotnet_build_keeps_restore_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Calculator.csproj"), "").unwrap();
+        let mut config = Config::default();
+
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::AutoDetected
+        );
+        assert_eq!(
+            config.test.build_command,
+            vec!["dotnet", "build", "Calculator.csproj"]
+        );
+        assert_eq!(
+            detect_test_command(dir.path()),
+            vec!["dotnet", "test", "Calculator.csproj"]
         );
     }
 
@@ -1505,14 +1901,24 @@ fail_on_uncovered_diff = true
     fn detect_csproj_only() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("MyApp.csproj"), "").unwrap();
-        assert_eq!(detect_test_command(dir.path()), vec!["dotnet", "test"]);
+        assert_eq!(
+            detect_test_command(dir.path()),
+            vec!["dotnet", "test", "MyApp.csproj"]
+        );
     }
 
     #[test]
     fn detect_sln_only() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("MyApp.sln"), "").unwrap();
-        assert_eq!(detect_test_command(dir.path()), vec!["dotnet", "test"]);
+        assert_eq!(
+            detect_test_command(dir.path()),
+            vec!["dotnet", "test", "MyApp.sln"]
+        );
+        assert_eq!(
+            detect_build_command(dir.path()),
+            vec!["dotnet", "build", "MyApp.sln"]
+        );
     }
 
     #[test]

--- a/src/languages/rust_lang.rs
+++ b/src/languages/rust_lang.rs
@@ -56,9 +56,12 @@ impl LanguageSupport for Rust {
         &self,
         candidate: &crate::MutationCandidate,
         node: &tree_sitter::Node,
-        _source: &[u8],
+        source: &[u8],
     ) -> bool {
         match candidate.operator_id.as_str() {
+            "remove_if_body" | "remove_else" => {
+                rust_if_removal_is_type_unsafe(candidate.operator_id.as_str(), node, source)
+            }
             "return_empty" => crate::languages::should_skip_return_empty_for_type(node, false),
             "string_to_empty" => {
                 crate::languages::should_skip_string_to_empty_in_compiled_context(node)
@@ -66,6 +69,79 @@ impl LanguageSupport for Rust {
             _ => false,
         }
     }
+}
+
+/// Removing an if branch changes its type independently of whether the
+/// enclosing if result is ignored. Retain candidates only when syntax proves
+/// the replacement is unit-compatible with its untouched branch; without an
+/// alternative, replacing the consequence with `{}` is itself unit.
+fn rust_if_removal_is_type_unsafe(operator: &str, node: &tree_sitter::Node, source: &[u8]) -> bool {
+    if node.kind() != "if_expression" {
+        return true;
+    }
+    let Some(consequence) = node.child_by_field_name("consequence") else {
+        return true;
+    };
+    match operator {
+        "remove_if_body" => node
+            .child_by_field_name("alternative")
+            .is_some_and(|alternative| !is_provably_unit_branch(&alternative, source)),
+        "remove_else" => !is_provably_unit_branch(&consequence, source),
+        _ => false,
+    }
+}
+
+/// Return whether syntax proves that this branch evaluates to `()`.
+fn is_provably_unit_branch(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    match node.kind() {
+        "unit_expression" => true,
+        "block" => {
+            let mut cursor = node.walk();
+            match node.named_children(&mut cursor).last() {
+                None => true,
+                Some(last) => {
+                    last.kind() == "unit_expression"
+                        || source_ends_with_semicolon(&last, source)
+                        || unsemicolonated_tail_if_is_provably_unit(&last, source)
+                }
+            }
+        }
+        "else_clause" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .next()
+                .is_some_and(|branch| is_provably_unit_branch(&branch, source))
+        }
+        "if_expression" => {
+            let Some(consequence) = node.child_by_field_name("consequence") else {
+                return false;
+            };
+            is_provably_unit_branch(&consequence, source)
+                && node
+                    .child_by_field_name("alternative")
+                    .is_none_or(|alternative| is_provably_unit_branch(&alternative, source))
+        }
+        _ => false,
+    }
+}
+
+/// Reuse the if proof after the enclosing block rules out a trailing semicolon.
+fn unsemicolonated_tail_if_is_provably_unit(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    if node.kind() != "expression_statement" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).next().is_some_and(|tail| {
+        tail.kind() == "if_expression" && is_provably_unit_branch(&tail, source)
+    })
+}
+
+/// A semicolon discards a statement value, making the containing block unit.
+fn source_ends_with_semicolon(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    source
+        .get(node.byte_range())
+        .and_then(|text| text.iter().rev().find(|&&byte| !byte.is_ascii_whitespace()))
+        == Some(&b';')
 }
 
 /// Check if a node has a preceding sibling `attribute_item` matching a predicate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ struct ExecuteOptions {
 struct ResolvedCheckConfig {
     config: togi::config::Config,
     fail_fast: bool,
-    has_explicit_build_cmd: bool,
     has_custom_test_cmd: bool,
     has_cli_timeout: bool,
     profile: Option<togi::config::ResourceProfile>,
@@ -336,7 +335,6 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let ResolvedCheckConfig {
         mut config,
         fail_fast,
-        has_explicit_build_cmd,
         has_custom_test_cmd,
         has_cli_timeout,
         profile,
@@ -358,7 +356,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         }
     }
     let _lock = togi::lock::acquire(&project_root)?;
-    config.resolve_build_command(&project_root);
+    let build_command_origin = config.resolve_build_command(&project_root);
     warn_if_resource_oversubscribed(config.test.jobs);
     let profile_env = if has_custom_test_cmd {
         HashMap::new()
@@ -391,7 +389,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     )?;
     if changed_files.is_empty() {
         if output_format == togi::cli::OutputFormat::Json {
-            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run, &project_root)?;
+            print_empty_json_check_output(&config, build_command_origin, dry_run, &project_root)?;
         }
         return Ok(());
     }
@@ -465,7 +463,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
             eprintln!("  - Changed files are in an unsupported language");
             eprintln!("  - All mutable nodes were filtered out (test files, noisy patterns)");
             eprintln!("  - max_per_run or max_per_file is set to 0 in togi.toml");
-            print_empty_json_check_output(&config, has_explicit_build_cmd, dry_run, &project_root)?;
+            print_empty_json_check_output(&config, build_command_origin, dry_run, &project_root)?;
         } else {
             println!("No mutations generated. Possible causes:");
             println!("  - Changed files are in an unsupported language");
@@ -500,7 +498,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         let mut commands = command_config(
             &config,
             &project_root,
-            has_explicit_build_cmd,
+            build_command_origin,
             has_custom_test_cmd,
             has_cli_timeout,
         );
@@ -544,7 +542,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
                 config.test.timeout = timeout_secs;
                 commands.timeout = Duration::from_secs(timeout_secs);
                 let timing = BaselineTiming {
-                    build_command: if has_explicit_build_cmd {
+                    build_command: if build_command_origin.runs_before_tests() {
                         config.test.build_command.clone()
                     } else {
                         vec![]
@@ -574,7 +572,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let (mut report, run_cancelled, direct_recipes) = if classified.to_run.is_empty() {
         // Every generated mutant sits on a zero-coverage line: nothing to run.
         (
-            coverage_only_report(&config, has_explicit_build_cmd),
+            coverage_only_report(&config, build_command_origin),
             false,
             BTreeMap::new(),
         )
@@ -716,7 +714,6 @@ fn exit_with(lock: togi::lock::LockGuard, code: i32) -> ! {
 fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConfig> {
     let mut config = togi::config::Config::load(cfg.config.as_deref())?;
     let has_custom_test_cmd = cfg.test_cmd.is_some();
-    let has_cli_build_cmd = cfg.build_cmd.is_some();
     let has_cli_timeout = cfg.timeout.is_some();
     let profile = cfg.profile.or(config.test.profile);
 
@@ -792,8 +789,9 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         config.mutations.incremental_history = false;
     }
     if let Some(cmd) = cfg.build_cmd {
-        config.test.build_command =
-            shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?;
+        config.test.set_build_command(
+            shell_words::split(&cmd).map_err(|e| anyhow::anyhow!("bad --build-cmd: {e}"))?,
+        );
     }
 
     if cfg.no_skip_defaults {
@@ -823,7 +821,6 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
         );
     }
 
-    let has_explicit_build_cmd = has_cli_build_cmd || !config.test.build_command.is_empty();
     let profile_fail_fast = profile.is_some_and(|profile| profile.default_fail_fast());
     let requested_fail_fast = cfg.fail_fast || profile_fail_fast;
     let fail_fast = requested_fail_fast && !has_custom_test_cmd;
@@ -839,7 +836,6 @@ fn resolve_config(cfg: togi::cli::CheckArgs) -> anyhow::Result<ResolvedCheckConf
     Ok(ResolvedCheckConfig {
         config,
         fail_fast,
-        has_explicit_build_cmd,
         has_custom_test_cmd,
         has_cli_timeout,
         profile,
@@ -1431,7 +1427,7 @@ fn merge_uncovered(report: &mut togi::MutationReport, uncovered: Vec<Mutation>) 
 /// coverage-suppressed and nothing had to be executed.
 fn coverage_only_report(
     config: &togi::config::Config,
-    build_command_explicit: bool,
+    build_command_origin: togi::config::BuildCommandOrigin,
 ) -> togi::MutationReport {
     togi::MutationReport {
         results: Vec::new(),
@@ -1442,7 +1438,7 @@ fn coverage_only_report(
         baseline_timing: None,
         duration: Duration::ZERO,
         test_command: Some(config.test.command.clone()),
-        build_command: if build_command_explicit {
+        build_command: if build_command_origin.runs_before_tests() {
             config.test.build_command.clone()
         } else {
             Vec::new()
@@ -1459,14 +1455,14 @@ fn coverage_only_report(
 
 fn print_empty_json_check_output(
     config: &togi::config::Config,
-    build_command_explicit: bool,
+    build_command_origin: togi::config::BuildCommandOrigin,
     dry_run: bool,
     project_root: &Path,
 ) -> anyhow::Result<()> {
     if dry_run {
         togi::report::json::print_dry_run(&[])?;
     } else {
-        let report = coverage_only_report(config, build_command_explicit);
+        let report = coverage_only_report(config, build_command_origin);
         let mut capture = togi::replay::ReplayReportCapture::capture(project_root, &[]);
         capture.revalidate(project_root);
         togi::report::json::print_report_with_baseline_and_replay(
@@ -1500,7 +1496,7 @@ fn print_dry_run(mutations: &[Mutation]) {
 fn command_config(
     config: &togi::config::Config,
     project_root: &Path,
-    build_command_explicit: bool,
+    build_command_origin: togi::config::BuildCommandOrigin,
     force_default_command: bool,
     force_default_timeout: bool,
 ) -> togi::runner::CommandConfig {
@@ -1544,12 +1540,8 @@ fn command_config(
         force_default_timeout,
         project_commands,
         language_commands,
-        build_command: if build_command_explicit {
-            config.test.build_command.clone()
-        } else {
-            vec![]
-        },
-        build_command_explicit,
+        build_command: config.test.build_command.clone(),
+        build_command_origin,
         timeout: Duration::from_secs(config.test.timeout),
         language_timeouts,
         test_selection: load_test_selection(

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -239,7 +239,7 @@ mod tests {
     use super::*;
     use crate::languages::LanguageSupport;
     use crate::languages::go::Go;
-    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python};
+    use crate::test_helpers::{find_node_by_kind, parse_go, parse_python, parse_rust};
     use crate::{ChangedFile, LineRange, MutationCandidate};
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -267,6 +267,24 @@ mod tests {
             mutation.replacement.as_bytes().iter().copied(),
         );
         String::from_utf8(mutated).unwrap()
+    }
+
+    fn assert_rust_library_compiles(source: &str) {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("lib.rs");
+        std::fs::write(&source_path, source).unwrap();
+        let output = std::process::Command::new("rustc")
+            .args(["--crate-type=lib", "--emit=metadata"])
+            .arg(&source_path)
+            .arg("-o")
+            .arg(dir.path().join("lib.rmeta"))
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "mutated Rust source must compile:\n{source}\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]
@@ -859,6 +877,443 @@ mod tests {
             "return_empty should be allowed for i32 return type, got: {:?}",
             mutations.iter().map(|m| &m.operator).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn rust_expression_if_filters_invalid_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "fn label(flag: bool) -> Option<String> {\n",
+            "    if flag {\n",
+            "        Some(\"yes\".to_owned())\n",
+            "    } else {\n",
+            "        None\n",
+            "    }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 7 }],
+        }];
+
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &[
+                "remove_if_body".into(),
+                "remove_else".into(),
+                "negate_condition".into(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !mutations.iter().any(|mutation| matches!(
+                mutation.operator.as_str(),
+                "remove_if_body" | "remove_else"
+            )),
+            "expression-valued Rust if removals must be filtered: {mutations:?}"
+        );
+        let control = mutations
+            .iter()
+            .find(|mutation| mutation.operator == "negate_condition")
+            .expect("the Rust feasibility filter must leave valid if mutations available");
+        let mutated = apply_mutation(src, control);
+        assert!(
+            !parse_rust(&mutated).root_node().has_error(),
+            "control mutation should remain valid Rust:\n{mutated}"
+        );
+        assert_rust_library_compiles(&mutated);
+    }
+
+    #[test]
+    fn rust_field_value_if_filters_invalid_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "struct Marker { value: Option<i32> }\n",
+            "fn label(flag: bool) -> Marker {\n",
+            "    Marker { value: if flag { Some(1) } else { None } }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange { start: 1, end: 4 }],
+        }];
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &[
+                "remove_if_body".into(),
+                "remove_else".into(),
+                "negate_condition".into(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !mutations.iter().any(|mutation| matches!(
+                mutation.operator.as_str(),
+                "remove_if_body" | "remove_else"
+            )),
+            "field-valued Rust if removals must be filtered: {mutations:?}"
+        );
+        let control = mutations
+            .iter()
+            .find(|mutation| mutation.operator == "negate_condition")
+            .expect("the Rust feasibility filter must preserve valid if mutations");
+        let mutated = apply_mutation(src, control);
+        assert!(
+            !parse_rust(&mutated).root_node().has_error(),
+            "control mutation should remain valid Rust:\n{mutated}"
+        );
+        assert_rust_library_compiles(&mutated);
+    }
+
+    #[test]
+    fn rust_nested_tail_if_filters_invalid_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "pub fn f(flag: bool) -> i32 {\n",
+            "    if flag {\n",
+            "        if flag {\n",
+            "            1\n",
+            "        } else {\n",
+            "            2\n",
+            "        }\n",
+            "    } else {\n",
+            "        3\n",
+            "    }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange {
+                start: 1,
+                end: src.lines().count(),
+            }],
+        }];
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &[
+                "remove_if_body".into(),
+                "remove_else".into(),
+                "negate_condition".into(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !mutations.iter().any(|mutation| matches!(
+                mutation.operator.as_str(),
+                "remove_if_body" | "remove_else"
+            )),
+            "nested value-producing Rust if removals must be filtered: {mutations:?}"
+        );
+        let controls: Vec<_> = mutations
+            .iter()
+            .filter(|mutation| mutation.operator == "negate_condition")
+            .collect();
+        assert_eq!(
+            controls.len(),
+            2,
+            "both nested if conditions should retain valid mutations: {mutations:?}"
+        );
+        for control in controls {
+            let mutated = apply_mutation(src, control);
+            assert!(
+                !parse_rust(&mutated).root_node().has_error(),
+                "control mutation should remain valid Rust:\n{mutated}"
+            );
+            assert_rust_library_compiles(&mutated);
+        }
+    }
+
+    #[test]
+    fn rust_match_arm_tail_if_filters_invalid_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "pub fn f(flag: bool) -> i32 {\n",
+            "    match flag {\n",
+            "        true => {\n",
+            "            if flag {\n",
+            "                1\n",
+            "            } else {\n",
+            "                2\n",
+            "            }\n",
+            "        }\n",
+            "        false => 3,\n",
+            "    }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange {
+                start: 1,
+                end: src.lines().count(),
+            }],
+        }];
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &[
+                "remove_if_body".into(),
+                "remove_else".into(),
+                "negate_condition".into(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !mutations.iter().any(|mutation| matches!(
+                mutation.operator.as_str(),
+                "remove_if_body" | "remove_else"
+            )),
+            "match-arm value-producing Rust if removals must be filtered: {mutations:?}"
+        );
+        let controls: Vec<_> = mutations
+            .iter()
+            .filter(|mutation| mutation.operator == "negate_condition")
+            .collect();
+        assert_eq!(
+            controls.len(),
+            1,
+            "the match-arm if condition should retain a valid mutation: {mutations:?}"
+        );
+        for control in controls {
+            let mutated = apply_mutation(src, control);
+            assert!(
+                !parse_rust(&mutated).root_node().has_error(),
+                "control mutation should remain valid Rust:\n{mutated}"
+            );
+            assert_rust_library_compiles(&mutated);
+        }
+    }
+
+    #[test]
+    fn rust_non_tail_nonunit_if_filters_invalid_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "fn work() {}\n",
+            "pub fn f(flag: bool) {\n",
+            "    if flag {\n",
+            "        1\n",
+            "    } else {\n",
+            "        2\n",
+            "    };\n",
+            "    work();\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange {
+                start: 1,
+                end: src.lines().count(),
+            }],
+        }];
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &[
+                "remove_if_body".into(),
+                "remove_else".into(),
+                "negate_condition".into(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            !mutations.iter().any(|mutation| matches!(
+                mutation.operator.as_str(),
+                "remove_if_body" | "remove_else"
+            )),
+            "non-unit if statement removals must be filtered: {mutations:?}"
+        );
+        let controls: Vec<_> = mutations
+            .iter()
+            .filter(|mutation| mutation.operator == "negate_condition")
+            .collect();
+        assert_eq!(
+            controls.len(),
+            1,
+            "the non-unit if condition should retain a valid mutation: {mutations:?}"
+        );
+        for control in controls {
+            let mutated = apply_mutation(src, control);
+            assert!(
+                !parse_rust(&mutated).root_node().has_error(),
+                "control mutation should remain valid Rust:\n{mutated}"
+            );
+            assert_rust_library_compiles(&mutated);
+        }
+    }
+
+    #[test]
+    fn rust_statement_and_unit_if_keep_valid_removal_mutations() {
+        for (name, src) in [
+            (
+                "statement",
+                concat!(
+                    "fn work() {}\n",
+                    "fn statement(flag: bool) -> i32 {\n",
+                    "    if flag {\n",
+                    "        work();\n",
+                    "    } else {\n",
+                    "        work();\n",
+                    "    }\n",
+                    "    3\n",
+                    "}\n",
+                ),
+            ),
+            (
+                "unit tail",
+                concat!(
+                    "fn work() {}\n",
+                    "fn unit_tail(flag: bool) {\n",
+                    "    if flag {\n",
+                    "        work();\n",
+                    "    } else {\n",
+                    "        work();\n",
+                    "    }\n",
+                    "}\n",
+                ),
+            ),
+        ] {
+            let tmp = TempDir::new().unwrap();
+            let rel = write_test_file(tmp.path(), "lib.rs", src);
+            let changed = vec![ChangedFile {
+                path: rel,
+                hunks: vec![LineRange {
+                    start: 1,
+                    end: src.lines().count(),
+                }],
+            }];
+            let mutations = generate_mutations(
+                &changed,
+                tmp.path(),
+                100,
+                0,
+                &["remove_if_body".into(), "remove_else".into()],
+            )
+            .unwrap();
+
+            for operator in ["remove_if_body", "remove_else"] {
+                let mutation = mutations
+                    .iter()
+                    .find(|mutation| mutation.operator == operator)
+                    .unwrap_or_else(|| {
+                        panic!("{name} Rust if should retain {operator}: {mutations:?}")
+                    });
+                let mutated = apply_mutation(src, mutation);
+                assert!(
+                    !parse_rust(&mutated).root_node().has_error(),
+                    "{operator} should parse as Rust:\n{mutated}"
+                );
+                assert_rust_library_compiles(&mutated);
+            }
+        }
+    }
+
+    #[test]
+    fn rust_nested_unit_if_keeps_all_removal_mutations() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "fn work() {}\n",
+            "pub fn f(a: bool, b: bool) {\n",
+            "    if a {\n",
+            "        if b {\n",
+            "            work();\n",
+            "        } else {\n",
+            "            work();\n",
+            "        }\n",
+            "    } else {\n",
+            "        work();\n",
+            "    }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange {
+                start: 1,
+                end: src.lines().count(),
+            }],
+        }];
+        let mutations = generate_mutations(
+            &changed,
+            tmp.path(),
+            100,
+            0,
+            &["remove_if_body".into(), "remove_else".into()],
+        )
+        .unwrap();
+        let removals: Vec<_> = mutations
+            .iter()
+            .filter(|mutation| {
+                matches!(mutation.operator.as_str(), "remove_if_body" | "remove_else")
+            })
+            .collect();
+        assert_eq!(
+            removals.len(),
+            4,
+            "both nested unit ifs should retain both removals: {mutations:?}"
+        );
+        for mutation in removals {
+            let mutated = apply_mutation(src, mutation);
+            assert!(
+                !parse_rust(&mutated).root_node().has_error(),
+                "unit if removal should parse as Rust:\n{mutated}"
+            );
+            assert_rust_library_compiles(&mutated);
+        }
+    }
+
+    #[test]
+    fn rust_no_else_never_if_keeps_remove_if_body() {
+        let tmp = TempDir::new().unwrap();
+        let src = concat!(
+            "fn never() -> ! { panic!() }\n",
+            "pub fn f(flag: bool) {\n",
+            "    if flag {\n",
+            "        never()\n",
+            "    }\n",
+            "}\n",
+        );
+        let rel = write_test_file(tmp.path(), "lib.rs", src);
+        let changed = vec![ChangedFile {
+            path: rel,
+            hunks: vec![LineRange {
+                start: 1,
+                end: src.lines().count(),
+            }],
+        }];
+        let mutations =
+            generate_mutations(&changed, tmp.path(), 100, 0, &["remove_if_body".into()]).unwrap();
+        let mutation = mutations
+            .iter()
+            .find(|mutation| mutation.operator == "remove_if_body")
+            .expect("no-else if replacement is always unit");
+        let mutated = apply_mutation(src, mutation);
+        assert!(
+            !parse_rust(&mutated).root_node().has_error(),
+            "no-else if removal should parse as Rust:\n{mutated}"
+        );
+        assert_rust_library_compiles(&mutated);
     }
 
     #[test]

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,3 +1,4 @@
+use crate::config::BuildCommandOrigin;
 use crate::source_identity::{
     is_normalized_project_relative_path, normalized_project_relative_path, range_matches,
     resolve_normalized_project_relative_path, source_fingerprint,
@@ -53,6 +54,8 @@ pub struct RegularDirectRecipe {
     pub test_command: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_command: Option<Vec<String>>,
+    /// The source of `build_command`; legacy reports default to configured.
+    pub build_command_origin: BuildCommandOrigin,
     pub timeout_ms: u64,
     pub env: BTreeMap<String, String>,
     pub respect_workspace_ignores: bool,
@@ -302,6 +305,8 @@ enum StoredReplayRecipe {
         test_command: Vec<String>,
         #[serde(default)]
         build_command: Option<Vec<String>>,
+        #[serde(default = "legacy_build_command_origin")]
+        build_command_origin: BuildCommandOrigin,
         timeout_ms: u64,
         #[serde(default)]
         env: BTreeMap<String, String>,
@@ -334,10 +339,8 @@ pub fn replay_mutation(
     let project_root = current_project_root()?;
     validate_project_and_source(&project_root, &validated)?;
 
-    let mut build_command = validated.recipe.build_command.clone();
-    if let Some(command) = &mut build_command {
-        normalize_auto_go_compile_output(command, crate::config::AUTO_GO_COMPILE_OUTPUT);
-    }
+    let build_command =
+        replay_build_command(&validated.recipe, crate::config::AUTO_GO_COMPILE_OUTPUT);
     let build_command_json = build_command
         .as_ref()
         .map(serde_json::to_string)
@@ -468,6 +471,7 @@ fn validate_report_mutation(
         StoredReplayRecipe::RegularDirect {
             test_command,
             build_command,
+            build_command_origin,
             timeout_ms,
             env,
             respect_workspace_ignores,
@@ -475,6 +479,7 @@ fn validate_report_mutation(
         } => RegularDirectRecipe {
             test_command,
             build_command,
+            build_command_origin,
             timeout_ms,
             env,
             respect_workspace_ignores,
@@ -705,24 +710,49 @@ fn is_valid_env_key(key: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-/// Normalize only the exact auto-detected Go compile command for replay.
-///
-/// Replay recipes retain their serialized command unchanged; this operates on
-/// the execution copy after validation, so cache identity remains host-specific.
-fn normalize_auto_go_compile_output(command: &mut [String], target_null_device: &str) {
-    const OUTPUT_INDEX: usize = 5;
-    let is_auto_go_compile = command.len() == 7
-        && command[0] == "go"
-        && command[1] == "test"
-        && command[2] == "-c"
-        && command[3] == "-vet=off"
-        && command[4] == "-o"
-        && (command[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_UNIX_OUTPUT
-            || command[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_WINDOWS_OUTPUT)
-        && command[6] == "./...";
-    if is_auto_go_compile && command[OUTPUT_INDEX] != target_null_device {
-        command[OUTPUT_INDEX] = target_null_device.to_owned();
+/// Clone a serialized build command for replay, adapting only the known
+/// auto-detected Go null-device argument to this host.
+fn replay_build_command(
+    recipe: &RegularDirectRecipe,
+    target_null_device: &str,
+) -> Option<Vec<String>> {
+    let mut build_command = recipe.build_command.clone();
+    if recipe.build_command_origin == BuildCommandOrigin::AutoDetected {
+        if let Some(command) = &mut build_command {
+            normalize_auto_go_compile_output(command, target_null_device);
+        }
     }
+    build_command
+}
+
+/// Normalize only the terminal exact auto-detected Go compile command.
+///
+/// The command may have a sandbox wrapper prefix. Replay recipes retain their
+/// serialized command unchanged; this operates on the execution copy after
+/// validation, so cache identity remains host-specific.
+fn normalize_auto_go_compile_output(command: &mut [String], target_null_device: &str) {
+    const AUTO_GO_COMPILE_ARG_COUNT: usize = 7;
+    const OUTPUT_INDEX: usize = 5;
+    if command.len() < AUTO_GO_COMPILE_ARG_COUNT {
+        return;
+    }
+    let suffix_start = command.len() - AUTO_GO_COMPILE_ARG_COUNT;
+    let suffix = &mut command[suffix_start..];
+    let is_auto_go_compile = suffix[0] == "go"
+        && suffix[1] == "test"
+        && suffix[2] == "-c"
+        && suffix[3] == "-vet=off"
+        && suffix[4] == "-o"
+        && (suffix[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_UNIX_OUTPUT
+            || suffix[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_WINDOWS_OUTPUT)
+        && suffix[6] == "./...";
+    if is_auto_go_compile && suffix[OUTPUT_INDEX] != target_null_device {
+        suffix[OUTPUT_INDEX] = target_null_device.to_owned();
+    }
+}
+
+fn legacy_build_command_origin() -> BuildCommandOrigin {
+    BuildCommandOrigin::Configured
 }
 
 fn result_name(result: MutationResult) -> &'static str {
@@ -763,6 +793,7 @@ mod tests {
                 replay: StoredReplayRecipe::RegularDirect {
                     test_command,
                     build_command: None,
+                    build_command_origin: BuildCommandOrigin::None,
                     timeout_ms: 1,
                     env: BTreeMap::new(),
                     respect_workspace_ignores: true,
@@ -895,19 +926,81 @@ mod tests {
         ]
     }
 
+    fn direct_recipe(
+        build_command: Option<Vec<String>>,
+        build_command_origin: BuildCommandOrigin,
+    ) -> RegularDirectRecipe {
+        RegularDirectRecipe {
+            test_command: vec!["test".into()],
+            build_command,
+            build_command_origin,
+            timeout_ms: 1_000,
+            env: BTreeMap::new(),
+            respect_workspace_ignores: true,
+            origin: DirectRecipeOrigin::Executed,
+        }
+    }
+
     #[test]
     fn normalizes_auto_go_compile_output_for_either_host() {
-        let mut unix_recipe = auto_go_compile_command("/dev/null");
-        normalize_auto_go_compile_output(&mut unix_recipe, "NUL");
-        assert_eq!(unix_recipe, auto_go_compile_command("NUL"));
+        let unix_recipe = direct_recipe(
+            Some(auto_go_compile_command("/dev/null")),
+            BuildCommandOrigin::AutoDetected,
+        );
+        assert_eq!(
+            replay_build_command(&unix_recipe, "NUL"),
+            Some(auto_go_compile_command("NUL"))
+        );
 
-        let mut windows_recipe = auto_go_compile_command("NUL");
-        normalize_auto_go_compile_output(&mut windows_recipe, "/dev/null");
-        assert_eq!(windows_recipe, auto_go_compile_command("/dev/null"));
+        let windows_recipe = direct_recipe(
+            Some(auto_go_compile_command("NUL")),
+            BuildCommandOrigin::AutoDetected,
+        );
+        assert_eq!(
+            replay_build_command(&windows_recipe, "/dev/null"),
+            Some(auto_go_compile_command("/dev/null"))
+        );
+    }
 
-        let mut same_host_recipe = auto_go_compile_command("/dev/null");
-        normalize_auto_go_compile_output(&mut same_host_recipe, "/dev/null");
-        assert_eq!(same_host_recipe, auto_go_compile_command("/dev/null"));
+    #[test]
+    fn normalizes_only_the_terminal_auto_go_compile_suffix_after_a_wrapper() {
+        let wrapper = vec!["sandbox".into(), "--".into()];
+        let mut wrapped_unix = wrapper.clone();
+        wrapped_unix.extend(auto_go_compile_command("/dev/null"));
+        let mut wrapped_windows = wrapper.clone();
+        wrapped_windows.extend(auto_go_compile_command("NUL"));
+
+        let mut expected_windows = wrapper.clone();
+        expected_windows.extend(auto_go_compile_command("NUL"));
+        assert_eq!(
+            replay_build_command(
+                &direct_recipe(Some(wrapped_unix), BuildCommandOrigin::AutoDetected),
+                "NUL"
+            ),
+            Some(expected_windows)
+        );
+
+        let mut expected_unix = wrapper;
+        expected_unix.extend(auto_go_compile_command("/dev/null"));
+        assert_eq!(
+            replay_build_command(
+                &direct_recipe(Some(wrapped_windows), BuildCommandOrigin::AutoDetected),
+                "/dev/null"
+            ),
+            Some(expected_unix)
+        );
+    }
+
+    #[test]
+    fn configured_auto_go_compile_lookalike_is_replayed_byte_for_byte() {
+        let build_command = auto_go_compile_command("/dev/null");
+        let recipe = direct_recipe(Some(build_command.clone()), BuildCommandOrigin::Configured);
+
+        assert_eq!(
+            replay_build_command(&recipe, "NUL"),
+            Some(build_command.clone())
+        );
+        assert_eq!(recipe.build_command, Some(build_command));
     }
 
     #[test]

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -334,12 +334,21 @@ pub fn replay_mutation(
     let project_root = current_project_root()?;
     validate_project_and_source(&project_root, &validated)?;
 
+    let mut build_command = validated.recipe.build_command.clone();
+    if let Some(command) = &mut build_command {
+        normalize_auto_go_compile_output(command, crate::config::AUTO_GO_COMPILE_OUTPUT);
+    }
+    let build_command_json = build_command
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
+
     let fresh = crate::runner::run_replay_mutation(
         &project_root,
         &validated.mutation,
         crate::runner::ReplayRunConfig {
             test_command: validated.recipe.test_command.clone(),
-            build_command: validated.recipe.build_command.clone(),
+            build_command,
             timeout: Duration::from_millis(validated.recipe.timeout_ms),
             env: validated
                 .recipe
@@ -371,11 +380,8 @@ pub fn replay_mutation(
         "Effective command: {}",
         serde_json::to_string(&validated.recipe.test_command)?
     );
-    if let Some(build_command) = &validated.recipe.build_command {
-        println!(
-            "Effective build command: {}",
-            serde_json::to_string(build_command)?
-        );
+    if let Some(build_command) = build_command_json {
+        println!("Effective build command: {build_command}");
     }
     if show_output {
         if let Some(output) = fresh
@@ -699,6 +705,26 @@ fn is_valid_env_key(key: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
+/// Normalize only the exact auto-detected Go compile command for replay.
+///
+/// Replay recipes retain their serialized command unchanged; this operates on
+/// the execution copy after validation, so cache identity remains host-specific.
+fn normalize_auto_go_compile_output(command: &mut [String], target_null_device: &str) {
+    const OUTPUT_INDEX: usize = 5;
+    let is_auto_go_compile = command.len() == 7
+        && command[0] == "go"
+        && command[1] == "test"
+        && command[2] == "-c"
+        && command[3] == "-vet=off"
+        && command[4] == "-o"
+        && (command[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_UNIX_OUTPUT
+            || command[OUTPUT_INDEX] == crate::config::AUTO_GO_COMPILE_WINDOWS_OUTPUT)
+        && command[6] == "./...";
+    if is_auto_go_compile && command[OUTPUT_INDEX] != target_null_device {
+        command[OUTPUT_INDEX] = target_null_device.to_owned();
+    }
+}
+
 fn result_name(result: MutationResult) -> &'static str {
     match result {
         MutationResult::Killed => "killed",
@@ -855,5 +881,43 @@ mod tests {
     fn command_validation_rejects_empty_commands() {
         assert!(validate_command(&[], "test").is_err());
         assert!(validate_command(&[String::new()], "test").is_err());
+    }
+
+    fn auto_go_compile_command(output: &str) -> Vec<String> {
+        vec![
+            "go".into(),
+            "test".into(),
+            "-c".into(),
+            "-vet=off".into(),
+            "-o".into(),
+            output.into(),
+            "./...".into(),
+        ]
+    }
+
+    #[test]
+    fn normalizes_auto_go_compile_output_for_either_host() {
+        let mut unix_recipe = auto_go_compile_command("/dev/null");
+        normalize_auto_go_compile_output(&mut unix_recipe, "NUL");
+        assert_eq!(unix_recipe, auto_go_compile_command("NUL"));
+
+        let mut windows_recipe = auto_go_compile_command("NUL");
+        normalize_auto_go_compile_output(&mut windows_recipe, "/dev/null");
+        assert_eq!(windows_recipe, auto_go_compile_command("/dev/null"));
+
+        let mut same_host_recipe = auto_go_compile_command("/dev/null");
+        normalize_auto_go_compile_output(&mut same_host_recipe, "/dev/null");
+        assert_eq!(same_host_recipe, auto_go_compile_command("/dev/null"));
+    }
+
+    #[test]
+    fn auto_go_compile_normalization_leaves_other_commands_unchanged() {
+        let mut configured = auto_go_compile_command("/dev/null");
+        configured.push("-tags=ci".into());
+        let original = configured.clone();
+
+        normalize_auto_go_compile_output(&mut configured, "NUL");
+
+        assert_eq!(configured, original);
     }
 }

--- a/src/report/json.rs
+++ b/src/report/json.rs
@@ -161,6 +161,7 @@ enum JsonMutationReplay {
         test_command: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         build_command: Option<Vec<String>>,
+        build_command_origin: crate::config::BuildCommandOrigin,
         timeout_ms: u64,
         env: BTreeMap<String, String>,
         respect_workspace_ignores: bool,
@@ -205,6 +206,7 @@ fn json_replay_mutation_fields(
             JsonMutationReplay::RegularDirect {
                 test_command: recipe.test_command.clone(),
                 build_command: recipe.build_command.clone(),
+                build_command_origin: recipe.build_command_origin,
                 timeout_ms: recipe.timeout_ms,
                 env: recipe.env.clone(),
                 respect_workspace_ignores: recipe.respect_workspace_ignores,
@@ -1134,6 +1136,7 @@ mod tests {
         let recipe = RegularDirectRecipe {
             test_command: vec!["cargo".into(), "test".into()],
             build_command: None,
+            build_command_origin: crate::config::BuildCommandOrigin::None,
             timeout_ms: 1_000,
             env: BTreeMap::new(),
             respect_workspace_ignores: true,
@@ -1159,6 +1162,10 @@ mod tests {
         assert_eq!(
             replayable["mutations"][0]["replay"]["kind"],
             "regular_direct"
+        );
+        assert_eq!(
+            replayable["mutations"][0]["replay"]["build_command_origin"],
+            "none"
         );
 
         let schema: Value = serde_json::from_str(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3552,11 +3552,17 @@ impl PreparedMutationRun {
         respect_workspace_ignores: bool,
         origin: DirectRecipeOrigin,
     ) -> RegularDirectRecipe {
+        let build_command = commands
+            .has_build_command()
+            .then(|| sandboxed_command(&commands.sandbox_command, &commands.build_command));
+        let build_command_origin = build_command
+            .as_ref()
+            .map(|_| commands.build_command_origin)
+            .unwrap_or(BuildCommandOrigin::None);
         RegularDirectRecipe {
             test_command: sandboxed_command(&commands.sandbox_command, test_command),
-            build_command: commands
-                .has_build_command()
-                .then(|| sandboxed_command(&commands.sandbox_command, &commands.build_command)),
+            build_command,
+            build_command_origin,
             timeout_ms: u64::try_from(self.selected_test.timeout.as_millis()).unwrap_or(u64::MAX),
             env: env
                 .iter()
@@ -7847,6 +7853,8 @@ mod tests {
                 .expect("regular result should capture a direct replay recipe");
             assert_eq!(recipe.origin, expected_origin);
             assert_eq!(recipe.test_command, successful_command());
+            assert_eq!(recipe.build_command, None);
+            assert_eq!(recipe.build_command_origin, BuildCommandOrigin::None);
         }
 
         let (dir, _file, mut mutation) = make_relative_test_setup();
@@ -7880,6 +7888,43 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn direct_recipe_omits_sandboxed_auto_build_suggestion() -> anyhow::Result<()> {
+        let (dir, _file, mutation) = make_relative_test_setup();
+        let mut commands = test_command_config();
+        commands.command = successful_command();
+        commands.build_command = successful_command();
+        commands.build_command_origin = BuildCommandOrigin::AutoDetected;
+        commands.sandbox_command = vec!["env".into()];
+        let mut expected_command = commands.sandbox_command.clone();
+        expected_command.extend(successful_command());
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: EarlyStopConfig::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: true,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let outcome = runner.run(vec![mutation.clone()]);
+        let recipe = outcome
+            .replay_recipes
+            .get(&mutation.id)
+            .expect("regular result should capture a direct replay recipe");
+        assert_eq!(recipe.test_command, expected_command);
+        assert_eq!(recipe.build_command, None);
+        assert_eq!(recipe.build_command_origin, BuildCommandOrigin::None);
+        Ok(())
+    }
 
     fn go_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
         let mut offset = 0usize;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,7 @@
 // Parallel test execution with timeouts
 
 use crate::cache::{self, CacheKey};
+use crate::config::BuildCommandOrigin;
 use crate::replay::{DirectRecipeOrigin, RegularDirectRecipe};
 use crate::source_identity::{
     normalized_project_relative_path, range_matches, resolve_normalized_project_relative_path,
@@ -42,9 +43,9 @@ fn write_workspace_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
 ///
 /// `command` is the default test command. Project and language commands can
 /// override it for matching mutations unless `force_default_command` is set
-/// by a CLI command override. `build_command`, when explicitly enabled by the
-/// CLI/config, runs before tests to classify uncompilable mutations as build
-/// errors.
+/// by a CLI command override. An enabled build command runs before tests to
+/// classify uncompilable mutations as build errors; its origin records whether
+/// it was auto-detected or user-configured.
 pub struct CommandConfig {
     /// Default test command, stored as argv.
     pub command: Vec<String>,
@@ -60,14 +61,20 @@ pub struct CommandConfig {
     pub language_commands: HashMap<String, Vec<String>>,
     /// Optional build-check command, stored as argv.
     pub build_command: Vec<String>,
-    /// Whether the build command came from user config/CLI rather than detection.
-    pub build_command_explicit: bool,
+    /// How the effective build command was selected.
+    pub build_command_origin: BuildCommandOrigin,
     /// Default per-mutation timeout.
     pub timeout: Duration,
     /// Per-language timeout overrides keyed by `LanguageSupport::name()`.
     pub language_timeouts: HashMap<String, Duration>,
     /// Optional source-line to test-name map used to narrow test commands.
     pub test_selection: Option<TestSelectionConfig>,
+}
+
+impl CommandConfig {
+    fn has_build_command(&self) -> bool {
+        self.build_command_origin.runs_before_tests() && !self.build_command.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -224,7 +231,7 @@ pub struct BaselineTimingConfig<'a> {
     pub test_command: &'a [String],
     pub build_command: &'a [String],
     pub sandbox_command: &'a [String],
-    pub build_command_explicit: bool,
+    pub build_command_origin: BuildCommandOrigin,
     pub timeout: Duration,
     pub env: &'a HashMap<String, String>,
     pub cancelled: &'a AtomicBool,
@@ -365,14 +372,15 @@ impl SelectedTestCommand {
     fn cache_context(
         &self,
         build_command: &[String],
-        build_command_explicit: bool,
+        build_command_origin: BuildCommandOrigin,
         sandbox_command: &[String],
         env: &HashMap<String, String>,
     ) -> String {
-        let build_str = if build_command_explicit {
-            format!("{build_command:?}")
-        } else {
-            String::new()
+        // Only configured checks participate in cache identity. A detected
+        // suggestion cannot change execution, so it must share no-build keys.
+        let build_str = match build_command_origin {
+            BuildCommandOrigin::None | BuildCommandOrigin::AutoDetected => String::new(),
+            BuildCommandOrigin::Configured => format!("{build_command:?}"),
         };
         let sandbox_str = if sandbox_command.is_empty() {
             String::new()
@@ -390,6 +398,7 @@ impl SelectedTestCommand {
             env_parts.join(",")
         )
     }
+
     fn is_narrowed(&self) -> bool {
         self.unnarrowed_argv.is_some()
     }
@@ -2159,19 +2168,20 @@ pub fn measure_baseline_timing(
     let workspace = copy_workspace_with_options(project_root, config.respect_workspace_ignores)
         .with_context(|| "could not create baseline timing workspace")?;
     let root = workspace.root();
-    let build_duration = if config.build_command_explicit && !config.build_command.is_empty() {
-        Some(measure_baseline_command(
-            SuiteFailurePhase::Build,
-            config.build_command,
-            config.sandbox_command,
-            root,
-            config.timeout,
-            config.env,
-            config.cancelled,
-        )?)
-    } else {
-        None
-    };
+    let build_duration =
+        if config.build_command_origin.runs_before_tests() && !config.build_command.is_empty() {
+            Some(measure_baseline_command(
+                SuiteFailurePhase::Build,
+                config.build_command,
+                config.sandbox_command,
+                root,
+                config.timeout,
+                config.env,
+                config.cancelled,
+            )?)
+        } else {
+            None
+        };
     let test_duration = measure_baseline_command(
         SuiteFailurePhase::Test,
         config.test_command,
@@ -2191,7 +2201,7 @@ pub fn measure_baseline_timing(
 ///
 /// Test selection is intentionally not applied: a narrowed command cannot
 /// establish that the full effective suite is healthy. Each suite runs in a
-/// fresh isolated workspace, with the opt-in build command immediately
+/// fresh isolated workspace, with the enabled build command immediately
 /// preceding its test command.
 pub fn check_baseline_health(
     project_root: &Path,
@@ -2214,9 +2224,7 @@ pub fn check_baseline_health(
             .with_context(|| "could not create baseline health workspace")?;
         let root = workspace.root();
         let timeout = baseline_suite_timeout(&suite, config.default_measurement_timeout);
-        let build_duration = if config.commands.build_command_explicit
-            && !config.commands.build_command.is_empty()
-        {
+        let build_duration = if config.commands.has_build_command() {
             Some(measure_baseline_command(
                 SuiteFailurePhase::Build,
                 &config.commands.build_command,
@@ -3308,7 +3316,7 @@ struct RunShared<'a> {
     project_root: &'a Path,
     commands: &'a CommandConfig,
     build_command: &'a [String],
-    build_command_explicit: bool,
+    build_command_origin: BuildCommandOrigin,
     env: &'a HashMap<String, String>,
     total: usize,
     verbose: bool,
@@ -3469,7 +3477,7 @@ impl PreparedMutationRun {
         let mutation_identity = cache_identity(project_root, mutation);
         let command_ctx = selected_test.cache_context(
             &context.commands.build_command,
-            context.commands.build_command_explicit,
+            context.commands.build_command_origin,
             context.commands.sandbox_command.as_slice(),
             context.env,
         );
@@ -3546,7 +3554,8 @@ impl PreparedMutationRun {
     ) -> RegularDirectRecipe {
         RegularDirectRecipe {
             test_command: sandboxed_command(&commands.sandbox_command, test_command),
-            build_command: (commands.build_command_explicit && !commands.build_command.is_empty())
+            build_command: commands
+                .has_build_command()
                 .then(|| sandboxed_command(&commands.sandbox_command, &commands.build_command)),
             timeout_ms: u64::try_from(self.selected_test.timeout.as_millis()).unwrap_or(u64::MAX),
             env: env
@@ -3760,7 +3769,7 @@ fn run_queued_mutation(
             shared.commands.sandbox_command.as_slice(),
             BuildCommand {
                 argv: shared.build_command,
-                explicit: shared.build_command_explicit,
+                origin: shared.build_command_origin,
             },
             prepared.selected_test.timeout,
             &workspace_root,
@@ -3806,7 +3815,7 @@ fn run_queued_mutation(
                             shared.commands.sandbox_command.as_slice(),
                             BuildCommand {
                                 argv: shared.build_command,
-                                explicit: shared.build_command_explicit,
+                                origin: shared.build_command_origin,
                             },
                             prepared.selected_test.timeout,
                             &workspace_root,
@@ -4158,7 +4167,7 @@ impl TestRunner {
             );
             let command_ctx = selected.cache_context(
                 &self.commands.build_command,
-                self.commands.build_command_explicit,
+                self.commands.build_command_origin,
                 &self.commands.sandbox_command,
                 &self.env,
             );
@@ -4407,7 +4416,7 @@ impl TestRunner {
         let source_contents = SourceContentCache::default();
         let project_root = Arc::new(self.project_root.clone());
         let build_command = Arc::new(self.commands.build_command.clone());
-        let build_command_explicit = self.commands.build_command_explicit;
+        let build_command_origin = self.commands.build_command_origin;
         let queue = Arc::new(Mutex::new(mutations.into_iter().collect::<VecDeque<_>>()));
         let results = Arc::new(Mutex::new(restored));
         let worker_count = workspace_pool.len().min(fresh_total).max(1);
@@ -4472,7 +4481,7 @@ impl TestRunner {
                                     project_root: project_root.as_ref().as_path(),
                                     commands,
                                     build_command: build_command.as_ref().as_slice(),
-                                    build_command_explicit,
+                                    build_command_origin,
                                     env,
                                     total,
                                     verbose,
@@ -5122,7 +5131,7 @@ impl TestRunner {
                 } else {
                     None
                 },
-                build_command: if self.commands.build_command_explicit {
+                build_command: if self.commands.has_build_command() {
                     sandboxed_command(&self.commands.sandbox_command, &self.commands.build_command)
                 } else {
                     vec![]
@@ -5207,7 +5216,7 @@ fn run_schema_workspace_mutation(
         );
     }
 
-    if runner.commands.build_command_explicit && !runner.commands.build_command.is_empty() {
+    if runner.commands.has_build_command() {
         let build = run_command(
             &runner.commands.build_command,
             &runner.commands.sandbox_command,
@@ -5343,7 +5352,7 @@ impl MutationOutcome {
 
 struct BuildCommand<'a> {
     argv: &'a [String],
-    explicit: bool,
+    origin: BuildCommandOrigin,
 }
 
 fn build_error_diagnostic_from_outcome(
@@ -5635,7 +5644,11 @@ pub fn run_replay_mutation(
         &[],
         BuildCommand {
             argv: build_command,
-            explicit: config.build_command.is_some(),
+            origin: if config.build_command.is_some() {
+                BuildCommandOrigin::Configured
+            } else {
+                BuildCommandOrigin::None
+            },
         },
         config.timeout,
         workspace.root(),
@@ -5696,7 +5709,7 @@ pub fn fuzz_apply_and_restore(project_root: &Path, mutation: &Mutation) -> anyho
         &[],
         BuildCommand {
             argv: &[],
-            explicit: false,
+            origin: BuildCommandOrigin::None,
         },
         Duration::from_secs(1),
         project_root,
@@ -5851,8 +5864,8 @@ fn run_single_mutation_with_replay_access(
         );
     }
 
-    // Explicit build check: skip expensive test if mutation doesn't compile.
-    if build_command.explicit && !build_command.argv.is_empty() {
+    // Configured build checks skip expensive tests when the mutation does not compile.
+    if build_command.origin.runs_before_tests() && !build_command.argv.is_empty() {
         let build_outcome = run_command(
             build_command.argv,
             sandbox_command,
@@ -7867,6 +7880,7 @@ mod tests {
         Ok(())
     }
 
+
     fn go_operator_mutation(id: u32, file: &str, source: &str, nth: usize) -> Mutation {
         let mut offset = 0usize;
         for index in 0..=nth {
@@ -7924,7 +7938,7 @@ mod tests {
         let selected = select_test_command(project_root, commands, mutation);
         let command_context = selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             env,
         );
@@ -8280,7 +8294,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(30),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -8469,7 +8483,7 @@ test "$runs" -eq 1
     }
 
     #[test]
-    fn selected_test_command_cache_context_preserves_argv_boundaries() {
+    fn selected_test_command_cache_context_elides_auto_build_suggestions() {
         let selected = SelectedTestCommand {
             argv: vec!["cargo test".into()],
             unnarrowed_argv: None,
@@ -8488,9 +8502,127 @@ test "$runs" -eq 1
         };
 
         assert_ne!(
-            selected.cache_context(&[], false, &[], &HashMap::new()),
-            ambiguous.cache_context(&[], false, &[], &HashMap::new())
+            selected.cache_context(&[], BuildCommandOrigin::None, &[], &HashMap::new()),
+            ambiguous.cache_context(&[], BuildCommandOrigin::None, &[], &HashMap::new())
         );
+
+        let no_build = selected.cache_context(&[], BuildCommandOrigin::None, &[], &HashMap::new());
+        let auto_build = selected.cache_context(
+            &["go".into(), "build".into(), "./...".into()],
+            BuildCommandOrigin::AutoDetected,
+            &[],
+            &HashMap::new(),
+        );
+        let configured_build = selected.cache_context(
+            &["go".into(), "build".into(), "./...".into()],
+            BuildCommandOrigin::Configured,
+            &[],
+            &HashMap::new(),
+        );
+        assert_eq!(no_build, auto_build);
+        assert_ne!(no_build, configured_build);
+        assert_eq!(
+            CacheKey::new(b"source", "mutation", "description", &no_build).test_command_hash,
+            CacheKey::new(b"source", "mutation", "description", &auto_build).test_command_hash
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auto_build_suggestion_reuses_an_exact_cache_verdict() -> anyhow::Result<()> {
+        let (dir, _file, mutation) = make_relative_test_setup();
+        let build_log = dir.path().join("build.log");
+        let test_log = dir.path().join("test.log");
+        let test_command = vec![
+            "sh".into(),
+            "-c".into(),
+            "printf invoked >> \"$1\"; exit 1".into(),
+            "test".into(),
+            test_log.display().to_string(),
+        ];
+        let no_build_commands = CommandConfig {
+            command: test_command.clone(),
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: vec![],
+            sandbox_command: vec![],
+            build_command_origin: BuildCommandOrigin::None,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        seed_reused_survivor(
+            dir.path(),
+            &no_build_commands,
+            &mutation,
+            ReuseSource::ExactCache,
+        )?;
+
+        let reused = TestRunner {
+            commands: no_build_commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+        .run(vec![mutation.clone()])
+        .report;
+        assert_eq!(
+            reused.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert!(!test_log.exists(), "the seeded verdict should be reused");
+
+        let auto_build_commands = CommandConfig {
+            command: test_command,
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: appending_log_command(&build_log),
+            sandbox_command: vec![],
+            build_command_origin: BuildCommandOrigin::AutoDetected,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+        let reused_auto = TestRunner {
+            commands: auto_build_commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+        .run(vec![mutation.clone()])
+        .report;
+
+        assert_eq!(reused_auto.results.len(), 1);
+        assert_eq!(reused_auto.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            reused_auto.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::ExactCache
+        );
+        assert!(!build_log.exists(), "a detected suggestion must not run");
+        assert!(!test_log.exists(), "the seeded verdict should be reused");
+        Ok(())
     }
 
     #[test]
@@ -8964,7 +9096,7 @@ test "$runs" -eq 1
                 "{};context={:016x}",
                 selected.cache_context(
                     &runner.commands.build_command,
-                    runner.commands.build_command_explicit,
+                    runner.commands.build_command_origin,
                     &runner.commands.sandbox_command,
                     &runner.env,
                 ),
@@ -9144,7 +9276,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: Some(selection.clone()),
@@ -9155,7 +9287,7 @@ test "$runs" -eq 1
             select_test_command_with_history(dir.path(), &command_config, &mutation, None);
         let command_ctx = selected.cache_context(
             &command_config.build_command,
-            false,
+            BuildCommandOrigin::None,
             &command_config.sandbox_command,
             &HashMap::new(),
         );
@@ -9259,7 +9391,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -9270,7 +9402,7 @@ test "$runs" -eq 1
         let selected = select_test_command(dir.path(), &commands, &cached);
         let context = selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             &env,
         );
@@ -9285,7 +9417,7 @@ test "$runs" -eq 1
         let selected = select_test_command(dir.path(), &commands, &historical);
         let command_context = selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             &env,
         );
@@ -9371,7 +9503,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -9381,7 +9513,7 @@ test "$runs" -eq 1
         let selected = select_test_command(dir.path(), &command_config, &mutation);
         let command_ctx = selected.cache_context(
             &command_config.build_command,
-            false,
+            BuildCommandOrigin::None,
             &command_config.sandbox_command,
             &HashMap::new(),
         );
@@ -9513,7 +9645,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -9582,7 +9714,7 @@ test "$runs" -eq 1
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -9593,7 +9725,7 @@ test "$runs" -eq 1
             let selected = select_test_command(dir, &commands, mutation);
             let command_ctx = selected.cache_context(
                 &commands.build_command,
-                false,
+                BuildCommandOrigin::None,
                 &commands.sandbox_command,
                 &HashMap::new(),
             );
@@ -9620,7 +9752,7 @@ test "$runs" -eq 1
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -10219,7 +10351,7 @@ test "$runs" -eq 1
                 test_command: &command,
                 build_command: &command,
                 sandbox_command: &[],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_secs(5),
                 env: &HashMap::new(),
                 cancelled: &AtomicBool::new(false),
@@ -10295,7 +10427,7 @@ test "$runs" -eq 1
             timeout: None,
         });
         commands.build_command = build_command;
-        commands.build_command_explicit = true;
+        commands.build_command_origin = BuildCommandOrigin::Configured;
 
         let mut env = HashMap::new();
         env.insert(
@@ -10560,7 +10692,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10583,7 +10715,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10648,7 +10780,7 @@ test "$runs" -eq 1
                     &[],
                     BuildCommand {
                         argv: &[],
-                        explicit: false,
+                        origin: BuildCommandOrigin::None,
                     },
                     Duration::from_secs(5),
                     &project,
@@ -10683,7 +10815,7 @@ test "$runs" -eq 1
                     &[],
                     BuildCommand {
                         argv: &[],
-                        explicit: false,
+                        origin: BuildCommandOrigin::None,
                     },
                     Duration::from_secs(5),
                     &project,
@@ -10723,7 +10855,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10747,7 +10879,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10771,7 +10903,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_millis(100),
             dir.path(),
@@ -10820,7 +10952,7 @@ test "$runs" -eq 1
                     "-c".to_string(),
                     "echo compile nope >&2; exit 1".to_string(),
                 ],
-                explicit: true,
+                origin: BuildCommandOrigin::Configured,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10851,7 +10983,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &["true".to_string()], // build succeeds
-                explicit: true,
+                origin: BuildCommandOrigin::Configured,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10866,7 +10998,7 @@ test "$runs" -eq 1
 
     #[cfg(unix)]
     #[test]
-    fn non_explicit_build_command_does_not_pre_filter() {
+    fn auto_detected_build_command_does_not_pre_filter() {
         let (dir, _file, mutation) = make_test_setup();
 
         let build_marker = dir.path().join("build_ran.marker");
@@ -10876,7 +11008,7 @@ test "$runs" -eq 1
             &[
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("touch {}", test_marker.display()),
+                format!("touch {}; exit 1", test_marker.display()),
             ],
             &[],
             BuildCommand {
@@ -10885,7 +11017,7 @@ test "$runs" -eq 1
                     "-c".to_string(),
                     format!("touch {}; exit 1", build_marker.display()),
                 ],
-                explicit: false,
+                origin: BuildCommandOrigin::AutoDetected,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10895,12 +11027,380 @@ test "$runs" -eq 1
             &AtomicBool::new(false),
         );
 
-        assert_eq!(outcome.result, MutationResult::Survived);
+        assert_eq!(outcome.result, MutationResult::Killed);
         assert!(
             !build_marker.exists(),
-            "non-explicit build command should not run"
+            "auto-detected build suggestion must not run"
         );
-        assert!(test_marker.exists(), "test command should still run");
+        assert!(test_marker.exists(), "test command should run directly");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_go_build_separates_compile_errors_from_test_kills() {
+        if std::process::Command::new("go")
+            .arg("version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping Go build classification test because go is unavailable");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module example.com/calculator\n").unwrap();
+        let source = "package calculator\n\nfunc Value() int { return 1 }\n";
+        let file = dir.path().join("calculator.go");
+        std::fs::write(&file, source).unwrap();
+        for (path, content) in [
+            ("one/shared/shared.go", "package shared\nfunc One() {}\n"),
+            ("two/shared/shared.go", "package shared\nfunc Two() {}\n"),
+        ] {
+            let path = dir.path().join(path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, content).unwrap();
+        }
+        let test_only_source = r#"package main
+
+import (
+    "fmt"
+    "os"
+    "testing"
+)
+
+func mark() {
+    if marker := os.Getenv("TOGI_GO_TEST_MARKER"); marker != "" {
+        _ = os.WriteFile(marker, []byte("ran"), 0o600)
+    }
+}
+
+func init() {
+    mark()
+}
+
+func TestMain(m *testing.M) {
+    mark()
+    os.Exit(m.Run())
+}
+
+func TestVetOnly(t *testing.T) {
+    fmt.Printf("%d", "not-an-int")
+}
+"#;
+        let test_only_file = dir.path().join("testonly/main_test.go");
+        std::fs::create_dir_all(test_only_file.parent().unwrap()).unwrap();
+        std::fs::write(&test_only_file, test_only_source).unwrap();
+
+        let offset = source.rfind('1').unwrap();
+        let mutation = |id: u32, replacement: &str| Mutation {
+            id,
+            file: PathBuf::from("calculator.go"),
+            language: "Go".into(),
+            line: 3,
+            column: offset + 1,
+            operator: "binary".into(),
+            description: format!("replace 1 with {replacement}"),
+            original: "1".into(),
+            replacement: replacement.into(),
+            byte_range: offset..offset + 1,
+        };
+        let mut config = crate::config::Config::default();
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::AutoDetected
+        );
+        assert_eq!(
+            config.test.build_command,
+            crate::config::AUTO_GO_COMPILE_COMMAND
+                .iter()
+                .map(|argument| (*argument).to_string())
+                .collect::<Vec<_>>()
+        );
+        let build_command = config.test.build_command.clone();
+        config.test.set_build_command(build_command);
+        let origin = config.test.build_command_origin;
+        assert_eq!(origin, BuildCommandOrigin::Configured);
+
+        let test_marker = dir.path().join("test_ran.marker");
+        let go_runtime_marker = dir.path().join("go_runtime.marker");
+        let failing_test = vec![
+            "sh".into(),
+            "-c".into(),
+            format!("touch {}; exit 1", test_marker.display()),
+        ];
+        let mut env = HashMap::new();
+        env.insert(
+            "TOGI_GO_TEST_MARKER".into(),
+            go_runtime_marker.display().to_string(),
+        );
+
+        let invalid = mutation(1, "+");
+        let invalid_outcome = run_single_mutation(
+            &failing_test,
+            &[],
+            BuildCommand {
+                argv: &config.test.build_command,
+                origin,
+            },
+            Duration::from_secs(30),
+            dir.path(),
+            ResolvedMutation::new(dir.path(), &invalid),
+            false,
+            &env,
+            &AtomicBool::new(false),
+        );
+        assert_eq!(invalid_outcome.result, MutationResult::BuildError);
+        assert_eq!(
+            invalid_outcome
+                .build_error_detail
+                .as_ref()
+                .map(|detail| detail.phase.as_str()),
+            Some("build_command")
+        );
+        assert!(
+            !test_marker.exists(),
+            "the test command must not be credited for a source-invalid mutant"
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), source);
+
+        let test_literal = "\"not-an-int\"";
+        let test_offset = test_only_source.find(test_literal).unwrap();
+        let invalid_test = Mutation {
+            id: 2,
+            file: PathBuf::from("testonly/main_test.go"),
+            language: "Go".into(),
+            line: 24,
+            column: test_offset + 1,
+            operator: "string".into(),
+            description: "break test-only source".into(),
+            original: test_literal.into(),
+            replacement: "\"".into(),
+            byte_range: test_offset..test_offset + test_literal.len(),
+        };
+        let invalid_test_outcome = run_single_mutation(
+            &failing_test,
+            &[],
+            BuildCommand {
+                argv: &config.test.build_command,
+                origin,
+            },
+            Duration::from_secs(30),
+            dir.path(),
+            ResolvedMutation::new(dir.path(), &invalid_test),
+            false,
+            &env,
+            &AtomicBool::new(false),
+        );
+        assert_eq!(invalid_test_outcome.result, MutationResult::BuildError);
+        assert!(
+            !test_marker.exists(),
+            "the test command must not be credited for a test-invalid mutant"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&test_only_file).unwrap(),
+            test_only_source
+        );
+
+        let valid = mutation(3, "2");
+        let valid_outcome = run_single_mutation(
+            &failing_test,
+            &[],
+            BuildCommand {
+                argv: &config.test.build_command,
+                origin,
+            },
+            Duration::from_secs(30),
+            dir.path(),
+            ResolvedMutation::new(dir.path(), &valid),
+            false,
+            &env,
+            &AtomicBool::new(false),
+        );
+        assert_eq!(valid_outcome.result, MutationResult::Killed);
+        assert!(
+            test_marker.exists(),
+            "a compilable mutant must reach the test command"
+        );
+        assert!(
+            !go_runtime_marker.exists(),
+            "the compile check must not execute init or TestMain"
+        );
+        assert!(
+            dir.path().read_dir().unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".test")),
+            "the compile check must not leave Go test binaries in the workspace"
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), source);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_dotnet_build_restores_ignored_assets_in_isolated_workspaces() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = "class Calculator { static bool Value() => true; }\n";
+        std::fs::write(
+            dir.path().join("Calculator.csproj"),
+            "<Project Sdk=\"Microsoft.NET.Sdk\" />\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("Calculator.cs"), source).unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "obj/\n").unwrap();
+        let source_assets = dir.path().join("obj/project.assets.json");
+        std::fs::create_dir_all(source_assets.parent().unwrap()).unwrap();
+        std::fs::write(&source_assets, "source-assets").unwrap();
+
+        let bin = dir.path().join("fake-dotnet-bin");
+        std::fs::create_dir(&bin).unwrap();
+        let fake_dotnet = bin.join("dotnet");
+        std::fs::write(
+            &fake_dotnet,
+            r#"#!/bin/sh
+case "$1" in
+  build)
+    case " $* " in
+      *" --no-restore "*) exit 31 ;;
+    esac
+    if [ -e obj/project.assets.json ]; then
+      printf 'cached\n' >> "$TOGI_DOTNET_LOG"
+    else
+      printf 'restored\n' >> "$TOGI_DOTNET_LOG"
+      mkdir -p obj
+      : > obj/project.assets.json
+    fi
+    ;;
+  test)
+    test -f obj/project.assets.json || exit 32
+    if grep -q 'false' Calculator.cs; then
+      exit 1
+    fi
+    ;;
+  *) exit 33 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_dotnet).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_dotnet, permissions).unwrap();
+
+        if !git_available() {
+            eprintln!("skipping dotnet isolated workspace test because git is unavailable");
+            return;
+        }
+        init_clean_git_fixture(dir.path());
+
+        let mut config = crate::config::Config::default();
+        assert_eq!(
+            config.resolve_build_command(dir.path()),
+            BuildCommandOrigin::AutoDetected
+        );
+        assert_eq!(
+            config.test.build_command,
+            vec!["dotnet", "build", "Calculator.csproj"]
+        );
+        let build_command = config.test.build_command.clone();
+        config.test.set_build_command(build_command);
+        let origin = config.test.build_command_origin;
+        assert_eq!(origin, BuildCommandOrigin::Configured);
+        assert_eq!(
+            crate::config::detect_test_command(dir.path()),
+            vec!["dotnet", "test", "Calculator.csproj"]
+        );
+
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".into(),
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+        let log = dir.path().join("dotnet.log");
+        env.insert("TOGI_DOTNET_LOG".into(), log.display().to_string());
+        let commands = CommandConfig {
+            command: vec!["dotnet".into(), "test".into()],
+            force_default_command: false,
+            force_default_timeout: false,
+            project_commands: vec![],
+            language_commands: HashMap::new(),
+            build_command: config.test.build_command,
+            sandbox_command: vec![],
+            build_command_origin: origin,
+            timeout: Duration::from_secs(5),
+            language_timeouts: HashMap::new(),
+            test_selection: None,
+        };
+
+        let baseline_cancelled = AtomicBool::new(false);
+        let timing = measure_baseline_timing(
+            dir.path(),
+            BaselineTimingConfig {
+                test_command: &commands.command,
+                build_command: &commands.build_command,
+                sandbox_command: &commands.sandbox_command,
+                build_command_origin: commands.build_command_origin,
+                timeout: commands.timeout,
+                env: &env,
+                cancelled: &baseline_cancelled,
+                respect_workspace_ignores: true,
+            },
+        )
+        .unwrap();
+        assert!(timing.build_duration.is_some());
+
+        let offset = source.find("true").unwrap();
+        let mutation = Mutation {
+            id: 0,
+            file: PathBuf::from("Calculator.cs"),
+            language: "c_sharp".into(),
+            line: 1,
+            column: offset + 1,
+            operator: "boolean".into(),
+            description: "replace true with false".into(),
+            original: "true".into(),
+            replacement: "false".into(),
+            byte_range: offset..offset + "true".len(),
+        };
+        let report = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env,
+            incremental_history: false,
+            force_rerun: true,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+        .run(vec![mutation.clone()])
+        .report;
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].0.id, mutation.id);
+        assert_eq!(report.results[0].1, MutationResult::Killed);
+        assert_eq!(report.build_errors, 0);
+        assert_eq!(
+            std::fs::read_to_string(log)
+                .unwrap()
+                .lines()
+                .collect::<Vec<_>>(),
+            ["restored", "restored"],
+            "both isolated baseline and mutation workspaces must restore ignored assets"
+        );
+        assert_eq!(
+            std::fs::read_to_string(source_assets).unwrap(),
+            "source-assets"
+        );
     }
 
     #[test]
@@ -10917,7 +11417,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -10940,7 +11440,7 @@ test "$runs" -eq 1
             &[],
             BuildCommand {
                 argv: &[],
-                explicit: false,
+                origin: BuildCommandOrigin::None,
             },
             Duration::from_secs(5),
             dir.path(),
@@ -11180,7 +11680,7 @@ sleep 10"#
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11246,7 +11746,7 @@ sleep 10"#
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11317,7 +11817,7 @@ int main(void) {
                 language_commands: HashMap::new(),
                 build_command: vec!["cc".into(), "calc.c".into(), "-o".into(), "calc".into()],
                 sandbox_command: vec![],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11388,7 +11888,7 @@ int main() {
                     "calc".into(),
                 ],
                 sandbox_command: vec![],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11446,7 +11946,7 @@ esac
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11499,7 +11999,7 @@ esac
                 language_commands: HashMap::new(),
                 build_command: vec!["sh".into(), "-c".into(), "sleep 1".into()],
                 sandbox_command: vec![],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_millis(50),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11561,7 +12061,7 @@ touch side_effect
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11620,7 +12120,7 @@ esac
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -11639,7 +12139,7 @@ esac
         };
         let cache_ctx = cache_selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             &cache_env,
         );
@@ -11717,7 +12217,7 @@ esac
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -11725,7 +12225,7 @@ esac
         let selected = select_test_command(dir.path(), &commands, &mutation);
         let command_context = selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             &HashMap::new(),
         );
@@ -11826,7 +12326,7 @@ func third(a, b int) bool { return a == b }
                     language_commands: HashMap::new(),
                     build_command: vec![],
                     sandbox_command: vec![],
-                    build_command_explicit: false,
+                    build_command_origin: BuildCommandOrigin::None,
                     timeout: Duration::from_secs(5),
                     language_timeouts: HashMap::new(),
                     test_selection: None,
@@ -11894,7 +12394,7 @@ func third(a, b int) bool { return a == b }
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -11998,7 +12498,7 @@ def second(c, d):
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: BuildCommandOrigin::None,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -12010,7 +12510,7 @@ def second(c, d):
             let selected = select_test_command(dir.path(), &commands, mutation);
             let context = selected.cache_context(
                 &commands.build_command,
-                commands.build_command_explicit,
+                commands.build_command_origin,
                 &commands.sandbox_command,
                 &env,
             );
@@ -12031,7 +12531,7 @@ def second(c, d):
         let selected = select_test_command(dir.path(), &commands, &python_history);
         let command_context = selected.cache_context(
             &commands.build_command,
-            commands.build_command_explicit,
+            commands.build_command_origin,
             &commands.sandbox_command,
             &env,
         );
@@ -12124,7 +12624,7 @@ func second(c, d int) bool { return c == d }
             language_commands: HashMap::new(),
             build_command: vec!["sh".into(), "-c".into(), build.into()],
             sandbox_command: vec![],
-            build_command_explicit: true,
+            build_command_origin: BuildCommandOrigin::Configured,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -12185,7 +12685,7 @@ func second(c, d int) bool { return c == d }
             language_commands: HashMap::new(),
             build_command: vec!["sh".into(), "-c".into(), build.into()],
             sandbox_command: vec![],
-            build_command_explicit: true,
+            build_command_origin: BuildCommandOrigin::Configured,
             timeout: Duration::from_secs(5),
             language_timeouts: HashMap::new(),
             test_selection: None,
@@ -12268,7 +12768,7 @@ class Calc {
                 language_commands: HashMap::new(),
                 build_command: vec!["javac".into(), "Calc.java".into()],
                 sandbox_command: vec![],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_secs(30),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12328,7 +12828,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(60),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12421,7 +12921,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12467,7 +12967,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12525,7 +13025,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12600,7 +13100,7 @@ mod tests {
                     language_commands: HashMap::new(),
                     build_command: vec![],
                     sandbox_command: vec![],
-                    build_command_explicit: false,
+                    build_command_origin: BuildCommandOrigin::None,
                     timeout: Duration::from_secs(5),
                     language_timeouts: HashMap::new(),
                     test_selection: None,
@@ -12668,7 +13168,7 @@ mod tests {
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12764,7 +13264,7 @@ sleep 0.2
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12840,7 +13340,7 @@ sleep 0.2
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12907,7 +13407,7 @@ rmdir "$lock"
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -12916,7 +13416,7 @@ rmdir "$lock"
             let selected = select_test_command(dir.path(), &commands, &cached_mutation);
             let cache_ctx = selected.cache_context(
                 &commands.build_command,
-                commands.build_command_explicit,
+                commands.build_command_origin,
                 &commands.sandbox_command,
                 &env,
             );
@@ -13016,7 +13516,7 @@ rmdir "$lock"
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13102,7 +13602,7 @@ rmdir "$lock"
                     "grep -q build_error *.txt && exit 1; exit 0".into(),
                 ],
                 sandbox_command: vec![],
-                build_command_explicit: true,
+                build_command_origin: BuildCommandOrigin::Configured,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13176,7 +13676,7 @@ rmdir "$lock"
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13244,7 +13744,7 @@ rmdir "$lock"
                 language_commands: lang_cmds,
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13292,7 +13792,7 @@ rmdir "$lock"
                 language_commands: lang_cmds,
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13365,7 +13865,7 @@ while [ "$(find "{barrier}" -type f | wc -l)" -lt 4 ]; do sleep 0.1; done"#,
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13446,7 +13946,7 @@ exit 1"#
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13503,7 +14003,7 @@ exit 1"#
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts: HashMap::new(),
                 test_selection: None,
@@ -13560,7 +14060,7 @@ exit 1"#
                 language_commands: HashMap::new(),
                 build_command: vec![],
                 sandbox_command: vec![],
-                build_command_explicit: false,
+                build_command_origin: BuildCommandOrigin::None,
                 timeout: Duration::from_secs(5),
                 language_timeouts,
                 test_selection: None,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -245,6 +245,25 @@ fn init_rejects_conflicting_java_routes_without_writing_config() {
     assert!(!dir.path().join("togi.toml").exists());
 }
 
+#[test]
+fn init_rejects_ambiguous_dotnet_routes_without_writing_fallback() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("App.sln"), "").unwrap();
+    fs::write(dir.path().join("App.csproj"), "").unwrap();
+
+    togi()
+        .arg("init")
+        .current_dir(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "multiple test runtimes detected (.sln/.csproj)",
+        ))
+        .stderr(predicate::str::contains("set [test] command in togi.toml"))
+        .stderr(predicate::str::contains("make test").not());
+    assert!(!dir.path().join("togi.toml").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn init_routes_non_primary_languages_over_cargo() {
@@ -1451,6 +1470,152 @@ fn check_failing_baseline_does_not_accept_a_preseeded_exact_cache_verdict() {
 
 #[cfg(unix)]
 #[test]
+fn check_configured_build_classifies_mutant_build_failure_before_test() {
+    let dir = setup_git_repo();
+    let fake_bin = dir.path().join("fake-go-bin");
+    let build_marker = dir.path().join("build_ran.marker");
+    let test_marker = dir.path().join("test_ran.marker");
+    let path = fake_go_path_env(&fake_bin);
+    let fake_go = fake_bin.join("go");
+    fs::write(
+        &fake_go,
+        format!(
+            "#!/bin/sh\nif grep -q '>=' main.go; then\n    touch {}\n    exit 1\nfi\n",
+            shell_quote(&build_marker)
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_go).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_go, permissions).unwrap();
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(&format!(
+            "if grep -q '>=' main.go; then touch {}; fi",
+            shell_quote(&test_marker)
+        ))
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--test-cmd",
+            &test_cmd,
+            "--build-cmd",
+            "go test -c -vet=off -o /dev/null ./...",
+            "--operators",
+            "gt_to_gte",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("PATH", path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["build_errors"], 1);
+    assert_eq!(report["killed"], 0);
+    assert_eq!(
+        report["build_command"],
+        serde_json::json!(["go", "test", "-c", "-vet=off", "-o", "/dev/null", "./..."])
+    );
+    assert!(build_marker.exists(), "configured build check did not run");
+    assert!(
+        !test_marker.exists(),
+        "test command ran after configured build failure"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_detected_build_suggestion_does_not_pre_filter_mutants() {
+    let dir = setup_git_repo();
+    let fake_bin = dir.path().join("fake-go-bin");
+    let build_marker = dir.path().join("build_ran.marker");
+    let test_marker = dir.path().join("test_ran.marker");
+    let path = fake_go_path_env(&fake_bin);
+    let fake_go = fake_bin.join("go");
+    fs::write(
+        &fake_go,
+        format!(
+            "#!/bin/sh\nif grep -q '>=' main.go; then\n    touch {}\n    exit 1\nfi\n",
+            shell_quote(&build_marker)
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_go).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_go, permissions).unwrap();
+    let test_cmd = format!(
+        "sh -c {}",
+        shell_quote_text(&format!(
+            "if grep -q '>=' main.go; then touch {}; exit 1; fi",
+            shell_quote(&test_marker)
+        ))
+    );
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--test-cmd",
+            &test_cmd,
+            "--operators",
+            "gt_to_gte",
+            "--max-per-run",
+            "1",
+            "--no-schemata",
+            "--force-rerun",
+            "--no-incremental-history",
+            "--fail-under",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("PATH", path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["build_errors"], 0);
+    assert_eq!(report["killed"], 1);
+    assert_eq!(report["build_command"], serde_json::json!([]));
+    assert!(
+        !build_marker.exists(),
+        "detected build suggestion must not execute"
+    );
+    assert!(
+        test_marker.exists(),
+        "mutant should run the configured test command"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn check_schemata_baselines_go_with_the_no_cache_argv() {
     let dir = setup_git_repo();
     let fake_bin = dir.path().join("fake-go-bin");
@@ -1460,6 +1625,7 @@ fn check_schemata_baselines_go_with_the_no_cache_argv() {
         r#"
 [test]
 command = ["go", "test", "./..."]
+build_command = ["true"]
 timeout = 5
 
 [mutations]
@@ -1514,6 +1680,7 @@ fn check_no_schemata_keeps_the_raw_go_test_argv() {
         r#"
 [test]
 command = ["go", "test", "./..."]
+build_command = ["true"]
 timeout = 5
 "#,
     )

--- a/tests/fixtures/polyglot/togi.toml
+++ b/tests/fixtures/polyglot/togi.toml
@@ -8,3 +8,6 @@ command = ["go", "test", "./..."]
 
 [test.languages.python]
 command = ["python3", "-m", "unittest"]
+
+[mutations]
+max_per_run = 23

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -117,7 +117,7 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: togi::config::BuildCommandOrigin::None,
             timeout: Duration::from_secs(30),
             language_timeouts: std::collections::HashMap::new(),
             test_selection: None,

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -71,7 +71,7 @@ fn run_fixture(case: FixtureCase) -> togi::MutationReport {
             language_commands: HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: togi::config::BuildCommandOrigin::None,
             timeout: Duration::from_secs(30),
             language_timeouts: HashMap::new(),
             test_selection: None,

--- a/tests/integration/verify.rs
+++ b/tests/integration/verify.rs
@@ -76,7 +76,7 @@ fn verify_mutation_outcomes_match_independent_replay() {
             language_commands: std::collections::HashMap::new(),
             build_command: vec![],
             sandbox_command: vec![],
-            build_command_explicit: false,
+            build_command_origin: togi::config::BuildCommandOrigin::None,
             timeout: Duration::from_secs(30),
             language_timeouts: std::collections::HashMap::new(),
             test_selection: None,

--- a/tests/replay.rs
+++ b/tests/replay.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use serde_json::{Value, json};
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -190,6 +191,52 @@ fn write_json(path: &Path, value: &Value) {
     fs::write(path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
 }
 
+fn fake_go_path(root: &Path) -> OsString {
+    let bin = root.join("fake-go-bin");
+    fs::create_dir(&bin).unwrap();
+    #[cfg(windows)]
+    {
+        let source = bin.join("go.rs");
+        let go = bin.join("go.exe");
+        fs::write(
+            &source,
+            r#"use std::{fs::OpenOptions, io::Write};
+
+fn main() {
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(std::env::var_os("TOGI_REPLAY_LOG").unwrap())
+        .unwrap();
+    log.write_all(b"g").unwrap();
+}"#,
+        )
+        .unwrap();
+        let status = std::process::Command::new("rustc")
+            .arg(source)
+            .arg("-o")
+            .arg(go)
+            .status()
+            .unwrap();
+        assert!(status.success(), "failed to build fake go.exe");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let go = bin.join("go");
+        fs::write(&go, "#!/bin/sh\nprintf g >> \"$TOGI_REPLAY_LOG\"\nexit 0\n").unwrap();
+        let mut permissions = fs::metadata(&go).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&go, permissions).unwrap();
+    }
+    let mut paths = vec![bin];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    std::env::join_paths(paths).unwrap()
+}
+
 fn assert_rejected_without_invocation(fixture: &ReplayFixture, contents: &[u8], id: &str) {
     fs::write(&fixture.report_path, contents).unwrap();
     fs::write(&fixture.log_path, []).unwrap();
@@ -367,6 +414,56 @@ fn replay_forces_a_real_direct_execution_without_source_or_cache_residue() {
         lock_before
     );
     assert!(fixture.report_dir.path().exists());
+}
+
+#[test]
+fn legacy_report_without_build_origin_replays_configured_go_lookalike_unchanged() {
+    let fixture = setup_replay_fixture();
+    let id = fixture.report["mutations"][0]["id"]
+        .as_u64()
+        .unwrap()
+        .to_string();
+
+    let mut legacy = fixture.report.clone();
+    let replay = legacy["mutations"][0]["replay"].as_object_mut().unwrap();
+    replay.insert(
+        "build_command".into(),
+        json!(["go", "test", "-c", "-vet=off", "-o", "NUL", "./..."]),
+    );
+    replay.remove("build_command_origin");
+    write_json(&fixture.report_path, &legacy);
+    fs::write(&fixture.log_path, []).unwrap();
+
+    let output = togi()
+        .args([
+            "replay",
+            &id,
+            "--report",
+            fixture.report_path.to_str().unwrap(),
+        ])
+        .current_dir(fixture.repo.path())
+        .env("TOGI_REPLAY_LOG", &fixture.log_path)
+        .env("PATH", fake_go_path(fixture.report_dir.path()))
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "legacy replay failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains(
+        "Effective build command: [\"go\",\"test\",\"-c\",\"-vet=off\",\"-o\",\"NUL\",\"./...\"]"
+    ));
+    let log = String::from_utf8(fs::read(&fixture.log_path).unwrap()).unwrap();
+    let ordered: String = log
+        .chars()
+        .filter(|character| !matches!(character, '\r' | '\n'))
+        .collect();
+    assert_eq!(
+        ordered, "gx",
+        "build command must run before the test command"
+    );
 }
 
 #[test]

--- a/togi.toml.example
+++ b/togi.toml.example
@@ -16,13 +16,16 @@
 # Default: auto-detected from project files, or ["make", "test"] if unknown.
 command = ["go", "test", "./..."]
 
-# Optional build command run before the test command. Uncomment to enable.
-# Mutations that fail this command are reported as build errors.
-# Auto-detected build commands are shown by `togi init`, but they are not used
-# as pre-filters unless build_command is set in togi.toml or via --build-cmd.
+# Optional build command run before the test command. Mutations that fail it
+# are reported as build errors and never run the test command. Uncomment to
+# opt in; when omitted, togi runs tests directly.
+# `togi init` may suggest a safe command from project markers, but detection
+# alone never enables a build pre-filter.
 # Type: array of strings
 # Default: []
-# build_command = ["go", "build", "./..."]
+# Suggested Go command: ["go", "test", "-c", "-vet=off", "-o", <host null device>, "./..."]
+# Use "/dev/null" on Unix and "NUL" on Windows when configuring the matching command.
+# build_command = ["go", "test", "-c", "-vet=off", "-o", "/dev/null", "./..."]
 
 # Optional sandbox wrapper prefixed to every build and test command.
 # Leave unset to run directly on the host or CI runner.


### PR DESCRIPTION
## Summary
- `fix(check)`: keeps safe build detection as a `togi init` suggestion; only configured `build_command` / `--build-cmd` prefilters mutants.
- `fix(rust)`: filters invalid expression-if removal mutants.
- `fix(replay)`: preserves configured build provenance and legacy report replay.
- `test(polyglot)`: caps the demo fixture at 23 mutations.

The Rust and replay fixes are necessary safety follow-ups to the #162 foundation.

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detects safe build commands for supported projects, including Makefiles.
  - Runs configured build checks before tests and reports compilation failures separately.
  - Preserves build-command details during replay, including legacy reports.
  - Provides clearer diagnostics for ambiguous .NET project roots.

- **Bug Fixes**
  - Prevents invalid Rust mutations in value-producing `if` expressions.
  - Improves platform-specific Go build-check handling.
  - Calibrates timeouts using build timing when available.

- **Documentation**
  - Updated configuration examples and guidance for automatic and custom build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->