### PR TITLE
fix(action): emit replay JSON without a second mutation campaign (#505)

### DIFF
--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -22,7 +22,7 @@ run_togi() (
   "$togi_bin" "$@"
 )
 
-if ! version_output="$(run_togi --version 2>&1)"; then
+if ! version_output="$(run_togi --version)"; then
   echo "Could not verify the installed Togi binary version." >&2
   exit 2
 fi

--- a/.github/scripts/run-togi.sh
+++ b/.github/scripts/run-togi.sh
@@ -1,6 +1,45 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+if [[ -z "${TOGI_BIN:-}" ]]; then
+  echo "TOGI_BIN must name the concrete installed Togi binary" >&2
+  exit 2
+fi
+if [[ -z "${TOGI_EXPECTED_VERSION:-}" ]]; then
+  echo "TOGI_EXPECTED_VERSION must name the installed Togi release tag" >&2
+  exit 2
+fi
+
+togi_bin="$TOGI_BIN"
+expected_tag="$TOGI_EXPECTED_VERSION"
+if [[ ! "$expected_tag" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "TOGI_EXPECTED_VERSION must be an immutable vX.Y.Z tag" >&2
+  exit 2
+fi
+
+run_togi() (
+  unset TOGI_BASE TOGI_TIMEOUT TOGI_FORMAT TOGI_TEST_CMD TOGI_REPORT_PATH TOGI_BIN TOGI_EXPECTED_VERSION
+  "$togi_bin" "$@"
+)
+
+if ! version_output="$(run_togi --version 2>&1)"; then
+  echo "Could not verify the installed Togi binary version." >&2
+  exit 2
+fi
+if [[ "$version_output" != "togi ${expected_tag#v}" ]]; then
+  echo "Installed Togi version does not match expected ${expected_tag}: ${version_output}" >&2
+  exit 2
+fi
+
+if ! check_help="$(run_togi help check 2>&1)"; then
+  echo "Could not verify that the installed Togi binary supports --json-report." >&2
+  exit 2
+fi
+if [[ "$check_help" != *"--json-report"* ]]; then
+  echo "The installed Togi binary does not support --json-report." >&2
+  exit 2
+fi
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required to generate Action report outputs" >&2
   exit 2
@@ -21,68 +60,32 @@ if ! rm -f "$report_path"; then
 fi
 
 review_args=(check)
-json_args=(check)
 
 if [[ -n "${TOGI_BASE:-}" ]]; then
   review_args+=(--base "$TOGI_BASE")
-  json_args+=(--base "$TOGI_BASE")
 fi
 
 if [[ -n "${TOGI_TIMEOUT:-}" ]]; then
   review_args+=(--timeout "$TOGI_TIMEOUT")
-  json_args+=(--timeout "$TOGI_TIMEOUT")
 fi
 
 if [[ -n "${TOGI_FORMAT:-}" ]]; then
   review_args+=(--format "$TOGI_FORMAT")
 fi
-json_args+=(--format json)
 
 if [[ -n "${TOGI_TEST_CMD:-}" ]]; then
   review_args+=(--test-cmd "$TOGI_TEST_CMD")
-  json_args+=(--test-cmd "$TOGI_TEST_CMD")
 fi
+review_args+=(--json-report "$report_path")
 
-togi_bin="${TOGI_BIN:-togi}"
-run_togi() (
-  unset TOGI_BASE TOGI_TIMEOUT TOGI_FORMAT TOGI_TEST_CMD TOGI_REPORT_PATH TOGI_BIN
-  "$togi_bin" "$@"
-)
-
-
-if [[ "${TOGI_FORMAT:-}" == "json" ]]; then
-  run_togi "${review_args[@]}" | tee "$report_path"
-  statuses=("${PIPESTATUS[@]}")
-  review_status=${statuses[0]}
-  tee_status=${statuses[1]}
-  if (( tee_status != 0 )); then
-    echo "Could not write report to ${report_path}" >&2
-    rm -f "$report_path"
-    exit 2
-  fi
-  json_status=$review_status
-else
-  run_togi "${review_args[@]}"
-  review_status=$?
-  case "$review_status" in
-    0|1)
-      ;;
-    *)
-      rm -f "$report_path"
-      exit "$review_status"
-      ;;
-  esac
-
-  run_togi "${json_args[@]}" >"$report_path"
-  json_status=$?
-fi
-
-case "$json_status" in
+run_togi "${review_args[@]}"
+review_status=$?
+case "$review_status" in
   0|1)
     ;;
   *)
     rm -f "$report_path"
-    exit "$json_status"
+    exit "$review_status"
     ;;
 esac
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "togi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1040,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "togi"
 version = "0.5.1"
 dependencies = [
@@ -1039,6 +1063,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "cap-tempfile",
+ "caseless",
  "clap",
  "ctrlc",
  "globset",
@@ -1226,6 +1251,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "togi"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.87"
 description = "Diff-targeted, multi-language mutation testing for pull requests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ toml = "1.1"
 # Output
 serde_json = "1"
 sha2 = "0.11"
+caseless = "0.2.2"
 
 # Filesystem
 tempfile = "3"

--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: 'togi-report'
   version:
-    description: 'togi version to use'
+    description: 'Immutable released togi version to use'
     required: false
-    default: 'latest'
+    default: 'v0.5.1'
 
 outputs:
   report-path:
@@ -53,44 +53,12 @@ runs:
       env:
         TOGI_VERSION_INPUT: ${{ inputs.version }}
       run: |
-        VERSION="${TOGI_VERSION_INPUT:-latest}"
-        validate_version() {
-          local value="$1"
-          if [[ "$value" == "latest" || "$value" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
-            return 0
-          fi
-          echo "Invalid Togi version: ${value}" >&2
-          exit 1
-        }
-        validate_version "$VERSION"
-        if [ "$VERSION" = "latest" ]; then
-          if command -v jq >/dev/null 2>&1; then
-            VERSION=$(curl -fsSL https://api.github.com/repos/Darkroom4364/togi/releases/latest | jq -er .tag_name)
-          elif command -v gh >/dev/null 2>&1; then
-            VERSION=$(gh api repos/Darkroom4364/togi/releases/latest -q .tag_name)
-          else
-            echo "Resolving latest Togi version requires gh or jq" >&2
-            exit 1
-          fi
-          validate_version "$VERSION"
-        fi
-        if [ -z "$VERSION" ]; then
-          echo "Could not resolve latest Togi release version" >&2
+        set -euo pipefail
+        VERSION="${TOGI_VERSION_INPUT:-v0.5.1}"
+        if [[ ! "$VERSION" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+          echo "Togi version must be an immutable vX.Y.Z tag" >&2
           exit 1
         fi
-
-        sha256_file() {
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "$1" | awk '{print $1}'
-          elif command -v shasum >/dev/null 2>&1; then
-            shasum -a 256 "$1" | awk '{print $1}'
-          elif command -v certutil >/dev/null 2>&1; then
-            certutil -hashfile "$1" SHA256 | sed -n '2p' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]'
-          else
-            echo "No SHA-256 tool found for release verification" >&2
-            exit 1
-          fi
-        }
 
         eval "$(bash "${{ github.action_path }}/.github/scripts/resolve-togi-asset.sh")"
         TEMP_ROOT="${RUNNER_TEMP:-.}"
@@ -98,22 +66,19 @@ runs:
           TEMP_ROOT=$(cygpath -u "$TEMP_ROOT")
         fi
         mkdir -p "$TEMP_ROOT"
+        eval "$(
+          TOGI_VERSION="$VERSION" TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_FETCH_DIR="$TEMP_ROOT" \
+            bash "${{ github.action_path }}/.github/scripts/fetch-togi-release-asset.sh"
+        )"
+        TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" \
+          TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" \
+          bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"
 
-        TOGI_ARCHIVE_PATH="${TEMP_ROOT}/${TOGI_ARCHIVE}"
-        curl -fL "https://github.com/Darkroom4364/togi/releases/download/${VERSION}/${TOGI_ARCHIVE}" -o "$TOGI_ARCHIVE_PATH"
-        CHECKSUMS_PATH="${TEMP_ROOT}/togi-checksums.txt"
-        curl -fL "https://github.com/Darkroom4364/togi/releases/download/${VERSION}/checksums.txt" -o "$CHECKSUMS_PATH"
-        EXPECTED_SHA=$(awk -v file="$TOGI_ARCHIVE" '$2 == file || $2 == "./" file { print $1 }' "$CHECKSUMS_PATH")
-        if [ -z "$EXPECTED_SHA" ]; then
-          echo "No checksum found for ${TOGI_ARCHIVE}" >&2
-          exit 1
-        fi
-        ACTUAL_SHA=$(sha256_file "$TOGI_ARCHIVE_PATH")
-        if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-          echo "Checksum mismatch for ${TOGI_ARCHIVE}" >&2
-          exit 1
-        fi
-        TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"
+        TOGI_BIN="${TEMP_ROOT}/togi-bin/${TOGI_BINARY}"
+        {
+          printf 'TOGI_BIN=%s\n' "$TOGI_BIN"
+          printf 'TOGI_EXPECTED_VERSION=%s\n' "$VERSION"
+        } >> "$GITHUB_ENV"
 
     - name: Run togi
       id: run-togi

--- a/action.yml
+++ b/action.yml
@@ -60,16 +60,35 @@ runs:
           exit 1
         fi
 
-        eval "$(bash "${{ github.action_path }}/.github/scripts/resolve-togi-asset.sh")"
+        unset resolver_output TOGI_ARCHIVE TOGI_BINARY TOGI_ARCHIVE_PATH
+        if ! resolver_output=$(bash "${{ github.action_path }}/.github/scripts/resolve-togi-asset.sh"); then
+          echo "Could not resolve Togi release asset" >&2
+          exit 1
+        fi
+        eval "$resolver_output"
+        if [[ -z "${TOGI_ARCHIVE:-}" || -z "${TOGI_BINARY:-}" ]]; then
+          echo "Togi release asset resolver returned incomplete metadata" >&2
+          exit 1
+        fi
+
         TEMP_ROOT="${RUNNER_TEMP:-.}"
         if command -v cygpath >/dev/null 2>&1; then
           TEMP_ROOT=$(cygpath -u "$TEMP_ROOT")
         fi
         mkdir -p "$TEMP_ROOT"
-        eval "$(
+        unset fetch_output TOGI_ARCHIVE_PATH
+        if ! fetch_output=$(
           TOGI_VERSION="$VERSION" TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_FETCH_DIR="$TEMP_ROOT" \
             bash "${{ github.action_path }}/.github/scripts/fetch-togi-release-asset.sh"
-        )"
+        ); then
+          echo "Could not fetch and verify Togi release asset" >&2
+          exit 1
+        fi
+        eval "$fetch_output"
+        if [[ -z "${TOGI_ARCHIVE_PATH:-}" ]]; then
+          echo "Togi release asset fetch returned no archive path" >&2
+          exit 1
+        fi
         TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" \
           TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" \
           bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
           exit 1
         fi
 
-        unset resolver_output TOGI_ARCHIVE TOGI_BINARY TOGI_ARCHIVE_PATH
+        unset resolver_output TOGI_ARCHIVE TOGI_BINARY TOGI_ARCHIVE_PATH TOGI_OS TOGI_ARCH
         if ! resolver_output=$(bash "${{ github.action_path }}/.github/scripts/resolve-togi-asset.sh"); then
           echo "Could not resolve Togi release asset" >&2
           exit 1
@@ -89,7 +89,7 @@ runs:
           echo "Togi release asset fetch returned no archive path" >&2
           exit 1
         fi
-        TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" \
+        RUNNER_TEMP="$TEMP_ROOT" TOGI_ARCHIVE="$TOGI_ARCHIVE" TOGI_BINARY="$TOGI_BINARY" \
           TOGI_ARCHIVE_PATH="$TOGI_ARCHIVE_PATH" \
           bash "${{ github.action_path }}/.github/scripts/install-togi-archive.sh"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -176,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +914,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "togi"
 version = "0.5.1"
 dependencies = [
@@ -912,6 +936,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "cap-tempfile",
+ "caseless",
  "clap",
  "ctrlc",
  "globset",
@@ -1106,6 +1131,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "utf8parse"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "togi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "cap-fs-ext",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,9 @@ pub struct CheckArgs {
     /// Output format
     #[arg(short, long, default_value = "terminal")]
     pub format: OutputFormat,
+    /// Also write the replayable JSON report to this path
+    #[arg(long, value_name = "PATH", conflicts_with = "dry_run")]
+    pub json_report: Option<PathBuf>,
 
     /// Resource profile for worker count and nested runner limits
     #[arg(long, value_enum)]
@@ -233,8 +236,26 @@ pub enum Commands {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use clap::Parser;
+    #[test]
+    fn json_report_argument_is_accepted_and_conflicts_with_dry_run() {
+        let cli = Cli::try_parse_from(["togi", "check", "--json-report", "report.json"]).unwrap();
+        match cli.command {
+            Commands::Check(args) => {
+                assert_eq!(args.json_report, Some(PathBuf::from("report.json")))
+            }
+            _ => panic!("expected Check command"),
+        }
+
+        let conflict =
+            Cli::try_parse_from(["togi", "check", "--json-report", "report.json", "--dry-run"]);
+        assert!(
+            conflict.is_err(),
+            "--json-report and --dry-run should conflict"
+        );
+    }
 
     #[test]
     fn check_all_conflicts_with_base() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
 use std::collections::{BTreeMap, HashMap};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
@@ -314,6 +315,7 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     let verbose = cfg.verbose;
     let show_output = cfg.show_output;
     let output_format = cfg.format;
+    let json_report_path = cfg.json_report.clone();
     let fail_under = cfg.fail_under;
     let max_survivors = match (cfg.first_survivor, cfg.max_survivors) {
         (true, _) => Some(1),
@@ -388,8 +390,15 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         &project_root,
     )?;
     if changed_files.is_empty() {
-        if output_format == togi::cli::OutputFormat::Json {
-            print_empty_json_check_output(&config, build_command_origin, dry_run, &project_root)?;
+        if output_format == togi::cli::OutputFormat::Json || json_report_path.is_some() {
+            emit_empty_json_check_output(
+                &config,
+                build_command_origin,
+                dry_run,
+                &project_root,
+                output_format == togi::cli::OutputFormat::Json,
+                json_report_path.as_deref(),
+            )?;
         }
         return Ok(());
     }
@@ -463,12 +472,21 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
             eprintln!("  - Changed files are in an unsupported language");
             eprintln!("  - All mutable nodes were filtered out (test files, noisy patterns)");
             eprintln!("  - max_per_run or max_per_file is set to 0 in togi.toml");
-            print_empty_json_check_output(&config, build_command_origin, dry_run, &project_root)?;
         } else {
             println!("No mutations generated. Possible causes:");
             println!("  - Changed files are in an unsupported language");
             println!("  - All mutable nodes were filtered out (test files, noisy patterns)");
             println!("  - max_per_run or max_per_file is set to 0 in togi.toml");
+        }
+        if output_format == togi::cli::OutputFormat::Json || json_report_path.is_some() {
+            emit_empty_json_check_output(
+                &config,
+                build_command_origin,
+                dry_run,
+                &project_root,
+                output_format == togi::cli::OutputFormat::Json,
+                json_report_path.as_deref(),
+            )?;
         }
         return Ok(());
     }
@@ -636,14 +654,26 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         }
     }
 
-    if output_format == togi::cli::OutputFormat::Json {
+    if output_format == togi::cli::OutputFormat::Json || json_report_path.is_some() {
         replay_capture.revalidate(&project_root_ref);
-        togi::report::print_report_with_baseline_and_replay(
+        let json = togi::report::json::to_json_string_with_baseline_and_replay(
             &report,
-            output_format,
             survivor_comparison.as_ref(),
-            Some((&replay_capture, &direct_recipes)),
+            &replay_capture,
+            &direct_recipes,
         )?;
+        if let Some(path) = &json_report_path {
+            write_json_report(path, &json)?;
+        }
+        if output_format == togi::cli::OutputFormat::Json {
+            println!("{json}");
+        } else {
+            togi::report::print_report_with_baseline(
+                &report,
+                output_format,
+                survivor_comparison.as_ref(),
+            )?;
+        }
     } else {
         togi::report::print_report_with_baseline(
             &report,
@@ -1455,26 +1485,73 @@ fn coverage_only_report(
     }
 }
 
-fn print_empty_json_check_output(
+fn emit_empty_json_check_output(
     config: &togi::config::Config,
     build_command_origin: togi::config::BuildCommandOrigin,
     dry_run: bool,
     project_root: &Path,
+    print_stdout: bool,
+    json_report_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     if dry_run {
-        togi::report::json::print_dry_run(&[])?;
+        if print_stdout {
+            togi::report::json::print_dry_run(&[])?;
+        }
     } else {
         let report = coverage_only_report(config, build_command_origin);
         let mut capture = togi::replay::ReplayReportCapture::capture(project_root, &[]);
         capture.revalidate(project_root);
-        togi::report::json::print_report_with_baseline_and_replay(
+        let json = togi::report::json::to_json_string_with_baseline_and_replay(
             &report,
             None,
             &capture,
             &BTreeMap::new(),
         )?;
+        if let Some(path) = json_report_path {
+            write_json_report(path, &json)?;
+        }
+        if print_stdout {
+            println!("{json}");
+        }
     }
     Ok(())
+}
+
+fn write_json_report(path: &Path, json: &str) -> anyhow::Result<()> {
+    publish_json_report(path, |staged| {
+        staged.write_all(json.as_bytes())?;
+        staged.write_all(b"\n")
+    })
+}
+
+fn publish_json_report(
+    path: &Path,
+    write_contents: impl FnOnce(&mut tempfile::NamedTempFile) -> std::io::Result<()>,
+) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut staged = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "could not create JSON report staging file in {}",
+            parent.display()
+        )
+    })?;
+    write_contents(&mut staged)
+        .with_context(|| format!("could not write JSON report {}", path.display()))?;
+    staged
+        .flush()
+        .with_context(|| format!("could not flush JSON report {}", path.display()))?;
+    staged
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("could not sync JSON report {}", path.display()))?;
+    staged
+        .persist(path)
+        .map(|_| ())
+        .map_err(|error| error.error)
+        .with_context(|| format!("could not publish JSON report {}", path.display()))
 }
 
 fn print_dry_run(mutations: &[Mutation]) {
@@ -1972,6 +2049,7 @@ mod tests {
             base: None,
             config: None,
             format: togi::cli::OutputFormat::Terminal,
+            json_report: None,
             profile: None,
             jobs: None,
             timeout: None,
@@ -2419,5 +2497,39 @@ example.com/calc/calc.go:9.29,10.11 1 0
         let total = stats.total_lines.get(Path::new("calc.go")).unwrap();
         assert!(total.contains(&4));
         assert!(total.contains(&10));
+    }
+    #[test]
+    fn json_report_publish_replaces_existing_report_after_staging() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let report_path = dir.path().join("report.json");
+        std::fs::write(
+            &report_path,
+            "{\"kind\":\"mutation_report\",\"old\":true}\n",
+        )?;
+
+        write_json_report(&report_path, "{\"kind\":\"mutation_report\",\"new\":true}")?;
+
+        assert_eq!(
+            std::fs::read_to_string(&report_path)?,
+            "{\"kind\":\"mutation_report\",\"new\":true}\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn json_report_publish_preserves_existing_report_on_write_failure() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let report_path = dir.path().join("report.json");
+        let existing = "{\"kind\":\"mutation_report\",\"old\":true}\n";
+        std::fs::write(&report_path, existing)?;
+
+        let error = publish_json_report(&report_path, |staged| {
+            staged.write_all(b"{\"kind\":\"mutation_report\",\"partial\":")?;
+            Err(std::io::Error::other("simulated write failure"))
+        });
+
+        assert!(error.is_err());
+        assert_eq!(std::fs::read_to_string(&report_path)?, existing);
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::ffi::{OsStr, OsString};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::process;
@@ -661,7 +662,18 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         }
     }
 
-    if output_format == togi::cli::OutputFormat::Json || json_report_path.is_some() {
+    // Test commands can change symlink topology. Re-resolve all publication
+    // paths after the campaign, before any report side effect.
+    validate_json_report_destinations(
+        json_report_path.as_deref(),
+        output_format,
+        save_baseline,
+        pr_comment.as_deref(),
+        &project_root_ref,
+    )?;
+
+    let json_stdout = output_format == togi::cli::OutputFormat::Json;
+    if json_stdout || json_report_path.is_some() {
         replay_capture.revalidate(&project_root_ref);
         let json = togi::report::json::to_json_string_with_baseline_and_replay(
             &report,
@@ -672,16 +684,11 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         if let Some(path) = &json_report_path {
             write_json_report(path, &json)?;
         }
-        if output_format == togi::cli::OutputFormat::Json {
+        if json_stdout {
             println!("{json}");
-        } else {
-            togi::report::print_report_with_baseline(
-                &report,
-                output_format,
-                survivor_comparison.as_ref(),
-            )?;
         }
-    } else {
+    }
+    if !json_stdout {
         togi::report::print_report_with_baseline(
             &report,
             output_format,
@@ -1535,7 +1542,7 @@ fn validate_json_report_destinations(
         return Ok(());
     };
     let current_dir = std::env::current_dir().context("could not determine current directory")?;
-    let normalized_json_report = normalize_output_destination(json_report_path, &current_dir)?;
+    let json_report_identity = destination_identity(json_report_path, &current_dir)?;
     let mut destinations = Vec::with_capacity(3);
 
     if output_format == togi::cli::OutputFormat::Html {
@@ -1549,7 +1556,10 @@ fn validate_json_report_destinations(
     }
 
     for (name, path) in destinations {
-        if normalized_json_report == normalize_output_destination(&path, &current_dir)? {
+        if same_output_destination(
+            &json_report_identity,
+            &destination_identity(&path, &current_dir)?,
+        ) {
             anyhow::bail!(
                 "--json-report {} conflicts with the {name} destination {}",
                 json_report_path.display(),
@@ -1560,45 +1570,136 @@ fn validate_json_report_destinations(
     Ok(())
 }
 
-fn normalize_output_destination(path: &Path, current_dir: &Path) -> anyhow::Result<PathBuf> {
-    let path = if path.is_absolute() {
+fn destination_identity(path: &Path, current_dir: &Path) -> anyhow::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
         current_dir.join(path)
     };
-    let mut normalized = PathBuf::new();
+    let (root, components) = absolute_output_destination_components(&absolute)?;
+    resolve_output_destination(root, components)
+}
+
+fn absolute_output_destination_components(
+    path: &Path,
+) -> anyhow::Result<(PathBuf, VecDeque<OsString>)> {
+    let mut root = PathBuf::new();
+    let mut components = VecDeque::new();
     for component in path.components() {
         match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Prefix(prefix) => root.push(prefix.as_os_str()),
+            Component::RootDir => root.push(component.as_os_str()),
             Component::CurDir => {}
-            Component::ParentDir => {
-                if !normalized.pop() && !normalized.has_root() {
-                    normalized.push(component.as_os_str());
-                }
+            Component::ParentDir | Component::Normal(_) => {
+                components.push_back(component.as_os_str().to_os_string());
             }
-            Component::Normal(part) => normalized.push(part),
         }
     }
-
-    let mut suffix = Vec::new();
-    let mut ancestor = normalized.as_path();
-    while !ancestor.exists() {
-        let name = ancestor
-            .file_name()
-            .context("output destination has no parent")?;
-        suffix.push(name);
-        ancestor = ancestor
-            .parent()
-            .context("output destination has no parent")?;
+    if !root.has_root() {
+        anyhow::bail!("output destination must be absolute: {}", path.display());
     }
-    let mut resolved = ancestor
-        .canonicalize()
-        .unwrap_or_else(|_| ancestor.to_path_buf());
-    for part in suffix.into_iter().rev() {
-        resolved.push(part);
+    Ok((root, components))
+}
+
+fn relative_output_destination_components(path: &Path) -> anyhow::Result<VecDeque<OsString>> {
+    let mut components = VecDeque::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir | Component::Normal(_) => {
+                components.push_back(component.as_os_str().to_os_string());
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!(
+                    "could not safely resolve output destination symlink target {}",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(components)
+}
+
+fn resolve_output_destination(
+    mut resolved: PathBuf,
+    mut components: VecDeque<OsString>,
+) -> anyhow::Result<PathBuf> {
+    let mut symlink_depth = 0;
+    while let Some(component) = components.pop_front() {
+        if component == OsStr::new("..") {
+            resolved.pop();
+            continue;
+        }
+
+        let candidate = resolved.join(&component);
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                symlink_depth += 1;
+                if symlink_depth > 40 {
+                    anyhow::bail!(
+                        "could not safely resolve output destination {}: too many symlinks",
+                        candidate.display()
+                    );
+                }
+
+                let target = std::fs::read_link(&candidate).with_context(|| {
+                    format!(
+                        "could not read output destination symlink {}",
+                        candidate.display()
+                    )
+                })?;
+                let mut target_components = if target.is_absolute() {
+                    let (target_root, components) =
+                        absolute_output_destination_components(&target)?;
+                    resolved = target_root;
+                    components
+                } else {
+                    relative_output_destination_components(&target)?
+                };
+                target_components.append(&mut components);
+                components = target_components;
+            }
+            Ok(_) => resolved.push(component),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // Queues retain only normal names and `..`; after a missing
+                // component, `..` would be ambiguous if the campaign creates
+                // that component before publishing an output.
+                if components
+                    .iter()
+                    .any(|remaining| remaining == OsStr::new(".."))
+                {
+                    anyhow::bail!(
+                        "could not safely resolve output destination {}: missing intermediate component",
+                        candidate.display()
+                    );
+                }
+                resolved.push(component);
+                resolved.extend(components);
+                return Ok(resolved);
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "could not resolve output destination component {}",
+                        candidate.display()
+                    )
+                });
+            }
+        }
     }
     Ok(resolved)
+}
+
+/// Deliberately reject case-only aliases even on case-sensitive volumes so an
+/// Action cannot overwrite a sidecar when a checkout runs on case-insensitive
+/// APFS or Windows. Valid UTF-8 paths use UAX canonical caseless matching;
+/// non-UTF-8 paths retain exact PathBuf equality and are never lossy-normalized.
+fn same_output_destination(left: &Path, right: &Path) -> bool {
+    left == right
+        || left
+            .to_str()
+            .zip(right.to_str())
+            .is_some_and(|(left, right)| caseless::canonical_caseless_match_str(left, right))
 }
 
 fn write_json_report(path: &Path, json: &str) -> anyhow::Result<()> {
@@ -2582,6 +2683,96 @@ example.com/calc/calc.go:9.29,10.11 1 0
         assert!(total.contains(&4));
         assert!(total.contains(&10));
     }
+    #[test]
+    fn destination_identity_resolves_equivalent_and_nested_missing_paths() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let current_dir = dir.path().join("current");
+        std::fs::create_dir_all(current_dir.join("existing/child"))?;
+
+        let absolute = current_dir.join("existing/report.json");
+        let relative = Path::new("existing/child/../report.json");
+        assert_eq!(
+            destination_identity(relative, &current_dir)?,
+            destination_identity(&absolute, &current_dir)?
+        );
+
+        let missing_leaf = current_dir.join("missing-leaf.json");
+        assert_eq!(
+            destination_identity(&missing_leaf, &current_dir)?,
+            destination_identity(&current_dir, &current_dir)?.join("missing-leaf.json")
+        );
+        let missing_nested = current_dir.join("missing/parent/report.json");
+        assert_eq!(
+            destination_identity(&missing_nested, &current_dir)?,
+            destination_identity(&current_dir, &current_dir)?.join("missing/parent/report.json")
+        );
+        assert!(
+            destination_identity(&current_dir.join("foo/../report.json"), &current_dir).is_err(),
+            "a parent traversal after a missing component is unsafe to preflight"
+        );
+        assert!(
+            same_output_destination(&absolute, &current_dir.join("EXISTING/REPORT.JSON")),
+            "case-only aliases are deliberately rejected for case-insensitive volumes"
+        );
+        assert!(
+            same_output_destination(
+                Path::new("/tmp/über-report.html"),
+                Path::new("/tmp/ÜBER-report.html")
+            ),
+            "valid UTF-8 aliases use Unicode-aware lowercase comparison"
+        );
+        assert!(
+            same_output_destination(Path::new("/tmp/café.md"), Path::new("/tmp/cafe\u{301}.md")),
+            "valid UTF-8 aliases normalize NFC and NFD before comparison"
+        );
+        assert!(
+            same_output_destination(Path::new("/tmp/straße.md"), Path::new("/tmp/STRASSE.md")),
+            "canonical caseless matching folds sharp s"
+        );
+        assert!(
+            same_output_destination(Path::new("/tmp/σigma.md"), Path::new("/tmp/ςIGMA.md")),
+            "canonical caseless matching folds Greek sigma variants"
+        );
+        assert!(
+            same_output_destination(Path::new("/tmp/σigma.md"), Path::new("/tmp/ΣIGMA.md")),
+            "canonical caseless matching folds Greek sigma case variants"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn destination_identity_does_not_conflate_non_utf8_paths() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut left = PathBuf::new();
+        left.push(OsStr::from_bytes(&[b'/', b't', 0xff]));
+        let mut right = PathBuf::new();
+        right.push(OsStr::from_bytes(&[b'/', b't', 0xfe]));
+        assert!(!same_output_destination(&left, &right));
+        assert!(same_output_destination(&left, &left));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn destination_identity_follows_symlinks_before_parent_components() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let current_dir = dir.path().join("current");
+        std::fs::create_dir_all(current_dir.join("target/nested"))?;
+        std::os::unix::fs::symlink("target/nested", current_dir.join("link"))?;
+        std::os::unix::fs::symlink("target/report.json", current_dir.join("togi-report.html"))?;
+
+        assert_eq!(
+            destination_identity(Path::new("link/../report.json"), &current_dir)?,
+            destination_identity(&current_dir.join("target/report.json"), &current_dir)?
+        );
+        assert_eq!(
+            destination_identity(Path::new("togi-report.html"), &current_dir)?,
+            destination_identity(&current_dir.join("target/report.json"), &current_dir)?
+        );
+        Ok(())
+    }
+
     #[test]
     fn json_report_publish_replaces_existing_report_after_staging() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::Parser;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -348,6 +348,13 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         }
         Err(error) => return Err(error),
     };
+    validate_json_report_destinations(
+        json_report_path.as_deref(),
+        output_format,
+        save_baseline,
+        pr_comment.as_deref(),
+        &project_root,
+    )?;
     let ambiguous_test_command = match config.resolve_test_command(&project_root) {
         togi::config::TestCommandResolution::Resolved => None,
         togi::config::TestCommandResolution::Ambiguous(ambiguity) => Some(ambiguity),
@@ -1515,6 +1522,83 @@ fn emit_empty_json_check_output(
         }
     }
     Ok(())
+}
+
+fn validate_json_report_destinations(
+    json_report_path: Option<&Path>,
+    output_format: togi::cli::OutputFormat,
+    save_baseline: bool,
+    pr_comment: Option<&Path>,
+    project_root: &Path,
+) -> anyhow::Result<()> {
+    let Some(json_report_path) = json_report_path else {
+        return Ok(());
+    };
+    let current_dir = std::env::current_dir().context("could not determine current directory")?;
+    let normalized_json_report = normalize_output_destination(json_report_path, &current_dir)?;
+    let mut destinations = Vec::with_capacity(3);
+
+    if output_format == togi::cli::OutputFormat::Html {
+        destinations.push(("HTML report", PathBuf::from("togi-report.html")));
+    }
+    if save_baseline {
+        destinations.push(("baseline", project_root.join(".togi-baseline")));
+    }
+    if let Some(path) = pr_comment {
+        destinations.push(("PR comment", path.to_path_buf()));
+    }
+
+    for (name, path) in destinations {
+        if normalized_json_report == normalize_output_destination(&path, &current_dir)? {
+            anyhow::bail!(
+                "--json-report {} conflicts with the {name} destination {}",
+                json_report_path.display(),
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn normalize_output_destination(path: &Path, current_dir: &Path) -> anyhow::Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !normalized.has_root() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    let mut suffix = Vec::new();
+    let mut ancestor = normalized.as_path();
+    while !ancestor.exists() {
+        let name = ancestor
+            .file_name()
+            .context("output destination has no parent")?;
+        suffix.push(name);
+        ancestor = ancestor
+            .parent()
+            .context("output destination has no parent")?;
+    }
+    let mut resolved = ancestor
+        .canonicalize()
+        .unwrap_or_else(|_| ancestor.to_path_buf());
+    for part in suffix.into_iter().rev() {
+        resolved.push(part);
+    }
+    Ok(resolved)
 }
 
 fn write_json_report(path: &Path, json: &str) -> anyhow::Result<()> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -909,6 +909,7 @@ fn check_all_mutants_uncovered_aborts_when_baseline_build_fails() {
         "SF:main.go\nDA:4,0\nDA:7,0\nend_of_record\n",
     )
     .unwrap();
+    let report_path = dir.path().join("baseline-failure-report.json");
 
     let output = togi()
         .args([
@@ -917,6 +918,8 @@ fn check_all_mutants_uncovered_aborts_when_baseline_build_fails() {
             "HEAD",
             "--format",
             "json",
+            "--json-report",
+            report_path.to_str().unwrap(),
             "--test-cmd",
             "true",
             "--build-cmd",
@@ -941,6 +944,7 @@ fn check_all_mutants_uncovered_aborts_when_baseline_build_fails() {
     assert!(failure.get("mutations").is_none());
     assert!(failure.get("mutation_score").is_none());
     assert!(!dir.path().join(".togi-cache").exists());
+    assert!(!report_path.exists());
 }
 
 #[test]
@@ -1046,6 +1050,134 @@ fn check_format_json_outputs_valid_json() {
 }
 
 #[test]
+fn check_json_report_sidecar_preserves_non_json_output_and_replays() {
+    let dir = setup_git_repo();
+    let report_path = dir.path().join("report.json");
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "github",
+            "--json-report",
+            report_path.to_str().unwrap(),
+            "--no-schemata",
+            "--test-cmd",
+            "true",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("::warning"));
+
+    let report: serde_json::Value = serde_json::from_slice(&fs::read(&report_path).unwrap())
+        .expect("sidecar must be valid JSON");
+    assert_eq!(report["kind"], "mutation_report");
+    assert_eq!(report["schema_version"], 1);
+    let mutation = report["mutations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|mutation| mutation["replay"]["kind"] == "regular_direct")
+        .expect("sidecar must contain a directly replayable mutation");
+    let mutant_id = mutation["id"].as_u64().unwrap().to_string();
+
+    togi()
+        .args([
+            "replay",
+            &mutant_id,
+            "--report",
+            report_path.to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_json_report_sidecar_reuses_json_stdout_payload() {
+    let dir = setup_git_repo();
+    let report_path = dir.path().join("report.json");
+    fs::write(&report_path, "stale report\n").unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "json",
+            "--json-report",
+            report_path.to_str().unwrap(),
+            "--no-schemata",
+            "--test-cmd",
+            "true",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, fs::read(&report_path).unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_json_report_staging_failure_preserves_existing_report() {
+    let dir = setup_git_repo();
+    let report_dir = dir.path().join("locked-report-directory");
+    fs::create_dir(&report_dir).unwrap();
+    let report_path = report_dir.join("report.json");
+    let existing = "{\"kind\":\"mutation_report\",\"old\":true}\n";
+    fs::write(&report_path, existing).unwrap();
+    let original_permissions = fs::metadata(&report_dir).unwrap().permissions();
+    let mut locked_permissions = original_permissions.clone();
+    locked_permissions.set_mode(0o500);
+    fs::set_permissions(&report_dir, locked_permissions).unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--base",
+            "HEAD",
+            "--format",
+            "github",
+            "--json-report",
+            report_path.to_str().unwrap(),
+            "--no-schemata",
+            "--test-cmd",
+            "true",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::set_permissions(&report_dir, original_permissions).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(fs::read_to_string(&report_path).unwrap(), existing);
+}
+
+#[test]
 fn check_format_json_dry_run_outputs_a_single_preview_document() {
     let dir = setup_git_repo();
 
@@ -1083,6 +1215,60 @@ fn check_format_json_dry_run_outputs_a_single_preview_document() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(!dir.path().join(".togi-cache").exists());
+}
+
+#[test]
+fn check_dry_run_rejects_json_report_and_preserves_existing_report() {
+    for has_mutations in [false, true] {
+        let dir = setup_git_repo();
+        if !has_mutations {
+            assert_command_success(
+                std::process::Command::new("git")
+                    .args(["add", "."])
+                    .current_dir(dir.path())
+                    .output()
+                    .unwrap(),
+                "commit no-diff setup",
+            );
+            assert_command_success(
+                std::process::Command::new("git")
+                    .args(["commit", "-m", "second"])
+                    .current_dir(dir.path())
+                    .output()
+                    .unwrap(),
+                "commit no-diff setup",
+            );
+        }
+        let report_path = dir.path().join("dry-run-report.json");
+        let existing = "{\"kind\":\"mutation_report\",\"schema_version\":1}\n";
+        fs::write(&report_path, existing).unwrap();
+
+        let output = togi()
+            .args([
+                "check",
+                "--base",
+                "HEAD",
+                "--format",
+                "json",
+                "--dry-run",
+                "--json-report",
+                report_path.to_str().unwrap(),
+                "--test-cmd",
+                "true",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("cannot be used with"),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(fs::read_to_string(&report_path).unwrap(), existing);
+    }
 }
 
 #[test]
@@ -1157,6 +1343,7 @@ fn check_format_json_no_mutations_outputs_an_empty_report() {
             .unwrap(),
         "commit no-diff setup",
     );
+    let report_path = dir.path().join("empty-report.json");
 
     let output = togi()
         .args([
@@ -1165,6 +1352,8 @@ fn check_format_json_no_mutations_outputs_an_empty_report() {
             "HEAD",
             "--format",
             "json",
+            "--json-report",
+            report_path.to_str().unwrap(),
             "--test-cmd",
             "true",
         ])
@@ -1183,6 +1372,9 @@ fn check_format_json_no_mutations_outputs_an_empty_report() {
     assert_eq!(value["planned_total"], 0);
     assert_eq!(value["mutation_score"], 100.0);
     assert_eq!(value["mutations"], serde_json::json!([]));
+    assert_eq!(value["kind"], "mutation_report");
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(output.stdout, fs::read(&report_path).unwrap());
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("No changes found"),
         "stderr: {}",
@@ -1220,6 +1412,7 @@ fn check_format_json_post_generation_no_mutations_outputs_empty_report() {
         "package main\n\nconst name = \"after\"\n\nfunc main() {}\n",
     )
     .unwrap();
+    let report_path = dir.path().join("post-generation-empty-report.json");
 
     let output = togi()
         .args([
@@ -1228,6 +1421,8 @@ fn check_format_json_post_generation_no_mutations_outputs_empty_report() {
             "HEAD",
             "--format",
             "json",
+            "--json-report",
+            report_path.to_str().unwrap(),
             "--operators",
             "string_to_empty",
             "--test-cmd",
@@ -1247,6 +1442,9 @@ fn check_format_json_post_generation_no_mutations_outputs_empty_report() {
     assert_eq!(value["total"], 0);
     assert_eq!(value["planned_total"], 0);
     assert_eq!(value["mutations"], serde_json::json!([]));
+    assert_eq!(value["kind"], "mutation_report");
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(output.stdout, fs::read(&report_path).unwrap());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("No mutations generated"),
@@ -3595,27 +3793,51 @@ if [[ -n "${FAKE_TOGI_ENV_LOG:-}" ]]; then
   printf 'TOGI_TEST_CMD=%s\n' "${TOGI_TEST_CMD-__unset__}" >> "$FAKE_TOGI_ENV_LOG"
   printf 'TOGI_REPORT_PATH=%s\n' "${TOGI_REPORT_PATH-__unset__}" >> "$FAKE_TOGI_ENV_LOG"
   printf 'TOGI_BIN=%s\n' "${TOGI_BIN-__unset__}" >> "$FAKE_TOGI_ENV_LOG"
+  printf 'TOGI_EXPECTED_VERSION=%s\n' "${TOGI_EXPECTED_VERSION-__unset__}" >> "$FAKE_TOGI_ENV_LOG"
   printf '%s\n' '--' >> "$FAKE_TOGI_ENV_LOG"
 fi
 
 args=("$@")
 format=terminal
+report_path=
 for ((index = 0; index < ${#args[@]}; index++)); do
-  if [[ "${args[index]}" == "--format" ]]; then
-    format="${args[$((index + 1))]}"
-    break
-  fi
+  case "${args[index]}" in
+    --format)
+      format="${args[$((index + 1))]}"
+      ;;
+    --json-report)
+      report_path="${args[$((index + 1))]}"
+      ;;
+  esac
 done
 for arg in "${args[@]}"; do
   printf '<%s>\n' "$arg" >> "$FAKE_TOGI_LOG"
 done
 printf '%s\n' '--' >> "$FAKE_TOGI_LOG"
+
+if [[ "${args[0]:-}" == "--version" ]]; then
+  printf 'togi %s\n' "${FAKE_TOGI_VERSION:-0.5.1}"
+  exit "${FAKE_TOGI_VERSION_STATUS:-0}"
+fi
+if [[ "${args[0]:-}" == "help" && "${args[1]:-}" == "check" ]]; then
+  if [[ "${FAKE_TOGI_SUPPORTS_JSON_REPORT:-1}" == "1" ]]; then
+    printf '%s\n' '--json-report <PATH>'
+  else
+    printf '%s\n' 'check help without JSON sidecar support'
+  fi
+  exit 0
+fi
+
+status="${FAKE_TOGI_STATUS:-0}"
+if [[ "$status" == "0" || "$status" == "1" ]] && [[ -n "$report_path" ]]; then
+  printf '%s\n' "${FAKE_TOGI_JSON:?}" > "$report_path"
+fi
 if [[ "$format" == "json" ]]; then
   printf '%s\n' "${FAKE_TOGI_JSON:?}"
-  exit "${FAKE_TOGI_JSON_STATUS:-0}"
+else
+  printf 'review-format=%s\n' "$format"
 fi
-printf 'review-format=%s\n' "$format"
-exit "${FAKE_TOGI_REVIEW_STATUS:-0}"
+exit "$status"
 "#,
     )
     .unwrap();
@@ -3641,28 +3863,27 @@ struct ActionHelperRun<'a> {
     timeout: Option<&'a str>,
     format: Option<&'a str>,
     test_cmd: Option<&'a str>,
-    review_status: i32,
-    json_status: i32,
+    status: i32,
     json: &'a str,
 }
 
-fn run_action_helper(
+fn action_helper_command(
     fixture: &ActionHelperFixture,
     run: ActionHelperRun<'_>,
-) -> std::process::Output {
+) -> std::process::Command {
     let helper = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/scripts/run-togi.sh");
     let mut command = std::process::Command::new("bash");
     command
         .arg(helper)
         .current_dir(fixture.dir.path())
         .env("TOGI_BIN", &fixture.fake_togi)
+        .env("TOGI_EXPECTED_VERSION", "v0.5.1")
         .env("RUNNER_TEMP", fixture.dir.path())
         .env("GITHUB_OUTPUT", &fixture.github_output)
         .env("TOGI_REPORT_PATH", &fixture.report_path)
         .env("FAKE_TOGI_LOG", &fixture.invocation_log)
         .env("FAKE_TOGI_ENV_LOG", &fixture.child_environment_log)
-        .env("FAKE_TOGI_REVIEW_STATUS", run.review_status.to_string())
-        .env("FAKE_TOGI_JSON_STATUS", run.json_status.to_string())
+        .env("FAKE_TOGI_STATUS", run.status.to_string())
         .env("FAKE_TOGI_JSON", run.json);
     for (name, value) in [
         ("TOGI_BASE", run.base),
@@ -3676,7 +3897,14 @@ fn run_action_helper(
             command.env_remove(name);
         }
     }
-    command.output().unwrap()
+    command
+}
+
+fn run_action_helper(
+    fixture: &ActionHelperFixture,
+    run: ActionHelperRun<'_>,
+) -> std::process::Output {
+    action_helper_command(fixture, run).output().unwrap()
 }
 
 fn action_helper_invocations(fixture: &ActionHelperFixture) -> Vec<Vec<String>> {
@@ -3697,8 +3925,24 @@ fn action_helper_invocations(fixture: &ActionHelperFixture) -> Vec<Vec<String>> 
     invocations
 }
 
+fn action_helper_check_invocations(fixture: &ActionHelperFixture) -> Vec<Vec<String>> {
+    action_helper_invocations(fixture)
+        .into_iter()
+        .filter(|invocation| invocation.first().is_some_and(|arg| arg == "check"))
+        .collect()
+}
+
 fn action_args(args: &[&str]) -> Vec<String> {
     args.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+fn action_args_with_report(fixture: &ActionHelperFixture, args: &[&str]) -> Vec<String> {
+    let mut args = action_args(args);
+    args.extend([
+        "--json-report".to_string(),
+        fixture.report_path.display().to_string(),
+    ]);
+    args
 }
 
 fn assert_action_outputs(fixture: &ActionHelperFixture) {
@@ -3729,8 +3973,7 @@ fn github_action_run_helper_preserves_selected_format_and_exit_one() {
             timeout: Some("45"),
             format: Some("github"),
             test_cmd: Some("cargo test --workspace --all-features"),
-            review_status: 1,
-            json_status: 1,
+            status: 1,
             json: NORMAL_ACTION_REPORT,
         },
     );
@@ -3748,28 +3991,22 @@ fn github_action_run_helper_preserves_selected_format_and_exit_one() {
     assert_eq!(
         action_helper_invocations(&fixture),
         vec![
-            action_args(&[
-                "check",
-                "--base",
-                "HEAD~1",
-                "--timeout",
-                "45",
-                "--format",
-                "github",
-                "--test-cmd",
-                "cargo test --workspace --all-features",
-            ]),
-            action_args(&[
-                "check",
-                "--base",
-                "HEAD~1",
-                "--timeout",
-                "45",
-                "--format",
-                "json",
-                "--test-cmd",
-                "cargo test --workspace --all-features",
-            ]),
+            action_args(&["--version"]),
+            action_args(&["help", "check"]),
+            action_args_with_report(
+                &fixture,
+                &[
+                    "check",
+                    "--base",
+                    "HEAD~1",
+                    "--timeout",
+                    "45",
+                    "--format",
+                    "github",
+                    "--test-cmd",
+                    "cargo test --workspace --all-features",
+                ],
+            ),
         ]
     );
     assert_eq!(
@@ -3777,6 +4014,153 @@ fn github_action_run_helper_preserves_selected_format_and_exit_one() {
         format!("{NORMAL_ACTION_REPORT}\n")
     );
     assert_action_outputs(&fixture);
+}
+
+#[test]
+fn github_action_run_helper_runs_each_selected_format_once() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    for format in [
+        None,
+        Some("terminal"),
+        Some("github"),
+        Some("html"),
+        Some("sarif"),
+        Some("json"),
+    ] {
+        let fixture = action_helper_fixture();
+        let output = run_action_helper(
+            &fixture,
+            ActionHelperRun {
+                base: None,
+                timeout: None,
+                format,
+                test_cmd: None,
+                status: 1,
+                json: NORMAL_ACTION_REPORT,
+            },
+        );
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{format:?} helper stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected_stdout = if format == Some("json") {
+            format!("{NORMAL_ACTION_REPORT}\n")
+        } else {
+            format!("review-format={}\n", format.unwrap_or("terminal"))
+        };
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected_stdout);
+        let mut expected_args = action_args(&["check"]);
+        if let Some(format) = format {
+            expected_args.extend(["--format".to_string(), format.to_string()]);
+        }
+        expected_args.extend([
+            "--json-report".to_string(),
+            fixture.report_path.display().to_string(),
+        ]);
+        assert_eq!(
+            action_helper_check_invocations(&fixture),
+            vec![expected_args],
+            "{format:?} must run exactly one check campaign"
+        );
+        assert_eq!(
+            fs::read_to_string(&fixture.report_path).unwrap(),
+            format!("{NORMAL_ACTION_REPORT}\n")
+        );
+        assert_action_outputs(&fixture);
+    }
+}
+
+#[test]
+fn github_action_run_helper_rejects_version_mismatches_before_check() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    for version in ["0.5.0", "0.5.2"] {
+        let fixture = action_helper_fixture();
+        let existing = "{\"kind\":\"mutation_report\",\"schema_version\":1}\n";
+        fs::write(&fixture.report_path, existing).unwrap();
+        let mut command = action_helper_command(
+            &fixture,
+            ActionHelperRun {
+                base: Some("HEAD~1"),
+                timeout: None,
+                format: Some("github"),
+                test_cmd: None,
+                status: 1,
+                json: NORMAL_ACTION_REPORT,
+            },
+        );
+        command.env("FAKE_TOGI_VERSION", version);
+        let output = command.output().unwrap();
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("does not match expected"),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            action_helper_invocations(&fixture),
+            vec![action_args(&["--version"])]
+        );
+        assert!(action_helper_check_invocations(&fixture).is_empty());
+        assert_eq!(fs::read_to_string(&fixture.report_path).unwrap(), existing);
+        assert!(
+            !fixture.github_output.exists()
+                || fs::read_to_string(&fixture.github_output)
+                    .unwrap()
+                    .is_empty()
+        );
+    }
+}
+
+#[test]
+fn github_action_run_helper_rejects_binary_without_json_report_before_check() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    let existing = "{\"kind\":\"mutation_report\",\"schema_version\":1}\n";
+    fs::write(&fixture.report_path, existing).unwrap();
+    let mut command = action_helper_command(
+        &fixture,
+        ActionHelperRun {
+            base: Some("HEAD~1"),
+            timeout: None,
+            format: Some("github"),
+            test_cmd: None,
+            status: 1,
+            json: NORMAL_ACTION_REPORT,
+        },
+    );
+    command.env("FAKE_TOGI_SUPPORTS_JSON_REPORT", "0");
+    let output = command.output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("does not support --json-report"));
+    assert_eq!(
+        action_helper_invocations(&fixture),
+        vec![action_args(&["--version"]), action_args(&["help", "check"])]
+    );
+    assert!(action_helper_check_invocations(&fixture).is_empty());
+    assert_eq!(fs::read_to_string(&fixture.report_path).unwrap(), existing);
+    assert!(
+        !fixture.github_output.exists()
+            || fs::read_to_string(&fixture.github_output)
+                .unwrap()
+                .is_empty()
+    );
 }
 
 #[test]
@@ -3794,8 +4178,7 @@ fn github_action_run_helper_isolates_private_environment_from_child_togi() {
             timeout: Some("120"),
             format: Some("github"),
             test_cmd: Some("cargo test --locked"),
-            review_status: 0,
-            json_status: 0,
+            status: 0,
             json: NORMAL_ACTION_REPORT,
         },
     );
@@ -3813,58 +4196,14 @@ fn github_action_run_helper_isolates_private_environment_from_child_togi() {
         "TOGI_TEST_CMD=__unset__\n",
         "TOGI_REPORT_PATH=__unset__\n",
         "TOGI_BIN=__unset__\n",
+        "TOGI_EXPECTED_VERSION=__unset__\n",
     );
     assert_eq!(
         fs::read_to_string(&fixture.child_environment_log).unwrap(),
-        format!("{isolated_child_environment}--\n{isolated_child_environment}--\n")
+        format!(
+            "{isolated_child_environment}--\n{isolated_child_environment}--\n{isolated_child_environment}--\n"
+        )
     );
-}
-
-#[test]
-fn github_action_run_helper_reuses_selected_json_stdout_once() {
-    if !bash_available() || !jq_available() {
-        eprintln!("skipping action helper test because bash or jq is unavailable");
-        return;
-    }
-
-    let fixture = action_helper_fixture();
-    let output = run_action_helper(
-        &fixture,
-        ActionHelperRun {
-            base: Some("HEAD~1"),
-            timeout: Some("45"),
-            format: Some("json"),
-            test_cmd: Some("go test ./..."),
-            review_status: 1,
-            json_status: 1,
-            json: NORMAL_ACTION_REPORT,
-        },
-    );
-
-    assert_eq!(output.status.code(), Some(1));
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        format!("{NORMAL_ACTION_REPORT}\n")
-    );
-    assert_eq!(
-        action_helper_invocations(&fixture),
-        vec![action_args(&[
-            "check",
-            "--base",
-            "HEAD~1",
-            "--timeout",
-            "45",
-            "--format",
-            "json",
-            "--test-cmd",
-            "go test ./...",
-        ])]
-    );
-    assert_eq!(
-        fs::read_to_string(&fixture.report_path).unwrap(),
-        format!("{NORMAL_ACTION_REPORT}\n")
-    );
-    assert_action_outputs(&fixture);
 }
 
 #[cfg(not(windows))]
@@ -3898,12 +4237,12 @@ fn github_action_run_helper_keeps_native_report_output_path() {
         .current_dir(fixture.dir.path())
         .env("PATH", path)
         .env("TOGI_BIN", &fixture.fake_togi)
+        .env("TOGI_EXPECTED_VERSION", "v0.5.1")
         .env("TOGI_REPORT_PATH", r"C:\runner\temp\togi-report.json")
         .env("RUNNER_TEMP", fixture.dir.path())
         .env("GITHUB_OUTPUT", &fixture.github_output)
         .env("FAKE_TOGI_LOG", &fixture.invocation_log)
-        .env("FAKE_TOGI_REVIEW_STATUS", "0")
-        .env("FAKE_TOGI_JSON_STATUS", "0")
+        .env("FAKE_TOGI_STATUS", "0")
         .env("FAKE_TOGI_JSON", NORMAL_ACTION_REPORT)
         .env("FAKE_CYGPATH_RESULT", &fixture.report_path)
         .env_remove("TOGI_BASE")
@@ -3916,11 +4255,11 @@ fn github_action_run_helper_keeps_native_report_output_path() {
     assert!(output.status.success());
     assert!(fixture.report_path.exists());
     assert_eq!(
-        action_helper_invocations(&fixture),
-        vec![
-            action_args(&["check", "--format", "github"]),
-            action_args(&["check", "--format", "json"]),
-        ]
+        action_helper_check_invocations(&fixture),
+        vec![action_args_with_report(
+            &fixture,
+            &["check", "--format", "github"],
+        )]
     );
     assert_eq!(
         fs::read_to_string(&fixture.github_output).unwrap(),
@@ -3943,8 +4282,7 @@ fn github_action_run_helper_omits_unset_review_flags() {
             timeout: None,
             format: None,
             test_cmd: None,
-            review_status: 0,
-            json_status: 0,
+            status: 0,
             json: NORMAL_ACTION_REPORT,
         },
     );
@@ -3955,11 +4293,8 @@ fn github_action_run_helper_omits_unset_review_flags() {
         "review-format=terminal\n"
     );
     assert_eq!(
-        action_helper_invocations(&fixture),
-        vec![
-            action_args(&["check"]),
-            action_args(&["check", "--format", "json"]),
-        ]
+        action_helper_check_invocations(&fixture),
+        vec![action_args_with_report(&fixture, &["check"])]
     );
     assert_action_outputs(&fixture);
 }
@@ -3971,7 +4306,7 @@ fn github_action_run_helper_removes_invalid_or_fatal_sidecar_reports() {
         return;
     }
 
-    for (json_status, json) in [(1, "not json"), (2, NORMAL_ACTION_REPORT)] {
+    for (status, json) in [(1, "not json"), (2, NORMAL_ACTION_REPORT)] {
         let fixture = action_helper_fixture();
         let output = run_action_helper(
             &fixture,
@@ -3980,8 +4315,7 @@ fn github_action_run_helper_removes_invalid_or_fatal_sidecar_reports() {
                 timeout: None,
                 format: Some("github"),
                 test_cmd: None,
-                review_status: 1,
-                json_status,
+                status,
                 json,
             },
         );
@@ -3989,7 +4323,7 @@ fn github_action_run_helper_removes_invalid_or_fatal_sidecar_reports() {
         assert_eq!(
             output.status.code(),
             Some(2),
-            "unexpected status for JSON sidecar status {json_status}\nstderr:\n{}",
+            "unexpected status for JSON sidecar status {status}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stderr)
         );
         assert!(!fixture.report_path.exists());
@@ -4018,18 +4352,18 @@ fn github_action_run_helper_propagates_fatal_review_and_cleans_stale_report() {
             timeout: None,
             format: Some("github"),
             test_cmd: None,
-            review_status: 2,
-            json_status: 0,
+            status: 2,
             json: NORMAL_ACTION_REPORT,
         },
     );
 
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(
-        action_helper_invocations(&fixture),
-        vec![action_args(&[
-            "check", "--base", "HEAD~1", "--format", "github",
-        ])]
+        action_helper_check_invocations(&fixture),
+        vec![action_args_with_report(
+            &fixture,
+            &["check", "--base", "HEAD~1", "--format", "github"],
+        )]
     );
     assert!(!fixture.report_path.exists());
     assert!(
@@ -4063,6 +4397,7 @@ fn github_action_report_replays_a_direct_mutation() {
         .arg(helper)
         .current_dir(repo.path())
         .env("TOGI_BIN", assert_cmd::cargo::cargo_bin("togi"))
+        .env("TOGI_EXPECTED_VERSION", "v0.5.0")
         .env("RUNNER_TEMP", report_dir.path())
         .env("GITHUB_OUTPUT", &github_output)
         .env("TOGI_BASE", "HEAD")
@@ -4151,7 +4486,7 @@ fn github_action_inputs_have_no_baked_in_defaults() {
     }
 
     for (name, default) in [
-        ("version", "'latest'"),
+        ("version", "'v0.5.1'"),
         ("upload-report", "'true'"),
         ("report-retention-days", "'14'"),
         ("report-artifact-name", "'togi-report'"),
@@ -4166,6 +4501,28 @@ fn github_action_inputs_have_no_baked_in_defaults() {
             "action.yml input `{name}` must keep its {default} default"
         );
     }
+    assert!(
+        !action_yml.contains("latest"),
+        "Action releases must not resolve a mutable version"
+    );
+    for expected in [
+        "VERSION=\"${TOGI_VERSION_INPUT:-v0.5.1}\"",
+        "^v[0-9]+[.][0-9]+[.][0-9]+$",
+        "resolve-togi-asset.sh",
+        "fetch-togi-release-asset.sh",
+        "install-togi-archive.sh",
+        "TOGI_BIN=\"${TEMP_ROOT}/togi-bin/${TOGI_BINARY}\"",
+        "printf 'TOGI_EXPECTED_VERSION=%s\\n' \"$VERSION\"",
+    ] {
+        assert!(
+            action_yml.contains(expected),
+            "action.yml must contain `{expected}`"
+        );
+    }
+    assert!(
+        !action_yml.contains("curl "),
+        "Action downloads must go through the verified fetch helper"
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,7 +2,10 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 #[cfg(unix)]
-use std::os::unix::{fs::PermissionsExt, process::CommandExt};
+use std::os::unix::{
+    fs::{PermissionsExt, symlink},
+    process::CommandExt,
+};
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::time::{Duration, Instant};
@@ -73,10 +76,9 @@ fn setup_git_repo() -> TempDir {
 }
 
 #[cfg(unix)]
-fn assert_json_report_destination_collision(
+fn assert_json_report_destination_preflight(
     dir: &TempDir,
     json_report_path: &Path,
-    destination: &Path,
     configure: impl FnOnce(&mut Command),
 ) {
     let campaign_marker = dir.path().join("campaign-ran");
@@ -86,7 +88,6 @@ fn assert_json_report_destination_collision(
         "#!/bin/sh\ntouch campaign-ran\n",
     )
     .unwrap();
-    let existing = fs::read_to_string(destination).unwrap();
 
     let mut command = togi();
     command
@@ -112,7 +113,65 @@ fn assert_json_report_destination_collision(
         !dir.path().join(".togi-cache").exists(),
         "collision must stop before mutation side effects"
     );
-    assert_eq!(fs::read_to_string(destination).unwrap(), existing);
+}
+
+#[cfg(unix)]
+fn assert_json_report_destination_collision(
+    dir: &TempDir,
+    json_report_path: &Path,
+    destination: &Path,
+    configure: impl FnOnce(&mut Command),
+) {
+    let existing = fs::read(destination).unwrap();
+    assert_json_report_destination_preflight(dir, json_report_path, configure);
+    assert_eq!(fs::read(destination).unwrap(), existing);
+}
+
+#[cfg(unix)]
+fn assert_missing_intermediate_destination_rejected(
+    dir: &TempDir,
+    json_report_path: &Path,
+    protected_output: &Path,
+    configure: impl FnOnce(&mut Command),
+) {
+    let missing_parent = dir.path().join("foo");
+    let campaign_marker = dir.path().join("campaign-ran");
+    assert!(!missing_parent.exists());
+    fs::write(
+        dir.path().join("create-foo.sh"),
+        "#!/bin/sh\nmkdir foo\ntouch campaign-ran\n",
+    )
+    .unwrap();
+    let existing = fs::read(protected_output).unwrap();
+
+    let mut command = togi();
+    command
+        .args(["check", "--all", "--path", "main.go", "--json-report"])
+        .arg(json_report_path)
+        .args(["--test-cmd", "sh create-foo.sh"])
+        .current_dir(dir.path());
+    configure(&mut command);
+    let output = command.output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("missing intermediate component"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !missing_parent.exists(),
+        "the test command must not create foo"
+    );
+    assert!(
+        !campaign_marker.exists(),
+        "the test command must not create a campaign marker"
+    );
+    assert!(
+        !dir.path().join(".togi-cache").exists(),
+        "missing intermediate paths must stop before a campaign"
+    );
+    assert_eq!(fs::read(protected_output).unwrap(), existing);
 }
 
 #[test]
@@ -1185,6 +1244,14 @@ fn check_json_report_sidecar_reuses_json_stdout_payload() {
 #[cfg(unix)]
 #[test]
 fn check_json_report_staging_failure_preserves_existing_report() {
+    if std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .is_ok_and(|output| output.status.success() && output.stdout == b"0\n")
+    {
+        eprintln!("skipping staging-failure test because the test runs as root");
+        return;
+    }
     let dir = setup_git_repo();
     let report_dir = dir.path().join("locked-report-directory");
     fs::create_dir(&report_dir).unwrap();
@@ -1251,6 +1318,252 @@ fn check_json_report_rejects_later_output_destination_collisions_before_campaign
     assert_json_report_destination_collision(&dir, &comment_sidecar, &comment, |command| {
         command.arg("--pr-comment").arg(&comment);
     });
+}
+
+#[cfg(unix)]
+#[test]
+fn check_json_report_rejects_symlink_output_aliases_before_campaign() {
+    let dangling_html_repo = setup_git_repo();
+    let dangling_html = dangling_html_repo.path().join("togi-report.html");
+    let dangling_html_sidecar = dangling_html_repo.path().join("report.json");
+    symlink("report.json", &dangling_html).unwrap();
+    assert_json_report_destination_preflight(
+        &dangling_html_repo,
+        &dangling_html_sidecar,
+        |command| {
+            command.args(["--format", "html"]);
+        },
+    );
+    assert!(!dangling_html_sidecar.exists());
+    assert!(
+        fs::symlink_metadata(&dangling_html)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let comment_repo = setup_git_repo();
+    let comment_target = comment_repo.path().join("comment-target");
+    fs::create_dir_all(comment_target.join("nested")).unwrap();
+    symlink(
+        "comment-target/nested",
+        comment_repo.path().join("comment-link"),
+    )
+    .unwrap();
+    let comment_sidecar = comment_target.join("togi-comment.md");
+    fs::write(&comment_sidecar, "JSON sidecar must survive\n").unwrap();
+    let comment_alias = PathBuf::from("comment-link")
+        .join("..")
+        .join("togi-comment.md");
+    assert_json_report_destination_collision(
+        &comment_repo,
+        &comment_sidecar,
+        &comment_sidecar,
+        |command| {
+            command.arg("--pr-comment").arg(&comment_alias);
+        },
+    );
+
+    let baseline_repo = setup_git_repo();
+    let dangling_baseline = baseline_repo.path().join(".togi-baseline");
+    let dangling_baseline_sidecar = baseline_repo.path().join("baseline-sidecar.json");
+    symlink("baseline-sidecar.json", &dangling_baseline).unwrap();
+    assert_json_report_destination_preflight(
+        &baseline_repo,
+        &dangling_baseline_sidecar,
+        |command| {
+            command.arg("--save-baseline");
+        },
+    );
+    assert!(!dangling_baseline_sidecar.exists());
+    assert!(
+        fs::symlink_metadata(&dangling_baseline)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn check_json_report_rejects_missing_intermediate_output_aliases_before_campaign() {
+    let html_repo = setup_git_repo();
+    let html_output = html_repo.path().join("togi-report.html");
+    fs::write(&html_output, "HTML output must survive\n").unwrap();
+    assert_missing_intermediate_destination_rejected(
+        &html_repo,
+        Path::new("foo/../togi-report.html"),
+        &html_output,
+        |command| {
+            command.args(["--format", "html"]);
+        },
+    );
+
+    let comment_repo = setup_git_repo();
+    let comment_output = comment_repo.path().join("togi-comment.md");
+    fs::write(&comment_output, "PR comment must survive\n").unwrap();
+    assert_missing_intermediate_destination_rejected(
+        &comment_repo,
+        Path::new("foo/../togi-comment.md"),
+        &comment_output,
+        |command| {
+            command.arg("--pr-comment").arg("togi-comment.md");
+        },
+    );
+}
+
+#[test]
+fn check_json_report_allows_distinct_nested_pr_comment_output() {
+    let dir = setup_git_repo();
+    let report_path = dir.path().join("report.json");
+    let comment_path = dir.path().join("reports/comment.md");
+    assert!(!comment_path.parent().unwrap().exists());
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--json-report",
+            report_path.to_str().unwrap(),
+            "--pr-comment",
+            comment_path.to_str().unwrap(),
+            "--no-schemata",
+            "--test-cmd",
+            "true",
+            "--fail-under",
+            "0",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(&report_path).unwrap()).expect("sidecar must be JSON");
+    assert_eq!(report["kind"], "mutation_report");
+    assert_eq!(report["schema_version"], 1);
+    assert!(
+        report["total"].as_u64().unwrap() > 0,
+        "the nested output path must not skip the mutation campaign"
+    );
+    let comment = fs::read_to_string(&comment_path).expect("nested PR comment must be written");
+    assert!(comment.contains("<!-- togi-mutation-report -->"));
+    assert_ne!(fs::read(&report_path).unwrap(), comment.as_bytes());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_json_report_revalidates_nested_pr_comment_after_campaign() {
+    let dir = setup_git_repo();
+    let report_path = dir.path().join("report.json");
+    let comment_path = Path::new("reports/report.json");
+    let campaign_marker = dir.path().join("campaign-ran");
+    let sentinel = "JSON sidecar must survive\n";
+    fs::write(&report_path, sentinel).unwrap();
+    assert!(!dir.path().join("reports").exists());
+    let root = dir.path().to_str().unwrap();
+    fs::write(
+        dir.path().join("create-reports-alias.sh"),
+        format!(
+            "#!/bin/sh\nif [ ! -L \"{root}/reports\" ]; then\n  rm -rf \"{root}/reports\"\n  ln -s . \"{root}/reports\"\nfi\ntouch \"{root}/campaign-ran\"\n"
+        ),
+    )
+    .unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--json-report",
+            report_path.to_str().unwrap(),
+            "--pr-comment",
+            comment_path.to_str().unwrap(),
+            "--no-schemata",
+            "--jobs",
+            "1",
+            "--test-cmd",
+            "sh create-reports-alias.sh",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("conflicts with"), "stderr: {stderr}");
+    assert!(
+        !stdout.contains("Results:"),
+        "the report renderer must not publish after the collision: {stdout}"
+    );
+    assert!(
+        !stderr.contains("PR comment written"),
+        "the PR comment writer must not publish after the collision: {stderr}"
+    );
+    assert!(
+        campaign_marker.exists(),
+        "the post-campaign check must run after test commands"
+    );
+    assert_eq!(fs::read_to_string(&report_path).unwrap(), sentinel);
+    assert!(
+        fs::symlink_metadata(dir.path().join("reports"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the test command must leave reports aliased to the project root"
+    );
+}
+
+#[test]
+fn check_json_report_rejects_case_only_html_alias_before_campaign() {
+    let dir = setup_git_repo();
+    let sidecar = dir.path().join("TOGI-REPORT.HTML");
+    let existing = "JSON sidecar must survive\n";
+    fs::write(&sidecar, existing).unwrap();
+
+    let output = togi()
+        .args([
+            "check",
+            "--all",
+            "--path",
+            "main.go",
+            "--format",
+            "html",
+            "--json-report",
+            sidecar.to_str().unwrap(),
+            "--test-cmd",
+            "command-that-must-not-run",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("conflicts with"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !dir.path().join(".togi-cache").exists(),
+        "case-only collision must stop before a campaign"
+    );
+    assert_eq!(fs::read_to_string(&sidecar).unwrap(), existing);
 }
 
 #[test]
@@ -3851,10 +4164,16 @@ fn action_install_run_script(action_path: &Path) -> String {
         .get("runs")
         .and_then(|runs| runs.get("steps"))
         .and_then(serde_yaml::Value::as_sequence)
-        .and_then(|steps| steps.first())
+        .and_then(|steps| {
+            steps.iter().find(|step| {
+                step.get("name")
+                    .and_then(serde_yaml::Value::as_str)
+                    .is_some_and(|name| name == "Install togi")
+            })
+        })
         .and_then(|step| step.get("run"))
         .and_then(serde_yaml::Value::as_str)
-        .expect("Install togi step must contain a shell script");
+        .expect("Action is missing the Install togi shell script");
     run.replace(
         "${{ github.action_path }}",
         action_path
@@ -3913,6 +4232,9 @@ done
 printf '%s\n' '--' >> "$FAKE_TOGI_LOG"
 
 if [[ "${args[0]:-}" == "--version" ]]; then
+  if [[ -n "${FAKE_TOGI_VERSION_STDERR:-}" ]]; then
+    printf '%s\n' "$FAKE_TOGI_VERSION_STDERR" >&2
+  fi
   printf 'togi %s\n' "${FAKE_TOGI_VERSION:-0.5.1}"
   exit "${FAKE_TOGI_VERSION_STATUS:-0}"
 fi
@@ -4218,6 +4540,39 @@ fn github_action_run_helper_rejects_version_mismatches_before_check() {
                     .is_empty()
         );
     }
+}
+
+#[test]
+fn github_action_run_helper_accepts_matching_version_with_stderr() {
+    if !bash_available() || !jq_available() {
+        eprintln!("skipping action helper test because bash or jq is unavailable");
+        return;
+    }
+
+    let fixture = action_helper_fixture();
+    let mut command = action_helper_command(
+        &fixture,
+        ActionHelperRun {
+            base: Some("HEAD~1"),
+            timeout: None,
+            format: Some("github"),
+            test_cmd: None,
+            status: 0,
+            json: NORMAL_ACTION_REPORT,
+        },
+    );
+    command.env("FAKE_TOGI_VERSION_STDERR", "binary loader warning");
+    let output = command.output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("binary loader warning"));
+    assert_eq!(action_helper_check_invocations(&fixture).len(), 1);
+    assert_action_outputs(&fixture);
 }
 
 #[test]
@@ -4552,9 +4907,10 @@ fn github_action_install_rejects_failed_fetch_without_ambient_archive_fallback()
     let action_path = dir.path().join("fake-action");
     let scripts = action_path.join(".github/scripts");
     fs::create_dir_all(&scripts).unwrap();
+    let resolver_log = dir.path().join("resolver-environment");
     fs::write(
         scripts.join("resolve-togi-asset.sh"),
-        "#!/usr/bin/env bash\nprintf 'TOGI_ARCHIVE=%q\\n' 'verified.tar.gz'\nprintf 'TOGI_BINARY=%q\\n' 'togi'\n",
+        "#!/usr/bin/env bash\nprintf '%s/%s\\n' \"${TOGI_OS-__unset__}\" \"${TOGI_ARCH-__unset__}\" > \"$RESOLVER_LOG\"\nprintf 'TOGI_ARCHIVE=%q\\n' 'verified.tar.gz'\nprintf 'TOGI_BINARY=%q\\n' 'togi'\n",
     )
     .unwrap();
     let fetch_log = dir.path().join("fetch-version");
@@ -4585,6 +4941,9 @@ fn github_action_install_rejects_failed_fetch_without_ambient_archive_fallback()
         .env("TOGI_ARCHIVE", "ambient-archive.tar.gz")
         .env("TOGI_BINARY", "ambient-togi")
         .env("TOGI_ARCHIVE_PATH", &ambient_archive)
+        .env("TOGI_OS", "forced-os")
+        .env("TOGI_ARCH", "forced-arch")
+        .env("RESOLVER_LOG", &resolver_log)
         .env("FETCH_LOG", &fetch_log)
         .env("INSTALL_MARKER", &install_marker)
         .output()
@@ -4596,7 +4955,12 @@ fn github_action_install_rejects_failed_fetch_without_ambient_archive_fallback()
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+
     assert_eq!(fs::read_to_string(&fetch_log).unwrap(), "v0.5.1\n");
+    assert_eq!(
+        fs::read_to_string(&resolver_log).unwrap(),
+        "__unset__/__unset__\n"
+    );
     assert!(
         !install_marker.exists(),
         "failed fetch must not execute the installer with an ambient archive"
@@ -4614,11 +4978,96 @@ fn github_action_install_rejects_failed_fetch_without_ambient_archive_fallback()
         "failed fetch must not publish a report or Action outputs"
     );
 }
+#[cfg(unix)]
+#[test]
+fn github_action_install_uses_the_resolved_temp_root() {
+    if !bash_available() {
+        eprintln!("skipping Action install path test because bash is unavailable");
+        return;
+    }
+
+    let dir = TempDir::new().unwrap();
+    let action_path = dir.path().join("fake-action");
+    let scripts = action_path.join(".github/scripts");
+    fs::create_dir_all(&scripts).unwrap();
+    fs::write(
+        scripts.join("resolve-togi-asset.sh"),
+        "#!/usr/bin/env bash\nprintf 'TOGI_ARCHIVE=%q\\n' 'verified.tar.gz'\nprintf 'TOGI_BINARY=%q\\n' 'togi'\n",
+    )
+    .unwrap();
+    fs::write(
+        scripts.join("fetch-togi-release-asset.sh"),
+        "#!/usr/bin/env bash\nprintf 'TOGI_ARCHIVE_PATH=%q\\n' \"$FAKE_ARCHIVE_PATH\"\n",
+    )
+    .unwrap();
+    let install_root_log = dir.path().join("install-root");
+    fs::write(
+        scripts.join("install-togi-archive.sh"),
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$RUNNER_TEMP\" > \"$INSTALL_ROOT_LOG\"\n",
+    )
+    .unwrap();
+
+    let fake_bin = dir.path().join("fake-bin");
+    fs::create_dir(&fake_bin).unwrap();
+    let cygpath = fake_bin.join("cygpath");
+    fs::write(
+        &cygpath,
+        "#!/usr/bin/env bash\n[[ \"$1\" == \"-u\" ]] || exit 2\nprintf '%s\\n' \"$FAKE_TEMP_ROOT\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&cygpath).unwrap().permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&cygpath, permissions).unwrap();
+
+    let raw_runner_temp = dir.path().join("raw-runner-temp");
+    let resolved_temp_root = dir.path().join("resolved-temp-root");
+    let archive_path = dir.path().join("verified.tar.gz");
+    fs::write(&archive_path, "verified archive").unwrap();
+    let github_env = dir.path().join("github-env");
+    let github_path = dir.path().join("github-path");
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").expect("PATH must be set"),
+    ));
+    let install_script = action_install_run_script(&action_path);
+    let output = std::process::Command::new("bash")
+        .args(["-c", install_script.as_str()])
+        .current_dir(dir.path())
+        .env("TOGI_VERSION_INPUT", "v0.5.1")
+        .env("RUNNER_TEMP", &raw_runner_temp)
+        .env("GITHUB_ENV", &github_env)
+        .env("GITHUB_PATH", &github_path)
+        .env("FAKE_TEMP_ROOT", &resolved_temp_root)
+        .env("FAKE_ARCHIVE_PATH", &archive_path)
+        .env("INSTALL_ROOT_LOG", &install_root_log)
+        .env("PATH", std::env::join_paths(paths).unwrap())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&install_root_log).unwrap(),
+        format!("{}\n", resolved_temp_root.display())
+    );
+    assert_eq!(
+        fs::read_to_string(&github_env).unwrap(),
+        format!(
+            "TOGI_BIN={}/togi-bin/togi\nTOGI_EXPECTED_VERSION=v0.5.1\n",
+            resolved_temp_root.display()
+        )
+    );
+}
 
 #[test]
 fn github_action_inputs_have_no_baked_in_defaults() {
     let action_yml =
         fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml")).unwrap();
+    let action: serde_yaml::Value = serde_yaml::from_str(&action_yml).unwrap();
 
     // Split the inputs: mapping into per-input blocks keyed by name.
     let mut blocks: Vec<(&str, Vec<&str>)> = Vec::new();
@@ -4673,8 +5122,17 @@ fn github_action_inputs_have_no_baked_in_defaults() {
             "action.yml input `{name}` must keep its {default} default"
         );
     }
+    let run_blocks = action
+        .get("runs")
+        .and_then(|runs| runs.get("steps"))
+        .and_then(serde_yaml::Value::as_sequence)
+        .expect("action.yml must contain composite Action steps")
+        .iter()
+        .filter_map(|step| step.get("run").and_then(serde_yaml::Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
-        !action_yml.contains("latest"),
+        !run_blocks.contains("latest"),
         "Action releases must not resolve a mutable version"
     );
     for expected in [
@@ -4684,6 +5142,7 @@ fn github_action_inputs_have_no_baked_in_defaults() {
         "fetch-togi-release-asset.sh",
         "install-togi-archive.sh",
         "TOGI_BIN=\"${TEMP_ROOT}/togi-bin/${TOGI_BINARY}\"",
+        "RUNNER_TEMP=\"$TEMP_ROOT\"",
         "printf 'TOGI_EXPECTED_VERSION=%s\\n' \"$VERSION\"",
     ] {
         assert!(
@@ -4692,7 +5151,7 @@ fn github_action_inputs_have_no_baked_in_defaults() {
         );
     }
     assert!(
-        !action_yml.contains("curl "),
+        !run_blocks.contains("curl "),
         "Action downloads must go through the verified fetch helper"
     );
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -72,6 +72,49 @@ fn setup_git_repo() -> TempDir {
     dir
 }
 
+#[cfg(unix)]
+fn assert_json_report_destination_collision(
+    dir: &TempDir,
+    json_report_path: &Path,
+    destination: &Path,
+    configure: impl FnOnce(&mut Command),
+) {
+    let campaign_marker = dir.path().join("campaign-ran");
+    let _ = fs::remove_file(&campaign_marker);
+    fs::write(
+        dir.path().join("record-campaign.sh"),
+        "#!/bin/sh\ntouch campaign-ran\n",
+    )
+    .unwrap();
+    let existing = fs::read_to_string(destination).unwrap();
+
+    let mut command = togi();
+    command
+        .args(["check", "--all", "--path", "main.go", "--json-report"])
+        .arg(json_report_path)
+        .args(["--test-cmd", "sh record-campaign.sh"])
+        .current_dir(dir.path());
+    configure(&mut command);
+    let output = command.output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty(), "stdout: {:?}", output.stdout);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("conflicts with"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !campaign_marker.exists(),
+        "collision must stop before a campaign"
+    );
+    assert!(
+        !dir.path().join(".togi-cache").exists(),
+        "collision must stop before mutation side effects"
+    );
+    assert_eq!(fs::read_to_string(destination).unwrap(), existing);
+}
+
 #[test]
 fn init_creates_config() {
     let dir = TempDir::new().unwrap();
@@ -1175,6 +1218,39 @@ fn check_json_report_staging_failure_preserves_existing_report() {
 
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(fs::read_to_string(&report_path).unwrap(), existing);
+}
+
+#[cfg(unix)]
+#[test]
+fn check_json_report_rejects_later_output_destination_collisions_before_campaign() {
+    let dir = setup_git_repo();
+
+    let html_parent = dir.path().join("html-parent");
+    fs::create_dir(&html_parent).unwrap();
+    let html_report = dir.path().join("togi-report.html");
+    fs::write(&html_report, "existing HTML report\n").unwrap();
+    let html_sidecar = html_parent.join("..").join("togi-report.html");
+    assert_json_report_destination_collision(&dir, &html_sidecar, &html_report, |command| {
+        command.args(["--format", "html"]);
+    });
+
+    let baseline_parent = dir.path().join("baseline-parent");
+    fs::create_dir(&baseline_parent).unwrap();
+    let baseline = dir.path().join(".togi-baseline");
+    fs::write(&baseline, "existing baseline\n").unwrap();
+    let baseline_sidecar = baseline_parent.join("..").join(".togi-baseline");
+    assert_json_report_destination_collision(&dir, &baseline_sidecar, &baseline, |command| {
+        command.arg("--save-baseline");
+    });
+
+    let comment_parent = dir.path().join("comment-parent");
+    fs::create_dir(&comment_parent).unwrap();
+    let comment = dir.path().join("togi-comment.md");
+    fs::write(&comment, "existing PR comment\n").unwrap();
+    let comment_sidecar = comment_parent.join("..").join("togi-comment.md");
+    assert_json_report_destination_collision(&dir, &comment_sidecar, &comment, |command| {
+        command.arg("--pr-comment").arg(&comment);
+    });
 }
 
 #[test]
@@ -3766,6 +3842,27 @@ fn jq_available() -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(unix)]
+fn action_install_run_script(action_path: &Path) -> String {
+    let action_yml =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("action.yml")).unwrap();
+    let action: serde_yaml::Value = serde_yaml::from_str(&action_yml).unwrap();
+    let run = action
+        .get("runs")
+        .and_then(|runs| runs.get("steps"))
+        .and_then(serde_yaml::Value::as_sequence)
+        .and_then(|steps| steps.first())
+        .and_then(|step| step.get("run"))
+        .and_then(serde_yaml::Value::as_str)
+        .expect("Install togi step must contain a shell script");
+    run.replace(
+        "${{ github.action_path }}",
+        action_path
+            .to_str()
+            .expect("temporary action path must be valid UTF-8"),
+    )
+}
+
 struct ActionHelperFixture {
     dir: TempDir,
     fake_togi: PathBuf,
@@ -4397,7 +4494,7 @@ fn github_action_report_replays_a_direct_mutation() {
         .arg(helper)
         .current_dir(repo.path())
         .env("TOGI_BIN", assert_cmd::cargo::cargo_bin("togi"))
-        .env("TOGI_EXPECTED_VERSION", "v0.5.0")
+        .env("TOGI_EXPECTED_VERSION", "v0.5.1")
         .env("RUNNER_TEMP", report_dir.path())
         .env("GITHUB_OUTPUT", &github_output)
         .env("TOGI_BASE", "HEAD")
@@ -4441,6 +4538,81 @@ fn github_action_report_replays_a_direct_mutation() {
         .current_dir(repo.path())
         .assert()
         .success();
+}
+
+#[cfg(unix)]
+#[test]
+fn github_action_install_rejects_failed_fetch_without_ambient_archive_fallback() {
+    if !bash_available() {
+        eprintln!("skipping Action install regression test because bash is unavailable");
+        return;
+    }
+
+    let dir = TempDir::new().unwrap();
+    let action_path = dir.path().join("fake-action");
+    let scripts = action_path.join(".github/scripts");
+    fs::create_dir_all(&scripts).unwrap();
+    fs::write(
+        scripts.join("resolve-togi-asset.sh"),
+        "#!/usr/bin/env bash\nprintf 'TOGI_ARCHIVE=%q\\n' 'verified.tar.gz'\nprintf 'TOGI_BINARY=%q\\n' 'togi'\n",
+    )
+    .unwrap();
+    let fetch_log = dir.path().join("fetch-version");
+    fs::write(
+        scripts.join("fetch-togi-release-asset.sh"),
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$TOGI_VERSION\" > \"$FETCH_LOG\"\nexit 1\n",
+    )
+    .unwrap();
+    let install_marker = dir.path().join("installer-ran");
+    fs::write(
+        scripts.join("install-togi-archive.sh"),
+        "#!/usr/bin/env bash\ntouch \"$INSTALL_MARKER\"\n",
+    )
+    .unwrap();
+    let github_output = dir.path().join("github-output");
+
+    let runner_temp = dir.path().join("runner-temp");
+    let github_env = dir.path().join("github-env");
+    let ambient_archive = dir.path().join("ambient-unverified.tar.gz");
+    fs::write(&ambient_archive, "unverified archive").unwrap();
+    let output = std::process::Command::new("bash")
+        .args(["-c", &action_install_run_script(&action_path)])
+        .current_dir(dir.path())
+        .env("GITHUB_OUTPUT", &github_output)
+        .env("TOGI_VERSION_INPUT", "v0.5.1")
+        .env("RUNNER_TEMP", &runner_temp)
+        .env("GITHUB_ENV", &github_env)
+        .env("TOGI_ARCHIVE", "ambient-archive.tar.gz")
+        .env("TOGI_BINARY", "ambient-togi")
+        .env("TOGI_ARCHIVE_PATH", &ambient_archive)
+        .env("FETCH_LOG", &fetch_log)
+        .env("INSTALL_MARKER", &install_marker)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Could not fetch and verify"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&fetch_log).unwrap(), "v0.5.1\n");
+    assert!(
+        !install_marker.exists(),
+        "failed fetch must not execute the installer with an ambient archive"
+    );
+    assert!(
+        !runner_temp.join("togi-bin").exists(),
+        "failed fetch must not publish a binary"
+    );
+    assert!(
+        !github_env.exists(),
+        "failed fetch must not publish binary or version environment"
+    );
+    assert!(
+        !runner_temp.join("togi-report.json").exists() && !github_output.exists(),
+        "failed fetch must not publish a report or Action outputs"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #505

Release-coupled v0.5.1 follows separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for saving check results as JSON reports, including empty and dry-run outputs.
  * Added safeguards against conflicts with existing HTML reports, baselines, and pull request comments.
* **Bug Fixes**
  * Improved report publishing to preserve existing files if writing fails.
  * Added reliable cleanup when reviews fail.
* **Chores**
  * Updated the bundled Togi version to immutable release `v0.5.1`.
  * Improved installation validation, version checks, checksum verification, and environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->