### PR TITLE
fix: fail closed on fresh timeout and build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,12 @@ git rev-parse --verify HEAD~1
 togi check --base HEAD~1
 ```
 
-Exit `0` means all mutations were killed. Exit `1` means the mutation run
-completed and found surviving mutants. Exit `2` means an execution error (for
-example configuration, Git, or parsing) that you should fix before relying on
-the result.
+Without `--fail-under`, exit `0` means the default mutation gate passed: no
+unaccepted survivors and no fresh timeouts or build errors; exit `1` means an
+unaccepted survivor or fresh timeout/build error. With an explicit `--fail-under`,
+its score threshold determines that gate instead; a baseline regression still exits
+`1`. Exit `2` means an execution error (for example configuration, Git, or parsing)
+that you should fix before relying on the result.
 
 If you intentionally want a source-based install tied to a reviewed revision:
 
@@ -575,7 +577,8 @@ settings such as `jobs` keep taking precedence.
 
 A nonempty `[test] build_command` or `--build-cmd` opts in to a build check
 before each mutant's test command. A failed configured build is reported as a
-build error and does not count as a test kill.
+build error rather than a test kill; a fresh build error fails the default
+no-`--fail-under` gate.
 
 `togi init` suggests a safe `build_command` when it detects exactly one root
 build system, but detection alone never runs a build before tests. Uncomment
@@ -904,8 +907,8 @@ reporting instructions.
 
 | Code | Meaning |
 |------|---------|
-| 0 | All mutations killed — tests are solid |
-| 1 | Survivors found, `--fail-under` threshold not met, or baseline regression |
+| 0 | Without `--fail-under`: no unaccepted survivors or fresh timeout/build-error outcomes. With `--fail-under`: score meets the threshold. No baseline regression. |
+| 1 | Without `--fail-under`: unaccepted survivors or fresh timeout/build-error outcomes; with `--fail-under`: threshold not met; or baseline regression. |
 | 2 | Error (config, git, parse failure) |
 | 130 | Interrupted (SIGINT) |
 
@@ -1040,13 +1043,15 @@ unique `report-artifact-name` in a matrix or when invoking the Action more than
 once, and use that same name when downloading. Set `upload-report: 'false'`
 only when you intentionally do not need the artifact. The `report-path`,
 `mutation-score`, and `survivor-count` outputs are runner-local evidence; the
-post-Action `if: always()` step records them after an intentional survivor
+post-Action `if: always()` step records them after an intentional mutation-gate
 failure without changing the failed Action result.
 
-Exit `1` means survivors, a `--fail-under` threshold miss, or a saved-baseline
-regression, so the example remains a PR gate. A failed baseline test or build
-is a fatal exit `2`, produces no normal mutation report, and leaves no valid
-Action outputs or artifact; `always()` does not make that error successful.
+Without `--fail-under`, exit `1` means an unaccepted survivor or fresh timeout/build
+error. With `--fail-under`, it means the score threshold was missed. A saved-baseline
+regression also exits `1`, so the example remains a PR gate.
+A failed baseline test or build is a fatal exit `2`, produces no normal mutation
+report, and leaves no valid Action outputs or artifact; `always()` does not make
+that error successful.
 
 Use `pull_request` for untrusted forks, keep the read-only permissions and
 disabled persisted credentials shown above, and do not expose secrets to this

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -316,8 +316,8 @@ route before they are reported, and the setting must be deleted.
 
 | Code | Meaning |
 |------|---------|
-| 0 | All mutations killed. No `--fail-under` breach and no baseline regression. |
-| 1 | Survivors found, `--fail-under` threshold not met, or baseline regression detected. |
+| 0 | Without `--fail-under`: no unaccepted survivors or fresh timeout/build-error outcomes. With `--fail-under`: score meets the threshold. No baseline regression. |
+| 1 | Without `--fail-under`: unaccepted survivors or fresh timeout/build-error outcomes; with `--fail-under`: threshold not met; or baseline regression detected. |
 | 2 | Error (configuration, git, parse failure). |
 | 130 | Interrupted by signal (SIGINT). |
 
@@ -357,3 +357,4 @@ vulnerability reporting.
 | 2026-07-28 | Initial compatibility contract. |
 | 2026-08-04 | Removed the macOS x86_64 (Intel) release target; pinned explicit per-target runners with runtime target/arch assertions; named native build/unit legs by tier and target; pinned the Tier-1 Integration Tests and Dogfood evidence jobs to `ubuntu-24.04` with the same assertion ([#485](https://github.com/Darkroom4364/togi/issues/485)). |
 | 2026-08-04 | Stated the v1 stability and deprecation policy: strict configuration parsing with stable documented keys (except the pre-v1 `confirm_survivors` removal), additive-only JSON schema 1 and SARIF 2.1.0 evolution, deprecation with migration instructions until v2, and v1 security-support scope ([#484](https://github.com/Darkroom4364/togi/issues/484)). |
+| 2026-08-10 | Fresh timeout and build-error mutation outcomes now fail the default no-`--fail-under` exit gate; exact-cache and incremental-history reuse do not invoke that fresh-outcome gate ([#503](https://github.com/Darkroom4364/togi/issues/503)). |

--- a/src/main.rs
+++ b/src/main.rs
@@ -745,11 +745,21 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
             );
             exit_with(_lock, 1);
         }
-    } else if report.survived > 0 && !loaded_baseline {
+    } else if has_fresh_timeout_or_build_error(&report) || (report.survived > 0 && !loaded_baseline)
+    {
         exit_with(_lock, 1);
     }
 
     Ok(())
+}
+
+fn has_fresh_timeout_or_build_error(report: &togi::MutationReport) -> bool {
+    report.results.iter().any(|(mutation, result)| {
+        matches!(
+            *result,
+            togi::MutationResult::Timeout | togi::MutationResult::BuildError
+        ) && !report.execution_for(mutation.id, *result).is_reused()
+    })
 }
 
 fn exit_with(lock: togi::lock::LockGuard, code: i32) -> ! {
@@ -2270,6 +2280,88 @@ mod tests {
             save_baseline: false,
             check_baseline: false,
             pr_comment: None,
+        }
+    }
+
+    fn report_with_outcome(
+        result: togi::MutationResult,
+        execution: Option<togi::MutationExecution>,
+    ) -> togi::MutationReport {
+        let mutation = togi::Mutation {
+            id: 0,
+            file: std::path::PathBuf::from("src/lib.rs"),
+            language: "rust".to_owned(),
+            line: 1,
+            column: 1,
+            operator: "op".to_owned(),
+            description: "description".to_owned(),
+            original: "a".to_owned(),
+            replacement: "b".to_owned(),
+            byte_range: 0..1,
+        };
+        let mut execution_provenance = std::collections::BTreeMap::new();
+        if let Some(execution) = execution {
+            execution_provenance.insert(mutation.id, execution);
+        }
+        togi::MutationReport {
+            results: vec![(mutation, result)],
+            execution_provenance,
+            selection_provenance: std::collections::BTreeMap::new(),
+            build_error_diagnostics: vec![],
+            schemata: None,
+            baseline_timing: None,
+            duration: std::time::Duration::ZERO,
+            test_command: None,
+            build_command: vec![],
+            planned_total: 1,
+            early_stop_reason: None,
+            total: 1,
+            killed: 0,
+            survived: 0,
+            timeout: if result == togi::MutationResult::Timeout {
+                1
+            } else {
+                0
+            },
+            build_errors: if result == togi::MutationResult::BuildError {
+                1
+            } else {
+                0
+            },
+        }
+    }
+
+    #[test]
+    fn fresh_timeout_and_build_error_trigger_default_outcome_gate() {
+        for result in [
+            togi::MutationResult::Timeout,
+            togi::MutationResult::BuildError,
+        ] {
+            assert!(
+                has_fresh_timeout_or_build_error(&report_with_outcome(result, None)),
+                "{result:?} should trigger the default outcome gate"
+            );
+        }
+    }
+
+    #[test]
+    fn reused_timeout_and_build_error_do_not_trigger_default_outcome_gate() {
+        for execution in [
+            togi::MutationExecution::ExactCache,
+            togi::MutationExecution::IncrementalHistory,
+        ] {
+            for result in [
+                togi::MutationResult::Timeout,
+                togi::MutationResult::BuildError,
+            ] {
+                assert!(
+                    !has_fresh_timeout_or_build_error(&report_with_outcome(
+                        result,
+                        Some(execution),
+                    )),
+                    "{execution:?} {result:?} should not trigger the default outcome gate"
+                );
+            }
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2891,7 +2891,7 @@ fn check_aborts_before_report_when_baseline_build_fails() {
 
 #[cfg(unix)]
 #[test]
-fn check_terminal_includes_build_error_diagnostics() {
+fn check_fresh_build_error_fails_default_gate_with_diagnostics() {
     let dir = setup_git_repo();
     let expected = tempfile::NamedTempFile::new().unwrap();
     fs::write(
@@ -2927,13 +2927,103 @@ fn check_terminal_includes_build_error_diagnostics() {
             "1",
             "--jobs",
             "1",
+            "--force-rerun",
+            "--no-incremental-history",
         ])
         .current_dir(dir.path())
         .assert()
-        .success()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "Results: 0 killed, 0 survived, 0 timeout, 1 build errors",
+        ))
         .stdout(predicate::str::contains("Build error diagnostics:"))
         .stdout(predicate::str::contains("build_command"))
         .stdout(predicate::str::contains("not-a-togi-command"));
+}
+
+#[cfg(unix)]
+#[test]
+fn check_fresh_timeout_fails_default_gate_with_or_without_baseline() {
+    for with_baseline in [false, true] {
+        let dir = setup_git_repo();
+        if with_baseline {
+            write_baseline(dir.path(), 0, 1);
+        }
+        let expected = tempfile::NamedTempFile::new().unwrap();
+        fs::write(
+            expected.path(),
+            fs::read(dir.path().join("main.go")).unwrap(),
+        )
+        .unwrap();
+        let test_cmd = format!(
+            "sh -c {}",
+            shell_quote_text(&format!(
+                "if cmp -s main.go {}; then exit 0; else sleep 2; fi",
+                shell_quote(expected.path())
+            ))
+        );
+
+        let mut command = togi();
+        command
+            .args([
+                "check",
+                "--base",
+                "HEAD",
+                "--format",
+                "json",
+                "--test-cmd",
+                &test_cmd,
+                "--timeout",
+                "1",
+                "--no-schemata",
+                "--operators",
+                "gt_to_gte",
+                "--max-per-run",
+                "1",
+                "--jobs",
+                "1",
+                "--force-rerun",
+                "--no-incremental-history",
+            ])
+            .current_dir(dir.path());
+        if with_baseline {
+            command.arg("--check-baseline");
+        }
+        let output = command.output().unwrap();
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "with_baseline={with_baseline}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if with_baseline {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                !stderr.contains("warning: no baseline found"),
+                "baseline should load: {stderr}"
+            );
+            assert!(
+                !stderr.contains("Mutation score regression detected!"),
+                "fresh timeout should fail independently of baseline regression: {stderr}"
+            );
+        }
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+                panic!(
+                    "invalid JSON report: {error}\nstdout:\n{}",
+                    String::from_utf8_lossy(&output.stdout)
+                )
+            });
+        assert_eq!(report["total"], 1);
+        assert_eq!(report["survived"], 0);
+        assert_eq!(report["timeout"], 1);
+        assert_eq!(report["build_errors"], 0);
+        assert_eq!(report["mutation_score"], 0.0);
+        assert_eq!(report["mutations"][0]["result"], "timeout");
+        assert_eq!(report["mutations"][0]["execution"]["state"], "executed");
+    }
 }
 
 fn write_baseline(dir: &Path, killed: usize, total: usize) {
@@ -5291,7 +5381,7 @@ fn github_action_guide_and_advisory_pin_released_contract() {
     for expected in [
         "Those inputs override `togi.toml`",
         "`format: github`; the Action preserves that review run and performs a second\nfull JSON mutation run",
-        "A failed baseline test or build\nis a fatal exit `2`",
+        "A failed baseline test or build is a fatal exit `2`",
         "Never use `pull_request_target` to run PR code.",
     ] {
         assert!(


### PR DESCRIPTION
Closes #503

- Fail the default completed-run gate on fresh `Timeout` and `BuildError` results without relabeling them as survivors.
- Exclude exact-cache and incremental-history reuse; explicit `--fail-under` retains score-threshold precedence, while baseline regressions still fail.
- Document the exit policy and add provenance plus fresh CLI regression coverage.

Validation:
- `cargo test --locked`
- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fresh mutation timeouts and build errors now correctly cause the default quality gate to fail with exit code 1 and clear diagnostics.
  * Results reused from cache or incremental history continue without triggering the fresh-outcome failure gate.
  * Timeout reporting now works consistently with or without a baseline.

* **Documentation**
  * Clarified exit-status behavior, threshold handling, baseline regressions, execution errors, and GitHub Action outcomes.
  * Updated compatibility guidance and exit-code tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->