### PR TITLE
fix: suppress identity return-empty mutations

### DIFF
--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -134,6 +134,11 @@ pub fn generate_mutations(
                     else {
                         continue;
                     };
+                    if candidate.operator_id == "return_empty"
+                        && candidate.replacement.as_bytes() == original.as_bytes()
+                    {
+                        continue;
+                    }
 
                     file_mutations.push(Mutation {
                         id: 0,
@@ -803,6 +808,85 @@ mod tests {
             mutations.is_empty(),
             "and/or returns are not necessarily boolean"
         );
+    }
+
+    #[test]
+    fn return_empty_skips_post_fixup_identity_candidates() {
+        let tmp = TempDir::new().unwrap();
+        let go_src = concat!(
+            "package main\n\n",
+            "func false_identity() bool { return false }\n",
+            "func zero_identity() int { return 0 }\n",
+            "func empty_identity() string { return \"\" }\n",
+            "func true_mutation() bool { return true }\n",
+            "func nonzero_mutation() int { return 1 }\n",
+            "func nonempty_mutation() string { return \"value\" }\n",
+        );
+        let go_rel = write_test_file(tmp.path(), "main.go", go_src);
+        let go_mutations = generate_mutations(
+            &[ChangedFile {
+                path: go_rel,
+                hunks: vec![LineRange {
+                    start: 1,
+                    end: go_src.lines().count(),
+                }],
+            }],
+            tmp.path(),
+            100,
+            0,
+            &["return_empty".into()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            go_mutations.len(),
+            3,
+            "only non-identity Go return_empty candidates should remain: {go_mutations:?}"
+        );
+        for (original, replacement) in [("true", "false"), ("1", "0"), ("\"value\"", "\"\"")] {
+            assert!(
+                go_mutations.iter().any(|mutation| {
+                    mutation.original == original && mutation.replacement == replacement
+                }),
+                "expected return_empty {original:?} -> {replacement:?}, got: {go_mutations:?}"
+            );
+        }
+        assert!(
+            go_mutations
+                .iter()
+                .all(|mutation| mutation.original != mutation.replacement),
+            "return_empty should not emit identical Go mutations: {go_mutations:?}"
+        );
+
+        let python_src = concat!(
+            "def false_identity():\n",
+            "    return False\n\n",
+            "def true_mutation():\n",
+            "    return True\n",
+        );
+        let python_rel = write_test_file(tmp.path(), "main.py", python_src);
+        let python_mutations = generate_mutations(
+            &[ChangedFile {
+                path: python_rel,
+                hunks: vec![LineRange {
+                    start: 1,
+                    end: python_src.lines().count(),
+                }],
+            }],
+            tmp.path(),
+            100,
+            0,
+            &["return_empty".into()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            python_mutations.len(),
+            1,
+            "only the non-identity Python return_empty candidate should remain: {python_mutations:?}"
+        );
+        assert_eq!(python_mutations[0].original, "True");
+        assert_eq!(python_mutations[0].replacement, "False");
     }
 
     #[test]

--- a/tests/integration/mutations.rs
+++ b/tests/integration/mutations.rs
@@ -159,9 +159,9 @@ fn end_to_end_go_fixture_reports_expected_outcomes_with_fresh_tests() {
     // mutations alongside expression/literal mutations. The fixture's tests
     // intentionally do not kill every generated mutation; these counts prove
     // Go actually ran instead of failing before test execution.
-    assert_eq!(report.total, 21);
+    assert_eq!(report.total, 20);
     assert_eq!(report.killed, 8);
-    assert_eq!(report.survived, 13);
+    assert_eq!(report.survived, 12);
     assert_eq!(report.timeout, 0);
     assert_eq!(report.build_errors, 0);
 }


### PR DESCRIPTION
Closes #64

## Scope
- Suppress post-fixup `return_empty` candidates only when replacement bytes exactly match the original span.
- Cover Go boolean/numeric/string identities and Python `False` fixup while retaining non-identity candidates.

## Validation
- `cargo test --locked`
- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
