### PR TITLE
docs: align install guidance with v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Try it: `examples/polyglot-demo.sh` runs a PR-sized Go + Rust + Python change th
 
 ### Linux x86_64 (Tier 1) first success
 
-This tested released-binary path is for Linux x86_64 only. See the
+GitHub Releases are the supported binary-install path. This tested release
+archive path is for Linux x86_64 only. See the
 [compatibility contract](docs/COMPATIBILITY.md) for other platforms and support
 tiers.
 
@@ -88,7 +89,7 @@ with a parent commit and at least one changed supported source line.
 ```bash
 (
   set -euo pipefail
-  TOGI_VERSION=v0.4.1
+  TOGI_VERSION=v0.5.2
   TOGI_ARCHIVE=togi-linux-x86_64.tar.gz
   RELEASE_BASE="https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}"
   TEMP_DIR="$(mktemp -d)"
@@ -124,8 +125,8 @@ its score threshold determines that gate instead; a baseline regression still ex
 `1`. Exit `2` means an execution error (for example configuration, Git, or parsing)
 that you should fix before relying on the result.
 
-If you intentionally want a source-based install tied to a reviewed revision:
-
+`togi` is not currently published on crates.io. If you intentionally want a
+source-based install tied to a reviewed revision:
 ```bash
 cargo install --git https://github.com/Darkroom4364/togi --rev <commit-sha> --locked
 ```
@@ -992,9 +993,9 @@ jobs:
       - name: Install project test dependencies
         run: npm ci
       - id: togi
-        uses: Darkroom4364/togi@a1503b2ebac4c63d377b015c4825b97cab25ec68 # v0.4.1
+        uses: Darkroom4364/togi@e692e2d169b7a717c6b911884e90c0bcd0d133b1 # v0.5.2
         with:
-          version: v0.4.1
+          version: v0.5.2
           base: origin/${{ github.base_ref }}
           test-cmd: npm test
           format: json
@@ -1022,9 +1023,10 @@ using another runner or architecture.
 `fetch-depth: 0` makes the PR base available for
 `origin/${{ github.base_ref }}`. The checkout therefore needs a Git history
 that contains the base branch and a project with changed supported source
-lines. The Action source and downloaded binary are both pinned to v0.4.1; do
-not replace `version: v0.4.1` with the mutable `latest` default unless that is
-an intentional upgrade policy.
+lines. The Action source commit and downloaded binary version are both pinned to
+the immutable version identifiers for v0.5.2: its release commit and `v0.5.2`
+release tag. When upgrading, update both together to a reviewed release commit
+and immutable version tag.
 
 The Action passes `--base`, `--timeout`, `--format`, and `--test-cmd` only for
 non-empty inputs. Those inputs override `togi.toml`; remove `test-cmd` to use

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5504,8 +5504,8 @@ fn github_action_guide_and_advisory_pin_released_contract() {
         "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
         "node-version: 24 # Choose the version required by this repository.",
         "name: Install project test dependencies\n        run: npm ci",
-        "Darkroom4364/togi@a1503b2ebac4c63d377b015c4825b97cab25ec68 # v0.4.1",
-        "version: v0.4.1",
+        "Darkroom4364/togi@e692e2d169b7a717c6b911884e90c0bcd0d133b1 # v0.5.2",
+        "version: v0.5.2",
         "base: origin/${{ github.base_ref }}",
         "test-cmd: npm test",
         "format: json",
@@ -5541,7 +5541,7 @@ fn github_action_guide_and_advisory_pin_released_contract() {
         ),
         (
             "run: npm ci",
-            "Darkroom4364/togi@a1503b2ebac4c63d377b015c4825b97cab25ec68",
+            "Darkroom4364/togi@e692e2d169b7a717c6b911884e90c0bcd0d133b1",
         ),
     ] {
         assert!(
@@ -5555,12 +5555,17 @@ fn github_action_guide_and_advisory_pin_released_contract() {
         "`format: github`; the Action preserves that review run and performs a second\nfull JSON mutation run",
         "A failed baseline test or build is a fatal exit `2`",
         "Never use `pull_request_target` to run PR code.",
+        "immutable version identifiers for v0.5.2",
     ] {
         assert!(
             readme.contains(expected),
             "README Action guidance is missing `{expected}`"
         );
     }
+    assert!(
+        !readme.contains("mutable `latest` default"),
+        "README Action guidance must not describe a mutable latest default"
+    );
 
     let advisory = fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/togi-action-advisory.yml"),
@@ -5584,6 +5589,47 @@ fn github_action_guide_and_advisory_pin_released_contract() {
             "advisory workflow is missing `{expected}`"
         );
     }
+}
+
+#[test]
+fn github_release_install_guide_documents_v0_5_2_contract() {
+    let readme = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"))
+        .unwrap()
+        .replace("\r\n", "\n");
+    let install_start = readme
+        .find("## Install\n")
+        .expect("README must contain an Install section");
+    let install_end = readme
+        .find("\n### Before first run\n")
+        .expect("Install section must end before Before first run");
+    let install = &readme[install_start..install_end];
+
+    for expected in [
+        "GitHub Releases are the supported binary-install path.",
+        "TOGI_VERSION=v0.5.2",
+        "TOGI_ARCHIVE=togi-linux-x86_64.tar.gz",
+        "https://github.com/Darkroom4364/togi/releases/download/${TOGI_VERSION}",
+        "curl -fsSLo \"$TOGI_ARCHIVE\"",
+        "curl -fsSLo checksums.txt",
+        "EXPECTED_SHA=$(awk",
+        "ACTUAL_SHA=$(sha256sum",
+        "Checksum mismatch",
+        "`togi` is not currently published on crates.io.",
+        "cargo install --git https://github.com/Darkroom4364/togi --rev <commit-sha> --locked",
+    ] {
+        assert!(
+            install.contains(expected),
+            "Install section is missing `{expected}`"
+        );
+    }
+    assert!(
+        !install.contains("TOGI_VERSION=v0.4.1"),
+        "Install section must not point the release archive at v0.4.1"
+    );
+    assert!(
+        !install.contains("cargo install togi"),
+        "Install section must not present an unavailable crates.io install"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #520

## Summary
- Make GitHub Releases the supported binary-install path and set the primary Linux x86_64 archive example to `v0.5.2`.
- Pin the README GitHub Action example to `e692e2d169b7a717c6b911884e90c0bcd0d133b1` (`v0.5.2`) and describe the paired immutable release commit and version tag.
- State that `togi` is not published on crates.io, retain the reviewed Git-revision route, and preserve historical v0.4.1 external-dogfood evidence.

## Verification
- `git diff --cached --check` (pre-commit) — passed
- `cargo test --test cli github_release_install_guide_documents_v0_5_2_contract` — passed
- `cargo test --test cli github_action_guide_and_advisory_pin_released_contract` — passed
- `cargo fmt -- --check` — passed
- `cargo test` — 938 passed, 11 ignored
- `cargo clippy --all-targets -- -D warnings` — passed
- Public `v0.5.2` annotated tag `6476dabb2bdcdc2948464ed8e227c9e117226cc2` peels to `e692e2d169b7a717c6b911884e90c0bcd0d133b1` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the v0.5.2 GitHub Release archives.
  * Added guidance for checksum verification and Git-based installation.
  * Clarified that crates.io publication is unavailable.
  * Updated GitHub Action examples with immutable v0.5.2 version and commit references.

* **Tests**
  * Added coverage to verify current installation guidance and prevent outdated or mutable references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->