### PR TITLE
fix: harden workspace cache and CI integrity

### DIFF
--- a/.github/scripts/check-pinned-actions.rs
+++ b/.github/scripts/check-pinned-actions.rs
@@ -1,0 +1,304 @@
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use std::{
+    env, fs,
+    io::Read,
+    path::{Component, Path, PathBuf},
+    process::ExitCode,
+};
+
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+const REVIEWED_ACTION_COMMITS: &[&str] = &[
+    "0sec-labs/foxguard/action@1fbe7f384d6dda358f2dc7f712dddf25b8e4be76",
+    "Darkroom4364/togi@a1503b2ebac4c63d377b015c4825b97cab25ec68",
+    "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
+    "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
+    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+    "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+    "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    "actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68",
+    "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+    "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+    "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8",
+    "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228",
+];
+
+#[derive(Clone, Copy)]
+enum ManifestKind {
+    Workflow,
+    Action,
+}
+
+fn main() -> ExitCode {
+    match check_manifests() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(diagnostics) => {
+            for diagnostic in diagnostics {
+                eprintln!("{diagnostic}");
+            }
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn check_manifests() -> Result<(), Vec<String>> {
+    let (root, manifests) = match manifest_arguments() {
+        Ok(arguments) => arguments,
+        Err(diagnostic) => return Err(vec![diagnostic]),
+    };
+    let mut diagnostics = Vec::new();
+
+    for relative_path in manifests {
+        check_manifest(&root, &relative_path, &mut diagnostics);
+    }
+
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(diagnostics)
+    }
+}
+
+fn manifest_arguments() -> Result<(PathBuf, Vec<PathBuf>), String> {
+    let mut arguments = env::args_os().skip(1);
+    let root = arguments.next().ok_or_else(|| {
+        "check-pinned-actions: expected a Git work-tree root followed by selected manifests"
+            .to_owned()
+    })?;
+    Ok((
+        PathBuf::from(root),
+        arguments.map(PathBuf::from).collect::<Vec<_>>(),
+    ))
+}
+
+fn check_manifest(root: &Path, relative_path: &Path, diagnostics: &mut Vec<String>) {
+    let display_path = relative_path.display().to_string();
+    if !is_safe_relative_path(relative_path) {
+        diagnostics.push(format!(
+            "{display_path}: $: selected manifest path must be relative to the Git work tree"
+        ));
+        return;
+    }
+    let kind = if is_workflow(relative_path) {
+        ManifestKind::Workflow
+    } else if is_action_manifest(relative_path) {
+        ManifestKind::Action
+    } else {
+        diagnostics.push(format!("{display_path}: $: unsupported manifest path"));
+        return;
+    };
+    let document = match read_document(root, relative_path, &display_path) {
+        Ok(document) => document,
+        Err(diagnostic) => {
+            diagnostics.push(diagnostic);
+            return;
+        }
+    };
+
+    match kind {
+        ManifestKind::Workflow => check_workflow(&document, &display_path, diagnostics),
+        ManifestKind::Action => check_action(&document, &display_path, diagnostics),
+    }
+}
+
+fn read_document(root: &Path, relative_path: &Path, display_path: &str) -> Result<Value, String> {
+    let path = root.join(relative_path);
+    let metadata = fs::metadata(&path)
+        .map_err(|error| format!("{display_path}: unable to read manifest: {error}"))?;
+    if metadata.len() > MAX_MANIFEST_BYTES {
+        return Err(format!(
+            "{display_path}: manifest exceeds the {MAX_MANIFEST_BYTES}-byte size limit"
+        ));
+    }
+
+    let mut source = Vec::with_capacity(metadata.len().min(MAX_MANIFEST_BYTES + 1) as usize);
+    fs::File::open(&path)
+        .and_then(|file| file.take(MAX_MANIFEST_BYTES + 1).read_to_end(&mut source))
+        .map_err(|error| format!("{display_path}: unable to read manifest: {error}"))?;
+    if source.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err(format!(
+            "{display_path}: manifest exceeds the {MAX_MANIFEST_BYTES}-byte size limit"
+        ));
+    }
+    let source = String::from_utf8(source)
+        .map_err(|error| format!("{display_path}: unable to read manifest: {error}"))?;
+
+    let mut documents = Vec::new();
+    for document in serde_yaml::Deserializer::from_str(&source) {
+        documents.push(
+            Value::deserialize(document)
+                .map_err(|error| format!("{display_path}: invalid YAML: {error}"))?,
+        );
+    }
+
+    match documents.len() {
+        1 => Ok(documents.pop().expect("one YAML document")),
+        count => Err(format!(
+            "{display_path}: expected exactly one YAML document, found {count}"
+        )),
+    }
+}
+
+fn is_workflow(path: &Path) -> bool {
+    let path = path.to_string_lossy();
+    path.starts_with(".github/workflows/") && (path.ends_with(".yml") || path.ends_with(".yaml"))
+}
+
+fn is_action_manifest(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("action.yml" | "action.yaml")
+    )
+}
+
+fn is_safe_relative_path(path: &Path) -> bool {
+    path.is_relative()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::CurDir | Component::Normal(_)))
+}
+
+fn check_workflow(document: &Value, file: &str, diagnostics: &mut Vec<String>) {
+    let Some(root) = untag(document).as_mapping() else {
+        diagnostics.push(format!("{file}: $: expected a workflow mapping"));
+        return;
+    };
+    reject_merge_key(root, file, "$", diagnostics);
+
+    let Some(jobs) = mapping_field(root, "jobs") else {
+        return;
+    };
+    let Some(jobs) = untag(jobs).as_mapping() else {
+        diagnostics.push(format!("{file}: jobs: expected a jobs mapping"));
+        return;
+    };
+    reject_merge_key(jobs, file, "jobs", diagnostics);
+
+    for (job_name, job) in jobs {
+        let Some(job_name) = untag(job_name).as_str() else {
+            diagnostics.push(format!("{file}: jobs: expected a string job key"));
+            continue;
+        };
+        check_job(job, file, &format!("jobs.{job_name}"), diagnostics);
+    }
+}
+
+fn check_job(job: &Value, file: &str, path: &str, diagnostics: &mut Vec<String>) {
+    let Some(job) = untag(job).as_mapping() else {
+        diagnostics.push(format!("{file}: {path}: expected a job mapping"));
+        return;
+    };
+    reject_merge_key(job, file, path, diagnostics);
+
+    if let Some(reference) = mapping_field(job, "uses") {
+        check_reference(reference, file, &format!("{path}.uses"), diagnostics);
+    }
+    if let Some(steps) = mapping_field(job, "steps") {
+        check_steps(steps, file, &format!("{path}.steps"), diagnostics);
+    }
+}
+
+fn check_action(document: &Value, file: &str, diagnostics: &mut Vec<String>) {
+    let Some(root) = untag(document).as_mapping() else {
+        diagnostics.push(format!("{file}: $: expected an action mapping"));
+        return;
+    };
+    reject_merge_key(root, file, "$", diagnostics);
+
+    let Some(runs) = mapping_field(root, "runs") else {
+        return;
+    };
+    let Some(runs) = untag(runs).as_mapping() else {
+        diagnostics.push(format!("{file}: runs: expected a runs mapping"));
+        return;
+    };
+    reject_merge_key(runs, file, "runs", diagnostics);
+
+    if mapping_field(runs, "using").and_then(|using| untag(using).as_str()) != Some("composite") {
+        return;
+    }
+
+    let Some(steps) = mapping_field(runs, "steps") else {
+        diagnostics.push(format!(
+            "{file}: runs.steps: composite actions must define a steps sequence"
+        ));
+        return;
+    };
+    check_steps(steps, file, "runs.steps", diagnostics);
+}
+
+fn check_steps(steps: &Value, file: &str, path: &str, diagnostics: &mut Vec<String>) {
+    let Some(steps) = untag(steps).as_sequence() else {
+        diagnostics.push(format!("{file}: {path}: expected a steps sequence"));
+        return;
+    };
+
+    for (index, step) in steps.iter().enumerate() {
+        let step_path = format!("{path}[{index}]");
+        let Some(step) = untag(step).as_mapping() else {
+            diagnostics.push(format!(
+                "{file}: {step_path}: expected an executable step mapping"
+            ));
+            continue;
+        };
+        reject_merge_key(step, file, &step_path, diagnostics);
+
+        if let Some(reference) = mapping_field(step, "uses") {
+            check_reference(reference, file, &format!("{step_path}.uses"), diagnostics);
+        }
+    }
+}
+
+fn check_reference(reference: &Value, file: &str, path: &str, diagnostics: &mut Vec<String>) {
+    let Some(reference) = untag(reference).as_str() else {
+        diagnostics.push(format!(
+            "{file}: {path}: uses must be a string action reference"
+        ));
+        return;
+    };
+
+    if reference.starts_with("./") || reference.starts_with("docker://") {
+        return;
+    }
+    if !is_full_sha(reference) {
+        diagnostics.push(format!(
+            "{file}: {path}: external action must be pinned to a full commit SHA: {reference}"
+        ));
+    } else if !REVIEWED_ACTION_COMMITS.contains(&reference) {
+        diagnostics.push(format!(
+            "{file}: {path}: external action must use a reviewed commit SHA: {reference}"
+        ));
+    }
+}
+
+fn reject_merge_key(mapping: &Mapping, file: &str, path: &str, diagnostics: &mut Vec<String>) {
+    if mapping_field(mapping, "<<").is_some() {
+        diagnostics.push(format!(
+            "{file}: {path}: YAML merge keys are unsupported in executable action mappings"
+        ));
+    }
+}
+
+fn mapping_field<'a>(mapping: &'a Mapping, name: &str) -> Option<&'a Value> {
+    mapping
+        .iter()
+        .find_map(|(key, value)| (untag(key).as_str() == Some(name)).then_some(untag(value)))
+}
+
+fn untag(value: &Value) -> &Value {
+    match value {
+        Value::Tagged(tagged) => untag(&tagged.value),
+        value => value,
+    }
+}
+
+fn is_full_sha(reference: &str) -> bool {
+    let Some((_, revision)) = reference.rsplit_once('@') else {
+        return false;
+    };
+    revision.len() == 40
+        && revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (byte.is_ascii_lowercase() && byte <= b'f'))
+}

--- a/.github/scripts/check-pinned-actions.sh
+++ b/.github/scripts/check-pinned-actions.sh
@@ -1,28 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-failed=0
+if [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null || true)" != "true" ]]; then
+  echo "check-pinned-actions.sh must run inside a Git work tree" >&2
+  exit 1
+fi
 
-while IFS= read -r line; do
-  file="${line%%:*}"
-  rest="${line#*:}"
-  line_no="${rest%%:*}"
-  match="${line##*uses: }"
-  ref="${match%%[[:space:]]*}"
+repo_root="$(git rev-parse --show-toplevel)"
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+manifests=()
 
-  case "$ref" in
-    ./*|docker://*|"")
-      continue
-      ;;
-    actions/*)
-      continue
-      ;;
-  esac
+while IFS= read -r -d '' manifest; do
+  manifests+=("$manifest")
+done < <(
+  git -C "$repo_root" ls-files -z --cached -- \
+    ':(glob).github/workflows/**/*.yml' \
+    ':(glob).github/workflows/**/*.yaml' \
+    ':(glob)**/action.yml' \
+    ':(glob)**/action.yaml'
+)
 
-  if [[ ! "$ref" =~ @[0-9a-f]{40}$ ]]; then
-    echo "$file:$line_no: external action must be pinned to a full commit SHA: $ref" >&2
-    failed=1
-  fi
-done < <(rg -n -o 'uses:\s+\S+' .github/workflows action.yml)
-
-exit "$failed"
+CARGO_TARGET_DIR="${TOGI_PINNED_ACTIONS_TARGET_DIR:-${TMPDIR:-/tmp}/togi-pinned-actions-target}" \
+  exec cargo run --locked --quiet --manifest-path "$script_root/Cargo.toml" \
+    --example check-pinned-actions -- "$repo_root" "${manifests[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             arch: x86_64
             tier: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -75,7 +75,7 @@ jobs:
     name: MSRV
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.87
@@ -95,7 +95,7 @@ jobs:
     name: Supply Chain
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -111,7 +111,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -128,8 +128,8 @@ jobs:
     name: VS Code Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - name: Test extension
@@ -140,7 +140,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -153,13 +153,13 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-bin: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.14.1
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
       - name: Integration tests
@@ -169,7 +169,7 @@ jobs:
     name: Dogfood (togi on togi)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -195,7 +195,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -210,7 +210,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-bin: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
       - name: Create job-private Go build cache

--- a/.github/workflows/dogfood-badge.yml
+++ b/.github/workflows/dogfood-badge.yml
@@ -17,7 +17,7 @@ jobs:
     name: "Update mutation score (dogfood: src/report/json.rs) badge"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable

--- a/.github/workflows/pr-loop-calibration.yml
+++ b/.github/workflows/pr-loop-calibration.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -26,7 +26,7 @@ jobs:
           TOGI_EXPECTED_TARGET: x86_64-unknown-linux-gnu
           TOGI_EXPECTED_ARCH: x86_64
         run: bash ./.github/scripts/assert-native-target.sh
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
       - name: Create job-private Go build cache

--- a/.github/workflows/pr-loop-regression-gate.yml
+++ b/.github/workflows/pr-loop-regression-gate.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
           TOGI_EXPECTED_TARGET: x86_64-unknown-linux-gnu
           TOGI_EXPECTED_ARCH: x86_64
         run: bash ./.github/scripts/assert-native-target.sh
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
       - name: Create job-private Go build cache

--- a/.github/workflows/pr-loop-scale-evidence.yml
+++ b/.github/workflows/pr-loop-scale-evidence.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -31,7 +31,7 @@ jobs:
           TOGI_EXPECTED_TARGET: x86_64-unknown-linux-gnu
           TOGI_EXPECTED_ARCH: x86_64
         run: bash ./.github/scripts/assert-native-target.sh
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
       - name: Create job-private Go build cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             arch: x86_64
             tier: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -72,7 +72,7 @@ jobs:
     name: MSRV
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: 1.87
@@ -92,7 +92,7 @@ jobs:
     name: Supply Chain
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -108,7 +108,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -125,8 +125,8 @@ jobs:
     name: VS Code Extension
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - name: Test extension
@@ -137,7 +137,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -150,14 +150,14 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-bin: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.14.1
           package-manager-cache: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
       - name: Integration tests
@@ -167,7 +167,7 @@ jobs:
     name: Dogfood (togi on togi)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -210,7 +210,7 @@ jobs:
             tier: 2
             name: togi-windows-x86_64
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
@@ -243,14 +243,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
       - name: Generate checksums
         run: sha256sum ./*.tar.gz ./*.zip > checksums.txt
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: |
             *.tar.gz
@@ -275,7 +275,7 @@ jobs:
       TOGI_VERSION: ${{ github.ref_name }}
       TOGI_WORKFLOW_HEAD: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Verify tag commit, workflow head, and release association
@@ -315,10 +315,10 @@ jobs:
       TOGI_EXPECTED_ARCHIVE: ${{ matrix.archive }}
       TOGI_EXPECTED_BINARY: ${{ matrix.binary }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         if: ${{ matrix.tier == 1 }}
         with:
           go-version: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["mutation-testing", "testing", "diff", "tree-sitter", "code-quality"]
 categories = ["development-tools::testing", "command-line-utilities"]
 
+[[example]]
+name = "check-pinned-actions"
+path = ".github/scripts/check-pinned-actions.rs"
+
 [features]
 # Narrowly exposes the libFuzzer execution harness; normal builds have no fuzz API.
 fuzzing = []

--- a/README.md
+++ b/README.md
@@ -875,6 +875,29 @@ dependency/build directories such as `node_modules`, `.venv`, `dist`, `build`,
 and `target`. Set `[mutations] respect_workspace_ignores = false` only when a
 test command genuinely needs ignored files copied into the mutation workspace.
 
+For copy-based workspaces, exact and incremental result reuse is bound to every
+copied source entry and its copied observable metadata. Git-worktree reuse is
+bound to the checked-out `HEAD`, a versioned tracked-file index, and the same
+dirty overlay applied to the workspace, including tracked files that match
+`.gitignore`, plus regular-file standard permissions (full Windows file
+attributes included) and regular-file and non-root directory mtimes actually
+materialized by that Git checkout and overlay. A dirty overlay symlink that
+resolves inside the project is copied as a regular file and keys its resolved
+target metadata at that destination; clean Git symlink leaves remain excluded,
+while their materialized non-root parent directories remain covered.
+Source-only untracked empty directories stay absent from Git worktrees and do
+not affect Git identity. Workspace-root mtimes and `.git` metadata are
+intentionally excluded. Clean tracked paths normally excluded from copies are
+included when Git materializes them; dirty changes to those paths force
+normal-copy fallback. If Git workspace creation or snapshotting fails, the
+whole campaign uses the separate copy-workspace cache domain.
+
+Regular workspace files are canonical execution inputs: Togi preserves bytes,
+the standard `std::fs::Permissions` value (including Windows file attributes),
+and mtime, but intentionally does not carry source ACLs, xattrs, ADS/resource
+forks, ownership, or link relationships into the sandbox. Those
+platform-specific metadata channels are therefore not cache inputs.
+
 ## Security model
 
 togi executes repository-defined build and test commands with the permissions of

--- a/README.md
+++ b/README.md
@@ -1072,8 +1072,8 @@ command = ["npm", "test"]
 
 `format: json` is the one-run path: its JSON stream becomes the replayable
 `togi-report.json`. To opt into GitHub annotations instead, set
-`format: github`; the Action preserves that review run and performs a second
-full JSON mutation run to create the replayable report.
+`format: github`; the Action runs one GitHub-format mutation campaign and writes
+a replayable JSON sidecar with `--json-report`.
 
 For a normal mutation report, the Action uploads `togi-report.json` as the
 `togi-report` artifact. This example explicitly retains it for 14 days. Set a

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ command = ["python3", "-m", "unittest", "discover"]
 
 Try it: `examples/polyglot-demo.sh` runs a PR-sized Go + Rust + Python change through one `togi check` — mutants from all three languages appear in the same report, the same mutation score, and the same `--fail-under` gate. No per-language glue, no stitched-together CI jobs.
 
+Both demos honor `CARGO_TARGET_DIR`; set `TOGI_BIN` to an executable Togi binary to skip their local build.
+
 ## Install
 
 ### Linux x86_64 (Tier 1) first success

--- a/README.md
+++ b/README.md
@@ -936,13 +936,13 @@ jobs:
   togi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: stable
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -1075,7 +1075,7 @@ Download and replay a report only in a checkout at the report's recorded source
 revision and only when the artifact is trusted:
 
 ```yaml
-- uses: actions/download-artifact@v8
+- uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
   if: ${{ always() }}
   with:
     name: togi-report
@@ -1104,12 +1104,12 @@ jobs:
   togi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       # Install togi as shown in "CI Integration" above
       - run: togi check --base origin/main --format sarif > togi-report.sarif
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3
         if: always()  # upload even when togi exits 1 on surviving mutants
         with:
           sarif_file: togi-report.sarif

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -1,16 +1,48 @@
 #!/usr/bin/env bash
 # Demo: togi finding test gaps in a Go project with weak tests
-# Requires: go, cargo build (or cargo install togi)
+# Requires: go and either cargo or an executable TOGI_BIN.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT="$SCRIPT_DIR/.."
-TOGI="$ROOT/target/debug/togi"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="${CARGO_TARGET_DIR:-"$ROOT/target"}"
+case "$TARGET_DIR" in
+  /*) ;;
+  *) TARGET_DIR="$ROOT/$TARGET_DIR" ;;
+esac
+TOGI="${TOGI_BIN:-"$TARGET_DIR/debug/togi"}"
+case "$TOGI" in
+  /*) ;;
+  *) TOGI="$ROOT/$TOGI" ;;
+esac
 FIXTURE="$ROOT/tests/fixtures/go"
 
+is_clean_survivor_report() {
+  local report survived timeout build_errors pattern
+
+  [[ -s "$1" ]] || return 1
+  report=$(<"$1")
+
+  pattern='"survived"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  survived="${BASH_REMATCH[1]}"
+  pattern='"timeout"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  timeout="${BASH_REMATCH[1]}"
+  pattern='"build_errors"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  build_errors="${BASH_REMATCH[1]}"
+
+  (( survived > 0 && timeout == 0 && build_errors == 0 ))
+}
+
 if [[ ! -x "$TOGI" ]]; then
+  if [[ -n "${TOGI_BIN:-}" ]]; then
+    echo "togi binary not found at $TOGI" >&2
+    exit 1
+  fi
   echo "Building togi..."
-  cargo build --manifest-path "$ROOT/Cargo.toml"
+  cargo build --manifest-path "$ROOT/Cargo.toml" --target-dir "$TARGET_DIR"
 fi
 
 echo "=== togi demo: finding test gaps ==="
@@ -27,6 +59,7 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 cp -r "$FIXTURE"/* "$WORK/"
 cd "$WORK"
+REPORT="$WORK/togi-report.json"
 
 # Set up git history: empty commit, then add all files
 git init -q
@@ -38,4 +71,16 @@ echo "Running: togi check --base HEAD~1 --test-cmd 'go test ./...' --jobs 1"
 echo ""
 
 # GOWORK=off avoids Go complaining about workspace in temp dirs
-GOWORK=off "$TOGI" check --base HEAD~1 --test-cmd "go test ./..." --timeout 30 --jobs 1 || true
+# A clean survivor report is expected; reject timeout and build-error reports.
+if GOWORK=off "$TOGI" check --base HEAD~1 --test-cmd "go test ./..." --timeout 30 --jobs 1 --json-report "$REPORT"; then
+  status=0
+else
+  status=$?
+fi
+if [[ "$status" != 0 && "$status" != 1 ]]; then
+  exit "$status"
+fi
+if ! is_clean_survivor_report "$REPORT"; then
+  echo "Expected a JSON report with survived > 0, timeout == 0, and build_errors == 0." >&2
+  exit 1
+fi

--- a/examples/polyglot-demo.sh
+++ b/examples/polyglot-demo.sh
@@ -1,16 +1,48 @@
 #!/usr/bin/env bash
 # Demo: togi on a polyglot change — one run, one report, one score gate.
-# Requires: go, cargo, python3, and a built togi (or cargo install togi).
+# Requires: go, python3, and either cargo or an executable TOGI_BIN.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT="$SCRIPT_DIR/.."
-TOGI="$ROOT/target/debug/togi"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="${CARGO_TARGET_DIR:-"$ROOT/target"}"
+case "$TARGET_DIR" in
+  /*) ;;
+  *) TARGET_DIR="$ROOT/$TARGET_DIR" ;;
+esac
+TOGI="${TOGI_BIN:-"$TARGET_DIR/debug/togi"}"
+case "$TOGI" in
+  /*) ;;
+  *) TOGI="$ROOT/$TOGI" ;;
+esac
 FIXTURE="$ROOT/tests/fixtures/polyglot"
 
+is_clean_survivor_report() {
+  local report survived timeout build_errors pattern
+
+  [[ -s "$1" ]] || return 1
+  report=$(<"$1")
+
+  pattern='"survived"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  survived="${BASH_REMATCH[1]}"
+  pattern='"timeout"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  timeout="${BASH_REMATCH[1]}"
+  pattern='"build_errors"[[:space:]]*:[[:space:]]*([0-9]+)'
+  [[ "$report" =~ $pattern ]] || return 1
+  build_errors="${BASH_REMATCH[1]}"
+
+  (( survived > 0 && timeout == 0 && build_errors == 0 ))
+}
+
 if [[ ! -x "$TOGI" ]]; then
+  if [[ -n "${TOGI_BIN:-}" ]]; then
+    echo "togi binary not found at $TOGI" >&2
+    exit 1
+  fi
   echo "Building togi..."
-  cargo build --manifest-path "$ROOT/Cargo.toml"
+  cargo build --manifest-path "$ROOT/Cargo.toml" --target-dir "$TARGET_DIR"
 fi
 
 echo "=== togi demo: one mutation run across Go + Rust + Python ==="
@@ -26,6 +58,7 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 cp -r "$FIXTURE"/* "$WORK/"
 cd "$WORK"
+REPORT="$WORK/togi-report.json"
 
 git init -q
 git config user.email "togi-demo@example.invalid"
@@ -38,8 +71,19 @@ echo "Running: togi check --base HEAD~1 --jobs 1"
 echo ""
 
 # GOWORK=off avoids Go complaining about workspace in temp dirs.
-# Exit code is non-zero while mutants survive — that is the score gate at work.
-GOWORK=off "$TOGI" check --base HEAD~1 --timeout 60 --jobs 1 || true
+# A clean survivor report is expected; reject timeout and build-error reports.
+if GOWORK=off "$TOGI" check --base HEAD~1 --timeout 60 --jobs 1 --json-report "$REPORT"; then
+  status=0
+else
+  status=$?
+fi
+if [[ "$status" != 0 && "$status" != 1 ]]; then
+  exit "$status"
+fi
+if ! is_clean_survivor_report "$REPORT"; then
+  echo "Expected a JSON report with survived > 0, timeout == 0, and build_errors == 0." >&2
+  exit 1
+fi
 
 echo ""
 echo "=== one run, one report, one gate — no per-language glue required ==="

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -6,7 +6,7 @@ use crate::{Mutation, MutationReport, MutationResult};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Write};
 use std::path::Path;
 
 const BASELINE_FILE: &str = ".togi-baseline";
@@ -201,8 +201,38 @@ fn compare_baseline_mutants(left: &BaselineMutant, right: &BaselineMutant) -> st
 /// Persist a baseline snapshot to `.togi-baseline` inside `dir`.
 pub fn save_baseline(baseline: &Baseline, dir: &Path) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(baseline)?;
-    std::fs::write(dir.join(BASELINE_FILE), json)?;
-    Ok(())
+    let path = dir.join(BASELINE_FILE);
+    publish_baseline(&path, |staged| staged.write_all(json.as_bytes()))
+}
+
+fn publish_baseline(
+    path: &Path,
+    write_contents: impl FnOnce(&mut tempfile::NamedTempFile) -> std::io::Result<()>,
+) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut staged = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "could not create baseline staging file in {}",
+            parent.display()
+        )
+    })?;
+    write_contents(&mut staged)
+        .with_context(|| format!("could not write baseline {}", path.display()))?;
+    staged
+        .flush()
+        .with_context(|| format!("could not flush baseline {}", path.display()))?;
+    staged
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("could not sync baseline {}", path.display()))?;
+    staged
+        .persist(path)
+        .map(|_| ())
+        .map_err(|error| error.error)
+        .with_context(|| format!("could not publish baseline {}", path.display()))
 }
 
 /// Build and persist a baseline only when a report is baseline-eligible.
@@ -667,6 +697,7 @@ mod tests {
             total: 5,
             mutant_snapshot: None,
         };
+        save_baseline(&make_baseline(0, 1), dir.path()).unwrap();
 
         save_baseline(&baseline, dir.path()).unwrap();
         let loaded = load_baseline(dir.path()).unwrap().unwrap();
@@ -674,6 +705,28 @@ mod tests {
         assert_eq!(loaded.killed, 3);
         assert_eq!(loaded.total, 5);
         assert_eq!(loaded.files["src/main.rs"].killed, 3);
+    }
+
+    #[test]
+    fn baseline_publish_preserves_existing_baseline_on_write_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let previous = make_baseline(2, 4);
+        save_baseline(&previous, dir.path()).unwrap();
+        let path = dir.path().join(BASELINE_FILE);
+        let previous_bytes = std::fs::read(&path).unwrap();
+
+        let error = publish_baseline(&path, |staged| {
+            staged.write_all(b"{\"files\":")?;
+            Err(std::io::Error::other("simulated write failure"))
+        });
+
+        assert!(error.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), previous_bytes);
+        let loaded = load_baseline(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            (loaded.killed, loaded.total),
+            (previous.killed, previous.total)
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -151,11 +151,14 @@ impl IncrementalHistoryStore {
             .and_then(|entry| reusable_history_result(entry.result))
     }
 
+    /// Returns a recorded killer only when its current relevant-test context
+    /// matches the workspace context under which it was learned.
     pub fn preferred_killer_test(
         &self,
         mutation_identity: &str,
         mutation_description: &str,
         tests: &[String],
+        relevant_test_hash_for_killer: impl Fn(&str) -> Option<u64>,
     ) -> Option<String> {
         let history = self.state.lock().ok()?;
         history
@@ -166,22 +169,27 @@ impl IncrementalHistoryStore {
                 entry.mutation_identity == mutation_identity
                     && entry.mutation_description == mutation_description
             })
-            .filter_map(|entry| entry.killer_test.as_ref())
-            .find(|killer| tests.iter().any(|test| test == *killer))
-            .cloned()
+            .filter_map(|entry| {
+                let killer = entry.killer_test.as_ref()?;
+                (tests.iter().any(|test| test == killer)
+                    && relevant_test_hash_for_killer(killer) == Some(entry.relevant_test_hash))
+                .then(|| killer.clone())
+            })
+            .next()
     }
 
     /// Killer test from the latest `Killed` history entry for this mutation
-    /// whose source and command hashes still match the current run — the
-    /// evidence learned selection clusters on. Returns `None` when there is
-    /// no such entry, the verdict was not `Killed`, or no killer test was
-    /// recorded.
+    /// whose source, command, and relevant-test hashes still match the current
+    /// run — the evidence learned selection clusters on. Returns `None` when
+    /// there is no such entry, the verdict was not `Killed`, or no killer test
+    /// was recorded.
     pub fn learned_killer_test(
         &self,
         mutation_identity: &str,
         mutation_description: &str,
         source_hash: u64,
         command_hash: u64,
+        relevant_test_hash: u64,
     ) -> Option<String> {
         let history = self.state.lock().ok()?;
         history
@@ -193,6 +201,7 @@ impl IncrementalHistoryStore {
                     && entry.mutation_description == mutation_description
                     && entry.source_hash == source_hash
                     && entry.command_hash == command_hash
+                    && entry.relevant_test_hash == relevant_test_hash
                     && entry.result == MutationResult::Killed
             })
             .and_then(|entry| entry.killer_test.clone())
@@ -581,9 +590,20 @@ mod tests {
             store.preferred_killer_test(
                 "src/lib.rs:0..1:op",
                 "desc",
-                &["test_add".into(), "test_max".into()]
+                &["test_add".into(), "test_max".into()],
+                |killer| (killer == "test_max").then_some(3),
             ),
             Some("test_max".into())
+        );
+        assert_eq!(
+            store.preferred_killer_test(
+                "src/lib.rs:0..1:op",
+                "desc",
+                &["test_add".into(), "test_max".into()],
+                |_| Some(4),
+            ),
+            None,
+            "a killer from another workspace context must not steer selection"
         );
         Ok(())
     }
@@ -609,7 +629,7 @@ mod tests {
 
         let reloaded = IncrementalHistoryStore::load(tmp.path());
         assert_eq!(
-            reloaded.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            reloaded.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2, 3),
             Some("test_add".into())
         );
         Ok(())
@@ -622,11 +642,15 @@ mod tests {
         store.record(killed_entry(Some("test_add")));
 
         assert_eq!(
-            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 9, 2),
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 9, 2, 3),
             None
         );
         assert_eq!(
-            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 9),
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 9, 3),
+            None
+        );
+        assert_eq!(
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2, 9),
             None
         );
         Ok(())
@@ -641,7 +665,7 @@ mod tests {
         store.record(entry);
 
         assert_eq!(
-            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2, 3),
             None
         );
         Ok(())
@@ -654,7 +678,7 @@ mod tests {
         store.record(killed_entry(None));
 
         assert_eq!(
-            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2),
+            store.learned_killer_test("src/lib.rs:0..1:op", "desc", 1, 2, 3),
             None
         );
         Ok(())

--- a/src/learned.rs
+++ b/src/learned.rs
@@ -9,10 +9,9 @@
 //! Killer-test equality is only a conservative *proxy* for subsumption, so
 //! skipping is strictly opt-in and strictly evidence-based: a mutant is only
 //! ever skipped when history holds a `Killed` verdict with a recorded killer
-//! test whose source and command hashes still match the current run. Any
-//! doubt (no entry, stale hashes, non-killed verdict, no killer test) means
-//! the mutant executes normally.
-
+//! test whose source, command, and relevant-test hashes still match the
+//! current run. Any doubt (no entry, stale hashes, non-killed verdict, no
+//! killer test) means the mutant executes normally.
 use crate::Mutation;
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,7 +1,7 @@
 //! File-based lock to prevent concurrent togi runs on the same repo.
 
 use anyhow::{Context, Result, bail};
-use std::fs::{self, File, OpenOptions};
+use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
@@ -76,6 +76,45 @@ fn flock_with_retry(file: &File) -> std::io::Result<()> {
     }
 }
 
+#[cfg(all(test, unix))]
+mod test_hooks {
+    use std::sync::mpsc::{Receiver, Sender, channel};
+    use std::sync::{LazyLock, Mutex};
+
+    struct AfterCreatePause {
+        created: Sender<()>,
+        resume: Receiver<()>,
+    }
+
+    static AFTER_CREATE_PAUSE: LazyLock<Mutex<Option<AfterCreatePause>>> =
+        LazyLock::new(|| Mutex::new(None));
+
+    pub(super) fn install_after_create_pause() -> (Receiver<()>, Sender<()>) {
+        let (created, created_rx) = channel();
+        let (resume, resume_rx) = channel();
+        let mut pause = AFTER_CREATE_PAUSE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(pause.is_none(), "after-create pause already installed");
+        *pause = Some(AfterCreatePause {
+            created,
+            resume: resume_rx,
+        });
+        (created_rx, resume)
+    }
+
+    pub(super) fn pause_after_create() {
+        if let Some(pause) = AFTER_CREATE_PAUSE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            pause.created.send(()).unwrap();
+            pause.resume.recv().unwrap();
+        }
+    }
+}
+
 /// Acquire a lock for the given project root directory.
 /// Returns an error if another togi process is already running.
 pub fn acquire(project_root: &Path) -> Result<LockGuard> {
@@ -94,8 +133,9 @@ pub fn acquire(project_root: &Path) -> Result<LockGuard> {
                 .open(&path)
             {
                 Ok(mut f) => {
+                    #[cfg(all(test, unix))]
+                    test_hooks::pause_after_create();
                     if let Err(e) = flock_with_retry(&f) {
-                        let _ = fs::remove_file(&path);
                         bail!(
                             "failed to acquire advisory lock on new file {}: {e}",
                             path.display()
@@ -157,8 +197,16 @@ pub fn acquire(project_root: &Path) -> Result<LockGuard> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::io::{BufRead, BufReader, Read};
+    #[cfg(unix)]
+    use std::process::{Command, Stdio};
+    #[cfg(unix)]
+    use std::thread;
 
     fn lock_test_guard() -> std::sync::MutexGuard<'static, ()> {
         static LOCK_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
@@ -204,5 +252,73 @@ mod tests {
 
         let _guard = acquire(dir.path()).unwrap();
         assert!(lock_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fast_path_flock_failure_keeps_holder_inode_reachable() {
+        let _serial = lock_test_guard();
+        let dir = TempDir::new().unwrap();
+        let lock_path = dir.path().join(LOCK_FILE);
+        let (created, resume) = test_hooks::install_after_create_pause();
+
+        let root = dir.path().to_path_buf();
+        let creator = thread::spawn(move || acquire(&root));
+        created.recv().unwrap();
+
+        // A separate process owns the advisory lock on the inode A just created.
+        let mut holder = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "lock::tests::fast_path_lock_race_holder",
+                "--nocapture",
+            ])
+            .env("TOGI_LOCK_RACE_HOLDER_PATH", &lock_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let mut holder_stdout = BufReader::new(holder.stdout.take().unwrap());
+        loop {
+            let mut line = String::new();
+            assert_ne!(holder_stdout.read_line(&mut line).unwrap(), 0);
+            if line.trim_end() == "TOGI_LOCK_RACE_HOLDER_READY" {
+                break;
+            }
+        }
+
+        resume.send(()).unwrap();
+        assert!(creator.join().unwrap().is_err());
+        assert!(lock_path.exists());
+        assert!(acquire(dir.path()).is_err());
+
+        std::io::Write::write_all(holder.stdin.as_mut().unwrap(), b"release").unwrap();
+        drop(holder.stdin.take());
+        let mut holder_output = String::new();
+        holder_stdout.read_to_string(&mut holder_output).unwrap();
+        assert!(holder.wait().unwrap().success(), "{holder_output}");
+
+        let _guard = acquire(dir.path()).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fast_path_lock_race_holder() {
+        let Some(lock_path) = std::env::var_os("TOGI_LOCK_RACE_HOLDER_PATH") else {
+            return;
+        };
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(lock_path)
+            .unwrap();
+        try_flock(&file).unwrap();
+        println!("TOGI_LOCK_RACE_HOLDER_READY");
+        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+
+        let mut release = [0];
+        std::io::Read::read_exact(&mut std::io::stdin(), &mut release).unwrap();
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -267,6 +267,9 @@ mod tests {
         created.recv().unwrap();
 
         // A separate process owns the advisory lock on the inode A just created.
+        // foxguard: ignore[rs/no-command-injection]
+        // `current_exe` is this active test binary; fixed child-test arguments and
+        // its subprocess are required to exercise the lock race.
         let mut holder = Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",

--- a/src/main.rs
+++ b/src/main.rs
@@ -629,9 +629,10 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
     merge_uncovered(&mut report, classified.uncovered);
 
     let baseline_eligible = togi::baseline::is_baseline_eligible(&report);
+    let worker_panic = has_fresh_mutation_worker_panic(&report);
     let mut should_fail = false;
     let partial_report = report.total < report.planned_total;
-    let baseline_actions_allowed = baseline_eligible;
+    let baseline_actions_allowed = baseline_eligible && !worker_panic;
     let mut baseline_score: Option<f64> = None;
     let mut loaded_baseline = false;
     let mut survivor_comparison = None;
@@ -734,19 +735,21 @@ fn run_check(cfg: togi::cli::CheckArgs, cancelled: Arc<AtomicBool>) -> anyhow::R
         eprintln!("PR comment written to {}", path.display());
     }
 
-    if should_fail {
-        exit_with(_lock, 1);
-    } else if let Some(threshold) = fail_under {
-        let gate_score = togi::report::fail_under_score(&report);
-        if gate_score < threshold {
+    match check_exit_action(
+        &report,
+        worker_panic,
+        should_fail,
+        fail_under,
+        loaded_baseline,
+    ) {
+        Some(CheckExitAction::Code(code)) => exit_with(_lock, code),
+        Some(CheckExitAction::FailUnder { score, threshold }) => {
             eprintln!(
-                "Fail-under gate score {gate_score:.1}% is below --fail-under threshold {threshold:.1}% (displayed mutation score is fresh-only)."
+                "Fail-under gate score {score:.1}% is below --fail-under threshold {threshold:.1}% (displayed mutation score is fresh-only)."
             );
             exit_with(_lock, 1);
         }
-    } else if has_fresh_timeout_or_build_error(&report) || (report.survived > 0 && !loaded_baseline)
-    {
-        exit_with(_lock, 1);
+        None => {}
     }
 
     Ok(())
@@ -759,6 +762,49 @@ fn has_fresh_timeout_or_build_error(report: &togi::MutationReport) -> bool {
             togi::MutationResult::Timeout | togi::MutationResult::BuildError
         ) && !report.execution_for(mutation.id, *result).is_reused()
     })
+}
+
+fn has_fresh_mutation_worker_panic(report: &togi::MutationReport) -> bool {
+    report.build_error_diagnostics.iter().any(|diagnostic| {
+        diagnostic.runner == "regular"
+            && diagnostic.phase == "mutation_worker_panic"
+            && report.results.iter().any(|(mutation, result)| {
+                mutation.id == diagnostic.mutation_id
+                    && *result == togi::MutationResult::BuildError
+                    && !report.execution_for(mutation.id, *result).is_reused()
+            })
+    })
+}
+
+#[derive(Debug, PartialEq)]
+enum CheckExitAction {
+    Code(i32),
+    FailUnder { score: f64, threshold: f64 },
+}
+
+fn check_exit_action(
+    report: &togi::MutationReport,
+    worker_panic: bool,
+    should_fail: bool,
+    fail_under: Option<f64>,
+    loaded_baseline: bool,
+) -> Option<CheckExitAction> {
+    if worker_panic {
+        return Some(CheckExitAction::Code(2));
+    }
+    if should_fail {
+        return Some(CheckExitAction::Code(1));
+    }
+    if let Some(threshold) = fail_under {
+        let score = togi::report::fail_under_score(report);
+        if score < threshold {
+            return Some(CheckExitAction::FailUnder { score, threshold });
+        }
+    } else if has_fresh_timeout_or_build_error(report) || (report.survived > 0 && !loaded_baseline)
+    {
+        return Some(CheckExitAction::Code(1));
+    }
+    None
 }
 
 fn exit_with(lock: togi::lock::LockGuard, code: i32) -> ! {
@@ -2344,6 +2390,56 @@ mod tests {
                 "{result:?} should trigger the default outcome gate"
             );
         }
+    }
+
+    #[test]
+    fn mutation_worker_panic_preempts_default_and_fail_under_gates() {
+        for (mode, should_fail, fail_under) in
+            [("default", true, None), ("--fail-under", false, Some(80.0))]
+        {
+            let mut report = report_with_outcome(togi::MutationResult::BuildError, None);
+            report
+                .build_error_diagnostics
+                .push(togi::BuildErrorDiagnostic::new(
+                    0,
+                    "regular",
+                    "mutation_worker_panic",
+                    vec![],
+                    "mutation worker panicked after dequeuing this mutation",
+                ));
+            let worker_panic = has_fresh_mutation_worker_panic(&report);
+
+            assert!(worker_panic, "{mode} should recognize the worker panic");
+            assert_eq!(
+                check_exit_action(&report, worker_panic, should_fail, fail_under, true),
+                Some(CheckExitAction::Code(2)),
+                "{mode} should take the terminal worker-panic branch"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_build_error_keeps_existing_exit_behavior() {
+        let mut report = report_with_outcome(togi::MutationResult::BuildError, None);
+        report
+            .build_error_diagnostics
+            .push(togi::BuildErrorDiagnostic::new(
+                0,
+                "regular",
+                "build_command",
+                vec![],
+                "configured build command failed",
+            ));
+
+        assert!(!has_fresh_mutation_worker_panic(&report));
+        assert_eq!(
+            check_exit_action(&report, false, false, None, false),
+            Some(CheckExitAction::Code(1))
+        );
+        assert_eq!(
+            check_exit_action(&report, false, false, Some(0.0), false),
+            None
+        );
     }
 
     #[test]

--- a/src/report/coverage.rs
+++ b/src/report/coverage.rs
@@ -22,7 +22,6 @@ pub fn write_html(report: &CoverageGateReport, path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
 pub fn print(report: &CoverageGateReport, format: OutputFormat) -> Result<()> {
     match format {
         OutputFormat::Json => print_json(report)?,
@@ -183,4 +182,189 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coverage::{CoverageMetric, CoverageUncoveredFile};
+    use std::path::Path;
+    use std::process::{Command, Output};
+    use tempfile::TempDir;
+
+    const CHILD_TEST: &str = "report::coverage::tests::coverage_router_child";
+    const REPORT_FILE: &str = "togi-coverage-report.html";
+    const STDOUT_BEGIN: &str = "__TOGI_COVERAGE_ROUTER_STDOUT_BEGIN__";
+    const STDOUT_END: &str = "__TOGI_COVERAGE_ROUTER_STDOUT_END__";
+
+    fn sample_report() -> CoverageGateReport {
+        CoverageGateReport {
+            line_coverage: CoverageMetric {
+                covered: 3,
+                total: 4,
+                threshold: Some(90.0),
+            },
+            diff_coverage: CoverageMetric {
+                covered: 1,
+                total: 2,
+                threshold: Some(80.0),
+            },
+            uncovered_changed_lines: vec![CoverageUncoveredFile {
+                file: "src/lib.rs".into(),
+                lines: vec![12],
+            }],
+            fail_on_uncovered_diff: true,
+        }
+    }
+
+    fn output_format(name: &str) -> OutputFormat {
+        match name {
+            "terminal" => OutputFormat::Terminal,
+            "json" => OutputFormat::Json,
+            "github" => OutputFormat::Github,
+            "html" => OutputFormat::Html,
+            "sarif" => OutputFormat::Sarif,
+            _ => panic!("unknown output format: {name}"),
+        }
+    }
+
+    #[test]
+    fn coverage_router_child() {
+        let Ok(api) = std::env::var("TOGI_COVERAGE_ROUTER_API") else {
+            return;
+        };
+        let format = output_format(
+            &std::env::var("TOGI_COVERAGE_ROUTER_FORMAT")
+                .expect("coverage router child format must be set"),
+        );
+        let report = sample_report();
+
+        println!("{STDOUT_BEGIN}");
+        let result = match api.as_str() {
+            "canonical" => print(&report, format),
+            "wrapper" => crate::report::print_coverage_gate_report(&report, format),
+            _ => panic!("unknown coverage router API: {api}"),
+        };
+        result.unwrap();
+        println!("{STDOUT_END}");
+    }
+
+    fn invoke(api: &str, format: &str, directory: &Path) -> Output {
+        Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", CHILD_TEST, "--nocapture"])
+            .env("TOGI_COVERAGE_ROUTER_API", api)
+            .env("TOGI_COVERAGE_ROUTER_FORMAT", format)
+            .current_dir(directory)
+            .output()
+            .unwrap()
+    }
+
+    fn routed_stdout(output: &[u8]) -> &str {
+        let output = std::str::from_utf8(output).unwrap();
+        let (_, output) = output
+            .split_once(STDOUT_BEGIN)
+            .expect("coverage router stdout start marker must be present");
+        let output = output
+            .strip_prefix('\n')
+            .expect("coverage router stdout start marker must end its line");
+        output
+            .split_once(STDOUT_END)
+            .expect("coverage router stdout end marker must be present")
+            .0
+    }
+
+    fn json_from_output(output: &str) -> serde_json::Value {
+        serde_json::from_str(output).expect("coverage JSON must parse")
+    }
+
+    #[test]
+    fn public_coverage_report_routes_match() {
+        for (format, writes_html) in [
+            ("terminal", false),
+            ("json", false),
+            ("github", false),
+            ("html", true),
+            ("sarif", false),
+        ] {
+            let canonical_dir = TempDir::new().unwrap();
+            let wrapper_dir = TempDir::new().unwrap();
+            let canonical = invoke("canonical", format, canonical_dir.path());
+            let wrapper = invoke("wrapper", format, wrapper_dir.path());
+
+            assert!(
+                canonical.status.success(),
+                "canonical {format} route failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&canonical.stdout),
+                String::from_utf8_lossy(&canonical.stderr),
+            );
+            assert!(
+                wrapper.status.success(),
+                "wrapper {format} route failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&wrapper.stdout),
+                String::from_utf8_lossy(&wrapper.stderr),
+            );
+            let canonical_stdout = routed_stdout(&canonical.stdout);
+            let wrapper_stdout = routed_stdout(&wrapper.stdout);
+            assert_eq!(
+                canonical_stdout, wrapper_stdout,
+                "{format} routes must have identical stdout"
+            );
+            if format == "html" {
+                assert!(
+                    canonical_stdout.is_empty(),
+                    "HTML route must not write stdout"
+                );
+            } else if format != "json" {
+                assert!(
+                    canonical_stdout.contains("Coverage gate failed"),
+                    "{format} route stdout: {canonical_stdout}"
+                );
+            }
+
+            let canonical_html = canonical_dir.path().join(REPORT_FILE);
+            let wrapper_html = wrapper_dir.path().join(REPORT_FILE);
+            assert_eq!(
+                canonical_html.exists(),
+                writes_html,
+                "canonical {format} route wrote an unexpected destination"
+            );
+            assert_eq!(
+                wrapper_html.exists(),
+                writes_html,
+                "wrapper {format} route wrote an unexpected destination"
+            );
+
+            if format == "json" {
+                assert_eq!(
+                    json_from_output(canonical_stdout),
+                    json_from_output(wrapper_stdout)
+                );
+            }
+
+            if writes_html {
+                assert_eq!(
+                    std::fs::read(canonical_html).unwrap(),
+                    std::fs::read(wrapper_html).unwrap(),
+                    "HTML routes must write the same report"
+                );
+                assert!(
+                    canonical.stderr.is_empty(),
+                    "canonical HTML route must not write stderr"
+                );
+                assert_eq!(
+                    String::from_utf8(wrapper.stderr).unwrap(),
+                    "HTML coverage report written to togi-coverage-report.html\n"
+                );
+            } else {
+                assert_eq!(
+                    canonical.stderr, wrapper.stderr,
+                    "{format} routes must have identical stderr"
+                );
+                assert!(
+                    canonical.stderr.is_empty(),
+                    "{format} routes must not write stderr"
+                );
+            }
+        }
+    }
 }

--- a/src/report/coverage.rs
+++ b/src/report/coverage.rs
@@ -250,6 +250,9 @@ mod tests {
     }
 
     fn invoke(api: &str, format: &str, directory: &Path) -> Output {
+        // foxguard: ignore[rs/no-command-injection]
+        // `current_exe` is this active test binary; fixed child-test arguments
+        // isolate stdout and current-directory behavior in a subprocess.
         Command::new(std::env::current_exe().unwrap())
             .args(["--exact", CHILD_TEST, "--nocapture"])
             .env("TOGI_COVERAGE_ROUTER_API", api)

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -286,18 +286,9 @@ pub fn print_coverage_gate_report(
     report: &crate::coverage::CoverageGateReport,
     format: crate::cli::OutputFormat,
 ) -> anyhow::Result<()> {
-    use crate::cli::OutputFormat;
-    match format {
-        OutputFormat::Json => coverage::print_json(report)?,
-        OutputFormat::Github => coverage::print_github(report),
-        OutputFormat::Html => {
-            let path = std::path::Path::new("togi-coverage-report.html");
-            coverage::write_html(report, path)?;
-            eprintln!("HTML coverage report written to {}", path.display());
-        }
-        // SARIF reports surviving mutants, not coverage gates; keep the gate readable.
-        OutputFormat::Sarif => coverage::print_terminal(report),
-        OutputFormat::Terminal => coverage::print_terminal(report),
+    coverage::print(report, format)?;
+    if matches!(format, crate::cli::OutputFormat::Html) {
+        eprintln!("HTML coverage report written to togi-coverage-report.html");
     }
     Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10159,6 +10159,7 @@ test "$runs" -eq 1
                 "-count=1".into(),
                 "./...".into(),
             ];
+            commands.timeout = Duration::from_secs(90);
             commands.test_selection = Some(selection.clone());
             commands
         };
@@ -10343,6 +10344,7 @@ test "$runs" -eq 1
                 "-count=1".into(),
                 "./...".into(),
             ];
+            commands.timeout = Duration::from_secs(90);
             commands.test_selection = Some(selection.clone());
             commands
         };
@@ -10436,6 +10438,7 @@ test "$runs" -eq 1
         run_git(root, &["init"]);
         run_git(root, &["config", "user.email", "test@example.com"]);
         run_git(root, &["config", "user.name", "Test"]);
+        run_git(root, &["config", "core.autocrlf", "false"]);
         let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
         std::fs::write(
             root.join("go.mod"),
@@ -10684,6 +10687,7 @@ test "$runs" -eq 1
                 "-count=1".into(),
                 "./...".into(),
             ];
+            commands.timeout = Duration::from_secs(90);
             commands.test_selection = Some(selection.clone());
             commands
         };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 const CAPTURED_OUTPUT_LIMIT: usize = 1024 * 1024;
 const CAPTURE_CLEANUP_TIMEOUT: Duration = Duration::from_millis(100);
@@ -427,27 +427,34 @@ fn select_test_command(
     commands: &CommandConfig,
     mutation: &Mutation,
 ) -> SelectedTestCommand {
-    select_test_command_with_history(project_root, commands, mutation, None)
+    select_test_command_with_history(project_root, commands, mutation, None, None)
 }
 
+/// Use a learned killer only when it matches the actual workspace-pool context.
 fn select_test_command_with_history(
     project_root: &Path,
     commands: &CommandConfig,
     mutation: &Mutation,
     history: Option<&cache::IncrementalHistoryStore>,
+    learned_selection_context: Option<LearnedSelectionContext<'_>>,
 ) -> SelectedTestCommand {
     let mut selected = select_unnarrowed_test_command(project_root, commands, mutation);
     selected.selection_active = commands.test_selection.is_some();
 
     if let Some(test_selection) = &commands.test_selection {
         if let Some(mut tests) = test_selection.tests_for(project_root, mutation) {
-            if let Some(preferred) = history.and_then(|history| {
-                history.preferred_killer_test(
-                    &cache_identity(project_root, mutation),
-                    &mutation.description,
-                    &tests,
-                )
-            }) {
+            if let Some(preferred) =
+                history
+                    .zip(learned_selection_context)
+                    .and_then(|(history, context)| {
+                        history.preferred_killer_test(
+                            &cache_identity(project_root, mutation),
+                            &mutation.description,
+                            &tests,
+                            |killer| context.relevant_test_hash_for_killer(&tests, killer),
+                        )
+                    })
+            {
                 tests.sort_by_key(|test| if *test == preferred { 0 } else { 1 });
             }
             let narrowed = narrow_test_command(selected.argv.clone(), &tests);
@@ -753,10 +760,47 @@ enum WorkspaceResetStrategy {
     },
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkspaceStrategy {
+    GitWorktree,
+    Copy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GitWorkspaceMtimeEntryKind {
+    RegularFile,
+    Directory,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GitWorkspaceMtimeEntry {
+    relative: PathBuf,
+    kind: GitWorkspaceMtimeEntryKind,
+    /// Canonical regular-file permissions when this is a regular file.
+    permissions: Option<fs::Permissions>,
+    permission_fingerprint: Option<u32>,
+    modified: SystemTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GitIndexEntry {
+    relative: PathBuf,
+    mode: String,
+    object_id: String,
+}
+
+struct GitWorkspaceMtimeSource {
+    kind: GitWorkspaceMtimeEntryKind,
+    source: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct GitWorktreeOverlay {
+    head: String,
+    index_entries: Vec<GitIndexEntry>,
     copy_paths: Vec<PathBuf>,
     remove_paths: Vec<PathBuf>,
+    mtime_entries: Vec<GitWorkspaceMtimeEntry>,
 }
 
 impl GitWorktreeOverlay {
@@ -767,7 +811,7 @@ impl GitWorktreeOverlay {
         for relative in &self.copy_paths {
             copy_overlay_file(project_root, workspace_root, relative)?;
         }
-        Ok(())
+        normalize_git_workspace_mtimes(workspace_root, &self.mtime_entries)
     }
 
     fn apply_replay(
@@ -794,6 +838,20 @@ impl GitWorktreeOverlay {
 impl WorkspaceCopy {
     pub(crate) fn root(&self) -> &Path {
         &self.root
+    }
+
+    fn strategy(&self) -> WorkspaceStrategy {
+        match &self.reset_strategy {
+            WorkspaceResetStrategy::Copy => WorkspaceStrategy::Copy,
+            WorkspaceResetStrategy::GitWorktree { .. } => WorkspaceStrategy::GitWorktree,
+        }
+    }
+
+    fn git_overlay(&self) -> Option<&GitWorktreeOverlay> {
+        match &self.reset_strategy {
+            WorkspaceResetStrategy::GitWorktree { overlay, .. } => Some(overlay),
+            WorkspaceResetStrategy::Copy => None,
+        }
     }
 
     fn reset(&self, project_root: &Path, respect_ignores: bool) -> std::io::Result<()> {
@@ -1454,6 +1512,7 @@ pub(crate) fn should_skip_workspace_entry(relative: &Path) -> bool {
                     | ".togi"
                     | ".togi-cache"
                     | ".togi.lock"
+                    | ".togi-baseline"
                     | ".codex"
                     | ".claude"
                     | "target"
@@ -1512,73 +1571,354 @@ fn should_copy_replay_workspace_entry(project_root: &Path, path: &Path) -> bool 
 /// Any stale stash from an interrupted prior reset is reclaimed before rename.
 const PRESERVED_WORKSPACE_DIRS: &[&str] = &["target"];
 
-fn cache_context_fingerprint(project_root: &Path) -> u64 {
-    git_cache_context_fingerprint(project_root)
-        .unwrap_or_else(|| filesystem_cache_context_fingerprint(project_root))
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkspaceCacheContextProvenance {
+    GitWorktreeV4,
+    WorkspaceCopy { respect_workspace_ignores: bool },
 }
 
-fn filesystem_cache_context_fingerprint(project_root: &Path) -> u64 {
-    let mut files = Vec::new();
-    collect_cache_context_files(project_root, project_root, &mut files);
-    files.sort_by_key(|path| normalized_cache_path(project_root, path));
+#[derive(Clone, Copy)]
+struct WorkspaceCacheContext {
+    fingerprint: u64,
+    provenance: WorkspaceCacheContextProvenance,
+}
 
-    let mut hasher = StableCacheHasher::default();
-    update_cache_hash(&mut hasher, b"filesystem");
-    for relative in files {
-        let path_key = normalized_cache_path(project_root, &relative);
-        update_cache_hash(&mut hasher, path_key.as_bytes());
-        if let Ok(content) = fs::read(project_root.join(&relative)) {
-            update_cache_hash(&mut hasher, &content);
+#[cfg(test)]
+fn cache_context_fingerprint(project_root: &Path) -> u64 {
+    workspace_cache_context(project_root, true).fingerprint
+}
+
+/// Fingerprint the actual strategy selected by a prebuilt workspace pool.
+///
+/// A Git worktree and a normal copy have intentionally distinct cache domains:
+/// their filesystem shapes differ even when their source bytes match.
+fn workspace_cache_context_for_strategy(
+    project_root: &Path,
+    respect_workspace_ignores: bool,
+    strategy: WorkspaceStrategy,
+    git_overlay: Option<&GitWorktreeOverlay>,
+) -> Option<WorkspaceCacheContext> {
+    match strategy {
+        WorkspaceStrategy::GitWorktree => git_overlay
+            .and_then(|overlay| git_cache_context_fingerprint_for_overlay(project_root, overlay))
+            .map(|fingerprint| WorkspaceCacheContext {
+                fingerprint,
+                provenance: WorkspaceCacheContextProvenance::GitWorktreeV4,
+            }),
+        WorkspaceStrategy::Copy => Some(WorkspaceCacheContext {
+            fingerprint: copied_workspace_fingerprint(project_root, respect_workspace_ignores),
+            provenance: WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores,
+            },
+        }),
+    }
+}
+
+#[cfg(test)]
+fn workspace_cache_context(
+    project_root: &Path,
+    respect_workspace_ignores: bool,
+) -> WorkspaceCacheContext {
+    if respect_workspace_ignores {
+        if let Some(fingerprint) = git_cache_context_fingerprint(project_root) {
+            return WorkspaceCacheContext {
+                fingerprint,
+                provenance: WorkspaceCacheContextProvenance::GitWorktreeV4,
+            };
         }
+    }
+
+    WorkspaceCacheContext {
+        fingerprint: copied_workspace_fingerprint(project_root, respect_workspace_ignores),
+        provenance: WorkspaceCacheContextProvenance::WorkspaceCopy {
+            respect_workspace_ignores,
+        },
+    }
+}
+
+#[cfg(test)]
+fn cache_context_fingerprint_for_workspace(
+    project_root: &Path,
+    respect_workspace_ignores: bool,
+) -> u64 {
+    workspace_cache_context(project_root, respect_workspace_ignores).fingerprint
+}
+
+/// Every Git worktree and copy-based workspace has an explicit format domain.
+/// V4 Git snapshots broad checkout metadata; V7 copy keys include full Windows
+/// file attributes rather than the prior readonly-only approximation.
+fn exact_cache_context(
+    command_context: &str,
+    cache_context_fingerprint: u64,
+    provenance: WorkspaceCacheContextProvenance,
+) -> String {
+    match provenance {
+        WorkspaceCacheContextProvenance::GitWorktreeV4 => format!(
+            "{command_context};workspace-git-worktree=v4;context={cache_context_fingerprint:016x}"
+        ),
+        WorkspaceCacheContextProvenance::WorkspaceCopy {
+            respect_workspace_ignores,
+        } => format!(
+            "{command_context};workspace-ignores={respect_workspace_ignores};workspace-copy=v7;context={cache_context_fingerprint:016x}"
+        ),
+    }
+}
+
+/// Frame a copied regular file's modification time with a stable
+/// representation, including explicit unavailable/error markers.
+fn update_copied_workspace_mtime_hash(hasher: &mut impl Hasher, metadata: Option<&fs::Metadata>) {
+    update_cache_hash(hasher, b"mtime-v1");
+    let Some(metadata) = metadata else {
+        update_cache_hash(hasher, b"metadata-unavailable");
+        return;
+    };
+    let Ok(modified) = metadata.modified() else {
+        update_cache_hash(hasher, b"mtime-unavailable");
+        return;
+    };
+    update_workspace_modified_time_hash(hasher, modified);
+}
+
+fn update_workspace_modified_time_hash(hasher: &mut impl Hasher, modified: SystemTime) {
+    match modified.duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => {
+            update_cache_hash(hasher, b"after-unix-epoch");
+            update_cache_hash(hasher, &duration.as_secs().to_le_bytes());
+            update_cache_hash(hasher, &duration.subsec_nanos().to_le_bytes());
+        }
+        Err(error) => {
+            let duration = error.duration();
+            update_cache_hash(hasher, b"before-unix-epoch");
+            update_cache_hash(hasher, &duration.as_secs().to_le_bytes());
+            update_cache_hash(hasher, &duration.subsec_nanos().to_le_bytes());
+        }
+    }
+}
+fn copied_regular_file_permissions_value(metadata: Option<&fs::Metadata>) -> u32 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        metadata
+            .map(|metadata| metadata.permissions().mode())
+            .unwrap_or_default()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        metadata
+            .map(|metadata| metadata.file_attributes())
+            .unwrap_or_default()
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        u32::from(
+            metadata
+                .map(|metadata| metadata.permissions().readonly())
+                .unwrap_or(false),
+        )
+    }
+}
+
+fn update_copied_regular_file_permissions_hash(
+    hasher: &mut impl Hasher,
+    metadata: Option<&fs::Metadata>,
+) {
+    update_cache_hash(
+        hasher,
+        &copied_regular_file_permissions_value(metadata).to_le_bytes(),
+    );
+}
+
+fn update_copied_regular_file_metadata_hash(hasher: &mut impl Hasher, source: &Path) {
+    let metadata = fs::symlink_metadata(source);
+    update_copied_regular_file_permissions_hash(hasher, metadata.as_ref().ok());
+    update_copied_workspace_mtime_hash(hasher, metadata.as_ref().ok());
+}
+
+fn update_copied_regular_file_hash(hasher: &mut impl Hasher, source: &Path) {
+    update_cache_hash(hasher, b"regular-file");
+    update_copied_regular_file_metadata_hash(hasher, source);
+    if let Ok(content) = fs::read(source) {
+        update_cache_hash(hasher, &content);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkspaceCopyEntryKind {
+    Directory,
+    RegularFile,
+}
+
+fn copied_workspace_entries(
+    project_root: &Path,
+    respect_workspace_ignores: bool,
+) -> Vec<(PathBuf, WorkspaceCopyEntryKind)> {
+    let mut builder = ignore::WalkBuilder::new(project_root);
+    configure_workspace_copy_walk(&mut builder, project_root, respect_workspace_ignores);
+
+    let mut entries = Vec::new();
+    for entry in builder.build() {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        if path == project_root {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(project_root) else {
+            continue;
+        };
+        if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_dir())
+        {
+            entries.push((relative.to_path_buf(), WorkspaceCopyEntryKind::Directory));
+        } else if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+            && fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+        {
+            entries.push((relative.to_path_buf(), WorkspaceCopyEntryKind::RegularFile));
+        }
+    }
+    entries.sort_by_key(|(path, _)| normalized_cache_path(project_root, path));
+    entries
+}
+
+fn update_copied_workspace_entry_hash(
+    hasher: &mut impl Hasher,
+    project_root: &Path,
+    relative: &Path,
+    kind: WorkspaceCopyEntryKind,
+) {
+    let source = project_root.join(relative);
+    let path_key = normalized_cache_path(project_root, relative);
+    update_cache_hash(hasher, path_key.as_bytes());
+    match kind {
+        WorkspaceCopyEntryKind::Directory => {
+            update_cache_hash(hasher, b"directory");
+            let metadata = fs::symlink_metadata(&source);
+            update_copied_workspace_mtime_hash(hasher, metadata.as_ref().ok());
+        }
+        WorkspaceCopyEntryKind::RegularFile => update_copied_regular_file_hash(hasher, &source),
+    }
+}
+
+/// Hash the canonical metadata snapshot applied to a Git workspace.
+fn update_git_workspace_mtime_entries_hash(
+    hasher: &mut impl Hasher,
+    project_root: &Path,
+    entries: &[GitWorkspaceMtimeEntry],
+) {
+    update_cache_hash(hasher, b"git-worktree-metadata-v2");
+    for entry in entries {
+        let path_key = if entry.relative.as_os_str().is_empty() {
+            "."
+        } else {
+            &normalized_cache_path(project_root, &entry.relative)
+        };
+        update_cache_hash(hasher, path_key.as_bytes());
+        update_cache_hash(
+            hasher,
+            match entry.kind {
+                GitWorkspaceMtimeEntryKind::RegularFile => b"regular-file",
+                GitWorkspaceMtimeEntryKind::Directory => b"directory",
+            },
+        );
+        if let Some(permission_fingerprint) = entry.permission_fingerprint {
+            update_cache_hash(hasher, &permission_fingerprint.to_le_bytes());
+        }
+        update_cache_hash(hasher, b"mtime-v1");
+        update_workspace_modified_time_hash(hasher, entry.modified);
+    }
+}
+
+/// Hash every non-root source entry that the workspace copier materializes.
+///
+/// This matches the canonical regular-file copy contract: bytes,
+/// `std::fs::Permissions` (including full Windows file attributes), and mtime
+/// are inputs; source-native ACLs, xattrs, ADS/resource forks, ownership, and
+/// links are deliberately not. Non-root directories include their source mtime
+/// because the copier restores it after descendants are materialized.
+fn copied_workspace_fingerprint(project_root: &Path, respect_workspace_ignores: bool) -> u64 {
+    let mut hasher = StableCacheHasher::default();
+    update_cache_hash(&mut hasher, b"workspace-copy-v7");
+    update_cache_hash(
+        &mut hasher,
+        if respect_workspace_ignores {
+            b"workspace-ignores=true"
+        } else {
+            b"workspace-ignores=false"
+        },
+    );
+    for (relative, kind) in copied_workspace_entries(project_root, respect_workspace_ignores) {
+        update_copied_workspace_entry_hash(&mut hasher, project_root, &relative, kind);
     }
     hasher.finish()
 }
 
+/// Fingerprint the `HEAD`, index, dirty overlay, and mtime snapshot actually
+/// materialized into an isolated Git workspace.
+///
+/// The mtime snapshot covers regular files and represented directories from the
+/// Git index and overlay. Source-only empty directories, `.git` internals,
+/// clean Git symlink leaves, and submodule internals are excluded, while their
+/// materialized non-root parent directories remain covered. A dirty overlay
+/// symlink contributes its resolved in-root regular target at its destination.
+#[cfg(test)]
 fn git_cache_context_fingerprint(project_root: &Path) -> Option<u64> {
-    if git_cache_context_is_dirty(project_root)? {
+    if !git_worktree_workspace_is_available(project_root) {
         return None;
     }
+    let overlay = collect_git_worktree_overlay(project_root).ok()?;
+    git_cache_context_fingerprint_for_overlay(project_root, &overlay)
+}
 
-    let output = std::process::Command::new("git")
-        .args(["ls-files", "-z", "-s", "--"])
-        .current_dir(project_root)
-        .output()
-        .ok()?;
-    if !output.status.success() {
+fn git_cache_context_fingerprint_for_overlay(
+    project_root: &Path,
+    overlay: &GitWorktreeOverlay,
+) -> Option<u64> {
+    if overlay.head.is_empty() {
         return None;
     }
-
-    let mut files = Vec::new();
-    for entry in output.stdout.split(|byte| *byte == 0) {
-        if entry.is_empty() {
-            continue;
-        }
-        let tab = entry.iter().position(|byte| *byte == b'\t')?;
-        let metadata = String::from_utf8_lossy(&entry[..tab]);
-        let mut fields = metadata.split_whitespace();
-        let _mode = fields.next()?;
-        let object_id = fields.next()?.to_string();
-        let relative = PathBuf::from(String::from_utf8_lossy(&entry[tab + 1..]).into_owned());
-        if is_cache_context_file(&relative) {
-            files.push((relative, object_id));
-        }
-    }
-
-    files.sort_by_key(|(path, _)| normalized_cache_path(project_root, path));
 
     let mut hasher = StableCacheHasher::default();
-    update_cache_hash(&mut hasher, b"git-index");
-    for (relative, object_id) in files {
-        let path_key = normalized_cache_path(project_root, &relative);
+    update_cache_hash(&mut hasher, b"git-worktree-v4");
+    update_cache_hash(&mut hasher, b"head");
+    update_cache_hash(&mut hasher, overlay.head.as_bytes());
+    update_cache_hash(&mut hasher, b"index");
+    for entry in &overlay.index_entries {
+        let path_key = normalized_cache_path(project_root, &entry.relative);
         update_cache_hash(&mut hasher, path_key.as_bytes());
-        update_cache_hash(&mut hasher, object_id.as_bytes());
+        update_cache_hash(&mut hasher, entry.mode.as_bytes());
+        update_cache_hash(&mut hasher, entry.object_id.as_bytes());
     }
+    update_cache_hash(&mut hasher, b"overlay-removals");
+    for relative in &overlay.remove_paths {
+        let path_key = normalized_cache_path(project_root, relative);
+        update_cache_hash(&mut hasher, path_key.as_bytes());
+    }
+    update_cache_hash(&mut hasher, b"overlay-copies");
+    for relative in &overlay.copy_paths {
+        let path_key = normalized_cache_path(project_root, relative);
+        update_cache_hash(&mut hasher, path_key.as_bytes());
+        match resolve_normal_overlay_source(project_root, relative) {
+            Ok(Some(source)) => match fs::read(source) {
+                Ok(content) => update_cache_hash(&mut hasher, &content),
+                Err(_) => return None,
+            },
+            Ok(None) => update_cache_hash(&mut hasher, b"removed"),
+            Err(_) => return None,
+        }
+    }
+    update_git_workspace_mtime_entries_hash(&mut hasher, project_root, &overlay.mtime_entries);
     Some(hasher.finish())
 }
 
+#[cfg(test)]
 fn git_cache_context_is_dirty(project_root: &Path) -> Option<bool> {
-    // No -M/--find-renames here: porcelain v1 -z then stays in the
-    // single-token "XY path\0" form this parser expects.
     let output = std::process::Command::new("git")
         .args([
             "status",
@@ -1593,17 +1933,7 @@ fn git_cache_context_is_dirty(project_root: &Path) -> Option<bool> {
     if !output.status.success() {
         return None;
     }
-
-    for entry in output.stdout.split(|byte| *byte == 0) {
-        if entry.len() <= 3 || entry[2] != b' ' {
-            continue;
-        }
-        let relative = PathBuf::from(String::from_utf8_lossy(&entry[3..]).into_owned());
-        if is_cache_context_file(&relative) {
-            return Some(true);
-        }
-    }
-    Some(false)
+    Some(!output.stdout.is_empty())
 }
 
 fn collect_cache_context_files(project_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
@@ -1850,13 +2180,17 @@ impl TestContextIndex {
         Self { files }
     }
 
+    /// Relevant-test identity is order-independent; command hashing preserves
+    /// the configured execution order.
     fn fingerprint_for_tests(&self, tests: &[String], fallback: u64) -> u64 {
         if tests.is_empty() || self.files.is_empty() {
             return fallback;
         }
 
+        let mut canonical_tests: Vec<&String> = tests.iter().collect();
+        canonical_tests.sort_unstable();
         let mut matched = BTreeSet::new();
-        for test in tests {
+        for test in &canonical_tests {
             let matches = self.files_for_test(test);
             if matches.is_empty() {
                 return fallback;
@@ -1865,8 +2199,8 @@ impl TestContextIndex {
         }
 
         let mut hasher = StableCacheHasher::default();
-        update_cache_hash(&mut hasher, b"selected-test-context-v1");
-        for test in tests {
+        update_cache_hash(&mut hasher, b"selected-test-context-v2");
+        for test in canonical_tests {
             update_cache_hash(&mut hasher, test.as_bytes());
         }
         for index in matched {
@@ -1904,6 +2238,26 @@ impl TestContextIndex {
                     .then_some(index)
             })
             .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LearnedSelectionContext<'a> {
+    test_context_index: &'a TestContextIndex,
+    cache_context_fingerprint: u64,
+    cache_context_provenance: WorkspaceCacheContextProvenance,
+}
+
+impl LearnedSelectionContext<'_> {
+    fn relevant_test_hash_for_killer(&self, tests: &[String], killer: &str) -> Option<u64> {
+        tests.iter().any(|test| test == killer).then(|| {
+            incremental_history_relevant_test_hash(
+                self.test_context_index
+                    .fingerprint_for_tests(tests, self.cache_context_fingerprint),
+                self.cache_context_fingerprint,
+                self.cache_context_provenance,
+            )
+        })
     }
 }
 
@@ -2011,6 +2365,15 @@ fn copy_workspace_with_options(
         }
     }
 
+    finish_copy_workspace(project_root, tempdir, root, respect_ignores)
+}
+
+fn copy_workspace_without_git(
+    project_root: &Path,
+    respect_ignores: bool,
+) -> std::io::Result<WorkspaceCopy> {
+    let tempdir = tempfile::tempdir()?;
+    let root = tempdir.path().join("workspace");
     finish_copy_workspace(project_root, tempdir, root, respect_ignores)
 }
 
@@ -2397,7 +2760,7 @@ fn create_git_worktree_workspace(
     let output = std::process::Command::new("git")
         .args(["worktree", "add", "--detach", "--quiet"])
         .arg(root)
-        .arg("HEAD")
+        .arg(&overlay.head)
         .current_dir(project_root)
         .output()?;
     if output.status.success() {
@@ -2445,10 +2808,104 @@ fn git_top_level(project_root: &Path) -> Option<PathBuf> {
     PathBuf::from(top_level.trim()).canonicalize().ok()
 }
 
+fn git_head_revision(project_root: &Path) -> std::io::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "HEAD"])
+        .current_dir(project_root)
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "could not resolve Git HEAD in {}\nstderr:\n{}",
+            project_root.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let head = String::from_utf8(output.stdout)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let head = head.trim();
+    if head.is_empty() {
+        return Err(std::io::Error::other(format!(
+            "could not resolve a non-empty Git HEAD in {}",
+            project_root.display()
+        )));
+    }
+    Ok(head.to_owned())
+}
+
+fn git_index_entries(project_root: &Path) -> std::io::Result<Vec<GitIndexEntry>> {
+    let output = std::process::Command::new("git")
+        .args(["ls-files", "-z", "-s", "--"])
+        .current_dir(project_root)
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "could not read Git index in {}\nstderr:\n{}",
+            project_root.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let mut entries = Vec::new();
+    for entry in output.stdout.split(|byte| *byte == 0) {
+        if entry.is_empty() {
+            continue;
+        }
+        let tab = entry
+            .iter()
+            .position(|byte| *byte == b'\t')
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "malformed Git index entry")
+            })?;
+        let metadata = String::from_utf8_lossy(&entry[..tab]);
+        let mut fields = metadata.split_whitespace();
+        let mode = fields
+            .next()
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing Git mode")
+            })?
+            .to_owned();
+        let object_id = fields
+            .next()
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing Git object id")
+            })?
+            .to_owned();
+        if fields.next() != Some("0") || fields.next().is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "unsupported Git index stage",
+            ));
+        }
+        let relative = safe_git_relative_path(&entry[tab + 1..]).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "unsafe Git index path")
+        })?;
+        entries.push(GitIndexEntry {
+            relative,
+            mode,
+            object_id,
+        });
+    }
+    entries.sort_by_key(|entry| normalized_cache_path(project_root, &entry.relative));
+    Ok(entries)
+}
+
+fn git_index_entry_is_regular(entry: &GitIndexEntry) -> bool {
+    entry.mode.starts_with("100")
+}
+
 fn collect_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorktreeOverlay> {
+    let head = git_head_revision(project_root)?;
+    let index_entries = git_index_entries(project_root)?;
     let changed_paths = git_z_output_paths(
         project_root,
-        &["diff", "--name-only", "-z", "--no-renames", "HEAD", "--"],
+        &[
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            head.as_str(),
+            "--",
+        ],
     )?;
     let untracked_paths = git_z_output_paths(
         project_root,
@@ -2460,7 +2917,10 @@ fn collect_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorkt
 
     for relative in changed_paths {
         if !should_overlay_workspace_entry(&relative) {
-            continue;
+            return Err(std::io::Error::other(format!(
+                "dirty copy-excluded path {} cannot be represented by a Git workspace",
+                relative.display()
+            )));
         }
         if project_root.join(&relative).is_file() {
             copy_paths.insert(relative);
@@ -2481,11 +2941,159 @@ fn collect_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorkt
     for copied in &copy_paths {
         remove_paths.remove(copied);
     }
+    let mtime_entries = collect_git_workspace_mtime_entries(
+        project_root,
+        &index_entries,
+        &copy_paths,
+        &remove_paths,
+    )?;
 
     Ok(GitWorktreeOverlay {
+        head,
+        index_entries,
         copy_paths: copy_paths.into_iter().collect(),
         remove_paths: remove_paths.into_iter().collect(),
+        mtime_entries,
     })
+}
+
+/// Snapshot canonical source metadata for regular Git index/overlay files and
+/// the non-root parent directories materialized for every index or overlay
+/// entry.
+///
+/// This follows Git-worktree shape: source-only empty directories, clean Git
+/// symlink leaves, submodules, workspace roots, and `.git` internals are
+/// excluded, but represented parent directories are included. A dirty overlay
+/// symlink instead uses its resolved in-root regular target. Clean tracked paths
+/// excluded from normal copies remain included when Git checks them out; dirty
+/// excluded paths force normal-copy fallback.
+fn collect_git_workspace_mtime_entries(
+    project_root: &Path,
+    index_entries: &[GitIndexEntry],
+    overlay_copy_paths: &BTreeSet<PathBuf>,
+    overlay_remove_paths: &BTreeSet<PathBuf>,
+) -> std::io::Result<Vec<GitWorkspaceMtimeEntry>> {
+    let mut entries = BTreeMap::new();
+
+    for entry in index_entries {
+        insert_git_workspace_parent_directories(project_root, &mut entries, &entry.relative)?;
+    }
+    for relative in overlay_remove_paths {
+        insert_git_workspace_parent_directories(project_root, &mut entries, relative)?;
+    }
+
+    for entry in index_entries {
+        if !git_index_entry_is_regular(entry)
+            || overlay_copy_paths.contains(&entry.relative)
+            || overlay_remove_paths.contains(&entry.relative)
+        {
+            continue;
+        }
+        insert_git_workspace_regular_entry(
+            &mut entries,
+            entry.relative.clone(),
+            project_root.join(&entry.relative),
+        )?;
+    }
+    for relative in overlay_copy_paths {
+        if let Some(source) = resolve_normal_overlay_source(project_root, relative)? {
+            insert_git_workspace_regular_entry(&mut entries, relative.clone(), source)?;
+        }
+    }
+
+    let regular_paths: Vec<PathBuf> = entries
+        .iter()
+        .filter(|(_, entry)| entry.kind == GitWorkspaceMtimeEntryKind::RegularFile)
+        .map(|(relative, _)| relative.clone())
+        .collect();
+    for relative in regular_paths {
+        insert_git_workspace_parent_directories(project_root, &mut entries, &relative)?;
+    }
+
+    let mut mtime_entries = Vec::with_capacity(entries.len());
+    for (relative, entry) in entries {
+        let metadata = fs::symlink_metadata(&entry.source)?;
+        let expected = match entry.kind {
+            GitWorkspaceMtimeEntryKind::RegularFile => metadata.file_type().is_file(),
+            GitWorkspaceMtimeEntryKind::Directory => metadata.file_type().is_dir(),
+        };
+        if !expected {
+            return Err(std::io::Error::other(format!(
+                "Git workspace metadata source {} changed type",
+                entry.source.display()
+            )));
+        }
+        let is_regular_file = entry.kind == GitWorkspaceMtimeEntryKind::RegularFile;
+        mtime_entries.push(GitWorkspaceMtimeEntry {
+            relative,
+            kind: entry.kind,
+            permissions: is_regular_file.then(|| metadata.permissions()),
+            permission_fingerprint: is_regular_file
+                .then(|| copied_regular_file_permissions_value(Some(&metadata))),
+            modified: metadata.modified()?,
+        });
+    }
+    mtime_entries.sort_by_key(|entry| {
+        (!entry.relative.as_os_str().is_empty())
+            .then(|| normalized_cache_path(project_root, &entry.relative))
+    });
+    Ok(mtime_entries)
+}
+
+/// Record the regular source copied into a Git-worktree destination.
+///
+/// For a dirty symlink overlay, `source` is the resolved in-root target while
+/// `relative` stays the regular destination path in the workspace.
+fn insert_git_workspace_regular_entry(
+    entries: &mut BTreeMap<PathBuf, GitWorkspaceMtimeSource>,
+    relative: PathBuf,
+    source: PathBuf,
+) -> std::io::Result<()> {
+    if !is_safe_relative_path(&relative) {
+        return Err(invalid_workspace_relative_path(&relative));
+    }
+    if !fs::symlink_metadata(&source)?.file_type().is_file() {
+        return Err(std::io::Error::other(format!(
+            "Git workspace metadata source {} is not a regular file",
+            source.display()
+        )));
+    }
+    entries.insert(
+        relative,
+        GitWorkspaceMtimeSource {
+            kind: GitWorkspaceMtimeEntryKind::RegularFile,
+            source,
+        },
+    );
+    Ok(())
+}
+
+/// Record non-root source directories that the Git checkout or overlay uses.
+///
+/// This deliberately records parents of clean symlinks and submodules without
+/// treating those leaves themselves as canonical regular files.
+fn insert_git_workspace_parent_directories(
+    project_root: &Path,
+    entries: &mut BTreeMap<PathBuf, GitWorkspaceMtimeSource>,
+    relative: &Path,
+) -> std::io::Result<()> {
+    let mut parent = relative.parent();
+    while let Some(current) = parent {
+        if current.as_os_str().is_empty() {
+            break;
+        }
+        if !is_safe_relative_path(current) {
+            return Err(invalid_workspace_relative_path(current));
+        }
+        entries
+            .entry(current.to_path_buf())
+            .or_insert_with(|| GitWorkspaceMtimeSource {
+                kind: GitWorkspaceMtimeEntryKind::Directory,
+                source: project_root.join(current),
+            });
+        parent = current.parent();
+    }
+    Ok(())
 }
 
 fn collect_replay_git_worktree_overlay(project_root: &Path) -> std::io::Result<GitWorktreeOverlay> {
@@ -2524,10 +3132,12 @@ fn collect_replay_git_worktree_overlay(project_root: &Path) -> std::io::Result<G
     for copied in &copy_paths {
         remove_paths.remove(copied);
     }
-
     Ok(GitWorktreeOverlay {
+        head: String::new(),
+        index_entries: Vec::new(),
         copy_paths: copy_paths.into_iter().collect(),
         remove_paths: remove_paths.into_iter().collect(),
+        mtime_entries: Vec::new(),
     })
 }
 
@@ -2783,6 +3393,13 @@ fn prepare_workspace_destination(
     Ok(destination)
 }
 
+/// Canonically copy a regular source file into a mutation workspace.
+///
+/// This is an execution sandbox, not an archival copy: it deliberately
+/// preserves only bytes, `std::fs::Permissions`, and mtime. Source ACLs,
+/// xattrs, ADS/resource forks, ownership, and link relationships are excluded
+/// so platform-specific or privilege-bearing metadata cannot affect copied
+/// execution. [`copied_workspace_fingerprint`] hashes this same contract.
 fn copy_regular_source_file_to_workspace(
     source: &Path,
     workspace_root: &Path,
@@ -2795,8 +3412,13 @@ fn copy_regular_source_file_to_workspace(
             source.display()
         )));
     }
+    let modified = metadata.modified()?;
     let destination = prepare_workspace_destination(workspace_root, relative)?;
-    fs::copy(source, destination)?;
+    let mut source_file = fs::File::open(source)?;
+    let mut destination_file = fs::File::create(destination)?;
+    std::io::copy(&mut source_file, &mut destination_file)?;
+    destination_file.set_times(fs::FileTimes::new().set_modified(modified))?;
+    destination_file.set_permissions(metadata.permissions())?;
     Ok(())
 }
 
@@ -2861,9 +3483,7 @@ fn copy_overlay_file(
         remove_workspace_path(&workspace_root.join(relative))?;
         return Ok(());
     };
-    let destination = prepare_workspace_destination(workspace_root, relative)?;
-    fs::copy(source, destination)?;
-    Ok(())
+    copy_regular_source_file_to_workspace(&source, workspace_root, relative)
 }
 
 /// Move preserved dirs to sibling stashes before deleting the workspace.
@@ -2903,14 +3523,12 @@ fn restore_workspace_dirs(
     Ok(())
 }
 
-fn populate_workspace(
+fn configure_workspace_copy_walk(
+    builder: &mut ignore::WalkBuilder,
     project_root: &Path,
-    root: &Path,
     respect_ignores: bool,
-) -> std::io::Result<()> {
+) {
     let project_root_for_filter = project_root.to_path_buf();
-
-    let mut builder = ignore::WalkBuilder::new(project_root);
     builder
         .hidden(false)
         .ignore(respect_ignores)
@@ -2921,6 +3539,130 @@ fn populate_workspace(
         .filter_entry(move |entry| {
             should_copy_workspace_entry(&project_root_for_filter, entry.path())
         });
+}
+
+/// `FILE_WRITE_ATTRIBUTES` (WinNT.h) permits [`fs::File::set_times`].
+#[cfg(windows)]
+const WINDOWS_FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+/// `FILE_FLAG_BACKUP_SEMANTICS` (WinBase.h) permits opening a directory.
+#[cfg(windows)]
+const WINDOWS_FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+
+/// Open a path with the rights required to update its mtime.
+///
+/// Windows requires `FILE_WRITE_ATTRIBUTES`, and directory handles additionally
+/// require `FILE_FLAG_BACKUP_SEMANTICS`; Unix retains the ordinary read handle.
+#[cfg(windows)]
+fn open_for_mtime_update(path: &Path, is_directory: bool) -> std::io::Result<fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let mut options = fs::OpenOptions::new();
+    options.access_mode(WINDOWS_FILE_WRITE_ATTRIBUTES);
+    if is_directory {
+        options.custom_flags(WINDOWS_FILE_FLAG_BACKUP_SEMANTICS);
+    }
+    options.open(path)
+}
+
+#[cfg(not(windows))]
+fn open_for_mtime_update(path: &Path, _is_directory: bool) -> std::io::Result<fs::File> {
+    fs::File::open(path)
+}
+
+/// Restore non-root source directory mtimes after all descendants have been
+/// created.
+///
+/// The canonical workspace-copy contract preserves non-root directory mtime
+/// but not directory modes, ACLs, xattrs, ownership, or other native metadata.
+fn restore_copied_workspace_directory_mtimes(
+    project_root: &Path,
+    workspace_root: &Path,
+    directories: &mut [PathBuf],
+) -> std::io::Result<()> {
+    directories.sort_by_key(|relative| std::cmp::Reverse(relative.components().count()));
+    for relative in directories {
+        let source = project_root.join(&relative);
+        let metadata = fs::symlink_metadata(&source)?;
+        if !metadata.file_type().is_dir() {
+            continue;
+        }
+        let modified = metadata.modified()?;
+        let destination = workspace_root.join(&relative);
+        if !fs::symlink_metadata(&destination)?.file_type().is_dir() {
+            return Err(std::io::Error::other(format!(
+                "workspace directory {} is not a directory",
+                destination.display()
+            )));
+        }
+        open_for_mtime_update(&destination, true)?
+            .set_times(fs::FileTimes::new().set_modified(modified))?;
+    }
+    Ok(())
+}
+
+fn set_workspace_entry_mtime(
+    destination: &Path,
+    modified: SystemTime,
+    kind: GitWorkspaceMtimeEntryKind,
+) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(destination)?;
+    let expected = match kind {
+        GitWorkspaceMtimeEntryKind::RegularFile => metadata.file_type().is_file(),
+        GitWorkspaceMtimeEntryKind::Directory => metadata.file_type().is_dir(),
+    };
+    if !expected {
+        return Err(std::io::Error::other(format!(
+            "workspace entry {} changed type before mtime normalization",
+            destination.display()
+        )));
+    }
+    open_for_mtime_update(
+        destination,
+        matches!(kind, GitWorkspaceMtimeEntryKind::Directory),
+    )?
+    .set_times(fs::FileTimes::new().set_modified(modified))
+}
+
+/// Apply the mtime snapshot that participates in the Git-worktree cache key.
+///
+/// Directories are timestamped after all overlay file creation, deepest first,
+/// so materialization cannot perturb their restored mtimes.
+fn normalize_git_workspace_mtimes(
+    workspace_root: &Path,
+    entries: &[GitWorkspaceMtimeEntry],
+) -> std::io::Result<()> {
+    let mut directories: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry.kind == GitWorkspaceMtimeEntryKind::Directory)
+        .collect();
+    directories.sort_by_key(|entry| std::cmp::Reverse(entry.relative.components().count()));
+
+    for entry in entries
+        .iter()
+        .filter(|entry| entry.kind == GitWorkspaceMtimeEntryKind::RegularFile)
+    {
+        let destination = workspace_root.join(&entry.relative);
+        set_workspace_entry_mtime(&destination, entry.modified, entry.kind)?;
+        if let Some(permissions) = &entry.permissions {
+            fs::set_permissions(destination, permissions.clone())?;
+        }
+    }
+
+    for entry in directories {
+        let destination = workspace_root.join(&entry.relative);
+        set_workspace_entry_mtime(&destination, entry.modified, entry.kind)?;
+    }
+    Ok(())
+}
+
+fn populate_workspace(
+    project_root: &Path,
+    root: &Path,
+    respect_ignores: bool,
+) -> std::io::Result<()> {
+    let mut builder = ignore::WalkBuilder::new(project_root);
+    configure_workspace_copy_walk(&mut builder, project_root, respect_ignores);
+    let mut directories = Vec::new();
 
     for entry in builder.build() {
         let entry = match entry {
@@ -2940,12 +3682,12 @@ fn populate_workspace(
 
         if entry.file_type().is_some_and(|ft| ft.is_dir()) {
             materialize_workspace_directory_at(root, relative)?;
+            directories.push(relative.to_path_buf());
         } else if entry.file_type().is_some_and(|ft| ft.is_file()) {
             copy_regular_source_file_to_workspace(path, root, relative)?;
         }
     }
-
-    Ok(())
+    restore_copied_workspace_directory_mtimes(project_root, root, &mut directories)
 }
 
 /// Populate a replay clone through capabilities rather than destination paths.
@@ -2999,11 +3741,14 @@ fn populate_replay_workspace(
 
 pub(crate) struct WorkspacePool {
     slots: Arc<Vec<WorkspaceCopy>>,
+    strategy: WorkspaceStrategy,
+    git_overlay: Option<GitWorktreeOverlay>,
     free_slots: Arc<(Mutex<VecDeque<usize>>, Condvar)>,
     dirty_slots: Arc<Mutex<Vec<bool>>>,
 }
 
 impl WorkspacePool {
+    #[cfg(test)]
     pub(crate) fn new(project_root: &Path, slots: usize) -> std::io::Result<Self> {
         Self::new_with_options(project_root, slots, true)
     }
@@ -3014,24 +3759,78 @@ impl WorkspacePool {
         respect_ignores: bool,
     ) -> std::io::Result<Self> {
         let slots = slots.max(1);
-        let mut copies = Vec::with_capacity(slots);
-        for _ in 0..slots {
-            let copy = if respect_ignores {
-                copy_workspace(project_root)?
-            } else {
-                copy_workspace_with_options(project_root, false)?
-            };
-            copies.push(copy);
+        if !respect_ignores {
+            return Self::new_copy_only(project_root, slots, false);
         }
 
+        let mut copies = Vec::with_capacity(slots);
+        for _ in 0..slots {
+            copies.push(copy_workspace(project_root)?);
+        }
+        if copies
+            .iter()
+            .all(|copy| copy.strategy() == WorkspaceStrategy::GitWorktree)
+        {
+            let first_overlay = copies
+                .first()
+                .and_then(WorkspaceCopy::git_overlay)
+                .expect("Git worktree slots must retain their overlay snapshot");
+            if copies
+                .iter()
+                .all(|copy| copy.git_overlay() == Some(first_overlay))
+            {
+                return Ok(Self::from_copies(copies, WorkspaceStrategy::GitWorktree));
+            }
+        }
+
+        // A Git workspace may fail or its snapshot may change partway through
+        // pool creation. Rebuild every slot as a normal copy so one cache
+        // domain never spans different shapes or metadata snapshots.
+        drop(copies);
+        Self::new_copy_only(project_root, slots, true)
+    }
+
+    fn new_copy_only(
+        project_root: &Path,
+        slots: usize,
+        respect_ignores: bool,
+    ) -> std::io::Result<Self> {
+        let slots = slots.max(1);
+        let mut copies = Vec::with_capacity(slots);
+        for _ in 0..slots {
+            copies.push(copy_workspace_without_git(project_root, respect_ignores)?);
+        }
+        Ok(Self::from_copies(copies, WorkspaceStrategy::Copy))
+    }
+
+    fn from_copies(copies: Vec<WorkspaceCopy>, strategy: WorkspaceStrategy) -> Self {
+        debug_assert!(!copies.is_empty());
+        let git_overlay = (strategy == WorkspaceStrategy::GitWorktree).then(|| {
+            copies
+                .first()
+                .and_then(WorkspaceCopy::git_overlay)
+                .expect("Git worktree pool must have a snapshot")
+                .clone()
+        });
+        let slots = copies.len();
         let free_slots = (0..slots).collect();
         let dirty_slots = vec![false; slots];
 
-        Ok(Self {
+        Self {
             slots: Arc::new(copies),
+            strategy,
+            git_overlay,
             free_slots: Arc::new((Mutex::new(free_slots), Condvar::new())),
             dirty_slots: Arc::new(Mutex::new(dirty_slots)),
-        })
+        }
+    }
+
+    fn strategy(&self) -> WorkspaceStrategy {
+        self.strategy
+    }
+
+    fn git_overlay(&self) -> Option<&GitWorktreeOverlay> {
+        self.git_overlay.as_ref()
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -3066,6 +3865,37 @@ impl WorkspacePool {
             needs_reset,
         }
     }
+}
+
+/// Create the campaign's complete workspace pool before cache classification.
+///
+/// If a Git slot cannot supply a Git context after creation, discard the pool
+/// and recreate it as copies before any result can be restored.
+fn prepare_campaign_workspace_pool(
+    project_root: &Path,
+    slots: usize,
+    respect_workspace_ignores: bool,
+) -> std::io::Result<(WorkspacePool, WorkspaceCacheContext)> {
+    let mut pool = WorkspacePool::new_with_options(project_root, slots, respect_workspace_ignores)?;
+    let context = match workspace_cache_context_for_strategy(
+        project_root,
+        respect_workspace_ignores,
+        pool.strategy(),
+        pool.git_overlay(),
+    ) {
+        Some(context) => context,
+        None => {
+            pool = WorkspacePool::new_copy_only(project_root, slots, respect_workspace_ignores)?;
+            workspace_cache_context_for_strategy(
+                project_root,
+                respect_workspace_ignores,
+                pool.strategy(),
+                pool.git_overlay(),
+            )
+            .expect("a normal copy pool always has a cache context")
+        }
+    };
+    Ok((pool, context))
 }
 
 pub(crate) struct WorkspaceSlot {
@@ -3368,6 +4198,7 @@ struct RunShared<'a> {
     early_stop: Option<&'a Arc<EarlyStopState>>,
     respect_workspace_ignores: bool,
     cache_context_fingerprint: u64,
+    cache_context_provenance: WorkspaceCacheContextProvenance,
     test_context_index: &'a TestContextIndex,
     source_contents: &'a SourceContentCache,
     history: Option<&'a cache::IncrementalHistoryStore>,
@@ -3399,15 +4230,53 @@ fn incremental_history_query(
     mutation: &Mutation,
     source_content: &[u8],
     command_context: &str,
-    relevant_test_hash: u64,
+    selected_test_hash: u64,
+    workspace_fingerprint: u64,
+    provenance: WorkspaceCacheContextProvenance,
 ) -> cache::IncrementalHistoryQuery {
     cache::IncrementalHistoryQuery {
         mutation_identity: cache_identity(project_root, mutation),
         mutation_description: mutation.description.clone(),
         source_hash: cache::hash_bytes(source_content),
         command_hash: cache::hash_str(command_context),
-        relevant_test_hash,
+        relevant_test_hash: incremental_history_relevant_test_hash(
+            selected_test_hash,
+            workspace_fingerprint,
+            provenance,
+        ),
     }
+}
+
+/// Bind selected-test history to every workspace identity domain. The V4 Git
+/// domain intentionally invalidates legacy entries that did not cover all
+/// actual Git-worktree inputs.
+fn incremental_history_relevant_test_hash(
+    selected_test_hash: u64,
+    workspace_fingerprint: u64,
+    provenance: WorkspaceCacheContextProvenance,
+) -> u64 {
+    let mut hasher = StableCacheHasher::default();
+    match provenance {
+        WorkspaceCacheContextProvenance::GitWorktreeV4 => {
+            update_cache_hash(&mut hasher, b"incremental-history-git-worktree-v4");
+        }
+        WorkspaceCacheContextProvenance::WorkspaceCopy {
+            respect_workspace_ignores,
+        } => {
+            update_cache_hash(&mut hasher, b"incremental-history-workspace-copy-v7");
+            update_cache_hash(
+                &mut hasher,
+                if respect_workspace_ignores {
+                    b"workspace-ignores=true"
+                } else {
+                    b"workspace-ignores=false"
+                },
+            );
+        }
+    }
+    update_cache_hash(&mut hasher, &selected_test_hash.to_le_bytes());
+    update_cache_hash(&mut hasher, &workspace_fingerprint.to_le_bytes());
+    hasher.finish()
 }
 
 fn record_incremental_history(
@@ -3502,17 +4371,56 @@ struct PreparedMutationContext<'a> {
     history: Option<&'a cache::IncrementalHistoryStore>,
     source_contents: &'a SourceContentCache,
     cache_context_fingerprint: u64,
+    cache_context_provenance: WorkspaceCacheContextProvenance,
     test_context_index: &'a TestContextIndex,
     env: &'a HashMap<String, String>,
 }
 
+struct CampaignCacheContext {
+    cache_context_fingerprint: u64,
+    cache_context_provenance: WorkspaceCacheContextProvenance,
+    test_context_index: TestContextIndex,
+}
+
+impl CampaignCacheContext {
+    fn from_workspace_context(project_root: &Path, cache_context: WorkspaceCacheContext) -> Self {
+        Self {
+            cache_context_fingerprint: cache_context.fingerprint,
+            cache_context_provenance: cache_context.provenance,
+            test_context_index: TestContextIndex::build(project_root),
+        }
+    }
+
+    fn learned_selection_context(&self) -> LearnedSelectionContext<'_> {
+        LearnedSelectionContext {
+            test_context_index: &self.test_context_index,
+            cache_context_fingerprint: self.cache_context_fingerprint,
+            cache_context_provenance: self.cache_context_provenance,
+        }
+    }
+
+    #[cfg(test)]
+    fn build(project_root: &Path, respect_workspace_ignores: bool) -> Self {
+        Self::from_workspace_context(
+            project_root,
+            workspace_cache_context(project_root, respect_workspace_ignores),
+        )
+    }
+}
+
 impl PreparedMutationRun {
     fn new(project_root: &Path, mutation: &Mutation, context: PreparedMutationContext<'_>) -> Self {
+        let learned_selection_context = LearnedSelectionContext {
+            test_context_index: context.test_context_index,
+            cache_context_fingerprint: context.cache_context_fingerprint,
+            cache_context_provenance: context.cache_context_provenance,
+        };
         let selected_test = select_test_command_with_history(
             project_root,
             context.commands,
             mutation,
             context.history,
+            Some(learned_selection_context),
         );
         let mutation_identity = cache_identity(project_root, mutation);
         let command_ctx = selected_test.cache_context(
@@ -3521,7 +4429,7 @@ impl PreparedMutationRun {
             context.commands.sandbox_command.as_slice(),
             context.env,
         );
-        let relevant_test_hash = context.test_context_index.fingerprint_for_tests(
+        let selected_test_hash = context.test_context_index.fingerprint_for_tests(
             &selected_test.selected_tests,
             context.cache_context_fingerprint,
         );
@@ -3530,11 +4438,16 @@ impl PreparedMutationRun {
                 &mutation_identity,
                 &mutation.description,
                 &selected_test.selected_tests,
+                |killer| {
+                    learned_selection_context
+                        .relevant_test_hash_for_killer(&selected_test.selected_tests, killer)
+                },
             )
         });
-        let cache_ctx = format!(
-            "{command_ctx};context={:016x}",
-            context.cache_context_fingerprint
+        let cache_ctx = exact_cache_context(
+            &command_ctx,
+            context.cache_context_fingerprint,
+            context.cache_context_provenance,
         );
         let source_content = context
             .source_contents
@@ -3545,7 +4458,9 @@ impl PreparedMutationRun {
                 mutation,
                 content,
                 &command_ctx,
-                relevant_test_hash,
+                selected_test_hash,
+                context.cache_context_fingerprint,
+                context.cache_context_provenance,
             )
         });
         let cache_key = source_content.as_ref().map(|content| {
@@ -3726,6 +4641,7 @@ fn run_queued_mutation(
             history: shared.history,
             source_contents: shared.source_contents,
             cache_context_fingerprint: shared.cache_context_fingerprint,
+            cache_context_provenance: shared.cache_context_provenance,
             test_context_index: shared.test_context_index,
             env: shared.env,
         },
@@ -4059,7 +4975,11 @@ impl TestRunner {
     /// Resolve reusable verdicts before early-stop decisions so the gate sees
     /// the complete fresh-work denominator rather than only cache hits
     /// encountered so far by workers.
-    fn preclassify_for_early_stop(&self, mutations: &[Mutation]) -> PreclassifiedMutations {
+    fn preclassify_for_early_stop(
+        &self,
+        mutations: &[Mutation],
+        campaign_context: &CampaignCacheContext,
+    ) -> PreclassifiedMutations {
         if !self.early_stop.is_enabled() {
             return PreclassifiedMutations {
                 fresh: mutations
@@ -4078,8 +4998,6 @@ impl TestRunner {
         }
 
         let source_contents = SourceContentCache::default();
-        let cache_context_hash = cache_context_fingerprint(&self.project_root);
-        let test_context_index = TestContextIndex::build(&self.project_root);
         let history = self
             .incremental_history
             .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
@@ -4106,8 +5024,9 @@ impl TestRunner {
                     commands: &self.commands,
                     history: history.as_ref(),
                     source_contents: &source_contents,
-                    cache_context_fingerprint: cache_context_hash,
-                    test_context_index: &test_context_index,
+                    cache_context_fingerprint: campaign_context.cache_context_fingerprint,
+                    cache_context_provenance: campaign_context.cache_context_provenance,
+                    test_context_index: &campaign_context.test_context_index,
                     env: &self.env,
                 },
             );
@@ -4165,11 +5084,59 @@ impl TestRunner {
         PreclassifiedMutations { fresh, restored }
     }
 
+    fn workspace_pool_failure_outcome(
+        &self,
+        mutations: Vec<Mutation>,
+        start: Instant,
+        runner: &str,
+        error: &std::io::Error,
+    ) -> RunOutcome {
+        eprintln!("warning: could not create isolated mutation workspaces: {error}");
+        let planned_total = mutations.len();
+        let records = mutations
+            .into_iter()
+            .map(|mutation| {
+                let diagnostic = BuildErrorDiagnostic::new(
+                    mutation.id,
+                    runner,
+                    "workspace_pool",
+                    vec![],
+                    format!("could not create isolated mutation workspaces: {error}"),
+                );
+                MutationRunRecord::new(mutation, MutationResult::BuildError, Some(diagnostic))
+            })
+            .collect();
+        self.outcome_from_records_with_status(records, start.elapsed(), planned_total, None)
+    }
+
     #[allow(clippy::manual_is_multiple_of)]
     pub fn run(&self, mutations: Vec<Mutation>) -> RunOutcome {
-        let (mutations, subsumed) = self.split_subsumed(mutations);
+        let start = Instant::now();
+        let initial_planned_total = mutations.len();
+        if mutations.is_empty() {
+            return self.outcome_from_records_with_status(
+                Vec::new(),
+                start.elapsed(),
+                initial_planned_total,
+                None,
+            );
+        }
+        let workspace_slots = workspace_pool_slot_count(self.parallelism, mutations.len());
+        let (workspace_pool, cache_context) = match prepare_campaign_workspace_pool(
+            &self.project_root,
+            workspace_slots,
+            self.respect_workspace_ignores,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                return self.workspace_pool_failure_outcome(mutations, start, "regular", &error);
+            }
+        };
+        let campaign_context =
+            CampaignCacheContext::from_workspace_context(&self.project_root, cache_context);
+        let (mutations, subsumed) = self.split_subsumed(mutations, &campaign_context);
         let planned_total = mutations.len();
-        let preclassified = self.preclassify_for_early_stop(&mutations);
+        let preclassified = self.preclassify_for_early_stop(&mutations, &campaign_context);
         let early_stop =
             EarlyStopState::for_config(self.early_stop.clone(), preclassified.fresh.len());
         if let Some(early_stop) = &early_stop {
@@ -4181,6 +5148,9 @@ impl TestRunner {
             early_stop,
             planned_total,
             Arc::new(AtomicUsize::new(0)),
+            workspace_pool,
+            &campaign_context,
+            start,
         );
         merge_subsumed(&mut outcome.report, subsumed);
         outcome
@@ -4189,8 +5159,32 @@ impl TestRunner {
     pub fn run_with_schemata(&self, mutations: Vec<Mutation>) -> RunOutcome {
         // Learned selection runs before schemata planning so subsumed
         // mutants never end up in schema rewrites.
-        let (mutations, subsumed) = self.split_subsumed(mutations);
-        let mut outcome = self.run_with_schemata_planned(mutations);
+        let start = Instant::now();
+        let initial_planned_total = mutations.len();
+        if mutations.is_empty() {
+            return self.outcome_from_records_with_status(
+                Vec::new(),
+                start.elapsed(),
+                initial_planned_total,
+                None,
+            );
+        }
+        let workspace_slots = workspace_pool_slot_count(self.parallelism, mutations.len());
+        let (workspace_pool, cache_context) = match prepare_campaign_workspace_pool(
+            &self.project_root,
+            workspace_slots,
+            self.respect_workspace_ignores,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                return self.workspace_pool_failure_outcome(mutations, start, "schemata", &error);
+            }
+        };
+        let campaign_context =
+            CampaignCacheContext::from_workspace_context(&self.project_root, cache_context);
+        let (mutations, subsumed) = self.split_subsumed(mutations, &campaign_context);
+        let mut outcome =
+            self.run_with_schemata_planned(mutations, workspace_pool, &campaign_context, start);
         merge_subsumed(&mut outcome.report, subsumed);
         outcome
     }
@@ -4200,7 +5194,11 @@ impl TestRunner {
     /// without the flag or without incremental history every mutation
     /// executes, exactly as before. `--force-rerun` still bypasses verdict
     /// restore for the canonical mutants but does not disable clustering.
-    fn split_subsumed(&self, mutations: Vec<Mutation>) -> (Vec<Mutation>, Vec<Mutation>) {
+    fn split_subsumed(
+        &self,
+        mutations: Vec<Mutation>,
+        campaign_context: &CampaignCacheContext,
+    ) -> (Vec<Mutation>, Vec<Mutation>) {
         if !self.learned_selection || !self.incremental_history {
             return (mutations, Vec::new());
         }
@@ -4213,6 +5211,7 @@ impl TestRunner {
                 &self.commands,
                 mutation,
                 Some(&history),
+                Some(campaign_context.learned_selection_context()),
             );
             let command_ctx = selected.cache_context(
                 &self.commands.build_command,
@@ -4220,11 +5219,21 @@ impl TestRunner {
                 &self.commands.sandbox_command,
                 &self.env,
             );
+            let selected_test_hash = campaign_context.test_context_index.fingerprint_for_tests(
+                &selected.selected_tests,
+                campaign_context.cache_context_fingerprint,
+            );
+            let relevant_test_hash = incremental_history_relevant_test_hash(
+                selected_test_hash,
+                campaign_context.cache_context_fingerprint,
+                campaign_context.cache_context_provenance,
+            );
             history.learned_killer_test(
                 &cache_identity(&self.project_root, mutation),
                 &mutation.description,
                 cache::hash_bytes(&source),
                 cache::hash_str(&command_ctx),
+                relevant_test_hash,
             )
         });
         if !partition.subsumed.is_empty() {
@@ -4237,13 +5246,18 @@ impl TestRunner {
         (partition.to_run, partition.subsumed)
     }
 
-    fn run_with_schemata_planned(&self, mutations: Vec<Mutation>) -> RunOutcome {
-        let start = Instant::now();
+    fn run_with_schemata_planned(
+        &self,
+        mutations: Vec<Mutation>,
+        workspace_pool: WorkspacePool,
+        campaign_context: &CampaignCacheContext,
+        start: Instant,
+    ) -> RunOutcome {
         if mutations.is_empty() {
             return self.outcome_from_records(Vec::new(), start.elapsed());
         }
         let planned_total = mutations.len();
-        let preclassified = self.preclassify_for_early_stop(&mutations);
+        let preclassified = self.preclassify_for_early_stop(&mutations, campaign_context);
         let pending_restores: HashMap<u32, RestoredMutationResult> = preclassified
             .fresh
             .iter()
@@ -4336,6 +5350,8 @@ impl TestRunner {
                 tested_counter.clone(),
                 restore_checked,
                 &pending_restores,
+                campaign_context,
+                &workspace_pool,
             ) {
                 Ok((records, demoted)) => {
                     schemata_summary.fast_path += records
@@ -4379,6 +5395,9 @@ impl TestRunner {
                 early_stop.clone(),
                 planned_total,
                 tested_counter,
+                workspace_pool,
+                campaign_context,
+                start,
             );
             all_records.extend(records_from_report(
                 fallback.report,
@@ -4402,7 +5421,7 @@ impl TestRunner {
         outcome
     }
 
-    #[allow(clippy::manual_is_multiple_of)]
+    #[allow(clippy::manual_is_multiple_of, clippy::too_many_arguments)]
     fn run_regular_with_state(
         &self,
         mutations: Vec<QueuedMutation>,
@@ -4410,8 +5429,10 @@ impl TestRunner {
         early_stop: Option<Arc<EarlyStopState>>,
         planned_total: usize,
         tested_counter: Arc<AtomicUsize>,
+        workspace_pool: WorkspacePool,
+        campaign_context: &CampaignCacheContext,
+        start: Instant,
     ) -> RunOutcome {
-        let start = Instant::now();
         let fresh_total = mutations.len();
         let total = fresh_total + restored.len();
         if fresh_total == 0
@@ -4430,43 +5451,7 @@ impl TestRunner {
         let counter = Arc::new(AtomicUsize::new(restored.len()));
         let verbose = self.verbose;
         let is_tty = std::io::stderr().is_terminal();
-        let workspace_slots = workspace_pool_slot_count(self.parallelism, fresh_total);
-
-        let workspace_pool_result = if self.respect_workspace_ignores {
-            WorkspacePool::new(&self.project_root, workspace_slots)
-        } else {
-            WorkspacePool::new_with_options(&self.project_root, workspace_slots, false)
-        };
-        let workspace_pool = match workspace_pool_result {
-            Ok(pool) => Arc::new(pool),
-            Err(e) => {
-                eprintln!("warning: could not create isolated mutation workspaces: {e}");
-                restored.extend(mutations.into_iter().map(|queued| {
-                    let diagnostic = BuildErrorDiagnostic::new(
-                        queued.mutation.id,
-                        "regular",
-                        "workspace_pool",
-                        vec![],
-                        format!("could not create isolated mutation workspaces: {e}"),
-                    );
-                    (
-                        queued.index,
-                        MutationRunRecord::new(
-                            queued.mutation,
-                            MutationResult::BuildError,
-                            Some(diagnostic),
-                        ),
-                    )
-                }));
-                restored.sort_by_key(|(index, _)| *index);
-                return self.outcome_from_records_with_status(
-                    restored.into_iter().map(|(_, record)| record).collect(),
-                    start.elapsed(),
-                    planned_total,
-                    early_stop.as_ref().and_then(|state| state.reason()),
-                );
-            }
-        };
+        let workspace_pool = Arc::new(workspace_pool);
 
         let source_contents = SourceContentCache::default();
         let project_root = Arc::new(self.project_root.clone());
@@ -4475,8 +5460,6 @@ impl TestRunner {
         let queue = Arc::new(Mutex::new(mutations.into_iter().collect::<VecDeque<_>>()));
         let results = Arc::new(Mutex::new(restored));
         let worker_count = workspace_pool.len().min(fresh_total).max(1);
-        let cache_context_hash = cache_context_fingerprint(&self.project_root);
-        let test_context_index = TestContextIndex::build(&self.project_root);
         let history = self
             .incremental_history
             .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
@@ -4496,7 +5479,7 @@ impl TestRunner {
                 let max_tested = self.max_tested;
                 let show_output = self.show_output;
                 let source_contents = &source_contents;
-                let test_context_index = &test_context_index;
+                let test_context_index = &campaign_context.test_context_index;
                 let history = history.as_ref();
                 let force_rerun = self.force_rerun;
                 let early_stop = early_stop.clone();
@@ -4546,7 +5529,10 @@ impl TestRunner {
                                     cancelled: &cancelled,
                                     early_stop: early_stop.as_ref(),
                                     respect_workspace_ignores: self.respect_workspace_ignores,
-                                    cache_context_fingerprint: cache_context_hash,
+                                    cache_context_fingerprint: campaign_context
+                                        .cache_context_fingerprint,
+                                    cache_context_provenance: campaign_context
+                                        .cache_context_provenance,
                                     test_context_index,
                                     source_contents,
                                     history,
@@ -4595,6 +5581,7 @@ impl TestRunner {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn run_schema_mutations(
         &self,
         language: &str,
@@ -4603,7 +5590,10 @@ impl TestRunner {
         tested_counter: Arc<AtomicUsize>,
         restore_checked: bool,
         pending_restores: &HashMap<u32, RestoredMutationResult>,
+        campaign_context: &CampaignCacheContext,
+        workspace_pool: &WorkspacePool,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
+        let workspace = workspace_pool.acquire();
         self.run_schema_mutations_inner(
             language,
             schema_mutations,
@@ -4611,6 +5601,8 @@ impl TestRunner {
             tested_counter,
             restore_checked,
             pending_restores,
+            campaign_context,
+            &workspace,
             true,
         )
     }
@@ -4624,22 +5616,22 @@ impl TestRunner {
         tested_counter: Arc<AtomicUsize>,
         restore_checked: bool,
         pending_restores: &HashMap<u32, RestoredMutationResult>,
+        campaign_context: &CampaignCacheContext,
+        workspace: &WorkspaceSlot,
         allow_build_bisection: bool,
     ) -> Result<(Vec<MutationRunRecord>, Vec<Mutation>), crate::schemata::SchemaRewriteError> {
+        workspace
+            .reset(&self.project_root, self.respect_workspace_ignores)
+            .map_err(|e| {
+                crate::schemata::SchemaRewriteError::new(format!(
+                    "could not reset schema workspace {}: {e}",
+                    workspace.root().display()
+                ))
+            })?;
         let rewrites =
             schema_rewrites_for_language(&self.project_root, language, schema_mutations)?;
-        let workspace =
-            copy_workspace_with_options(&self.project_root, self.respect_workspace_ignores)
-                .map_err(|e| {
-                    crate::schemata::SchemaRewriteError::new(format!(
-                        "could not create schema workspace: {e}"
-                    ))
-                })?;
-
         let mut results = Vec::with_capacity(schema_mutations.len());
         let source_contents = SourceContentCache::default();
-        let cache_context_hash = cache_context_fingerprint(&self.project_root);
-        let test_context_index = TestContextIndex::build(&self.project_root);
         let history = self
             .incremental_history
             .then(|| cache::IncrementalHistoryStore::load(&self.project_root));
@@ -4671,8 +5663,9 @@ impl TestRunner {
                     commands: &self.commands,
                     history: history.as_ref(),
                     source_contents: &source_contents,
-                    cache_context_fingerprint: cache_context_hash,
-                    test_context_index: &test_context_index,
+                    cache_context_fingerprint: campaign_context.cache_context_fingerprint,
+                    cache_context_provenance: campaign_context.cache_context_provenance,
+                    test_context_index: &campaign_context.test_context_index,
                     env: &self.env,
                 },
             );
@@ -4781,7 +5774,7 @@ impl TestRunner {
                     .unwrap_or_else(|| "no compiler diagnostic captured".into());
 
                 if allow_build_bisection {
-                    match self.bisect_schema_build_batch(language, remaining) {
+                    match self.bisect_schema_build_batch(language, remaining, workspace) {
                         Ok((salvaged_batches, newly_demoted)) => {
                             let salvaged_count: usize =
                                 salvaged_batches.iter().map(|batch| batch.len()).sum();
@@ -4803,6 +5796,8 @@ impl TestRunner {
                                     tested_counter.clone(),
                                     restore_checked,
                                     pending_restores,
+                                    campaign_context,
+                                    workspace,
                                     false,
                                 ) {
                                     Ok((batch_records, batch_demoted)) => {
@@ -4982,23 +5977,17 @@ impl TestRunner {
         &self,
         language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
+        workspace: &WorkspaceSlot,
     ) -> Result<
         (Vec<Vec<crate::schemata::SchemaMutation>>, Vec<Mutation>),
         crate::schemata::SchemaRewriteError,
     > {
-        let workspace =
-            copy_workspace_with_options(&self.project_root, self.respect_workspace_ignores)
-                .map_err(|e| {
-                    crate::schemata::SchemaRewriteError::new(format!(
-                        "could not create schema bisection workspace: {e}"
-                    ))
-                })?;
         let mut salvaged_batches = Vec::new();
         let mut demoted = Vec::new();
         self.partition_schema_build_batch(
             language,
             schema_mutations,
-            &workspace,
+            workspace,
             &mut salvaged_batches,
             &mut demoted,
         )?;
@@ -5009,7 +5998,7 @@ impl TestRunner {
         &self,
         language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
-        workspace: &WorkspaceCopy,
+        workspace: &WorkspaceSlot,
         salvaged_batches: &mut Vec<Vec<crate::schemata::SchemaMutation>>,
         demoted: &mut Vec<Mutation>,
     ) -> Result<(), crate::schemata::SchemaRewriteError> {
@@ -5045,7 +6034,7 @@ impl TestRunner {
         &self,
         language: &str,
         schema_mutations: &[crate::schemata::SchemaMutation],
-        workspace: &WorkspaceCopy,
+        workspace: &WorkspaceSlot,
     ) -> Result<Option<bool>, crate::schemata::SchemaRewriteError> {
         workspace
             .reset(&self.project_root, self.respect_workspace_ignores)
@@ -8089,7 +9078,11 @@ mod tests {
                     &source,
                     &cache_identity(project_root, mutation),
                     &mutation.description,
-                    &format!("{command_context};context={context_hash:016x}"),
+                    &exact_cache_context(
+                        &command_context,
+                        context_hash,
+                        workspace_cache_context(project_root, true).provenance,
+                    ),
                 );
                 cache::store(project_root, &key, result);
             }
@@ -8102,6 +9095,8 @@ mod tests {
                     &command_context,
                     test_context_index
                         .fingerprint_for_tests(&selected.selected_tests, context_hash),
+                    context_hash,
+                    workspace_cache_context(project_root, true).provenance,
                 );
                 cache::IncrementalHistoryStore::load(project_root).record(
                     cache::IncrementalHistoryEntry {
@@ -8256,6 +9251,65 @@ test "$runs" -eq 1
     }
 
     #[test]
+    fn workspace_history_hash_binds_selected_tests_to_workspace_context() {
+        let selected_test_hash = 0x0123_4567_89ab_cdef;
+        let first_workspace = 0x1111_2222_3333_4444;
+        let second_workspace = 0x5555_6666_7777_8888;
+
+        let first_git = incremental_history_relevant_test_hash(
+            selected_test_hash,
+            first_workspace,
+            WorkspaceCacheContextProvenance::GitWorktreeV4,
+        );
+        assert_ne!(
+            first_git, selected_test_hash,
+            "V4 Git history must not match legacy selected-test-only entries"
+        );
+        assert_ne!(
+            first_git,
+            incremental_history_relevant_test_hash(
+                selected_test_hash,
+                second_workspace,
+                WorkspaceCacheContextProvenance::GitWorktreeV4,
+            ),
+            "V4 Git history must bind every Git-worktree input"
+        );
+        let first_true = incremental_history_relevant_test_hash(
+            selected_test_hash,
+            first_workspace,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            },
+        );
+        let first_false = incremental_history_relevant_test_hash(
+            selected_test_hash,
+            first_workspace,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: false,
+            },
+        );
+        assert_ne!(
+            first_true, first_git,
+            "copy-based history must not match Git-worktree entries"
+        );
+        assert_ne!(
+            first_false, first_true,
+            "false-policy history must not match default fallback entries"
+        );
+        assert_ne!(
+            first_false,
+            incremental_history_relevant_test_hash(
+                selected_test_hash,
+                second_workspace,
+                WorkspaceCacheContextProvenance::WorkspaceCopy {
+                    respect_workspace_ignores: false,
+                },
+            ),
+            "false-policy history must bind the copied workspace fingerprint"
+        );
+    }
+
+    #[test]
     fn source_content_cache_reads_each_file_once_lazily() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("src.txt");
@@ -8282,7 +9336,7 @@ test "$runs" -eq 1
     }
 
     #[test]
-    fn git_cache_context_uses_index_when_context_is_clean() {
+    fn git_cache_context_tracks_clean_index_and_dirty_overlay() {
         if !git_available() {
             return;
         }
@@ -8307,9 +9361,11 @@ test "$runs" -eq 1
 
         let clean = git_cache_context_fingerprint(root).expect("clean git fingerprint");
         std::fs::write(root.join("src/lib.rs"), b"pub fn value() -> i32 { 2 }\n").unwrap();
-        assert!(
-            git_cache_context_fingerprint(root).is_none(),
-            "dirty source files should fall back to filesystem hashing"
+        let source_overlay =
+            git_cache_context_fingerprint(root).expect("dirty source overlay fingerprint");
+        assert_ne!(
+            source_overlay, clean,
+            "dirty source overlays must change the Git-worktree context"
         );
         assert_ne!(
             cache_context_fingerprint(root),
@@ -8322,10 +9378,1810 @@ test "$runs" -eq 1
             b"#[test]\nfn changed() {}\n",
         )
         .unwrap();
-        assert!(
-            git_cache_context_fingerprint(root).is_none(),
-            "dirty test files should fall back to filesystem hashing"
+        assert_ne!(
+            git_cache_context_fingerprint(root).expect("dirty test overlay fingerprint"),
+            source_overlay,
+            "dirty test overlays must change the Git-worktree context"
         );
+    }
+
+    #[test]
+    fn git_context_tracks_clean_copy_fallback_metadata() -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        let regular_file = root.join("fixture.txt");
+        let directory = root.join("fixture");
+        std::fs::create_dir(&directory)?;
+        std::fs::write(&regular_file, b"fixture")?;
+        std::fs::write(directory.join("nested.txt"), b"nested")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        set_file_modification_time(&regular_file, 1_000_000_000)?;
+        set_file_modification_time(&directory, 1_100_000_000)?;
+        let initial = workspace_cache_context(root, true);
+        assert_eq!(
+            initial.provenance,
+            WorkspaceCacheContextProvenance::GitWorktreeV4
+        );
+        assert_eq!(
+            git_cache_context_is_dirty(root),
+            Some(false),
+            "mtime-only source metadata must leave the Git overlay clean"
+        );
+
+        let (git_pool, git_context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(git_pool.strategy(), WorkspaceStrategy::GitWorktree);
+        assert_eq!(git_context.fingerprint, initial.fingerprint);
+        {
+            let workspace = git_pool.acquire();
+            assert_eq!(
+                std::fs::metadata(&regular_file)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture.txt"))?.modified()?,
+                "Git worktree regular files must receive captured source mtimes"
+            );
+            assert_eq!(
+                std::fs::metadata(&directory)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture"))?.modified()?,
+                "Git worktree directories must receive captured source mtimes"
+            );
+        }
+
+        {
+            let workspace = git_pool.acquire();
+            assert!(workspace.needs_reset());
+            workspace.reset(root, true)?;
+            assert_eq!(
+                std::fs::metadata(&regular_file)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture.txt"))?.modified()?,
+                "Git reset must restore the captured regular-file mtime"
+            );
+            assert_eq!(
+                std::fs::metadata(&directory)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture"))?.modified()?,
+                "Git reset must restore the captured non-root directory mtime"
+            );
+        }
+
+        set_file_modification_time(&regular_file, 1_700_000_000)?;
+        let regular_file_changed = workspace_cache_context(root, true);
+        assert_ne!(
+            regular_file_changed.fingerprint, initial.fingerprint,
+            "a clean tracked regular file mtime must affect a fresh Git context"
+        );
+        assert_eq!(
+            workspace_cache_context_for_strategy(
+                root,
+                true,
+                git_pool.strategy(),
+                git_pool.git_overlay(),
+            )
+            .expect("the prebuilt Git pool has a context")
+            .fingerprint,
+            git_context.fingerprint,
+            "the context must use the prebuilt workspace metadata snapshot"
+        );
+
+        set_file_modification_time(&directory, 1_800_000_000)?;
+        let changed = workspace_cache_context(root, true);
+        assert_ne!(
+            changed.fingerprint, regular_file_changed.fingerprint,
+            "a copied non-root directory mtime must affect a fresh Git context"
+        );
+
+        drop(git_pool);
+        // Capability probing still succeeds, but `git worktree add` fails.
+        std::fs::write(root.join(".git/worktrees"), b"block worktree creation")?;
+        let (fallback_pool, fallback_context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(fallback_pool.strategy(), WorkspaceStrategy::Copy);
+        assert_eq!(
+            fallback_context.provenance,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            }
+        );
+        {
+            let workspace = fallback_pool.acquire();
+            assert_eq!(
+                std::fs::metadata(&regular_file)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture.txt"))?.modified()?
+            );
+            assert_eq!(
+                std::fs::metadata(&directory)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture"))?.modified()?
+            );
+        }
+        assert_ne!(
+            exact_cache_context("test-command", initial.fingerprint, initial.provenance),
+            exact_cache_context(
+                "test-command",
+                fallback_context.fingerprint,
+                fallback_context.provenance,
+            ),
+            "Git and fallback-copy results must not share exact-cache entries"
+        );
+        assert_ne!(
+            incremental_history_relevant_test_hash(
+                0x0123_4567_89ab_cdef,
+                initial.fingerprint,
+                initial.provenance,
+            ),
+            incremental_history_relevant_test_hash(
+                0x0123_4567_89ab_cdef,
+                fallback_context.fingerprint,
+                fallback_context.provenance,
+            ),
+            "Git and fallback-copy results must not share incremental or learned entries"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn git_workspace_keeps_untracked_empty_directories_absent_and_normalizes_tracked_excluded_metadata()
+    -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::write(root.join("fixture.txt"), b"fixture")?;
+        let tracked_directory = root.join("target");
+        let tracked_file = tracked_directory.join("fixture.txt");
+        std::fs::create_dir(&tracked_directory)?;
+        std::fs::write(&tracked_file, b"tracked but copy-excluded")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let before = workspace_cache_context(root, true);
+        let untracked_empty_directory = root.join("runtime/empty");
+        std::fs::create_dir_all(&untracked_empty_directory)?;
+        assert_eq!(
+            workspace_cache_context(root, true).fingerprint,
+            before.fingerprint,
+            "source-only untracked empty directories must not affect Git identity"
+        );
+        set_file_modification_time(&tracked_file, 1_000_000_000)?;
+        set_file_modification_time(&tracked_directory, 1_100_000_000)?;
+        let changed = workspace_cache_context(root, true);
+        assert_ne!(
+            changed.fingerprint, before.fingerprint,
+            "tracked Git-worktree inputs excluded from normal copies must affect identity"
+        );
+
+        let workspace = copy_workspace(root)?;
+        assert_eq!(workspace.strategy(), WorkspaceStrategy::GitWorktree);
+        assert_eq!(
+            std::fs::metadata(&tracked_file)?.modified()?,
+            std::fs::metadata(workspace.root().join("target/fixture.txt"))?.modified()?
+        );
+        assert_eq!(
+            std::fs::metadata(&tracked_directory)?.modified()?,
+            std::fs::metadata(workspace.root().join("target"))?.modified()?
+        );
+        assert!(
+            !workspace.root().join("runtime").exists(),
+            "Git worktrees must not materialize source-only untracked empty directories"
+        );
+
+        set_file_modification_time(&workspace.root().join("target/fixture.txt"), 1_700_000_000)?;
+        set_file_modification_time(&workspace.root().join("target"), 1_800_000_000)?;
+        workspace.reset(root, true)?;
+        assert_eq!(
+            std::fs::metadata(&tracked_file)?.modified()?,
+            std::fs::metadata(workspace.root().join("target/fixture.txt"))?.modified()?,
+            "Git resets must restore tracked copy-excluded source file mtimes"
+        );
+        assert_eq!(
+            std::fs::metadata(&tracked_directory)?.modified()?,
+            std::fs::metadata(workspace.root().join("target"))?.modified()?,
+            "Git resets must restore tracked copy-excluded source directory mtimes"
+        );
+        assert!(
+            !workspace.root().join("runtime").exists(),
+            "Git resets must keep source-only untracked empty directories absent"
+        );
+
+        let copy = copy_workspace_without_git(root, true)?;
+        assert!(
+            copy.root().join("runtime/empty").is_dir(),
+            "normal copies must retain their admitted untracked empty directories"
+        );
+        assert!(
+            !copy.root().join("target").exists(),
+            "normal copies must retain their copy-excluded shape"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_context_tracks_dirty_symlink_overlay_target_metadata() -> anyhow::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::write(root.join(".gitignore"), b"ignored-target.txt\n")?;
+        std::fs::write(root.join("fixture.txt"), b"fixture")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let target = root.join("ignored-target.txt");
+        std::fs::write(&target, b"overlay target")?;
+        symlink("ignored-target.txt", root.join("overlay.txt"))?;
+        set_file_modification_time(&target, 1_000_000_000)?;
+        let initial_target_mtime = std::fs::metadata(&target)?.modified()?;
+        let initial = workspace_cache_context(root, true);
+        assert_eq!(
+            initial.provenance,
+            WorkspaceCacheContextProvenance::GitWorktreeV4
+        );
+
+        let workspace = copy_workspace(root)?;
+        assert_eq!(workspace.strategy(), WorkspaceStrategy::GitWorktree);
+        let destination = workspace.root().join("overlay.txt");
+        assert!(
+            fs::symlink_metadata(&destination)?.file_type().is_file(),
+            "a dirty overlay symlink must materialize as a regular file"
+        );
+        assert_eq!(
+            std::fs::metadata(&target)?.modified()?,
+            std::fs::metadata(&destination)?.modified()?,
+            "the overlay destination must receive resolved-target mtime"
+        );
+
+        set_file_modification_time(&target, 1_700_000_000)?;
+        let changed = workspace_cache_context(root, true);
+        assert_ne!(
+            changed.fingerprint, initial.fingerprint,
+            "resolved dirty symlink-target metadata must affect Git identity"
+        );
+        workspace.reset(root, true)?;
+        assert_eq!(
+            initial_target_mtime,
+            std::fs::metadata(&destination)?.modified()?,
+            "Git resets must restore the captured overlay-target mtime"
+        );
+        drop(workspace);
+        let changed_workspace = copy_workspace(root)?;
+        assert_eq!(
+            std::fs::metadata(&target)?.modified()?,
+            std::fs::metadata(changed_workspace.root().join("overlay.txt"))?.modified()?,
+            "a fresh Git workspace must receive the changed resolved-target mtime"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_context_tracks_parent_mtime_of_clean_tracked_symlink() -> anyhow::Result<()> {
+        use std::os::unix::fs::symlink;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::write(root.join("target.txt"), b"target")?;
+        let links = root.join("links");
+        std::fs::create_dir(&links)?;
+        symlink("../target.txt", links.join("fixture-link"))?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        set_file_modification_time(&links, 1_000_000_000)?;
+        let initial_parent_mtime = std::fs::metadata(&links)?.modified()?;
+        let initial = workspace_cache_context(root, true);
+        let workspace = copy_workspace(root)?;
+        assert_eq!(workspace.strategy(), WorkspaceStrategy::GitWorktree);
+        assert!(
+            fs::symlink_metadata(workspace.root().join("links/fixture-link"))?
+                .file_type()
+                .is_symlink(),
+            "clean Git symlinks must retain their excluded link representation"
+        );
+        assert_eq!(
+            initial_parent_mtime,
+            std::fs::metadata(workspace.root().join("links"))?.modified()?,
+            "Git worktrees must normalize parents materialized for clean symlinks"
+        );
+
+        set_file_modification_time(&links, 1_700_000_000)?;
+        let changed = workspace_cache_context(root, true);
+        assert_ne!(
+            changed.fingerprint, initial.fingerprint,
+            "clean symlink parent mtime must affect Git identity"
+        );
+        workspace.reset(root, true)?;
+        assert_eq!(
+            initial_parent_mtime,
+            std::fs::metadata(workspace.root().join("links"))?.modified()?,
+            "Git reset must restore the captured clean-symlink parent mtime"
+        );
+        drop(workspace);
+        let changed_workspace = copy_workspace(root)?;
+        assert_eq!(
+            std::fs::metadata(&links)?.modified()?,
+            std::fs::metadata(changed_workspace.root().join("links"))?.modified()?,
+            "a fresh Git workspace must receive the changed clean-symlink parent mtime"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_tracked_copy_excluded_source_falls_back_to_normal_copy() -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::create_dir(root.join("target"))?;
+        std::fs::write(
+            root.join("target/fixture.txt"),
+            b"tracked but copy-excluded",
+        )?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+        run_git(root, &["rm", "target/fixture.txt"]);
+
+        let (pool, context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(
+            pool.strategy(),
+            WorkspaceStrategy::Copy,
+            "a dirty tracked copy-excluded path must fail closed to normal copy"
+        );
+        assert_eq!(
+            context.provenance,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            }
+        );
+        assert!(
+            !pool.acquire().root().join("target").exists(),
+            "the normal-copy fallback retains its own source shape"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn assert_exact_cache_tracks_ignored_workspace_input(
+        ignored_relative: &str,
+    ) -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::create_dir_all(root.join("src"))?;
+        std::fs::write(
+            root.join(".gitignore"),
+            format!("{ignored_relative}\ntarget/\nruntime-link\n"),
+        )?;
+        std::fs::write(root.join("src/lib.rs"), b"hello world")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let ignored_input = root.join(ignored_relative);
+        std::fs::create_dir_all(
+            ignored_input
+                .parent()
+                .expect("ignored fixture must have a parent directory"),
+        )?;
+        std::fs::write(&ignored_input, b"kill")?;
+        let excluded_input = root.join("target/runtime.txt");
+        std::fs::create_dir_all(excluded_input.parent().expect("target input has a parent"))?;
+        std::fs::write(&excluded_input, b"excluded-before")?;
+        let included_context = cache_context_fingerprint_for_workspace(root, false);
+        std::fs::write(&excluded_input, b"excluded-after")?;
+        assert_eq!(
+            cache_context_fingerprint_for_workspace(root, false),
+            included_context,
+            "hard-excluded workspace files must not affect the false-policy context"
+        );
+        std::os::unix::fs::symlink(&ignored_input, root.join("runtime-link"))?;
+        assert_eq!(
+            cache_context_fingerprint_for_workspace(root, false),
+            included_context,
+            "uncopied symlinks must not affect the false-policy context"
+        );
+        assert!(
+            git_cache_context_fingerprint(root).is_some(),
+            "ignored untracked inputs must leave the Git workspace clean"
+        );
+
+        let default_context = cache_context_fingerprint_for_workspace(root, true);
+        {
+            let workspace = copy_workspace(root)?;
+            assert!(
+                !workspace.root().join(ignored_relative).exists(),
+                "the default workspace must not copy ignored inputs"
+            );
+        }
+        {
+            let workspace = copy_workspace_with_options(root, false)?;
+            assert_eq!(
+                std::fs::read(workspace.root().join(ignored_relative))?,
+                b"kill"
+            );
+            assert!(
+                !workspace.root().join("target/runtime.txt").exists(),
+                "hard-excluded directories must not be copied"
+            );
+            assert!(
+                !workspace.root().join("runtime-link").exists(),
+                "symlinks must not be copied"
+            );
+        }
+
+        let mutation = make_test_mutation(Path::new("src/lib.rs"));
+        let mut commands = test_command_config();
+        commands.command = vec![
+            "sh".into(),
+            "-c".into(),
+            format!("test \"$(cat {ignored_relative})\" = survive"),
+        ];
+        let selected = select_test_command(root, &commands, &mutation);
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_origin,
+            &commands.sandbox_command,
+            &HashMap::new(),
+        );
+        let source = std::fs::read(root.join("src/lib.rs"))?;
+        let initial_key = CacheKey::new(
+            &source,
+            &cache_identity(root, &mutation),
+            &mutation.description,
+            &exact_cache_context(
+                &command_context,
+                included_context,
+                WorkspaceCacheContextProvenance::WorkspaceCopy {
+                    respect_workspace_ignores: false,
+                },
+            ),
+        );
+        cache::store(root, &initial_key, MutationResult::Killed);
+
+        std::fs::write(&ignored_input, b"survive")?;
+        assert_eq!(
+            cache_context_fingerprint_for_workspace(root, true),
+            default_context,
+            "ignored input must not invalidate the default policy"
+        );
+        let changed_context = cache_context_fingerprint_for_workspace(root, false);
+        assert_ne!(
+            changed_context, included_context,
+            "ignored copied workspace input must invalidate the false-policy context"
+        );
+        assert_ne!(
+            exact_cache_context(
+                &command_context,
+                default_context,
+                WorkspaceCacheContextProvenance::GitWorktreeV4,
+            ),
+            exact_cache_context(
+                &command_context,
+                changed_context,
+                WorkspaceCacheContextProvenance::WorkspaceCopy {
+                    respect_workspace_ignores: false,
+                },
+            ),
+            "workspace ignore policies must have distinct exact-cache identities"
+        );
+
+        let report = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root: root.to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: false,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+        .run(vec![mutation.clone()])
+        .report;
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].0.id, mutation.id);
+        assert_eq!(report.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            report.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(report.execution_counts().exact_cache_reused, 0);
+        assert_eq!(report.execution_counts().executed, 1);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_cache_tracks_ignored_context_when_workspace_ignores_are_disabled() -> anyhow::Result<()>
+    {
+        if !git_available() {
+            return Ok(());
+        }
+
+        assert_exact_cache_tracks_ignored_workspace_input("tests/ignored_test.rs")?;
+        assert_exact_cache_tracks_ignored_workspace_input("fixtures/expected.txt")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_cache_tracks_ignored_workspace_file_modes() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        std::fs::create_dir_all(root.join("src"))?;
+        std::fs::write(root.join(".gitignore"), b"helper.sh\n")?;
+        std::fs::write(root.join("src/lib.rs"), b"hello world")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let helper = root.join("helper.sh");
+        std::fs::write(&helper, b"#!/bin/sh\nexit 0\n")?;
+        let mut permissions = std::fs::metadata(&helper)?.permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&helper, permissions)?;
+        let helper_content = std::fs::read(&helper)?;
+        let default_context = cache_context_fingerprint_for_workspace(root, true);
+        let non_executable_context = cache_context_fingerprint_for_workspace(root, false);
+        assert!(
+            git_cache_context_fingerprint(root).is_some(),
+            "the ignored helper must leave the Git workspace clean"
+        );
+
+        let mutation = make_test_mutation(Path::new("src/lib.rs"));
+        let test_command = vec!["sh".into(), "-c".into(), "test -x helper.sh".into()];
+        let run = |force_rerun| {
+            let mut commands = test_command_config();
+            commands.command = test_command.clone();
+            TestRunner {
+                commands,
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: false,
+                env: HashMap::new(),
+                incremental_history: false,
+                force_rerun,
+                learned_selection: false,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }
+            .run(vec![mutation.clone()])
+            .report
+        };
+
+        let killed = run(false);
+        assert_eq!(killed.results.len(), 1);
+        assert_eq!(killed.results[0].1, MutationResult::Killed);
+        assert_eq!(
+            killed.execution_for(mutation.id, MutationResult::Killed),
+            MutationExecution::Executed
+        );
+
+        let mut permissions = std::fs::metadata(&helper)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&helper, permissions)?;
+        assert_eq!(
+            std::fs::read(&helper)?,
+            helper_content,
+            "the helper content must remain unchanged across chmod"
+        );
+        assert_eq!(
+            cache_context_fingerprint_for_workspace(root, true),
+            default_context,
+            "ignored chmod must not alter default-policy identity"
+        );
+        assert_ne!(
+            cache_context_fingerprint_for_workspace(root, false),
+            non_executable_context,
+            "copied helper mode must invalidate false-policy identity"
+        );
+
+        let survived = run(false);
+        assert_eq!(survived.results.len(), 1);
+        assert_eq!(survived.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            survived.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+
+        let forced = run(true);
+        assert_eq!(forced.results.len(), 1);
+        assert_eq!(forced.results[0].1, MutationResult::Survived);
+        assert_eq!(forced.results[0].1, survived.results[0].1);
+        assert_eq!(
+            forced.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(forced.execution_counts().exact_cache_reused, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn false_policy_history_tracks_ignored_arbitrary_data_file_changes() -> anyhow::Result<()> {
+        if !git_available()
+            || !std::process::Command::new("go")
+                .arg("version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\n";
+        std::fs::write(
+            root.join("go.mod"),
+            "module example.com/cachefixture\ngo 1.20\n",
+        )?;
+        std::fs::write(root.join("calc.go"), source)?;
+        std::fs::write(
+            root.join("calc_test.go"),
+            "package calc\n\nimport (\n    \"os\"\n    \"testing\"\n)\n\nfunc TestSelected(t *testing.T) {\n    fixture, err := os.ReadFile(\"fixture.txt\")\n    if err != nil {\n        t.Fatal(err)\n    }\n    if string(fixture) != \"survive\" {\n        t.Fatal(\"fixture says kill\")\n    }\n}\n",
+        )?;
+        std::fs::write(root.join(".gitignore"), b"fixture.txt\n")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+        std::fs::write(root.join("fixture.txt"), b"kill")?;
+
+        let mut mutation = go_operator_mutation(0, "calc.go", source, 0);
+        mutation.line = 3;
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            root,
+            Path::new("calc.go"),
+            mutation.line,
+            vec!["TestSelected".into()],
+        );
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec![
+                "go".into(),
+                "test".into(),
+                "-count=1".into(),
+                "./...".into(),
+            ];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let run = |force_rerun| {
+            TestRunner {
+                commands: make_commands(),
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: false,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun,
+                learned_selection: false,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }
+            .run(vec![mutation.clone()])
+            .report
+        };
+
+        let commands = make_commands();
+        let selected = select_test_command(root, &commands, &mutation);
+        assert!(selected.is_narrowed());
+        assert_eq!(selected.selected_tests, vec!["TestSelected"]);
+        let initial_context = cache_context_fingerprint_for_workspace(root, false);
+        let initial_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, initial_context);
+        let initial_history_hash = incremental_history_relevant_test_hash(
+            initial_selected_hash,
+            initial_context,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: false,
+            },
+        );
+        let killed = run(false);
+        assert_eq!(killed.results.len(), 1);
+        assert_eq!(killed.results[0].1, MutationResult::Killed);
+        assert_eq!(
+            killed.execution_for(mutation.id, MutationResult::Killed),
+            MutationExecution::Executed
+        );
+
+        std::fs::write(root.join("fixture.txt"), b"survive")?;
+        let changed_context = cache_context_fingerprint_for_workspace(root, false);
+        assert_ne!(
+            changed_context, initial_context,
+            "the copied ignored input must change the workspace fingerprint"
+        );
+        let changed_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, changed_context);
+        assert_eq!(
+            changed_selected_hash, initial_selected_hash,
+            "the narrowed-test hash intentionally excludes this runtime input"
+        );
+        assert_ne!(
+            incremental_history_relevant_test_hash(
+                changed_selected_hash,
+                changed_context,
+                WorkspaceCacheContextProvenance::WorkspaceCopy {
+                    respect_workspace_ignores: false,
+                },
+            ),
+            initial_history_hash,
+            "false-policy history must also bind the copied workspace"
+        );
+        let command_context = selected.cache_context(
+            &commands.build_command,
+            commands.build_command_origin,
+            &commands.sandbox_command,
+            &HashMap::new(),
+        );
+        let changed_key = CacheKey::new(
+            &std::fs::read(root.join("calc.go"))?,
+            &cache_identity(root, &mutation),
+            &mutation.description,
+            &exact_cache_context(
+                &command_context,
+                changed_context,
+                WorkspaceCacheContextProvenance::WorkspaceCopy {
+                    respect_workspace_ignores: false,
+                },
+            ),
+        );
+        assert_eq!(
+            cache::lookup(root, &changed_key),
+            None,
+            "the changed copied input must not share the initial exact key"
+        );
+
+        let survived = run(false);
+        assert_eq!(survived.results.len(), 1);
+        assert_eq!(survived.results[0].1, MutationResult::Survived);
+        assert_eq!(
+            survived.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 1);
+        assert_eq!(
+            cache::lookup(root, &changed_key),
+            Some(MutationResult::Survived),
+            "fresh execution must replace rather than repopulate a stale exact verdict"
+        );
+
+        let forced = run(true);
+        assert_eq!(forced.results.len(), 1);
+        assert_eq!(forced.results[0].1, MutationResult::Survived);
+        assert_eq!(forced.results[0].1, survived.results[0].1);
+        assert_eq!(
+            forced.execution_for(mutation.id, MutationResult::Survived),
+            MutationExecution::Executed
+        );
+        assert_eq!(forced.execution_counts().exact_cache_reused, 0);
+        assert_eq!(forced.execution_counts().incremental_history_reused, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn learned_selection_rejects_stale_killers_after_ignored_empty_directory_removal()
+    -> anyhow::Result<()> {
+        if !git_available()
+            || !std::process::Command::new("go")
+                .arg("version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
+        std::fs::write(
+            root.join("go.mod"),
+            "module example.com/learnedfixture\ngo 1.20\n",
+        )?;
+        std::fs::write(root.join("calc.go"), source)?;
+        std::fs::write(
+            root.join("calc_test.go"),
+            "package calc\n\nimport (\n    \"os\"\n    \"testing\"\n)\n\nfunc TestSelected(t *testing.T) {\n    if _, err := os.Stat(\"runtime\"); err == nil {\n        t.Fatal(\"runtime directory says kill\")\n    }\n}\n",
+        )?;
+        std::fs::write(root.join(".gitignore"), b"runtime/\n")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+        std::fs::create_dir(root.join("runtime"))?;
+        let default_context = cache_context_fingerprint_for_workspace(root, true);
+        {
+            let default_workspace = copy_workspace(root)?;
+            assert!(
+                !default_workspace.root().join("runtime").exists(),
+                "the default workspace must not materialize ignored directories"
+            );
+        }
+        let initial_context = cache_context_fingerprint_for_workspace(root, false);
+
+        let mut first = go_operator_mutation(1, "calc.go", source, 0);
+        first.line = 3;
+        let mut second = go_operator_mutation(2, "calc.go", source, 1);
+        second.line = 4;
+        let mutations = vec![first, second];
+        let mut selection = TestSelectionConfig::new();
+        for mutation in &mutations {
+            selection.insert(
+                root,
+                Path::new("calc.go"),
+                mutation.line,
+                vec!["TestSelected".into()],
+            );
+        }
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec![
+                "go".into(),
+                "test".into(),
+                "-count=1".into(),
+                "./...".into(),
+            ];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let run = |force_rerun| {
+            TestRunner {
+                commands: make_commands(),
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: false,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }
+            .run(mutations.clone())
+            .report
+        };
+
+        let killed = run(false);
+        assert_eq!(killed.results.len(), 2);
+        assert_eq!(killed.killed, 2);
+        assert_eq!(killed.subsumed_count(), 0);
+        assert_eq!(killed.execution_counts().executed, 2);
+
+        std::fs::remove_dir(root.join("runtime"))?;
+        assert_eq!(
+            cache_context_fingerprint_for_workspace(root, true),
+            default_context,
+            "removing an ignored directory must not invalidate the default policy"
+        );
+        assert_ne!(
+            cache_context_fingerprint_for_workspace(root, false),
+            initial_context,
+            "an admitted ignored directory must change false-policy identity"
+        );
+        let survived = run(false);
+        assert_eq!(survived.results.len(), 2);
+        assert_eq!(survived.subsumed_count(), 0);
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 2);
+        for mutation in &mutations {
+            assert_eq!(
+                survived
+                    .results
+                    .iter()
+                    .find(|(candidate, _)| candidate.id == mutation.id)
+                    .map(|(_, result)| *result),
+                Some(MutationResult::Survived)
+            );
+            assert_eq!(
+                survived.execution_for(mutation.id, MutationResult::Survived),
+                MutationExecution::Executed
+            );
+        }
+
+        let forced = run(true);
+        assert_eq!(forced.results.len(), 2);
+        assert_eq!(forced.subsumed_count(), 0);
+        assert_eq!(forced.execution_counts().exact_cache_reused, 0);
+        assert_eq!(forced.execution_counts().incremental_history_reused, 0);
+        assert_eq!(forced.execution_counts().executed, 2);
+        assert!(
+            forced
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Survived)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn git_worktree_context_rejects_stale_killers_after_dirty_tracked_ignored_fixture_mtime_changes()
+    -> anyhow::Result<()> {
+        if !git_available()
+            || !std::process::Command::new("go")
+                .arg("version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
+        std::fs::write(
+            root.join("go.mod"),
+            "module example.com/mtimefixture\ngo 1.20\n",
+        )?;
+        std::fs::write(root.join("calc.go"), source)?;
+        std::fs::write(
+            root.join("calc_test.go"),
+            "package calc\n\nimport (\n    \"os\"\n    \"testing\"\n)\n\nfunc TestSelected(t *testing.T) {\n    info, err := os.Stat(\"fixture.txt\")\n    if err != nil {\n        t.Fatal(err)\n    }\n    if info.ModTime().Unix() < 1500000000 {\n        t.Fatal(\"fixture mtime says kill\")\n    }\n}\n",
+        )?;
+        assert!(
+            !is_cache_context_file(Path::new("fixture.txt")),
+            "the regression fixture must remain outside the narrow verdict-context classifier"
+        );
+        std::fs::write(root.join(".gitignore"), b"fixture.txt\n")?;
+        let fixture = root.join("fixture.txt");
+        std::fs::write(&fixture, b"base")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["add", "-f", "fixture.txt"]);
+        run_git(root, &["commit", "-m", "initial"]);
+        let clean_context = cache_context_fingerprint_for_workspace(root, true);
+        {
+            let workspace = copy_workspace(root)?;
+            assert_eq!(
+                std::fs::read(workspace.root().join("fixture.txt"))?,
+                b"base",
+                "a tracked ignored file must be present in a clean Git workspace"
+            );
+        }
+
+        std::fs::write(&fixture, b"unchanged")?;
+        set_file_modification_time(&fixture, 1_000_000_000)?;
+        assert_eq!(
+            git_cache_context_is_dirty(root),
+            Some(true),
+            "a dirty arbitrary tracked fixture must select the Git overlay"
+        );
+        let fixture_content = std::fs::read(&fixture)?;
+        let initial_context = cache_context_fingerprint_for_workspace(root, true);
+        assert_ne!(
+            initial_context, clean_context,
+            "a dirty tracked ignored fixture must invalidate clean Git identity"
+        );
+        assert_eq!(
+            workspace_cache_context(root, true).provenance,
+            WorkspaceCacheContextProvenance::GitWorktreeV4,
+            "dirty Git worktrees use the matching overlay identity"
+        );
+
+        let mut first = go_operator_mutation(1, "calc.go", source, 0);
+        first.line = 3;
+        let mut second = go_operator_mutation(2, "calc.go", source, 1);
+        second.line = 4;
+        let mutations = vec![first, second];
+        let mut selection = TestSelectionConfig::new();
+        for mutation in &mutations {
+            selection.insert(
+                root,
+                Path::new("calc.go"),
+                mutation.line,
+                vec!["TestSelected".into()],
+            );
+        }
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec![
+                "go".into(),
+                "test".into(),
+                "-count=1".into(),
+                "./...".into(),
+            ];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let commands = make_commands();
+        let selected = select_test_command(root, &commands, &mutations[0]);
+        assert!(selected.is_narrowed());
+        let initial_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, initial_context);
+        let initial_history_hash = incremental_history_relevant_test_hash(
+            initial_selected_hash,
+            initial_context,
+            workspace_cache_context(root, true).provenance,
+        );
+        let run = |force_rerun| {
+            TestRunner {
+                commands: make_commands(),
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }
+            .run(mutations.clone())
+            .report
+        };
+
+        let killed = run(false);
+        assert_eq!(killed.results.len(), 2);
+        assert_eq!(killed.killed, 2);
+        assert_eq!(killed.subsumed_count(), 0);
+        assert_eq!(killed.execution_counts().executed, 2);
+
+        set_file_modification_time(&fixture, 1_700_000_000)?;
+        assert_eq!(std::fs::read(&fixture)?, fixture_content);
+        let changed_context = cache_context_fingerprint_for_workspace(root, true);
+        assert_ne!(
+            changed_context, initial_context,
+            "a dirty tracked ignored fixture mtime must invalidate Git overlay identity"
+        );
+        let changed_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, changed_context);
+        assert_eq!(
+            changed_selected_hash, initial_selected_hash,
+            "the narrowed-test hash intentionally excludes the helper mtime"
+        );
+        assert_ne!(
+            incremental_history_relevant_test_hash(
+                changed_selected_hash,
+                changed_context,
+                workspace_cache_context(root, true).provenance,
+            ),
+            initial_history_hash,
+            "Git-worktree history must bind dirty overlay metadata"
+        );
+
+        let survived = run(false);
+        assert_eq!(survived.results.len(), 2);
+        assert_eq!(survived.subsumed_count(), 0);
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 2);
+        assert!(
+            survived
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Survived)
+        );
+
+        let forced = run(true);
+        assert_eq!(forced.results.len(), 2);
+        assert_eq!(forced.subsumed_count(), 0);
+        assert_eq!(forced.execution_counts().exact_cache_reused, 0);
+        assert_eq!(forced.execution_counts().incremental_history_reused, 0);
+        assert_eq!(forced.execution_counts().executed, 2);
+        assert!(
+            forced
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Survived)
+        );
+        Ok(())
+    }
+
+    fn assert_normal_copy_fallback_rejects_stale_mtime_reuse(
+        use_schemata: bool,
+    ) -> anyhow::Result<()> {
+        if !git_available()
+            || !std::process::Command::new("go")
+                .arg("version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
+        std::fs::write(
+            root.join("go.mod"),
+            "module example.com/fallbackmtimefixture\ngo 1.20\n",
+        )?;
+        std::fs::write(root.join("calc.go"), source)?;
+        std::fs::write(
+            root.join("calc_test.go"),
+            "package calc\n\nimport (\n    \"os\"\n    \"testing\"\n)\n\nfunc TestSelected(t *testing.T) {\n    info, err := os.Stat(\"fixture.txt\")\n    if err != nil {\n        t.Fatal(err)\n    }\n    if info.ModTime().Unix() < 1500000000 {\n        t.Fatal(\"fixture mtime says kill\")\n    }\n}\n",
+        )?;
+        assert!(
+            !is_cache_context_file(Path::new("fixture.txt")),
+            "the regression fixture must remain outside the narrow verdict-context classifier"
+        );
+        let fixture = root.join("fixture.txt");
+        std::fs::write(&fixture, b"fixture")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        set_file_modification_time(&fixture, 1_000_000_000)?;
+        assert_eq!(
+            git_cache_context_is_dirty(root),
+            Some(false),
+            "mtime-only source metadata must leave the Git overlay clean"
+        );
+        std::fs::write(root.join(".git/worktrees"), b"block worktree creation")?;
+        let (initial_pool, initial_context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(initial_pool.strategy(), WorkspaceStrategy::Copy);
+        assert_eq!(
+            initial_context.provenance,
+            WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            },
+            "cache lookup must use the actual normal-copy fallback domain"
+        );
+        drop(initial_pool);
+        {
+            let workspace = copy_workspace(root)?;
+            assert!(
+                matches!(&workspace.reset_strategy, WorkspaceResetStrategy::Copy),
+                "the injected worktree failure must use the normal copy fallback"
+            );
+            assert_eq!(
+                std::fs::metadata(&fixture)?.modified()?,
+                std::fs::metadata(workspace.root().join("fixture.txt"))?.modified()?
+            );
+        }
+
+        let mut first = go_operator_mutation(1, "calc.go", source, 0);
+        first.line = 3;
+        let mut second = go_operator_mutation(2, "calc.go", source, 1);
+        second.line = 4;
+        let mutations = vec![first, second];
+        let mut selection = TestSelectionConfig::new();
+        for mutation in &mutations {
+            selection.insert(
+                root,
+                Path::new("calc.go"),
+                mutation.line,
+                vec!["TestSelected".into()],
+            );
+        }
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec![
+                "go".into(),
+                "test".into(),
+                "-count=1".into(),
+                "./...".into(),
+            ];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let commands = make_commands();
+        let selected = select_test_command(root, &commands, &mutations[0]);
+        assert!(selected.is_narrowed());
+        let initial_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, initial_context.fingerprint);
+        let initial_history_hash = incremental_history_relevant_test_hash(
+            initial_selected_hash,
+            initial_context.fingerprint,
+            initial_context.provenance,
+        );
+        let run = |force_rerun| {
+            let runner = TestRunner {
+                commands: make_commands(),
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            if use_schemata {
+                runner.run_with_schemata(mutations.clone()).report
+            } else {
+                runner.run(mutations.clone()).report
+            }
+        };
+
+        let killed = run(false);
+        assert_eq!(killed.results.len(), 2);
+        assert_eq!(killed.killed, 2);
+        assert_eq!(killed.subsumed_count(), 0);
+        assert_eq!(killed.execution_counts().executed, 2);
+
+        let fixture_content = std::fs::read(&fixture)?;
+        let (control_pool, control_context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(control_pool.strategy(), WorkspaceStrategy::Copy);
+        assert_eq!(
+            control_context.fingerprint, initial_context.fingerprint,
+            "Togi control state must not alter the source workspace identity"
+        );
+        drop(control_pool);
+        set_file_modification_time(&fixture, 1_700_000_000)?;
+        assert_eq!(std::fs::read(&fixture)?, fixture_content);
+        let (changed_pool, changed_context) = prepare_campaign_workspace_pool(root, 1, true)?;
+        assert_eq!(changed_pool.strategy(), WorkspaceStrategy::Copy);
+        drop(changed_pool);
+        assert_ne!(
+            changed_context.fingerprint, initial_context.fingerprint,
+            "a copy-observable clean tracked mtime must invalidate fallback identity"
+        );
+        let changed_selected_hash = TestContextIndex::build(root)
+            .fingerprint_for_tests(&selected.selected_tests, changed_context.fingerprint);
+        assert_eq!(
+            changed_selected_hash, initial_selected_hash,
+            "the narrowed-test hash intentionally excludes the helper mtime"
+        );
+        assert_ne!(
+            incremental_history_relevant_test_hash(
+                changed_selected_hash,
+                changed_context.fingerprint,
+                changed_context.provenance,
+            ),
+            initial_history_hash,
+            "incremental and learned identities must bind fallback metadata"
+        );
+
+        let survived = run(false);
+        assert_eq!(survived.results.len(), 2);
+        assert_eq!(survived.subsumed_count(), 0);
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 2);
+        assert!(
+            survived
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Survived)
+        );
+        if use_schemata {
+            assert!(
+                survived.schemata.is_some(),
+                "the shared campaign context must reach the schemata path"
+            );
+        }
+
+        let forced = run(true);
+        assert_eq!(forced.results.len(), 2);
+        assert_eq!(forced.subsumed_count(), 0);
+        assert_eq!(forced.execution_counts().exact_cache_reused, 0);
+        assert_eq!(forced.execution_counts().incremental_history_reused, 0);
+        assert_eq!(forced.execution_counts().executed, 2);
+        assert!(
+            forced
+                .results
+                .iter()
+                .all(|(_, result)| *result == MutationResult::Survived)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn normal_copy_fallback_rejects_stale_mtime_reuse_in_regular_runs() -> anyhow::Result<()> {
+        assert_normal_copy_fallback_rejects_stale_mtime_reuse(false)
+    }
+
+    #[test]
+    fn normal_copy_fallback_rejects_stale_mtime_reuse_in_schemata_runs() -> anyhow::Result<()> {
+        assert_normal_copy_fallback_rejects_stale_mtime_reuse(true)
+    }
+
+    #[cfg(unix)]
+    fn assert_workspace_contexts_do_not_share_reuse(
+        initial: WorkspaceCacheContext,
+        changed: WorkspaceCacheContext,
+    ) {
+        assert_ne!(
+            exact_cache_context("test-command", initial.fingerprint, initial.provenance),
+            exact_cache_context("test-command", changed.fingerprint, changed.provenance),
+            "workspace strategies must have distinct exact-cache domains"
+        );
+        assert_ne!(
+            incremental_history_relevant_test_hash(
+                0x0123_4567_89ab_cdef,
+                initial.fingerprint,
+                initial.provenance,
+            ),
+            incremental_history_relevant_test_hash(
+                0x0123_4567_89ab_cdef,
+                changed.fingerprint,
+                changed.provenance,
+            ),
+            "workspace strategies must have distinct incremental and learned domains"
+        );
+    }
+
+    #[cfg(unix)]
+    fn assert_tracked_ignored_pool_shape(
+        root: &Path,
+        expected_strategy: WorkspaceStrategy,
+    ) -> anyhow::Result<WorkspaceCacheContext> {
+        let (pool, context) = prepare_campaign_workspace_pool(root, 2, true)?;
+        assert_eq!(pool.strategy(), expected_strategy);
+        assert_eq!(pool.len(), 2);
+        let expected_fixture = expected_strategy == WorkspaceStrategy::GitWorktree;
+        let first = pool.acquire();
+        let second = pool.acquire();
+        assert_eq!(
+            first.root().join("fixture.txt").exists(),
+            expected_fixture,
+            "the first slot must match its cache-visible workspace shape"
+        );
+        assert_eq!(
+            second.root().join("fixture.txt").exists(),
+            expected_fixture,
+            "all slots must share the same workspace strategy"
+        );
+        let expected_provenance = match expected_strategy {
+            WorkspaceStrategy::GitWorktree => WorkspaceCacheContextProvenance::GitWorktreeV4,
+            WorkspaceStrategy::Copy => WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            },
+        };
+        assert_eq!(context.provenance, expected_provenance);
+        Ok(context)
+    }
+
+    #[cfg(unix)]
+    fn assert_tracked_ignored_strategy_transition_rejects_stale_reuse(
+        first_strategy: WorkspaceStrategy,
+        use_schemata: bool,
+    ) -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
+        std::fs::write(root.join("calc.go"), source)?;
+        std::fs::write(root.join(".gitignore"), b"fixture.txt\n")?;
+        std::fs::write(root.join("fixture.txt"), b"tracked but ignored")?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["add", "-f", "fixture.txt"]);
+        run_git(root, &["commit", "-m", "initial"]);
+
+        let worktrees = root.join(".git/worktrees");
+        if first_strategy == WorkspaceStrategy::Copy {
+            std::fs::write(&worktrees, b"block worktree creation")?;
+        }
+        let initial_context = assert_tracked_ignored_pool_shape(root, first_strategy)?;
+
+        let mut first = go_operator_mutation(1, "calc.go", source, 0);
+        first.line = 3;
+        let mut second = go_operator_mutation(2, "calc.go", source, 1);
+        second.line = 4;
+        let mutations = vec![first, second];
+        let mut selection = TestSelectionConfig::new();
+        for mutation in &mutations {
+            selection.insert(
+                root,
+                Path::new("calc.go"),
+                mutation.line,
+                vec!["TestFixture".into()],
+            );
+        }
+        let script = if first_strategy == WorkspaceStrategy::GitWorktree {
+            "test ! -e fixture.txt"
+        } else {
+            "test -e fixture.txt"
+        };
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec!["sh".into(), "-c".into(), script.into()];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let run = || {
+            let runner = TestRunner {
+                commands: make_commands(),
+                parallelism: 2,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun: false,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            if use_schemata {
+                runner.run_with_schemata(mutations.clone()).report
+            } else {
+                runner.run(mutations.clone()).report
+            }
+        };
+
+        let killed = run();
+        assert_eq!(killed.killed, 2);
+        assert_eq!(killed.subsumed_count(), 0);
+        assert_eq!(killed.execution_counts().executed, 2);
+
+        let changed_strategy = match first_strategy {
+            WorkspaceStrategy::GitWorktree => {
+                std::fs::write(&worktrees, b"block worktree creation")?;
+                WorkspaceStrategy::Copy
+            }
+            WorkspaceStrategy::Copy => {
+                std::fs::remove_file(&worktrees)?;
+                WorkspaceStrategy::GitWorktree
+            }
+        };
+        let changed_context = assert_tracked_ignored_pool_shape(root, changed_strategy)?;
+        assert_workspace_contexts_do_not_share_reuse(initial_context, changed_context);
+
+        let survived = run();
+        assert_eq!(survived.results.len(), 2);
+        assert_eq!(survived.survived, 2);
+        assert_eq!(survived.subsumed_count(), 0);
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 2);
+        if use_schemata {
+            assert!(
+                survived.schemata.is_some(),
+                "the selected pool context must also govern schemata execution"
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn assert_identical_tree_head_transition_rejects_stale_reuse(
+        use_schemata: bool,
+    ) -> anyhow::Result<()> {
+        if !git_available() {
+            return Ok(());
+        }
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        run_git(root, &["init"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+        let source = "package calc\n\nfunc Equal(a, b int) bool { return a == b }\nfunc Other(a, b int) bool { return a == b }\n";
+        std::fs::write(root.join("calc.go"), source)?;
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-m", "initial"]);
+        let initial_head = git_snapshot_revision(root)?;
+        let (initial_pool, initial_context) = prepare_campaign_workspace_pool(root, 2, true)?;
+        assert_eq!(initial_pool.strategy(), WorkspaceStrategy::GitWorktree);
+        drop(initial_pool);
+
+        let mut first = go_operator_mutation(1, "calc.go", source, 0);
+        first.line = 3;
+        let mut second = go_operator_mutation(2, "calc.go", source, 1);
+        second.line = 4;
+        let mutations = vec![first, second];
+        let mut selection = TestSelectionConfig::new();
+        for mutation in &mutations {
+            selection.insert(
+                root,
+                Path::new("calc.go"),
+                mutation.line,
+                vec!["TestHead".into()],
+            );
+        }
+        let script = format!("test \"$(git rev-parse HEAD)\" != \"{initial_head}\"");
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec!["sh".into(), "-c".into(), script.clone()];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let run = || {
+            let runner = TestRunner {
+                commands: make_commands(),
+                parallelism: 2,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: Default::default(),
+                respect_workspace_ignores: true,
+                env: HashMap::new(),
+                incremental_history: true,
+                force_rerun: false,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            if use_schemata {
+                runner.run_with_schemata(mutations.clone()).report
+            } else {
+                runner.run(mutations.clone()).report
+            }
+        };
+
+        let killed = run();
+        assert_eq!(killed.killed, 2);
+        assert_eq!(killed.subsumed_count(), 0);
+        assert_eq!(killed.execution_counts().executed, 2);
+
+        // An empty commit changes only HEAD: the checked-out tree remains the
+        // same, and child worktrees are detached at that new object id.
+        run_git(root, &["commit", "--allow-empty", "-m", "same tree"]);
+        let changed_head = git_snapshot_revision(root)?;
+        assert_ne!(changed_head, initial_head);
+        let (changed_pool, changed_context) = prepare_campaign_workspace_pool(root, 2, true)?;
+        assert_eq!(changed_pool.strategy(), WorkspaceStrategy::GitWorktree);
+        drop(changed_pool);
+        assert_workspace_contexts_do_not_share_reuse(initial_context, changed_context);
+
+        let survived = run();
+        assert_eq!(survived.results.len(), 2);
+        assert_eq!(survived.survived, 2);
+        assert_eq!(survived.subsumed_count(), 0);
+        assert_eq!(survived.execution_counts().exact_cache_reused, 0);
+        assert_eq!(survived.execution_counts().incremental_history_reused, 0);
+        assert_eq!(survived.execution_counts().executed, 2);
+        if use_schemata {
+            assert!(
+                survived.schemata.is_some(),
+                "HEAD identity must reach the schemata path"
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tracked_ignored_git_to_copy_rejects_stale_reuse_in_regular_runs() -> anyhow::Result<()> {
+        assert_tracked_ignored_strategy_transition_rejects_stale_reuse(
+            WorkspaceStrategy::GitWorktree,
+            false,
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tracked_ignored_copy_to_git_rejects_stale_reuse_in_regular_runs() -> anyhow::Result<()> {
+        assert_tracked_ignored_strategy_transition_rejects_stale_reuse(
+            WorkspaceStrategy::Copy,
+            false,
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tracked_ignored_git_to_copy_rejects_stale_reuse_in_schemata_runs() -> anyhow::Result<()> {
+        assert_tracked_ignored_strategy_transition_rejects_stale_reuse(
+            WorkspaceStrategy::GitWorktree,
+            true,
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identical_tree_heads_reject_stale_reuse_in_regular_runs() -> anyhow::Result<()> {
+        assert_identical_tree_head_transition_rejects_stale_reuse(false)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identical_tree_heads_reject_stale_reuse_in_schemata_runs() -> anyhow::Result<()> {
+        assert_identical_tree_head_transition_rejects_stale_reuse(true)
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn copied_workspace_fingerprint_tracks_readonly_permission() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("helper.txt");
+        std::fs::write(&file, b"helper")?;
+
+        let mut permissions = std::fs::metadata(&file)?.permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&file, permissions)?;
+        let writable = copied_workspace_fingerprint(dir.path(), false);
+
+        let mut permissions = std::fs::metadata(&file)?.permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&file, permissions)?;
+        let readonly = copied_workspace_fingerprint(dir.path(), false);
+
+        let mut permissions = std::fs::metadata(&file)?.permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&file, permissions)?;
+        assert_ne!(readonly, writable);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn copied_workspace_fingerprint_tracks_windows_file_attributes() -> anyhow::Result<()> {
+        use std::os::windows::{ffi::OsStrExt, fs::MetadataExt};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_ATTRIBUTE_HIDDEN, FILE_ATTRIBUTE_NORMAL, SetFileAttributesW,
+        };
+
+        fn set_file_attributes(path: &Path, attributes: u32) -> std::io::Result<()> {
+            let path: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+            if unsafe { SetFileAttributesW(path.as_ptr(), attributes) } == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("helper.txt");
+        std::fs::write(&file, b"helper")?;
+        let initial = copied_workspace_fingerprint(dir.path(), false);
+
+        let original_attributes = std::fs::metadata(&file)?.file_attributes();
+        let hidden_attributes =
+            (original_attributes & !FILE_ATTRIBUTE_NORMAL) | FILE_ATTRIBUTE_HIDDEN;
+        set_file_attributes(&file, hidden_attributes)?;
+        let hidden = copied_workspace_fingerprint(dir.path(), false);
+        assert_ne!(
+            hidden, initial,
+            "non-readonly Windows file attributes must affect copied-workspace identity"
+        );
+
+        let workspace = copy_workspace_with_options(dir.path(), false)?;
+        assert_eq!(
+            std::fs::metadata(&file)?.file_attributes(),
+            std::fs::metadata(workspace.root().join("helper.txt"))?.file_attributes(),
+            "canonical copies must retain the Windows attributes their fingerprint hashes"
+        );
+        set_file_attributes(&file, original_attributes)?;
+        Ok(())
+    }
+
+    #[test]
+    fn copied_workspace_fingerprint_tracks_modification_time() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("helper.txt");
+        std::fs::write(&file, b"helper")?;
+        set_file_modification_time(&file, 1_000_000_000)?;
+        let before = copied_workspace_fingerprint(dir.path(), false);
+
+        set_file_modification_time(&file, 1_700_000_000)?;
+        assert_ne!(copied_workspace_fingerprint(dir.path(), false), before);
+        Ok(())
+    }
+
+    #[test]
+    fn copied_workspace_fingerprint_tracks_non_root_directories_and_preserves_their_mtimes()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let runtime = dir.path().join("runtime");
+        let nested = runtime.join("nested");
+        std::fs::create_dir_all(&nested)?;
+        set_file_modification_time(&runtime, 1_000_000_000)?;
+        set_file_modification_time(&nested, 1_100_000_000)?;
+        let initial = copied_workspace_fingerprint(dir.path(), false);
+
+        {
+            let workspace = copy_workspace_with_options(dir.path(), false)?;
+            for relative in [Path::new("runtime"), Path::new("runtime/nested")] {
+                assert_eq!(
+                    std::fs::metadata(dir.path().join(relative))?.modified()?,
+                    std::fs::metadata(workspace.root().join(relative))?.modified()?,
+                    "{relative:?} mtime must match after child creation"
+                );
+            }
+        }
+
+        set_file_modification_time(&runtime, 1_700_000_000)?;
+        let changed_mtime = copied_workspace_fingerprint(dir.path(), false);
+        assert_ne!(
+            changed_mtime, initial,
+            "non-root source directory mtime must affect copied-workspace identity"
+        );
+        std::fs::remove_dir_all(&runtime)?;
+        assert_ne!(
+            copied_workspace_fingerprint(dir.path(), false),
+            changed_mtime,
+            "removing an admitted empty directory must affect copied-workspace identity"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn copied_workspace_fingerprint_excludes_workspace_root_mtime() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("helper.txt"), b"helper")?;
+        set_file_modification_time(dir.path(), 1_000_000_000)?;
+        let before = copied_workspace_fingerprint(dir.path(), false);
+
+        set_file_modification_time(dir.path(), 1_700_000_000)?;
+        assert_eq!(
+            copied_workspace_fingerprint(dir.path(), false),
+            before,
+            "workspace-root mtime belongs to excluded control-state metadata"
+        );
+        Ok(())
+    }
+    #[cfg(windows)]
+    #[test]
+    fn windows_mtime_update_handle_supports_directories() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let directory = dir.path().join("directory");
+        std::fs::create_dir(&directory)?;
+
+        set_file_modification_time(&directory, 1_000_000_000)?;
+        assert_eq!(
+            std::fs::metadata(&directory)?
+                .modified()?
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_secs(),
+            1_000_000_000
+        );
+        Ok(())
     }
 
     #[test]
@@ -8405,6 +11261,14 @@ test "$runs" -eq 1
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn set_file_modification_time(path: &Path, seconds_since_epoch: u64) -> std::io::Result<()> {
+        let is_directory = fs::symlink_metadata(path)?.file_type().is_dir();
+        open_for_mtime_update(path, is_directory)?.set_times(
+            fs::FileTimes::new()
+                .set_modified(std::time::UNIX_EPOCH + Duration::from_secs(seconds_since_epoch)),
+        )
     }
 
     fn init_clean_git_fixture(root: &Path) {
@@ -9195,6 +12059,7 @@ test "$runs" -eq 1
         )
         .unwrap();
 
+        let cached_context = workspace_cache_context(dir.path(), true);
         let mut runner = confirmation_runner(dir.path(), commands, env);
         runner.force_rerun = false;
         let report = runner.run(vec![mutation.clone()]).report;
@@ -9225,15 +12090,15 @@ test "$runs" -eq 1
             &source,
             &cache_identity(dir.path(), &mutation),
             &mutation.description,
-            &format!(
-                "{};context={:016x}",
-                selected.cache_context(
+            &exact_cache_context(
+                &selected.cache_context(
                     &runner.commands.build_command,
                     runner.commands.build_command_origin,
                     &runner.commands.sandbox_command,
                     &runner.env,
                 ),
-                cache_context_fingerprint(dir.path())
+                cached_context.fingerprint,
+                cached_context.provenance,
             ),
         );
         assert_eq!(
@@ -9352,7 +12217,7 @@ test "$runs" -eq 1
     }
 
     #[test]
-    fn select_test_command_prioritizes_history_killer() -> anyhow::Result<()> {
+    fn select_test_command_scopes_history_killer_to_workspace_context() -> anyhow::Result<()> {
         let tmp = tempfile::tempdir()?;
         let mut selection = TestSelectionConfig::new();
         selection.insert(
@@ -9368,6 +12233,18 @@ test "$runs" -eq 1
 
         let mut mutation = make_test_mutation(Path::new("src/calc.py"));
         mutation.line = 3;
+        let test_context_index = TestContextIndex::default();
+        let learned_selection_context = LearnedSelectionContext {
+            test_context_index: &test_context_index,
+            cache_context_fingerprint: 0x0123_4567_89ab_cdef,
+            cache_context_provenance: WorkspaceCacheContextProvenance::WorkspaceCopy {
+                respect_workspace_ignores: true,
+            },
+        };
+        let candidate_tests = vec!["test_slow".into(), "test_fast".into()];
+        let relevant_test_hash = learned_selection_context
+            .relevant_test_hash_for_killer(&candidate_tests, "test_fast")
+            .expect("recorded killer must be a candidate");
         let history = cache::IncrementalHistoryStore::load(tmp.path());
         history.record(cache::IncrementalHistoryEntry {
             mutation_identity: cache_identity(tmp.path(), &mutation),
@@ -9375,17 +12252,123 @@ test "$runs" -eq 1
             result: MutationResult::Killed,
             source_hash: 1,
             command_hash: 2,
-            relevant_test_hash: 3,
-            covering_tests: vec!["test_slow".into(), "test_fast".into()],
+            relevant_test_hash,
+            covering_tests: candidate_tests,
             killer_test: Some("test_fast".into()),
         });
 
-        let selected =
-            select_test_command_with_history(tmp.path(), &commands, &mutation, Some(&history));
+        let selected = select_test_command_with_history(
+            tmp.path(),
+            &commands,
+            &mutation,
+            Some(&history),
+            Some(learned_selection_context),
+        );
 
         assert_eq!(
             selected.argv,
             vec!["pytest", "-k", "test_fast or test_slow"]
+        );
+        let git_selection_context = LearnedSelectionContext {
+            test_context_index: &test_context_index,
+            cache_context_fingerprint: learned_selection_context.cache_context_fingerprint,
+            cache_context_provenance: WorkspaceCacheContextProvenance::GitWorktreeV4,
+        };
+        let cross_context = select_test_command_with_history(
+            tmp.path(),
+            &commands,
+            &mutation,
+            Some(&history),
+            Some(git_selection_context),
+        );
+        assert_eq!(
+            cross_context.argv,
+            vec!["pytest", "-k", "test_slow or test_fast"],
+            "a copy-domain killer must not reorder Git-worktree selection"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn learned_selection_reorders_a_fresh_fast_killer() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        std::fs::write(
+            root.join("calc.py"),
+            "hello\n\ndef test_slow():\n    pass\n\ndef test_fast():\n    pass\n",
+        )?;
+        let log_dir = tempfile::tempdir()?;
+        let log = log_dir.path().join("pytest.log");
+        let bin = root.join("bin");
+        std::fs::create_dir(&bin)?;
+        let pytest = bin.join("pytest");
+        std::fs::write(
+            &pytest,
+            b"#!/bin/sh\nprintf '<%s>\\n' \"$*\" >> \"$TOGI_TEST_LOG\"\nprintf 'test test_fast ... FAILED\\n'\nexit 1\n",
+        )?;
+        let mut permissions = std::fs::metadata(&pytest)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&pytest, permissions)?;
+
+        let mut selection = TestSelectionConfig::new();
+        selection.insert(
+            root,
+            Path::new("calc.py"),
+            1,
+            vec!["test_slow".into(), "test_fast".into()],
+        );
+        let mutation = make_test_mutation(Path::new("calc.py"));
+        let make_commands = || {
+            let mut commands = test_command_config();
+            commands.command = vec!["pytest".into()];
+            commands.test_selection = Some(selection.clone());
+            commands
+        };
+        let mut env = HashMap::new();
+        env.insert(
+            "PATH".into(),
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+        env.insert("TOGI_TEST_LOG".into(), log.display().to_string());
+        let run = || {
+            TestRunner {
+                commands: make_commands(),
+                parallelism: 1,
+                project_root: root.to_path_buf(),
+                verbose: false,
+                show_output: false,
+                max_tested: None,
+                early_stop: EarlyStopConfig::default(),
+                respect_workspace_ignores: true,
+                env: env.clone(),
+                incremental_history: true,
+                force_rerun: true,
+                learned_selection: true,
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }
+            .run(vec![mutation.clone()])
+            .report
+        };
+
+        let first = run();
+        assert_eq!(first.killed, 1);
+        let history: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(root.join(".togi-cache/history.json"))?)?;
+        assert_eq!(history["entries"][0]["killer_test"], "test_fast");
+
+        let second = run();
+        assert_eq!(second.killed, 1);
+        assert_eq!(
+            std::fs::read_to_string(log)?.lines().collect::<Vec<_>>(),
+            ["<-k test_slow or test_fast>", "<-k test_fast or test_slow>"],
+            "the learned fast killer must move ahead of the configured slow test"
         );
         Ok(())
     }
@@ -9417,7 +12400,7 @@ test "$runs" -eq 1
 
         let command_config = commands();
         let selected =
-            select_test_command_with_history(dir.path(), &command_config, &mutation, None);
+            select_test_command_with_history(dir.path(), &command_config, &mutation, None, None);
         let command_ctx = selected.cache_context(
             &command_config.build_command,
             BuildCommandOrigin::None,
@@ -9426,7 +12409,7 @@ test "$runs" -eq 1
         );
         let context_hash = cache_context_fingerprint(dir.path());
         let test_context_index = TestContextIndex::build(dir.path());
-        let relevant_test_hash =
+        let selected_test_hash =
             test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
         let source = std::fs::read(&file)?;
         let query = incremental_history_query(
@@ -9434,7 +12417,9 @@ test "$runs" -eq 1
             &mutation,
             &source,
             &command_ctx,
-            relevant_test_hash,
+            selected_test_hash,
+            context_hash,
+            workspace_cache_context(dir.path(), true).provenance,
         );
         cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
             mutation_identity: query.mutation_identity.clone(),
@@ -9543,7 +12528,11 @@ test "$runs" -eq 1
             &std::fs::read(dir.path().join(&cached.file))?,
             &cache_identity(dir.path(), &cached),
             &cached.description,
-            &format!("{context};context={context_hash:016x}"),
+            &exact_cache_context(
+                &context,
+                context_hash,
+                workspace_cache_context(dir.path(), true).provenance,
+            ),
         );
         cache::store(dir.path(), &key, MutationResult::BuildError);
 
@@ -9562,6 +12551,8 @@ test "$runs" -eq 1
             &source,
             &command_context,
             test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash),
+            context_hash,
+            workspace_cache_context(dir.path(), true).provenance,
         );
         cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
             mutation_identity: query.mutation_identity,
@@ -9652,7 +12643,7 @@ test "$runs" -eq 1
         );
         let context_hash = cache_context_fingerprint(dir.path());
         let test_context_index = TestContextIndex::build(dir.path());
-        let relevant_test_hash =
+        let selected_test_hash =
             test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
         let source = std::fs::read(&file)?;
         let query = incremental_history_query(
@@ -9660,7 +12651,9 @@ test "$runs" -eq 1
             &mutation,
             &source,
             &command_ctx,
-            relevant_test_hash,
+            selected_test_hash,
+            context_hash,
+            workspace_cache_context(dir.path(), true).provenance,
         );
         cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
             mutation_identity: query.mutation_identity.clone(),
@@ -9835,9 +12828,8 @@ test "$runs" -eq 1
 
     /// Seed a Killed entry with a shared killer test for each mutation.
     ///
-    /// `relevant_test_hash` is deliberately stale so verdict restore misses:
-    /// the canonical mutant really executes, making the subsumed siblings'
-    /// skipped execution observable in the report.
+    /// `force_rerun` bypasses verdict restore so the canonical mutant executes,
+    /// while learned selection still consumes this matching evidence.
     fn seed_killer_cluster_history(dir: &Path, file: &Path, mutations: &[Mutation]) {
         let commands = CommandConfig {
             command: failing_command(),
@@ -9854,6 +12846,7 @@ test "$runs" -eq 1
         };
         let store = cache::IncrementalHistoryStore::load(dir);
         let source = std::fs::read(file).expect("source file should exist");
+        let campaign_context = CampaignCacheContext::build(dir, true);
         for mutation in mutations {
             let selected = select_test_command(dir, &commands, mutation);
             let command_ctx = selected.cache_context(
@@ -9862,13 +12855,21 @@ test "$runs" -eq 1
                 &commands.sandbox_command,
                 &HashMap::new(),
             );
+            let selected_test_hash = campaign_context.test_context_index.fingerprint_for_tests(
+                &selected.selected_tests,
+                campaign_context.cache_context_fingerprint,
+            );
             store.record(cache::IncrementalHistoryEntry {
                 mutation_identity: cache_identity(dir, mutation),
                 mutation_description: mutation.description.clone(),
                 result: MutationResult::Killed,
                 source_hash: cache::hash_bytes(&source),
                 command_hash: cache::hash_str(&command_ctx),
-                relevant_test_hash: 3,
+                relevant_test_hash: incremental_history_relevant_test_hash(
+                    selected_test_hash,
+                    campaign_context.cache_context_fingerprint,
+                    campaign_context.cache_context_provenance,
+                ),
                 covering_tests: vec!["test_shared".into()],
                 killer_test: Some("test_shared".into()),
             });
@@ -9899,7 +12900,7 @@ test "$runs" -eq 1
             respect_workspace_ignores: true,
             env: HashMap::new(),
             incremental_history: true,
-            force_rerun: false,
+            force_rerun: true,
             learned_selection,
             cancelled: Arc::new(AtomicBool::new(false)),
         }
@@ -10128,6 +13129,7 @@ test "$runs" -eq 1
         std::fs::create_dir_all(root.join("target/debug")).unwrap();
         std::fs::write(root.join(".gitignore"), b"ignored.txt\n").unwrap();
         std::fs::write(root.join("ignored.txt"), b"copy me").unwrap();
+        set_file_modification_time(&root.join("ignored.txt"), 1_000_000_000).unwrap();
         std::fs::write(root.join("src/lib.rs"), b"pub fn f() {}\n").unwrap();
         std::fs::write(root.join("target/debug/build-artifact"), b"skip").unwrap();
 
@@ -10136,6 +13138,16 @@ test "$runs" -eq 1
         assert_eq!(
             std::fs::read(copy.root().join("ignored.txt")).unwrap(),
             b"copy me"
+        );
+        assert_eq!(
+            std::fs::metadata(copy.root().join("ignored.txt"))
+                .unwrap()
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1_000_000_000
         );
         assert!(copy.root().join("src/lib.rs").exists());
         assert!(!copy.root().join("target").exists());
@@ -10436,6 +13448,36 @@ test "$runs" -eq 1
                 .is_file()
         );
         assert_eq!(std::fs::read(destination)?, b"overlay contents");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_overlay_copy_preserves_regular_file_metadata() -> std::io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().join("project");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir(&root)?;
+        std::fs::create_dir(&workspace)?;
+        let source = root.join("helper.sh");
+        std::fs::write(&source, b"#!/bin/sh\nexit 0\n")?;
+        set_file_modification_time(&source, 1_000_000_000)?;
+        let mut permissions = std::fs::metadata(&source)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&source, permissions)?;
+
+        copy_overlay_file(&root, &workspace, Path::new("helper.sh"))?;
+        let destination = workspace.join("helper.sh");
+        assert_eq!(
+            std::fs::metadata(&destination)?.modified()?,
+            std::fs::metadata(&source)?.modified()?
+        );
+        assert_eq!(
+            std::fs::metadata(&destination)?.permissions().mode() & 0o777,
+            0o755
+        );
         Ok(())
     }
 
@@ -11850,6 +14892,45 @@ sleep 10"#
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
     }
 
+    #[test]
+    fn pre_cancelled_campaigns_preserve_regular_and_schemata_reporting() {
+        let (dir, _, mutation) = make_relative_test_setup();
+        let runner = TestRunner {
+            commands: test_command_config(),
+            parallelism: 1,
+            project_root: dir.path().to_path_buf(),
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: false,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(true)),
+        };
+
+        let regular = runner.run(vec![mutation.clone()]);
+        assert!(regular.cancelled);
+        assert!(regular.report.results.is_empty());
+        assert_eq!(regular.report.total, 0);
+        assert_eq!(regular.report.planned_total, 1);
+        assert!(regular.report.schemata.is_none());
+
+        let schemata = runner.run_with_schemata(vec![mutation]);
+        assert!(schemata.cancelled);
+        assert!(schemata.report.results.is_empty());
+        assert_eq!(schemata.report.total, 0);
+        assert_eq!(schemata.report.planned_total, 1);
+        let summary = schemata
+            .report
+            .schemata
+            .expect("pre-cancelled schemata run must retain its summary");
+        assert_eq!(summary.fast_path, 0);
+        assert_eq!(summary.fallback, 1);
+    }
+
     #[cfg(unix)]
     #[test]
     fn run_with_schemata_reports_unsupported_runner_fallback() {
@@ -12276,9 +15357,10 @@ esac
             &commands.sandbox_command,
             &cache_env,
         );
-        let cache_ctx = format!(
-            "{cache_ctx};context={:016x}",
-            cache_context_fingerprint(dir.path())
+        let cache_ctx = exact_cache_context(
+            &cache_ctx,
+            cache_context_fingerprint(dir.path()),
+            workspace_cache_context(dir.path(), true).provenance,
         );
         let key = CacheKey::new(
             source.as_bytes(),
@@ -12365,14 +15447,16 @@ esac
         let source_content = std::fs::read(dir.path().join("calc.go"))?;
         let context_hash = cache_context_fingerprint(dir.path());
         let test_context_index = TestContextIndex::build(dir.path());
-        let relevant_test_hash =
+        let selected_test_hash =
             test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash);
         let query = incremental_history_query(
             dir.path(),
             &mutation,
             &source_content,
             &command_context,
-            relevant_test_hash,
+            selected_test_hash,
+            context_hash,
+            workspace_cache_context(dir.path(), true).provenance,
         );
         cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
             mutation_identity: query.mutation_identity,
@@ -12758,7 +15842,11 @@ def second(c, d):
                 &commands.sandbox_command,
                 &env,
             );
-            let context = format!("{context};context={context_hash:016x}");
+            let context = exact_cache_context(
+                &context,
+                context_hash,
+                workspace_cache_context(dir.path(), true).provenance,
+            );
             let source = std::fs::read(dir.path().join(&mutation.file))?;
             let key = CacheKey::new(
                 &source,
@@ -12786,6 +15874,8 @@ def second(c, d):
             &source,
             &command_context,
             test_context_index.fingerprint_for_tests(&selected.selected_tests, context_hash),
+            context_hash,
+            workspace_cache_context(dir.path(), true).provenance,
         );
         cache::IncrementalHistoryStore::load(dir.path()).record(cache::IncrementalHistoryEntry {
             mutation_identity: query.mutation_identity,
@@ -13752,9 +16842,10 @@ rmdir "$lock"
                 &commands.sandbox_command,
                 &env,
             );
-            let cache_ctx = format!(
-                "{cache_ctx};context={:016x}",
-                cache_context_fingerprint(dir.path())
+            let cache_ctx = exact_cache_context(
+                &cache_ctx,
+                cache_context_fingerprint(dir.path()),
+                workspace_cache_context(dir.path(), true).provenance,
             );
             let cached_content = std::fs::read(&cached_file).unwrap();
             let key = CacheKey::new(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -221,6 +221,33 @@ pub struct RunOutcome {
     pub cancelled: bool,
 }
 
+#[cfg(test)]
+type MutationWorkerAfterDequeueHook = Arc<dyn Fn(&Path, &Mutation) + Send + Sync>;
+
+#[cfg(test)]
+static MUTATION_WORKER_AFTER_DEQUEUE_HOOK: std::sync::LazyLock<
+    Mutex<Option<MutationWorkerAfterDequeueHook>>,
+> = std::sync::LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
+fn set_mutation_worker_after_dequeue_hook(hook: Option<MutationWorkerAfterDequeueHook>) {
+    let hook_slot = &*MUTATION_WORKER_AFTER_DEQUEUE_HOOK;
+    *hook_slot
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = hook;
+}
+
+#[cfg(test)]
+fn run_mutation_worker_after_dequeue_hook(project_root: &Path, mutation: &Mutation) {
+    let hook = MUTATION_WORKER_AFTER_DEQUEUE_HOOK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(hook) = hook {
+        hook(project_root, mutation);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaselineMeasurement {
     pub build_duration: Option<Duration>,
@@ -5459,6 +5486,7 @@ impl TestRunner {
         let build_command_origin = self.commands.build_command_origin;
         let queue = Arc::new(Mutex::new(mutations.into_iter().collect::<VecDeque<_>>()));
         let results = Arc::new(Mutex::new(restored));
+        let worker_failed = Arc::new(AtomicBool::new(false));
         let worker_count = workspace_pool.len().min(fresh_total).max(1);
         let history = self
             .incremental_history
@@ -5467,6 +5495,7 @@ impl TestRunner {
         thread::scope(|scope| {
             for _ in 0..worker_count {
                 let queue = queue.clone();
+                let worker_failed = worker_failed.clone();
                 let results = results.clone();
                 let workspace_pool = workspace_pool.clone();
                 let project_root = project_root.clone();
@@ -5486,7 +5515,10 @@ impl TestRunner {
 
                 scope.spawn(move || {
                     loop {
-                        if cancelled.load(Ordering::Relaxed) || should_stop_early(&early_stop) {
+                        if cancelled.load(Ordering::Relaxed)
+                            || worker_failed.load(Ordering::Acquire)
+                            || should_stop_early(&early_stop)
+                        {
                             break;
                         }
 
@@ -5495,12 +5527,18 @@ impl TestRunner {
                         else {
                             break;
                         };
-                        if should_stop_early(&early_stop) {
+                        if worker_failed.load(Ordering::Acquire) || should_stop_early(&early_stop) {
                             reservation.release();
                             break;
                         }
                         let next = match queue.lock() {
-                            Ok(mut queue) => queue.pop_front(),
+                            Ok(mut queue) => {
+                                if worker_failed.load(Ordering::Acquire) {
+                                    None
+                                } else {
+                                    queue.pop_front()
+                                }
+                            }
                             Err(_) => {
                                 eprintln!("warning: mutation queue mutex poisoned");
                                 break;
@@ -5509,8 +5547,18 @@ impl TestRunner {
                         let Some(queued) = next else {
                             break;
                         };
+                        let panic_index = queued.index;
+                        let panic_mutation = queued.mutation.clone();
 
                         let outcome = catch_unwind(PanicBoundary(|| {
+                            if worker_failed.load(Ordering::Acquire) {
+                                return None;
+                            }
+                            #[cfg(test)]
+                            run_mutation_worker_after_dequeue_hook(
+                                project_root.as_ref().as_path(),
+                                &queued.mutation,
+                            );
                             run_queued_mutation(
                                 queued,
                                 reservation,
@@ -5550,7 +5598,28 @@ impl TestRunner {
                                 }
                             },
                             Ok(None) => {}
-                            Err(_) => eprintln!("warning: mutation task panicked"),
+                            Err(_) => {
+                                worker_failed.store(true, Ordering::Release);
+                                let diagnostic = BuildErrorDiagnostic::new(
+                                    panic_mutation.id,
+                                    "regular",
+                                    "mutation_worker_panic",
+                                    vec![],
+                                    "mutation worker panicked after dequeuing this mutation",
+                                );
+                                let mut results = results
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                results.push((
+                                    panic_index,
+                                    MutationRunRecord::new(
+                                        panic_mutation,
+                                        MutationResult::BuildError,
+                                        Some(diagnostic),
+                                    ),
+                                ));
+                                break;
+                            }
                         }
                     }
                 });
@@ -16276,6 +16345,75 @@ mod tests {
 
         let report = runner.run(mutations).report;
         assert_eq!(report.total, 2, "should stop after max_tested");
+    }
+
+    #[test]
+    fn worker_panic_records_build_error_and_stops_campaign() {
+        let (dir, file, first) = make_test_setup();
+        let mut second = make_test_mutation(&file);
+        second.id = 2;
+        second.description = "second mutation".into();
+        let project_root = dir.path().to_path_buf();
+        let mutation_id = first.id;
+        let panicked = Arc::new(AtomicBool::new(false));
+        let hook_root = project_root.clone();
+        let hook_panicked = panicked.clone();
+        set_mutation_worker_after_dequeue_hook(Some(Arc::new(move |root, mutation| {
+            if root == hook_root.as_path()
+                && mutation.id == mutation_id
+                && !hook_panicked.swap(true, Ordering::AcqRel)
+            {
+                panic!("simulated mutation worker panic after dequeue");
+            }
+        })));
+
+        let command_log = dir.path().join("worker-command.log");
+        let mut commands = test_command_config();
+        commands.command = appending_log_command(&command_log);
+        let runner = TestRunner {
+            commands,
+            parallelism: 1,
+            project_root,
+            verbose: false,
+            show_output: false,
+            max_tested: None,
+            early_stop: Default::default(),
+            respect_workspace_ignores: true,
+            env: HashMap::new(),
+            incremental_history: false,
+            force_rerun: true,
+            learned_selection: false,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+
+        let outcome = runner.run(vec![first, second]);
+        set_mutation_worker_after_dequeue_hook(None);
+
+        assert!(panicked.load(Ordering::Acquire));
+        assert!(!outcome.cancelled);
+        let report = outcome.report;
+        assert_eq!(report.planned_total, 2);
+        assert_eq!(report.total, 1);
+        let (recorded, result) = report
+            .results
+            .first()
+            .expect("the panicked mutation should be recorded");
+        assert_eq!(recorded.id, mutation_id);
+        assert_eq!(*result, MutationResult::BuildError);
+        assert_eq!(report.build_errors, 1);
+        let diagnostic = report
+            .build_error_diagnostics
+            .first()
+            .expect("the panic should retain a build-error diagnostic");
+        assert_eq!(diagnostic.mutation_id, mutation_id);
+        assert_eq!(diagnostic.runner, "regular");
+        assert_eq!(diagnostic.phase, "mutation_worker_panic");
+        assert!(diagnostic.message.contains("mutation worker panicked"));
+        assert!(
+            !command_log.exists(),
+            "no later mutation should be scheduled"
+        );
+        assert!(!crate::baseline::is_baseline_eligible(&report));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10510,6 +10510,7 @@ test "$runs" -eq 1
                 "-count=1".into(),
                 "./...".into(),
             ];
+            commands.timeout = Duration::from_secs(90);
             commands.test_selection = Some(selection.clone());
             commands
         };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -862,6 +862,79 @@ fn setup_two_line_mutation_repo() -> TempDir {
     dir
 }
 
+#[test]
+fn check_coverage_gate_preserves_each_output_format() {
+    for (format, expected_stdout, writes_html) in [
+        ("terminal", "Coverage gate failed", false),
+        ("json", "", false),
+        ("github", "## Coverage gate failed", false),
+        ("html", "", true),
+        ("sarif", "Coverage gate failed", false),
+    ] {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("main.go"),
+            "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("lcov.info"),
+            "SF:main.go\nDA:4,0\nend_of_record\n",
+        )
+        .unwrap();
+
+        let output = togi()
+            .args([
+                "check",
+                "--all",
+                "--format",
+                format,
+                "--test-cmd",
+                "true",
+                "--coverage-file",
+                "lcov.info",
+                "--min-line-coverage",
+                "100",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        assert_eq!(output.status.code(), Some(1), "{format}: {output:?}");
+        if format == "json" {
+            let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+                .unwrap_or_else(|error| panic!("invalid coverage JSON: {error}"));
+            assert_eq!(report["line_coverage"]["covered"], 0);
+        } else {
+            assert!(
+                String::from_utf8_lossy(&output.stdout).contains(expected_stdout),
+                "{format} stdout: {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+        }
+
+        let html = dir.path().join("togi-coverage-report.html");
+        assert_eq!(html.exists(), writes_html, "{format} HTML destination");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if writes_html {
+            assert!(
+                fs::read_to_string(html)
+                    .unwrap()
+                    .contains("Coverage gate failed")
+            );
+            assert!(
+                stderr.ends_with("HTML coverage report written to togi-coverage-report.html\n"),
+                "{format} stderr: {stderr}"
+            );
+        } else {
+            assert!(
+                !stderr.contains("HTML coverage report written to togi-coverage-report.html"),
+                "{format} stderr: {stderr}"
+            );
+        }
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn check_classifies_zero_coverage_mutants_as_uncovered() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5481,6 +5481,397 @@ fn production_upload_artifact_pins_are_immutable() {
     }
 }
 
+fn initialize_fixture_git_index(fixture: &TempDir) {
+    assert!(
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(fixture.path())
+            .status()
+            .expect("initialize fixture Git index")
+            .success(),
+        "fixture Git initialization must succeed"
+    );
+    assert!(
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(fixture.path())
+            .status()
+            .expect("stage fixture manifests")
+            .success(),
+        "fixture manifests must stage"
+    );
+}
+
+#[test]
+fn pinned_actions_checker_semantically_checks_local_composites() {
+    if !bash_available() {
+        eprintln!("skipping pinned-actions checker test because bash is unavailable");
+        return;
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let checker = root.join(".github/scripts/check-pinned-actions.sh");
+    let production = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(root)
+        .output()
+        .expect("run production pinned-actions checker");
+    assert!(
+        production.status.success(),
+        "production actions must be pinned\nstderr:\n{}",
+        String::from_utf8_lossy(&production.stderr)
+    );
+
+    let non_git_fixture = TempDir::new().expect("create non-Git fixture");
+    let non_git = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(non_git_fixture.path())
+        .output()
+        .expect("run checker outside a Git work tree");
+    assert!(
+        !non_git.status.success(),
+        "checker must reject a non-Git worktree"
+    );
+    assert!(
+        String::from_utf8_lossy(&non_git.stderr)
+            .contains("check-pinned-actions.sh must run inside a Git work tree"),
+        "unexpected non-Git checker stderr:\n{}",
+        String::from_utf8_lossy(&non_git.stderr)
+    );
+
+    let fixture = TempDir::new().expect("create mutable-action fixture");
+    fs::create_dir_all(fixture.path().join(".github/workflows"))
+        .expect("create mutable-action workflow directory");
+    fs::create_dir_all(fixture.path().join(".github/actions/unpinned/inner"))
+        .expect("create nested mutable-action directory");
+    fs::write(
+        fixture.path().join(".github/workflows/mutable.yml"),
+        r#"name: mutable
+inputs:
+  uses: actions/setup-go@v7
+jobs:
+  reusable:
+    uses: actions/checkout@v7
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/unpinned
+      - uses: docker://alpine:3.20
+      - name: ignored input
+        with:
+          uses: actions/setup-go@v7
+          <<: ignored
+"#,
+    )
+    .expect("write fixture workflow");
+    fs::write(
+        fixture.path().join(".github/workflows/spaced name.yml"),
+        "name: spaced\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v7\n",
+    )
+    .expect("write spaced workflow");
+    fs::write(
+        fixture.path().join(".github/actions/unpinned/action.yml"),
+        r#"name: outer
+runs:
+  using: composite
+  steps:
+    - uses : actions/checkout@v7
+    - "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    - uses: ./inner
+"#,
+    )
+    .expect("write outer composite action");
+    fs::write(
+        fixture.path().join("action.yml"),
+        "name: root\nruns:\n  using: composite\n  steps:\n    - uses: actions/cache@v4\n",
+    )
+    .expect("write root composite action");
+    fs::write(
+        fixture
+            .path()
+            .join(".github/actions/unpinned/inner/action.yaml"),
+        r#"name: inner
+description: "uses : actions/setup-go@v7"
+inputs:
+  uses:
+    default: actions/setup-go@v7
+runs:
+  using: composite
+  steps:
+    # uses : actions/upload-artifact@v7
+    - "uses": actions/attest-build-provenance@8beda2b7ed98355c0e97c0a63bec38ae472e66c4
+    - 'uses' : actions/checkout@v7
+    - "u\u0073es": actions/setup-node@v7
+    - uses: !action actions/setup-dotnet@v6
+"#,
+    )
+    .expect("write nested composite action");
+    initialize_fixture_git_index(&fixture);
+
+    let rejection = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(fixture.path())
+        .output()
+        .expect("run mutable-action fixture checker");
+    assert!(
+        !rejection.status.success(),
+        "nested composite action pins must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&rejection.stderr);
+    for expected in [
+        ".github/workflows/mutable.yml: jobs.reusable.uses: external action must be pinned to a full commit SHA: actions/checkout@v7",
+        ".github/workflows/spaced name.yml: jobs.test.steps[0].uses: external action must be pinned to a full commit SHA: actions/checkout@v7",
+        "action.yml: runs.steps[0].uses: external action must be pinned to a full commit SHA: actions/cache@v4",
+        ".github/actions/unpinned/action.yml: runs.steps[0].uses: external action must be pinned to a full commit SHA: actions/checkout@v7",
+        ".github/actions/unpinned/inner/action.yaml: runs.steps[0].uses: external action must use a reviewed commit SHA: actions/attest-build-provenance@8beda2b7ed98355c0e97c0a63bec38ae472e66c4",
+        ".github/actions/unpinned/inner/action.yaml: runs.steps[1].uses: external action must be pinned to a full commit SHA: actions/checkout@v7",
+        ".github/actions/unpinned/inner/action.yaml: runs.steps[2].uses: external action must be pinned to a full commit SHA: actions/setup-node@v7",
+        ".github/actions/unpinned/inner/action.yaml: runs.steps[3].uses: external action must be pinned to a full commit SHA: actions/setup-dotnet@v6",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "checker must report semantic action location `{expected}`\nstderr:\n{stderr}"
+        );
+    }
+    assert!(
+        !stderr.contains("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"),
+        "checker must accept a quoted reviewed SHA\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("actions/setup-go@v7")
+            && !stderr.contains("actions/upload-artifact@v7")
+            && !stderr.contains("./.github/actions/unpinned")
+            && !stderr.contains("docker://alpine:3.20")
+            && !stderr.contains("YAML merge keys are unsupported"),
+        "checker must ignore non-action data and exempt local and Docker actions\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn pinned_actions_checker_reads_worktree_content_for_staged_manifests() {
+    if !bash_available() {
+        eprintln!("skipping pinned-actions checker test because bash is unavailable");
+        return;
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let checker = root.join(".github/scripts/check-pinned-actions.sh");
+    let fixture = TempDir::new().expect("create staged-manifest fixture");
+    let workflow = fixture.path().join(".github/workflows/staged.yml");
+    fs::create_dir_all(workflow.parent().expect("workflow parent"))
+        .expect("create staged-manifest workflow directory");
+    fs::write(
+        &workflow,
+        "name: staged\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n",
+    )
+    .expect("write staged workflow");
+    initialize_fixture_git_index(&fixture);
+    fs::write(
+        &workflow,
+        "name: staged\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v7\n",
+    )
+    .expect("change staged workflow in the working tree");
+
+    let rejection = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(fixture.path())
+        .output()
+        .expect("run staged-manifest fixture checker");
+    assert!(
+        !rejection.status.success(),
+        "checker must inspect working-tree content for staged manifest paths"
+    );
+    assert!(
+        String::from_utf8_lossy(&rejection.stderr).contains(
+            ".github/workflows/staged.yml: jobs.test.steps[0].uses: external action must be pinned to a full commit SHA: actions/checkout@v7"
+        ),
+        "checker must reject the unstaged working-tree mutation\nstderr:\n{}",
+        String::from_utf8_lossy(&rejection.stderr)
+    );
+}
+
+#[test]
+fn pinned_actions_checker_fails_closed_on_aliases_and_merges() {
+    if !bash_available() {
+        eprintln!("skipping pinned-actions checker test because bash is unavailable");
+        return;
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let checker = root.join(".github/scripts/check-pinned-actions.sh");
+    let fixture = TempDir::new().expect("create alias fixture");
+    fs::create_dir_all(fixture.path().join(".github/workflows"))
+        .expect("create alias workflow directory");
+    fs::create_dir_all(fixture.path().join(".github/actions/merge"))
+        .expect("create merge action directory");
+    fs::write(
+        fixture.path().join(".github/workflows/aliases.yml"),
+        r#"name: aliases
+root_template: &root_template
+  ignored: true
+<<: *root_template
+jobs:
+  job_template: &job_template
+    ignored: true
+  <<: *job_template
+  test:
+    <<: &job_merge
+      ignored: true
+    runs-on: ubuntu-latest
+    steps:
+      - &shared_step
+        uses: actions/setup-dotnet@v6
+      - *shared_step
+      - &shared_merge
+        uses: actions/download-artifact@v8
+      - <<: *shared_merge
+"#,
+    )
+    .expect("write alias workflow");
+    fs::write(
+        fixture.path().join(".github/actions/merge/action.yml"),
+        r#"name: merge action
+runs:
+  <<: &runs_merge
+    ignored: true
+  using: composite
+  steps: []
+"#,
+    )
+    .expect("write merge action");
+    initialize_fixture_git_index(&fixture);
+
+    let rejection = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(fixture.path())
+        .output()
+        .expect("run alias fixture checker");
+    assert!(
+        !rejection.status.success(),
+        "aliases and merges must not bypass the checker"
+    );
+    let stderr = String::from_utf8_lossy(&rejection.stderr);
+    assert!(
+        stderr.contains(
+            ".github/workflows/aliases.yml: jobs.test.steps[1].uses: external action must be pinned to a full commit SHA: actions/setup-dotnet@v6"
+        ),
+        "checker must inspect a direct aliased executable step\nstderr:\n{stderr}"
+    );
+    for expected in [
+        ".github/workflows/aliases.yml: $: YAML merge keys are unsupported in executable action mappings",
+        ".github/workflows/aliases.yml: jobs: YAML merge keys are unsupported in executable action mappings",
+        ".github/workflows/aliases.yml: jobs.test: YAML merge keys are unsupported in executable action mappings",
+        ".github/workflows/aliases.yml: jobs.test.steps[3]: YAML merge keys are unsupported in executable action mappings",
+        ".github/actions/merge/action.yml: runs: YAML merge keys are unsupported in executable action mappings",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "checker must reject traversal-relevant merge key `{expected}`\nstderr:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn pinned_actions_checker_rejects_unreadable_and_invalid_manifests() {
+    if !bash_available() {
+        eprintln!("skipping pinned-actions checker test because bash is unavailable");
+        return;
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let checker = root.join(".github/scripts/check-pinned-actions.sh");
+    let fixture = TempDir::new().expect("create invalid-manifest fixture");
+    let workflows = fixture.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("create invalid-manifest workflow directory");
+    fs::write(
+        workflows.join("duplicate.yml"),
+        "name: duplicate\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n",
+    )
+    .expect("write duplicate-key workflow");
+    fs::write(
+        workflows.join("multi.yml"),
+        "name: first\n---\nname: second\n",
+    )
+    .expect("write multi-document workflow");
+    fs::write(
+        workflows.join("unknown-alias.yml"),
+        "name: unknown alias\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - *missing\n",
+    )
+    .expect("write unknown-alias workflow");
+    fs::write(
+        workflows.join("recursive-alias.yml"),
+        "name: recursive alias\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - &loop [*loop]\n",
+    )
+    .expect("write recursive-alias workflow");
+    fs::write(
+        workflows.join("oversized.yml"),
+        format!("name: oversized\n# {}\n", "a".repeat(1024 * 1024)),
+    )
+    .expect("write oversized workflow");
+    let removed = workflows.join("removed.yml");
+    fs::write(
+        &removed,
+        "name: removed\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n",
+    )
+    .expect("write removable workflow");
+    initialize_fixture_git_index(&fixture);
+    fs::remove_file(&removed).expect("remove staged workflow from the working tree");
+
+    let rejection = std::process::Command::new("bash")
+        .arg(&checker)
+        .current_dir(fixture.path())
+        .output()
+        .expect("run invalid-manifest fixture checker");
+    assert!(
+        !rejection.status.success(),
+        "invalid selected manifests must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&rejection.stderr);
+    for expected in [
+        ".github/workflows/duplicate.yml: invalid YAML:",
+        ".github/workflows/multi.yml: expected exactly one YAML document, found 2",
+        ".github/workflows/unknown-alias.yml: invalid YAML:",
+        ".github/workflows/oversized.yml: manifest exceeds the 1048576-byte size limit",
+        ".github/workflows/removed.yml: unable to read manifest:",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "checker must fail closed for `{expected}`\nstderr:\n{stderr}"
+        );
+    }
+    assert!(
+        stderr.contains(".github/workflows/recursive-alias.yml: invalid YAML:")
+            || stderr.contains(
+                ".github/workflows/recursive-alias.yml: jobs.test.steps[0]: expected an executable step mapping"
+            ),
+        "checker must reject recursive aliases with a clear diagnostic\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn readme_action_examples_use_commit_pins() {
+    let readme = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"))
+        .unwrap()
+        .replace("\r\n", "\n");
+
+    for expected in [
+        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0",
+        "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0",
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
+        "github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3",
+    ] {
+        assert!(
+            readme.contains(expected),
+            "README action example must contain commit pin `{expected}`"
+        );
+    }
+    assert!(
+        !readme
+            .contains("github/codeql-action/upload-sarif@5ba2889ada762081db2c4f32a729827dce632c7b"),
+        "README must not use the v3 annotated tag object as a pin"
+    );
+}
+
 #[test]
 fn github_action_guide_and_advisory_pin_released_contract() {
     let readme = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"))
@@ -6305,7 +6696,8 @@ fn pr_loop_benchmark_workflow_collects_observational_evidence() {
     let checkout = steps
         .iter()
         .find(|step| {
-            step.get("uses").and_then(|value| value.as_str()) == Some("actions/checkout@v7")
+            step.get("uses").and_then(|value| value.as_str())
+                == Some("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")
         })
         .expect("benchmark job must checkout");
     assert_eq!(
@@ -6327,7 +6719,10 @@ fn pr_loop_benchmark_workflow_collects_observational_evidence() {
             "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8",
             Some("stable"),
         ),
-        ("actions/setup-go@v7", Some("1.26.5")),
+        (
+            "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+            Some("1.26.5"),
+        ),
     ] {
         let step = steps
             .iter()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6016,7 +6016,7 @@ fn github_action_guide_and_advisory_pin_released_contract() {
 
     for expected in [
         "Those inputs override `togi.toml`",
-        "`format: github`; the Action preserves that review run and performs a second\nfull JSON mutation run",
+        "`format: github`; the Action runs one GitHub-format mutation campaign and writes\na replayable JSON sidecar with `--json-report`",
         "A failed baseline test or build is a fatal exit `2`",
         "Never use `pull_request_target` to run PR code.",
         "immutable version identifiers for v0.5.2",

--- a/tests/integration/benchmarks.rs
+++ b/tests/integration/benchmarks.rs
@@ -1290,7 +1290,10 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
         .and_then(|value| value.as_sequence())
         .ok_or_else(|| "benchmark job has no step sequence".to_string())?;
     let expected = [
-        ("uses", "actions/checkout@v7"),
+        (
+            "uses",
+            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        ),
         (
             "uses",
             "dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8",
@@ -1300,7 +1303,10 @@ fn validate_pr_loop_benchmark_step_set(job: &serde_yaml::Value) -> Result<(), St
             "uses",
             "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
         ),
-        ("uses", "actions/setup-go@v7"),
+        (
+            "uses",
+            "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+        ),
         ("name", "Create job-private Go build cache"),
         ("name", "Check benchmark prerequisites"),
         ("name", "Build release binary"),
@@ -1478,7 +1484,8 @@ fn ci_pr_loop_benchmark_contract_is_structural() {
     let checkout = steps
         .iter()
         .find(|step| {
-            step.get("uses").and_then(|value| value.as_str()) == Some("actions/checkout@v7")
+            step.get("uses").and_then(|value| value.as_str())
+                == Some("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")
         })
         .expect("benchmark job must check out the repository");
     assert_eq!(
@@ -2165,7 +2172,10 @@ fn pr_loop_calibration_workflow_is_manual_read_only_and_retained() {
     };
     let setup_go = steps
         .iter()
-        .find(|item| item["uses"].as_str() == Some("actions/setup-go@v7"))
+        .find(|item| {
+            item["uses"].as_str()
+                == Some("actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e")
+        })
         .expect("calibration must set up Go");
     assert_eq!(
         setup_go["with"]["go-version"].as_str(),
@@ -4199,7 +4209,10 @@ fn pr_loop_regression_gate_workflow_is_fail_closed_and_comparator_driven() {
 
     let checkout = steps
         .iter()
-        .find(|item| item["uses"].as_str() == Some("actions/checkout@v7"))
+        .find(|item| {
+            item["uses"].as_str()
+                == Some("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")
+        })
         .expect("gate must check out the repository");
     assert_eq!(
         checkout["with"]["persist-credentials"].as_bool(),
@@ -4238,7 +4251,10 @@ fn pr_loop_regression_gate_workflow_is_fail_closed_and_comparator_driven() {
     }
     let setup_go = steps
         .iter()
-        .find(|item| item["uses"].as_str() == Some("actions/setup-go@v7"))
+        .find(|item| {
+            item["uses"].as_str()
+                == Some("actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e")
+        })
         .expect("gate must set up Go");
     assert_eq!(
         setup_go["with"]["go-version"].as_str(),

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -4,8 +4,14 @@
 //!
 
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(unix)]
+use std::process::Output;
 use std::time::Duration;
 use togi::{ChangedFile, LineRange};
 
@@ -223,6 +229,7 @@ fn csharp_fixture_runs_end_to_end() {
 fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
     // The demo creates commits, so it must not rely on a CI runner's identity.
     let clean_home = tempfile::tempdir().unwrap();
+    let cargo_target_dir = tempfile::tempdir().unwrap();
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let output = Command::new("bash")
         .arg("examples/polyglot-demo.sh")
@@ -230,6 +237,8 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
         .env("HOME", clean_home.path())
         .env("XDG_CONFIG_HOME", clean_home.path().join("config"))
         .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("CARGO_TARGET_DIR", cargo_target_dir.path())
+        .env_remove("TOGI_BIN")
         .output()
         .expect("failed to run polyglot demo");
     assert!(
@@ -237,6 +246,10 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
         "polyglot demo failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        cargo_target_dir.path().join("debug/togi").is_file(),
+        "polyglot demo did not build to the external target directory"
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -261,4 +274,173 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
         has_clean_results,
         "polyglot demo reported a timeout or build error\nstdout:\n{stdout}"
     );
+}
+
+#[cfg(unix)]
+fn demo_test_tools_available() -> bool {
+    ["bash", "git"].into_iter().all(|tool| {
+        Command::new(tool)
+            .arg("--version")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(unix)]
+struct DemoRun {
+    output: Output,
+    fake_togi: PathBuf,
+    invocations: String,
+}
+
+#[cfg(unix)]
+fn run_demo_with_fake_togi(script: &str, status: i32, report: &str) -> DemoRun {
+    let fixture = tempfile::tempdir().unwrap();
+    let target_dir = fixture.path().join("external-target");
+    let fake_togi = target_dir.join("debug/togi");
+    fs::create_dir_all(fake_togi.parent().unwrap()).unwrap();
+    fs::write(
+        &fake_togi,
+        r#"#!/usr/bin/env bash
+set -eu
+report=
+while (($#)); do
+  case "$1" in
+    --json-report)
+      report="${2:?missing report path}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+[[ -n "$report" ]]
+printf '%s\n' "$0" >> "$FAKE_TOGI_LOG"
+printf '%s\n' "$FAKE_TOGI_REPORT" > "$report"
+exit "$FAKE_TOGI_STATUS"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_togi).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_togi, permissions).unwrap();
+
+    let home = fixture.path().join("home");
+    fs::create_dir(&home).unwrap();
+    let invocation_log = fixture.path().join("fake-togi.log");
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output = Command::new("bash")
+        .arg(root.join(script))
+        .current_dir(&root)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .env_remove("TOGI_BIN")
+        .env("FAKE_TOGI_LOG", &invocation_log)
+        .env("FAKE_TOGI_STATUS", status.to_string())
+        .env("FAKE_TOGI_REPORT", report)
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_AUTHOR_NAME", "Togi Test")
+        .env("GIT_AUTHOR_EMAIL", "togi-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "Togi Test")
+        .env("GIT_COMMITTER_EMAIL", "togi-test@example.invalid")
+        .output()
+        .expect("failed to run demo");
+
+    DemoRun {
+        output,
+        fake_togi,
+        invocations: fs::read_to_string(invocation_log).expect("fake togi was not invoked"),
+    }
+}
+
+#[cfg(unix)]
+fn demo_report(survived: usize, timeout: usize, build_errors: usize) -> String {
+    format!(r#"{{"survived":{survived},"timeout":{timeout},"build_errors":{build_errors}}}"#)
+}
+
+#[cfg(unix)]
+#[test]
+fn demo_scripts_honor_external_target_dir_for_clean_survivors() {
+    if !demo_test_tools_available() {
+        eprintln!("skipping demo script test: bash and git are required");
+        return;
+    }
+
+    for script in ["examples/demo.sh", "examples/polyglot-demo.sh"] {
+        for (status, report) in [(0, demo_report(1, 0, 0)), (1, demo_report(1, 0, 0))] {
+            let run = run_demo_with_fake_togi(script, status, &report);
+            assert!(
+                run.output.status.success(),
+                "{script} should accept clean exit {status}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&run.output.stdout),
+                String::from_utf8_lossy(&run.output.stderr)
+            );
+            assert_eq!(
+                run.invocations,
+                format!("{}\n", run.fake_togi.display()),
+                "{script} did not use the binary in CARGO_TARGET_DIR"
+            );
+            if script == "examples/polyglot-demo.sh" {
+                assert!(
+                    String::from_utf8_lossy(&run.output.stdout).contains(
+                        "=== one run, one report, one gate — no per-language glue required ==="
+                    ),
+                    "polyglot demo should complete after clean exit {status}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn demo_scripts_reject_invalid_reports_and_fatal_exit_codes() {
+    if !demo_test_tools_available() {
+        eprintln!("skipping demo script test: bash and git are required");
+        return;
+    }
+
+    for script in ["examples/demo.sh", "examples/polyglot-demo.sh"] {
+        for (kind, status, report, expected_status, expects_diagnostic) in [
+            ("missing survivor report", 0, demo_report(0, 0, 0), 1, true),
+            ("build-error report", 1, demo_report(1, 0, 1), 1, true),
+            ("timeout report", 1, demo_report(1, 1, 0), 1, true),
+            ("command error", 2, demo_report(1, 0, 0), 2, false),
+            ("interrupt", 130, demo_report(1, 0, 0), 130, false),
+            ("unexpected exit", 42, demo_report(1, 0, 0), 42, false),
+        ] {
+            let run = run_demo_with_fake_togi(script, status, &report);
+            assert_eq!(
+                run.output.status.code(),
+                Some(expected_status),
+                "{script} should propagate {kind}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&run.output.stdout),
+                String::from_utf8_lossy(&run.output.stderr)
+            );
+            assert_eq!(
+                run.invocations,
+                format!("{}\n", run.fake_togi.display()),
+                "{script} did not use the binary in CARGO_TARGET_DIR"
+            );
+            if expects_diagnostic {
+                assert!(
+                    String::from_utf8_lossy(&run.output.stderr).contains(
+                        "Expected a JSON report with survived > 0, timeout == 0, and build_errors == 0."
+                    ),
+                    "{script} should diagnose {kind}"
+                );
+            }
+            if script == "examples/polyglot-demo.sh" {
+                assert!(
+                    !String::from_utf8_lossy(&run.output.stdout).contains(
+                        "=== one run, one report, one gate — no per-language glue required ==="
+                    ),
+                    "polyglot demo printed its success banner after {kind}"
+                );
+            }
+        }
+    }
 }

--- a/tests/integration/smoke.rs
+++ b/tests/integration/smoke.rs
@@ -278,13 +278,16 @@ fn polyglot_demo_routes_mutations_to_each_language_test_suite() {
 
 #[cfg(unix)]
 fn demo_test_tools_available() -> bool {
-    ["bash", "git"].into_iter().all(|tool| {
-        Command::new(tool)
+    Command::new("bash")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+        && Command::new("git")
             .arg("--version")
             .output()
             .map(|output| output.status.success())
             .unwrap_or(false)
-    })
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
- Pin and validate GitHub Action references.
- Bind cache reuse to materialized workspace state and fail closed on worker panic.
- Preserve lock/baseline integrity, demo report expectations, coverage routing, and Action documentation semantics.

Verified: `git diff --check`, `cargo fmt --check`, `cargo test --locked`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, and `.github/scripts/check-pinned-actions.sh`.